### PR TITLE
feat(ui): sign-in-required banner for the active agent (auth/status)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,20 @@ This means:
 
 ---
 
+## Language
+
+**Everything written into the repository or any project platform MUST be in English.** This keeps the project ready to go global. The rule is non-negotiable and applies to:
+
+- Source code: identifiers, comments, docstrings, log/error messages, test names.
+- Documentation: READMEs, CHANGELOGs, `FOR-DEV.md`/`FOR-HUMAN.md`, architecture docs, in-repo notes.
+- Git: commit messages, branch names, tags.
+- GitHub (and any future platform): pull request titles/descriptions, issue titles/bodies, review comments, labels, release notes.
+- User-facing strings stay localized through the normal i18n flow (e.g. the Flutter ARB files) — English is the source/base locale; other locales are additions, never a replacement.
+
+The only exception is direct conversational communication with the maintainer (chat replies, end-of-task summaries), which may be in the maintainer's preferred language. That exception never leaks into anything committed or published.
+
+---
+
 ## Monorepo structure
 
 ```

--- a/uxnanmobile/.gitignore
+++ b/uxnanmobile/.gitignore
@@ -1,6 +1,7 @@
 # Miscellaneous
 *.class
 *.log
+flutter_mobile_logs.txt
 *.pyc
 *.swp
 .DS_Store

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,21 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **Agent sign-in banner (`auth/status`).** The conversation screen now queries
+  the bridge's sanitized per-agent `auth/status` for the active thread's agent
+  and shows a warning banner above the composer when that agent is **not signed
+  in on the PC** (turns won't run until the user logs into its CLI there). New
+  `AuthStatus` entity (tolerant parser, never carries tokens),
+  `ThreadManager.loadAuthStatus(agentId)` and an `authStatusProvider`
+  `FutureProvider.family`, mirroring the existing `agentModels`/
+  `agentCapabilities` providers. The banner is gated on actually holding this
+  thread's PC channel (`connectedHere`) and degrades to nothing while offline or
+  against an older bridge. Informational only for now — there is no in-app login
+  yet (the bridge's `auth/login` is still a stub), so it points the user to the
+  PC; it also renders a "Signing in…" state for `loginInProgress`.
+
 ### Fixed
 
 - **Notifications wrongly suppressed on the threads list.** The "currently

--- a/uxnanmobile/FOR-DEV.md
+++ b/uxnanmobile/FOR-DEV.md
@@ -329,6 +329,23 @@ browser and multi-PC connection correctness are now DONE — see below.)
 - ☐ **iOS APNs** — verify end-to-end on a real device once the Firebase project
   + APNs key exist (FOR-HUMAN).
 
+## Account / auth
+
+- ☑ **Sign-in status banner (`auth/status`)** — DONE: the conversation screen
+  queries the bridge's sanitized per-agent `auth/status` for the active thread's
+  agent (`AuthStatus` entity + `ThreadManager.loadAuthStatus` +
+  `authStatusProvider` family) and shows a warning banner above the composer
+  when the agent is not signed in on the PC. Gated on `connectedHere`; degrades
+  to nothing offline / against an older bridge. ☐ On-device: verify the banner
+  appears when the agent CLI is logged out on the PC and clears once it's
+  authenticated.
+- ⊘ **Interactive login from the app — OUT OF SCOPE (product decision).** The
+  banner is informational by design: signing an agent in/out is done on the PC
+  (each agent's own CLI login), not from the phone. The app deliberately does
+  NOT drive `auth/login`/`auth/logout`. The `loginInProgress` state is still
+  rendered for completeness if a bridge ever reports it, but no in-app login
+  action is planned.
+
 ## Tooling
 
 - ☐ Adopt `freezed`/`json_serializable` if/when entity boilerplate warrants it.

--- a/uxnanmobile/l10n/app_en.arb
+++ b/uxnanmobile/l10n/app_en.arb
@@ -169,6 +169,19 @@
   "approvalFullTitle": "Full access",
   "approvalFullBody": "Unrestricted access to the internet and any file.",
 
+  "authRequiresLoginTitle": "Agent not signed in",
+  "@authRequiresLoginTitle": {
+    "description": "Banner title shown when the active thread's agent is not logged in on the PC."
+  },
+  "authRequiresLoginBody": "Sign in to this agent's CLI on your PC to start sending messages.",
+  "@authRequiresLoginBody": {
+    "description": "Banner body explaining the agent must be logged in on the PC."
+  },
+  "authLoginInProgress": "Signing in on your PC…",
+  "@authLoginInProgress": {
+    "description": "Banner shown while an interactive login is in progress on the PC."
+  },
+
   "gitActionsTitle": "Source control",
   "gitCleanState": "Working tree clean",
   "gitDirtyState": "Uncommitted changes",

--- a/uxnanmobile/l10n/app_es.arb
+++ b/uxnanmobile/l10n/app_es.arb
@@ -154,6 +154,10 @@
   "approvalFullTitle": "Acceso completo",
   "approvalFullBody": "Acceso sin restricciones a internet y a cualquier archivo.",
 
+  "authRequiresLoginTitle": "Agente sin sesión iniciada",
+  "authRequiresLoginBody": "Inicia sesión en la CLI de este agente en tu PC para empezar a enviar mensajes.",
+  "authLoginInProgress": "Iniciando sesión en tu PC…",
+
   "gitActionsTitle": "Control de versiones",
   "gitCleanState": "Árbol de trabajo limpio",
   "gitDirtyState": "Cambios sin confirmar",

--- a/uxnanmobile/lib/application/managers/thread_manager.dart
+++ b/uxnanmobile/lib/application/managers/thread_manager.dart
@@ -7,6 +7,7 @@ import 'package:uxnan/application/processors/domain_event.dart';
 import 'package:uxnan/core/utils/logger.dart';
 import 'package:uxnan/domain/entities/agent_descriptor.dart';
 import 'package:uxnan/domain/entities/agent_model.dart';
+import 'package:uxnan/domain/entities/auth_status.dart';
 import 'package:uxnan/domain/entities/message.dart';
 import 'package:uxnan/domain/entities/project.dart';
 import 'package:uxnan/domain/entities/thread.dart';
@@ -301,6 +302,19 @@ class ThreadManager {
       for (final raw in models)
         if (AgentModel.fromAny(raw) case final model?) model,
     ];
+  }
+
+  /// Loads the sanitized auth status the bridge reports for [agentId]
+  /// (`auth/status`), or null when the bridge does not answer with a status
+  /// (e.g. an older bridge that left the method unimplemented). The result
+  /// never carries tokens — it only says whether the agent needs a login on
+  /// the PC. Used to surface a "requires login" banner.
+  Future<AuthStatus?> loadAuthStatus(String agentId) async {
+    final response = await _sendRequest('auth/status', {'agentId': agentId});
+    final result = response.result;
+    return result is Map
+        ? AuthStatus.fromJson(result.cast<String, dynamic>())
+        : null;
   }
 
   /// Starts a new thread (`thread/start`) for [projectId], optionally overriding

--- a/uxnanmobile/lib/domain/entities/auth_status.dart
+++ b/uxnanmobile/lib/domain/entities/auth_status.dart
@@ -1,0 +1,66 @@
+import 'package:equatable/equatable.dart';
+
+/// The sanitized authentication status of a bridge agent (`auth/status`).
+///
+/// Mirrors the bridge contract `AuthStatus = { agentId, requiresLogin,
+/// loginInProgress, authenticatedProvider?, displayName?, transportMode,
+/// platform }`. It is SANITIZED by design — the bridge never sends tokens or
+/// keys; login is detected from the existence of the agent's auth file, never
+/// its contents. The parser is tolerant so the app degrades gracefully against
+/// newer bridges.
+class AuthStatus extends Equatable {
+  /// Creates an [AuthStatus].
+  const AuthStatus({
+    required this.agentId,
+    required this.requiresLogin,
+    required this.loginInProgress,
+    this.authenticatedProvider,
+    this.displayName,
+    this.transportMode,
+    this.platform,
+  });
+
+  /// Reconstructs an [AuthStatus] from an `auth/status` result.
+  factory AuthStatus.fromJson(Map<String, dynamic> json) => AuthStatus(
+        agentId: json['agentId'] as String? ?? '',
+        requiresLogin: json['requiresLogin'] == true,
+        loginInProgress: json['loginInProgress'] == true,
+        authenticatedProvider: json['authenticatedProvider'] as String?,
+        displayName: json['displayName'] as String?,
+        transportMode: json['transportMode'] as String?,
+        platform: json['platform'] as String?,
+      );
+
+  /// The agent's wire identifier (see `AgentId.wireId`).
+  final String agentId;
+
+  /// Whether the agent must be logged in on the PC before it can be used.
+  final bool requiresLogin;
+
+  /// Whether an interactive login is currently in progress on the PC.
+  final bool loginInProgress;
+
+  /// The provider the agent is authenticated against, when known (sanitized —
+  /// never a token).
+  final String? authenticatedProvider;
+
+  /// A human-readable name for the agent, when the bridge provides one.
+  final String? displayName;
+
+  /// The transport the bridge answered over (`local` or `relay`), when known.
+  final String? transportMode;
+
+  /// The bridge host's platform identifier, when known.
+  final String? platform;
+
+  @override
+  List<Object?> get props => [
+        agentId,
+        requiresLogin,
+        loginInProgress,
+        authenticatedProvider,
+        displayName,
+        transportMode,
+        platform,
+      ];
+}

--- a/uxnanmobile/lib/l10n/app_localizations.dart
+++ b/uxnanmobile/lib/l10n/app_localizations.dart
@@ -950,6 +950,24 @@ abstract class AppLocalizations {
   /// **'Unrestricted access to the internet and any file.'**
   String get approvalFullBody;
 
+  /// Banner title shown when the active thread's agent is not logged in on the PC.
+  ///
+  /// In en, this message translates to:
+  /// **'Agent not signed in'**
+  String get authRequiresLoginTitle;
+
+  /// Banner body explaining the agent must be logged in on the PC.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign in to this agent\'s CLI on your PC to start sending messages.'**
+  String get authRequiresLoginBody;
+
+  /// Banner shown while an interactive login is in progress on the PC.
+  ///
+  /// In en, this message translates to:
+  /// **'Signing in on your PC…'**
+  String get authLoginInProgress;
+
   /// No description provided for @gitActionsTitle.
   ///
   /// In en, this message translates to:

--- a/uxnanmobile/lib/l10n/app_localizations_en.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_en.dart
@@ -457,6 +457,16 @@ class AppLocalizationsEn extends AppLocalizations {
       'Unrestricted access to the internet and any file.';
 
   @override
+  String get authRequiresLoginTitle => 'Agent not signed in';
+
+  @override
+  String get authRequiresLoginBody =>
+      'Sign in to this agent\'s CLI on your PC to start sending messages.';
+
+  @override
+  String get authLoginInProgress => 'Signing in on your PC…';
+
+  @override
   String get gitActionsTitle => 'Source control';
 
   @override

--- a/uxnanmobile/lib/l10n/app_localizations_es.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_es.dart
@@ -458,6 +458,16 @@ class AppLocalizationsEs extends AppLocalizations {
       'Acceso sin restricciones a internet y a cualquier archivo.';
 
   @override
+  String get authRequiresLoginTitle => 'Agente sin sesión iniciada';
+
+  @override
+  String get authRequiresLoginBody =>
+      'Inicia sesión en la CLI de este agente en tu PC para empezar a enviar mensajes.';
+
+  @override
+  String get authLoginInProgress => 'Iniciando sesión en tu PC…';
+
+  @override
   String get gitActionsTitle => 'Control de versiones';
 
   @override

--- a/uxnanmobile/lib/presentation/providers/application_providers.dart
+++ b/uxnanmobile/lib/presentation/providers/application_providers.dart
@@ -9,6 +9,7 @@ import 'package:uxnan/application/managers/workspace_browser.dart';
 import 'package:uxnan/application/processors/incoming_message_processor.dart';
 import 'package:uxnan/domain/entities/agent_descriptor.dart';
 import 'package:uxnan/domain/entities/agent_model.dart';
+import 'package:uxnan/domain/entities/auth_status.dart';
 import 'package:uxnan/domain/entities/connection_recovery_state.dart';
 import 'package:uxnan/domain/entities/git/git_action_log_entry.dart';
 import 'package:uxnan/domain/entities/git/git_repo_state.dart';
@@ -190,6 +191,15 @@ final agentsProvider = FutureProvider<List<AgentDescriptor>>(
 /// The models a given agent reports (`agent/models`), for the model picker.
 final agentModelsProvider = FutureProvider.family<List<AgentModel>, String>(
   (ref, agentId) => ref.watch(threadManagerProvider).loadModels(agentId),
+);
+
+/// The sanitized auth status the bridge reports for an agent (`auth/status`),
+/// or null when unavailable (offline, or an older bridge). Drives the
+/// "requires login" banner on the conversation screen. Resolves to an
+/// AsyncError while offline; consumers read `.value` so a missing status simply
+/// shows no banner.
+final authStatusProvider = FutureProvider.family<AuthStatus?, String>(
+  (ref, agentId) => ref.watch(threadManagerProvider).loadAuthStatus(agentId),
 );
 
 /// Map of threadId → the concrete model id the agent resolved most recently

--- a/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
@@ -172,6 +172,13 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
     final connectedHere = connectedId != null &&
         (thread?.deviceId == null || thread!.deviceId == connectedId);
     final effectivePhase = connectedHere ? phase : ConnectionPhase.disconnected;
+    // The active agent's sign-in status on the PC (only meaningful while we
+    // hold this thread's channel). `.value` is null while offline or on an
+    // older bridge, so a missing status simply shows no banner.
+    final authStatus = connectedHere && thread != null
+        ? ref.watch(authStatusProvider(thread.agentId)).value
+        : null;
+    final requiresLogin = authStatus?.requiresLogin ?? false;
     final gitBranch = ref.watch(gitRepoStateProvider).value?.branch;
     final resolvedModel = ref.watch(resolvedModelProvider(widget.threadId));
     final usage = ref.watch(contextUsageForProvider(widget.threadId));
@@ -261,6 +268,13 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
               ),
             ),
           ),
+          // Sign-in warning: the agent on this PC is not logged in, so turns
+          // won't run until the user signs into its CLI on the PC. Kept above
+          // the composer (not in the scrolling list) so it stays visible.
+          if (requiresLogin)
+            _LoginRequiredBanner(
+              loginInProgress: authStatus!.loginInProgress,
+            ),
           // Access/approval mode lives directly above the composer (its own
           // affordance, alert-coloured on full access), shown only for agents
           // that gate tools.
@@ -421,6 +435,88 @@ class _ConversationMenu extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// A full-width warning above the composer when the active thread's agent is
+/// not signed in on the PC: turns won't run until the user logs into the
+/// agent's CLI there. There is no in-app login yet (the bridge's `auth/login`
+/// is a stub), so this is informational — it points the user to the PC.
+class _LoginRequiredBanner extends StatelessWidget {
+  const _LoginRequiredBanner({required this.loginInProgress});
+
+  /// Whether an interactive login is currently running on the PC.
+  final bool loginInProgress;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final l10n = AppLocalizations.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        UxnanSpacing.lg,
+        UxnanSpacing.xs,
+        UxnanSpacing.lg,
+        0,
+      ),
+      child: Material(
+        color: colors.errorContainer,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: UxnanSpacing.md,
+            vertical: UxnanSpacing.sm,
+          ),
+          child: Row(
+            children: [
+              if (loginInProgress)
+                SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: colors.onErrorContainer,
+                  ),
+                )
+              else
+                Icon(
+                  Icons.login_rounded,
+                  size: 20,
+                  color: colors.onErrorContainer,
+                ),
+              const SizedBox(width: UxnanSpacing.sm),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      loginInProgress
+                          ? l10n.authLoginInProgress
+                          : l10n.authRequiresLoginTitle,
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: colors.onErrorContainer,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (!loginInProgress) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        l10n.authRequiresLoginBody,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colors.onErrorContainer,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/uxnanmobile/test/unit/application/thread_manager_test.dart
+++ b/uxnanmobile/test/unit/application/thread_manager_test.dart
@@ -77,6 +77,13 @@ void main() {
                 {'agentId': 'codex', 'displayName': 'Codex', 'available': true},
               ],
             },
+          'auth/status' => {
+              'agentId': params?['agentId'],
+              'requiresLogin': true,
+              'loginInProgress': false,
+              'transportMode': 'local',
+              'platform': 'win32',
+            },
           'thread/start' => {
               'id': 'th-new',
               'title': params?['title'] ?? 'New',
@@ -210,6 +217,17 @@ void main() {
     expect(agents.single.agentId, 'codex');
     expect(agents.single.available, isTrue);
     expect(sentMethods, contains('agent/list'));
+  });
+
+  test('loadAuthStatus sends auth/status with the agentId and parses it',
+      () async {
+    final status = await manager.loadAuthStatus('codex');
+    expect(status, isNotNull);
+    expect(status!.agentId, 'codex');
+    expect(status.requiresLogin, isTrue);
+    expect(status.loginInProgress, isFalse);
+    expect(status.transportMode, 'local');
+    expect(sentMethods, contains('auth/status'));
   });
 
   test('startThread sends thread/start and persists the result', () async {

--- a/uxnanmobile/test/unit/domain/entities/auth_status_test.dart
+++ b/uxnanmobile/test/unit/domain/entities/auth_status_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uxnan/domain/entities/auth_status.dart';
+
+void main() {
+  group('AuthStatus.fromJson', () {
+    test('parses a full sanitized status', () {
+      final status = AuthStatus.fromJson({
+        'agentId': 'claude-code',
+        'requiresLogin': false,
+        'loginInProgress': true,
+        'authenticatedProvider': 'anthropic',
+        'displayName': 'Claude Code',
+        'transportMode': 'local',
+        'platform': 'win32',
+      });
+      expect(status.agentId, 'claude-code');
+      expect(status.requiresLogin, isFalse);
+      expect(status.loginInProgress, isTrue);
+      expect(status.authenticatedProvider, 'anthropic');
+      expect(status.displayName, 'Claude Code');
+      expect(status.transportMode, 'local');
+      expect(status.platform, 'win32');
+    });
+
+    test('defaults the booleans to false and leaves optionals null', () {
+      final status = AuthStatus.fromJson({'agentId': 'codex'});
+      expect(status.agentId, 'codex');
+      expect(status.requiresLogin, isFalse);
+      expect(status.loginInProgress, isFalse);
+      expect(status.authenticatedProvider, isNull);
+      expect(status.displayName, isNull);
+      expect(status.transportMode, isNull);
+      expect(status.platform, isNull);
+    });
+
+    test('treats non-bool truthy values as false (tolerant)', () {
+      final status = AuthStatus.fromJson({
+        'agentId': 'codex',
+        'requiresLogin': 'yes',
+        'loginInProgress': 1,
+      });
+      expect(status.requiresLogin, isFalse);
+      expect(status.loginInProgress, isFalse);
+    });
+
+    test('falls back to an empty agentId when missing', () {
+      expect(AuthStatus.fromJson(const {}).agentId, '');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First mobile↔bridge link after the `bridge-mvp-next` merge (PR #7): surface the bridge's sanitized per-agent `auth/status` in the app.

The conversation screen now queries `auth/status { agentId }` for the active thread's agent and shows a warning banner above the composer when that agent is **not signed in on the PC** — turns won't run until the user logs into its CLI there.

## What changed

- **`AuthStatus` entity** (`lib/domain/entities/auth_status.dart`) — tolerant parser, never carries tokens/keys.
- **`ThreadManager.loadAuthStatus(agentId)`** — calls `auth/status`, mirrors `loadModels`.
- **`authStatusProvider`** (`FutureProvider.family`) — mirrors `agentModelsProvider` / `agentCapabilitiesProvider`.
- **`_LoginRequiredBanner`** on the conversation screen — M3 styling; gated on `connectedHere`; degrades to nothing while offline or against an older bridge. Renders a "Signing in…" state for `loginInProgress`.
- i18n strings (English base + Spanish) + regenerated localizations.
- CHANGELOG + FOR-DEV updated.

## Scope decision

Signing an agent in/out is done **on the PC** (each agent's own CLI login). The app deliberately does **not** drive `auth/login`/`auth/logout` — that is out of scope for the mobile app by product decision. The banner is informational: it points the user to the PC.

## Verification

- `flutter analyze` — no issues.
- `flutter test` — 208 tests pass (incl. 5 new: 4 `AuthStatus` parser tests + 1 `ThreadManager.loadAuthStatus` test).
- UI reviewed and approved on-device by the maintainer.

## Notes

Also includes two small, related commits: a repo-wide **English-only** language rule in `AGENTS.md`, and a `.gitignore` entry for the local `flutter_mobile_logs.txt` run log.
