### PR TITLE
feat: integrate the pi CLI as an agent (bridge + mobile)

### DIFF
--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -6,6 +6,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 ## [Unreleased]
 
 ### Added
+- **pi agent wired** (`src/adapters/pi-adapter.ts`, `resolve-pi.ts`, registered in
+  `bridge.ts`): drives the `pi` CLI (`@earendil-works/pi-coding-agent`) via
+  `pi -p --mode json`, parsing its newline-JSON stream (streamed `text_delta`s,
+  final text + `usage.totalTokens`, `session` id for `--session-id` continuity,
+  `stopReason`/`errorMessage` and plain-text startup errors). Model selection
+  (`--model provider/model`), reasoning effort (`--thinking`, advertised per model
+  from `pi --list-models`' `thinking` column), and a tool posture
+  (`permissionMode`: `acceptEdits` default / `default` read-only / `bypassPermissions`)
+  are all wired. Auth detected by `~/.pi/agent/auth.json` existence. Reports
+  `reportsContextUsage`. Validated against `pi` 0.79.1.
 - **Agents advertise `reportsContextUsage`** (`claude-adapter.ts`,
   `codex-adapter.ts`): Claude and Codex set the new capability flag so the phone
   shows their context meter (at 0 before the first turn); OpenCode leaves it

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -38,6 +38,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   renders whatever is advertised, so new levels need no app change).
 
 ### Fixed
+- **pi model picker no longer empty** (`src/adapters/pi-adapter.ts`, `src/adapters/spawn.ts`):
+  `pi --list-models` prints its table to **stderr**, but `listModels()` only read
+  stdout, so `agent/models` returned `[]` and the phone's model selector showed no
+  models when pi was the agent. The adapter now accumulates **both** stdout and
+  stderr before parsing (stdin/stdout split verified against `pi` 0.79.1: `-p --mode
+  json` events stay on stdout, so turn streaming is unaffected). `SpawnedProcess`
+  gains an optional `stderr` stream.
 - **Reasoning effort now reaches Claude Code and Codex** (`src/adapters/claude-adapter.ts`,
   `src/adapters/codex-adapter.ts`): `turn/send`'s `effort` was carried by the
   contract but silently dropped by both adapters (only OpenCode consumed it via

--- a/bridge/FOR-DEV.md
+++ b/bridge/FOR-DEV.md
@@ -261,7 +261,9 @@ hosting** (the phone connects directly to the bridge on the same network).
           model; no fast mode.
         - **OpenCode**: reasoning/variant already wired (`--variant`); everything is
           provider/model-dependent and must be enumerated at runtime, never assumed.
-        - **Gemini / pi-agent / aider**: TBD when those adapters land.
+        - **pi**: reasoning = `--thinking` (off/minimal/low/medium/high/xhigh),
+          advertised per model (the `thinking` column of `--list-models`).
+        - **Gemini / aider**: TBD when those adapters land.
 
       **Proposed design (3 layers):**
         1. **`shared/`** — extend per-model discovery so each `AgentModel` (or a
@@ -349,11 +351,31 @@ The OpenCode adapter is the template for any "one-shot per-turn CLI" agent:
       alias resolves to is captured from the `system/init` event and emitted as
       `model_resolved`. `result.usage` is parsed (with the tier context window)
       for the context indicator.
+- [x] **pi** — `src/adapters/pi-adapter.ts`. WIRED via `pi -p --mode json`
+      (`--session-id <id>` for continuity, `--model <provider/model>`,
+      `--thinking <off|minimal|low|medium|high|xhigh>` for reasoning effort).
+      Parses the newline-JSON stream (`session` → captures the session id;
+      `message_update`/`text_delta` → streamed text; `message_end` assistant →
+      final text + `usage.totalTokens` + `stopReason`/`errorMessage`; `agent_end`
+      → completion). `thinking_*` events are NOT emitted as answer text. Tool
+      posture via `agents['pi-agent'].permissionMode` (default `acceptEdits` →
+      pi's built-in read/bash/edit/write; `default` → `--tools read,grep,find,ls`
+      read-only; `bypassPermissions` → `--approve`). Binary resolved by
+      `resolve-pi.ts` (`node <@earendil-works/pi-coding-agent/dist/cli.js>`).
+      **Model discovery:** `pi --list-models` table → `AgentModel[]`
+      (id `provider/model`; the reasoning knob advertised for models whose
+      `thinking` column is `yes`). Validated live against `pi` 0.79.1.
+      **Auth:** detected by the existence of `~/.pi/agent/auth.json` (per-provider
+      credentials; multi-provider, so no single public provider name).
+      **FOR-DEV follow-ups:** map the resolved model's context window for a `%`
+      context ring (today pi reports raw `totalTokens`, shown as a count like
+      Codex); surface pi's `thinking`/tool-call events as structured content if a
+      use case appears.
 - [ ] **Gemini CLI** — capture its non-interactive JSON stream first. New scaffold.
 - [ ] **JSONL history fallback** (`session-jsonl-history`) — read agent session
       JSONL/SQLite from disk for `turn/list` when the runtime has no fresh data
       (§5.8.8). Needs each agent's real on-disk format.
-- [ ] Later: pi-agent, Aider.
+- [ ] Later: Aider.
 
 ## Daemon lifecycle & ops
 - [x] **Single-instance lock + `stop`** (Phase 3) — `src/lock-file.ts`,

--- a/bridge/src/account-status.ts
+++ b/bridge/src/account-status.ts
@@ -35,6 +35,10 @@ const AUTH_FILES: Partial<Record<AgentId, string[]>> = {
   codex: ['.codex/auth.json'],
   'claude-code': ['.claude/.credentials.json', '.claude.json'],
   opencode: ['.local/share/opencode/auth.json', '.config/opencode/auth.json'],
+  // pi stores per-provider credentials (OAuth/API keys) in one auth file; its
+  // existence means at least one provider is logged in. pi is multi-provider, so
+  // no single public provider name is surfaced.
+  'pi-agent': ['.pi/agent/auth.json'],
 };
 
 export interface AccountStatusDeps {

--- a/bridge/src/adapters/pi-adapter.ts
+++ b/bridge/src/adapters/pi-adapter.ts
@@ -369,6 +369,10 @@ export class PiAdapter extends BaseAgentAdapter {
    * List the models pi reports via `pi --list-models` (account-aware: only
    * providers the user has configured appear). The output is a table, parsed by
    * {@link parsePiModelList}. Resolves to `[]` if the spawn fails or times out.
+   *
+   * Note: pi prints the `--list-models` table to STDERR, not stdout (verified
+   * against pi 0.79.1), so we accumulate BOTH streams. Without this the phone's
+   * model picker shows no models for the pi agent.
    */
   listModels(): Promise<AgentModel[]> {
     return new Promise((resolve) => {
@@ -395,10 +399,13 @@ export class PiAdapter extends BaseAgentAdapter {
       }
 
       const timer = setTimeout(() => finish([]), MODEL_LIST_TIMEOUT_MS);
-      const reader = createInterface({ input: child.stdout });
-      reader.on('line', (line) => {
-        output += `${line}\n`;
-      });
+      // pi emits the table on stderr; read stdout too so we stay correct if a
+      // future version moves it. Parse the combined output on close.
+      const collect = (chunk: unknown): void => {
+        output += String(chunk);
+      };
+      child.stdout.on('data', collect);
+      child.stderr?.on('data', collect);
       child.on('error', () => finish([]));
       child.on('close', () => finish(parsePiModelList(output, this.#defaultModel)));
     });

--- a/bridge/src/adapters/pi-adapter.ts
+++ b/bridge/src/adapters/pi-adapter.ts
@@ -1,0 +1,430 @@
+/**
+ * pi adapter (`@earendil-works/pi-coding-agent`, the `pi` CLI — real agent).
+ *
+ * pi does NOT speak the generic bridge agent IPC. Each turn spawns
+ * `pi -p --mode json …` as a one-shot process and maps its newline-JSON event
+ * stream onto the bridge's agent events (same one-shot pattern as the OpenCode,
+ * Claude Code and Codex adapters). Session continuity is preserved by capturing
+ * the session `id` from the `session` event and passing `--session-id <id>` on
+ * the next turn — validated live against `pi` 0.79.1.
+ *
+ * Critical detail: `pi -p` blocks reading stdin when stdin is an open pipe, so we
+ * spawn with stdin IGNORED (the shared `defaultSpawn`). The prompt is passed as
+ * an argv element with `shell:false`, so it is never interpolated into a shell.
+ *
+ * Captured `--mode json` event shapes (one JSON object per line):
+ *   { "type":"session", "id":"019…", "cwd":"…" }
+ *   { "type":"message_update", "assistantMessageEvent":{ "type":"text_delta", "delta":"…" } }
+ *   { "type":"message_end", "message":{ "role":"assistant", "content":[{ "type":"text","text":"…" }],
+ *       "usage":{ "input":…, "output":…, "totalTokens":… }, "stopReason":"stop"|"error", "errorMessage"?:"…" } }
+ *   { "type":"agent_end", "messages":[…], "willRetry":false }
+ * (`thinking_*` assistant events carry the model's reasoning and are NOT emitted
+ * as answer text.) A startup failure (e.g. a provider with no API key) prints a
+ * plain-text line instead of JSON; we surface that as the turn error.
+ *
+ * See bridge/FOR-DEV.md (agent adapters) and bridge/docs/testing.md.
+ */
+import { createInterface } from 'node:readline';
+import type {
+  AgentCapabilities,
+  AgentConfig,
+  AgentId,
+  AgentModel,
+  AgentModelOption,
+  SendTurnOptions,
+} from '@uxnan/shared';
+import { BaseAgentAdapter } from './base-adapter.js';
+import { effortValues, reasoningOption, reasoningValue } from './run-options.js';
+import { defaultSpawn, type SpawnFn, type SpawnedProcess } from './spawn.js';
+
+/** Hard cap on the `--list-models` spawn before giving up. */
+const MODEL_LIST_TIMEOUT_MS = 8000;
+
+const PI_CAPABILITIES: AgentCapabilities = {
+  // Plan mode is a pi extension, not core, so it's not advertised here.
+  planMode: false,
+  streaming: true,
+  // pi runs its tools autonomously in `-p` mode (no per-turn approval RPC).
+  approvals: false,
+  forking: true,
+  images: true,
+  reportsContextUsage: true,
+};
+
+/** Reasoning-effort levels pi's `--thinking` flag accepts (verified via `pi --help`). */
+const PI_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+
+/** The `reasoning` knob advertised on pi models that support thinking. */
+const PI_REASONING_OPTION: AgentModelOption = reasoningOption(effortValues(PI_THINKING_LEVELS));
+
+/**
+ * Tool posture passed to pi:
+ *  - `default`           → `--tools read,grep,find,ls` (read-only; no bash/edit/write);
+ *  - `acceptEdits`       → pi's default built-in tools (read/bash/edit/write);
+ *  - `bypassPermissions` → default tools + `--approve` (trust project-local files).
+ */
+export type PiPermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions';
+
+export interface PiAdapterOptions {
+  /** Executable to spawn (resolved path; see resolve-pi.ts). */
+  binaryPath?: string;
+  /** Args prepended before the adapter args (e.g. `[cli.js]` when running via node). */
+  prependArgs?: string[];
+  /** Default model (`provider/model`) when the thread/turn doesn't pick one. */
+  defaultModel?: string;
+  /** Tool posture (default `acceptEdits`). */
+  permissionMode?: PiPermissionMode;
+  /** Injected spawn function (tests). */
+  spawnFn?: SpawnFn;
+}
+
+interface ActiveRun {
+  child: SpawnedProcess;
+  threadId: string;
+}
+
+/** A normalized pi event extracted from one `--mode json` line. */
+export interface PiEvent {
+  kind: 'session' | 'delta' | 'final' | 'end' | 'other';
+  /** Only set for `session`: the session id (for `--session-id` continuity). */
+  sessionId?: string;
+  /** `delta`: the streamed text chunk. `final`: the assistant message's full text. */
+  text?: string;
+  /** Only set for `final`: context-occupying token count, if reported. */
+  tokens?: number;
+  /** Only set for `final`: whether the assistant message ended in error. */
+  isError?: boolean;
+  /** Only set for `final`: the error message, when present. */
+  errorText?: string;
+}
+
+/**
+ * Sum the context-occupying tokens from a pi `usage` object
+ * (`{ input, output, cacheRead, cacheWrite, totalTokens, cost }`). Prefers the
+ * reported `totalTokens`, falling back to `input + output`.
+ */
+export function parsePiUsageTokens(usage: unknown): number | undefined {
+  if (!isRecord(usage)) return undefined;
+  const num = (key: string): number => (typeof usage[key] === 'number' ? (usage[key] as number) : 0);
+  const total = num('totalTokens') > 0 ? num('totalTokens') : num('input') + num('output');
+  return total > 0 ? total : undefined;
+}
+
+/** Parse one `pi -p --mode json` line, or null if it isn't JSON. */
+export function parsePiLine(line: string): PiEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(trimmed) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  switch (parsed['type']) {
+    case 'session': {
+      const id = typeof parsed['id'] === 'string' ? parsed['id'] : undefined;
+      return { kind: 'session', ...(id !== undefined ? { sessionId: id } : {}) };
+    }
+    case 'message_update': {
+      const event = isRecord(parsed['assistantMessageEvent'])
+        ? parsed['assistantMessageEvent']
+        : undefined;
+      if (event && event['type'] === 'text_delta' && typeof event['delta'] === 'string') {
+        return { kind: 'delta', text: event['delta'] };
+      }
+      // thinking_*, text_start/end and other updates carry no answer text.
+      return { kind: 'other' };
+    }
+    case 'message_end': {
+      const message = isRecord(parsed['message']) ? parsed['message'] : undefined;
+      if (!message || message['role'] !== 'assistant') return { kind: 'other' };
+      const text = extractAssistantText(message['content']);
+      const tokens = parsePiUsageTokens(message['usage']);
+      const errorMessage =
+        typeof message['errorMessage'] === 'string' ? message['errorMessage'] : undefined;
+      const isError = message['stopReason'] === 'error' || errorMessage !== undefined;
+      return {
+        kind: 'final',
+        ...(text.length > 0 ? { text } : {}),
+        ...(tokens !== undefined ? { tokens } : {}),
+        isError,
+        ...(errorMessage !== undefined ? { errorText: errorMessage } : {}),
+      };
+    }
+    case 'agent_end':
+      return { kind: 'end' };
+    default:
+      return { kind: 'other' };
+  }
+}
+
+/**
+ * Parse the `pi --list-models` table into {@link AgentModel}s. Each row is
+ * `provider model context max-out thinking images` (whitespace-separated, no
+ * field contains spaces). `id` is `provider/model` (the `--model` routing key);
+ * models whose `thinking` column is `yes` advertise the reasoning knob.
+ */
+export function parsePiModelList(output: string, defaultModel?: string): AgentModel[] {
+  const out: AgentModel[] = [];
+  const seen = new Set<string>();
+  for (const raw of output.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line) continue;
+    const cols = line.split(/\s+/);
+    if (cols.length < 6) continue;
+    const provider = cols[0]!;
+    const model = cols[1]!;
+    const thinking = cols[4]!;
+    if (provider === 'provider') continue; // header row
+    const id = `${provider}/${model}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push({
+      id,
+      displayName: model,
+      description: provider,
+      isDefault: id === defaultModel,
+      ...(thinking === 'yes' ? { options: [PI_REASONING_OPTION] } : {}),
+    });
+  }
+  return out;
+}
+
+export class PiAdapter extends BaseAgentAdapter {
+  readonly agentId: AgentId = 'pi-agent';
+  readonly capabilities = PI_CAPABILITIES;
+
+  readonly #binaryPath: string;
+  readonly #prependArgs: string[];
+  readonly #defaultModel: string | undefined;
+  readonly #permissionMode: PiPermissionMode;
+  readonly #spawn: SpawnFn;
+  /** threadId → pi session id, for `--session-id` continuity. */
+  readonly #sessionByThread = new Map<string, string>();
+  /** turnId → in-flight run, for cancellation. */
+  readonly #active = new Map<string, ActiveRun>();
+  #defaultCwd = process.cwd();
+
+  constructor(options: PiAdapterOptions = {}) {
+    super();
+    this.#binaryPath = options.binaryPath ?? 'pi';
+    this.#prependArgs = options.prependArgs ?? [];
+    this.#defaultModel = options.defaultModel;
+    this.#permissionMode = options.permissionMode ?? 'acceptEdits';
+    this.#spawn = options.spawnFn ?? defaultSpawn;
+  }
+
+  get defaultModel(): string | undefined {
+    return this.#defaultModel;
+  }
+
+  start(config: AgentConfig): Promise<void> {
+    if (config.cwd) this.#defaultCwd = config.cwd;
+    return Promise.resolve();
+  }
+
+  stop(): Promise<void> {
+    for (const run of this.#active.values()) {
+      run.child.kill();
+    }
+    this.#active.clear();
+    return Promise.resolve();
+  }
+
+  sendTurn(options: SendTurnOptions): Promise<void> {
+    const { threadId, turnId, text } = options;
+    const cwd = options.cwd ?? this.#defaultCwd;
+    const model = options.service ?? this.#defaultModel;
+    const effort = reasoningValue(options);
+    const sessionId = this.#sessionByThread.get(threadId);
+
+    const args = ['-p', '--mode', 'json'];
+    if (this.#permissionMode === 'default') args.push('--tools', 'read,grep,find,ls');
+    else if (this.#permissionMode === 'bypassPermissions') args.push('--approve');
+    if (model) args.push('--model', model);
+    // Reasoning effort → pi's `--thinking <off|minimal|low|medium|high|xhigh>`.
+    if (effort) args.push('--thinking', effort);
+    // Resume the thread's session (created on the first turn); the prompt is the
+    // final positional, never shell-interpolated.
+    if (sessionId) args.push('--session-id', sessionId);
+    args.push(text);
+
+    let child: SpawnedProcess;
+    try {
+      child = this.#spawn(this.#binaryPath, [...this.#prependArgs, ...args], cwd);
+    } catch (err) {
+      this.emit({
+        type: 'turn_error',
+        threadId,
+        turnId,
+        data: { text: `failed to launch pi: ${errorMessage(err)}` },
+      });
+      return Promise.resolve();
+    }
+
+    this.#active.set(turnId, { child, threadId });
+    this.emit({ type: 'turn_started', threadId, turnId });
+
+    let full = '';
+    let finalText = '';
+    let tokens: number | undefined;
+    let errored = false;
+    let errorMsg: string | undefined;
+    // Non-JSON output (e.g. a startup "No API key found" error) — surfaced if the
+    // turn produces no content.
+    const plainLines: string[] = [];
+    let completed = false;
+
+    const finish = (): void => {
+      if (completed) return;
+      completed = true;
+      const body = full.length > 0 ? full : finalText;
+      if (errored && body.length === 0) {
+        this.emit({
+          type: 'turn_error',
+          threadId,
+          turnId,
+          data: { text: errorMsg ?? plainText(plainLines) ?? 'pi error' },
+        });
+        return;
+      }
+      if (body.length === 0 && plainLines.length > 0 && !errored) {
+        // No JSON content and no terminal event: surface the plain output.
+        this.emit({
+          type: 'turn_error',
+          threadId,
+          turnId,
+          data: { text: plainText(plainLines) ?? 'pi produced no output' },
+        });
+        return;
+      }
+      const usage = tokens !== undefined ? { tokens } : undefined;
+      this.emit({
+        type: 'turn_completed',
+        threadId,
+        turnId,
+        data: { text: body, ...(usage !== undefined ? { usage } : {}) },
+      });
+    };
+
+    const reader = createInterface({ input: child.stdout });
+    reader.on('line', (line) => {
+      const event = parsePiLine(line);
+      if (!event) {
+        const trimmed = line.trim();
+        if (trimmed.length > 0) plainLines.push(trimmed);
+        return;
+      }
+      if (event.kind === 'session' && event.sessionId) {
+        this.#sessionByThread.set(threadId, event.sessionId);
+      } else if (event.kind === 'delta' && event.text) {
+        full += event.text;
+        this.emit({ type: 'delta', threadId, turnId, data: { text: event.text } });
+      } else if (event.kind === 'final') {
+        if (event.text) finalText = event.text;
+        if (event.tokens !== undefined) tokens = event.tokens;
+        if (event.isError) {
+          errored = true;
+          if (event.errorText) errorMsg = event.errorText;
+        }
+      } else if (event.kind === 'end') {
+        finish();
+      }
+    });
+
+    child.on('error', (err) => {
+      reader.close();
+      this.#active.delete(turnId);
+      if (!completed) {
+        completed = true;
+        this.emit({
+          type: 'turn_error',
+          threadId,
+          turnId,
+          data: { text: `pi process error: ${err.message}` },
+        });
+      }
+    });
+
+    child.on('close', () => {
+      reader.close();
+      this.#active.delete(turnId);
+      finish();
+    });
+
+    return Promise.resolve();
+  }
+
+  cancelTurn(threadId: string, turnId: string): Promise<void> {
+    const run = this.#active.get(turnId);
+    if (run) {
+      run.child.kill();
+      this.#active.delete(turnId);
+      this.emit({ type: 'turn_aborted', threadId, turnId });
+    }
+    return Promise.resolve();
+  }
+
+  /**
+   * List the models pi reports via `pi --list-models` (account-aware: only
+   * providers the user has configured appear). The output is a table, parsed by
+   * {@link parsePiModelList}. Resolves to `[]` if the spawn fails or times out.
+   */
+  listModels(): Promise<AgentModel[]> {
+    return new Promise((resolve) => {
+      let settled = false;
+      let output = '';
+      let child: SpawnedProcess;
+      const finish = (models: AgentModel[]): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try {
+          child.kill();
+        } catch {
+          /* already gone */
+        }
+        resolve(models);
+      };
+
+      try {
+        child = this.#spawn(this.#binaryPath, [...this.#prependArgs, '--list-models'], this.#defaultCwd);
+      } catch {
+        resolve([]);
+        return;
+      }
+
+      const timer = setTimeout(() => finish([]), MODEL_LIST_TIMEOUT_MS);
+      const reader = createInterface({ input: child.stdout });
+      reader.on('line', (line) => {
+        output += `${line}\n`;
+      });
+      child.on('error', () => finish([]));
+      child.on('close', () => finish(parsePiModelList(output, this.#defaultModel)));
+    });
+  }
+}
+
+function extractAssistantText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  let text = '';
+  for (const block of content) {
+    if (isRecord(block) && block['type'] === 'text' && typeof block['text'] === 'string') {
+      text += block['text'];
+    }
+  }
+  return text;
+}
+
+function plainText(lines: string[]): string | undefined {
+  const joined = lines.join('\n').trim();
+  return joined.length > 0 ? joined : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/bridge/src/adapters/resolve-pi.ts
+++ b/bridge/src/adapters/resolve-pi.ts
@@ -1,0 +1,54 @@
+/**
+ * Resolves the pi CLI (`@earendil-works/pi-coding-agent`) to something
+ * `child_process.spawn` can run directly with `shell:false` (so the user prompt
+ * is never interpolated into a shell — no command injection).
+ *
+ * The npm package exposes `dist/cli.js` (a Node entry) behind a `.cmd`/`.ps1`
+ * shim that cannot be spawned with `shell:false`, so we spawn `node <cli.js>` —
+ * robust across platforms (same approach as the Codex adapter).
+ */
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface ResolvedPi {
+  /** Executable to spawn (`shell:false`). For the npm entry this is `process.execPath` (node). */
+  binaryPath: string;
+  /** Args prepended before the adapter args (e.g. `[cli.js]` when running via node). */
+  prependArgs: string[];
+  /** Whether the resolved target is known to exist on disk. */
+  available: boolean;
+}
+
+/** Candidate npm-global `dist/cli.js` locations for `@earendil-works/pi-coding-agent`. */
+function npmEntryCandidates(): string[] {
+  const candidates: string[] = [];
+  const rel = join('@earendil-works', 'pi-coding-agent', 'dist', 'cli.js');
+  if (process.platform === 'win32') {
+    const appData = process.env['APPDATA'];
+    if (appData) candidates.push(join(appData, 'npm', 'node_modules', rel));
+  } else {
+    candidates.push(join('/usr', 'local', 'lib', 'node_modules', rel));
+    candidates.push(join(homedir(), '.npm-global', 'lib', 'node_modules', rel));
+  }
+  return candidates;
+}
+
+/**
+ * Resolve the pi binary. An explicit `configured` path always wins; we only
+ * report availability for it. Otherwise we auto-detect a runnable target.
+ */
+export function resolvePiBinary(configured?: string): ResolvedPi {
+  if (configured && configured.length > 0) {
+    return { binaryPath: configured, prependArgs: [], available: existsSync(configured) };
+  }
+  for (const entry of npmEntryCandidates()) {
+    if (existsSync(entry)) {
+      return { binaryPath: process.execPath, prependArgs: [entry], available: true };
+    }
+  }
+  // Fall back to the launcher name; availability unknown (PATH lookup at spawn).
+  // On POSIX the `pi` npm bin spawns directly (node shebang); on Windows the
+  // shim would need a shell, so we report it as not available until configured.
+  return { binaryPath: 'pi', prependArgs: [], available: process.platform !== 'win32' };
+}

--- a/bridge/src/adapters/spawn.ts
+++ b/bridge/src/adapters/spawn.ts
@@ -9,6 +9,12 @@ import { spawn } from 'node:child_process';
 /** Minimal child-process surface the adapters rely on (so it can be faked in tests). */
 export interface SpawnedProcess {
   stdout: NodeJS.ReadableStream;
+  /**
+   * Optional stderr stream. Most adapters read JSON from stdout, but some CLI
+   * sub-commands (e.g. `pi --list-models`) print their human-facing table to
+   * stderr, so adapters that need it read from here too.
+   */
+  stderr?: NodeJS.ReadableStream;
   on(event: 'close', listener: (code: number | null) => void): unknown;
   on(event: 'error', listener: (err: Error) => void): unknown;
   kill(signal?: NodeJS.Signals): unknown;

--- a/bridge/src/bridge.ts
+++ b/bridge/src/bridge.ts
@@ -36,6 +36,8 @@ import { ClaudeCodeAdapter } from './adapters/claude-adapter.js';
 import { resolveClaudeBinary } from './adapters/resolve-claude.js';
 import { CodexAdapter } from './adapters/codex-adapter.js';
 import { resolveCodexBinary } from './adapters/resolve-codex.js';
+import { PiAdapter } from './adapters/pi-adapter.js';
+import { resolvePiBinary } from './adapters/resolve-pi.js';
 import { ProjectRegistry } from './projects/project-registry.js';
 import { BrowseService } from './workspace/browse-service.js';
 import { PushService } from './push/push-service.js';
@@ -168,6 +170,22 @@ export async function startBridge(options: StartBridgeOptions = {}): Promise<Bri
       displayName: 'Codex',
       available: codex.available,
       ...(codexSettings.model !== undefined ? { defaultModel: codexSettings.model } : {}),
+    },
+  );
+  // pi: real agent driven via `pi -p --mode json` (see FOR-DEV.md).
+  const piSettings = config.agents['pi-agent'] ?? {};
+  const pi = resolvePiBinary(piSettings.binaryPath);
+  agentManager.register(
+    new PiAdapter({
+      binaryPath: pi.binaryPath,
+      prependArgs: pi.prependArgs,
+      permissionMode: piSettings.permissionMode ?? 'acceptEdits',
+      ...(piSettings.model !== undefined ? { defaultModel: piSettings.model } : {}),
+    }),
+    {
+      displayName: 'pi',
+      available: pi.available,
+      ...(piSettings.model !== undefined ? { defaultModel: piSettings.model } : {}),
     },
   );
   const startedAt = now();

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -72,6 +72,16 @@ export {
 } from './adapters/codex-adapter.js';
 export { resolveCodexBinary, type ResolvedCodex } from './adapters/resolve-codex.js';
 export {
+  PiAdapter,
+  parsePiLine,
+  parsePiModelList,
+  parsePiUsageTokens,
+  type PiAdapterOptions,
+  type PiEvent,
+  type PiPermissionMode,
+} from './adapters/pi-adapter.js';
+export { resolvePiBinary, type ResolvedPi } from './adapters/resolve-pi.js';
+export {
   OpenCodeAdapter,
   parseOpenCodeLine,
   parseModelList,

--- a/bridge/test/adapters/pi-adapter.test.ts
+++ b/bridge/test/adapters/pi-adapter.test.ts
@@ -1,0 +1,254 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PassThrough } from 'node:stream';
+import { EventEmitter } from 'node:events';
+import {
+  PiAdapter,
+  parsePiLine,
+  parsePiModelList,
+  parsePiUsageTokens,
+  type SpawnedProcess,
+} from '../../src/index.js';
+import type { AgentStreamEvent } from '@uxnan/shared';
+
+// --- a fake `pi` process whose stdout we feed with `--mode json` lines ---
+interface FakeSpawn {
+  args: string[];
+  feed(lines: string[]): void;
+}
+
+function fakeSpawner(): {
+  spawnFn: (command: string, args: string[], cwd: string) => SpawnedProcess;
+  last(): FakeSpawn;
+} {
+  const spawns: FakeSpawn[] = [];
+  const spawnFn = (_command: string, args: string[]): SpawnedProcess => {
+    const stdout = new PassThrough();
+    const emitter = new EventEmitter();
+    stdout.on('end', () => emitter.emit('close', 0));
+    const proc: SpawnedProcess = {
+      stdout,
+      on: (event: string, listener: (...a: unknown[]) => void) => emitter.on(event, listener),
+      kill: () => emitter.emit('close', 0),
+    } as SpawnedProcess;
+    spawns.push({
+      args,
+      feed: (lines) => {
+        for (const line of lines) stdout.write(`${line}\n`);
+        stdout.end();
+      },
+    });
+    return proc;
+  };
+  return { spawnFn, last: () => spawns[spawns.length - 1]! };
+}
+
+function collect(adapter: PiAdapter): {
+  events: AgentStreamEvent[];
+  done: Promise<AgentStreamEvent[]>;
+} {
+  const events: AgentStreamEvent[] = [];
+  let resolve!: (e: AgentStreamEvent[]) => void;
+  const done = new Promise<AgentStreamEvent[]>((r) => (resolve = r));
+  adapter.onEvent((event) => {
+    events.push(event);
+    if (event.type === 'turn_completed' || event.type === 'turn_error') resolve(events);
+  });
+  return { events, done };
+}
+
+const SESSION = '{"type":"session","version":3,"id":"sess-1","cwd":"/p"}';
+const AGENT_END = '{"type":"agent_end","messages":[],"willRetry":false}';
+
+function assistantEnd(text: string, opts: { tokens?: number; error?: string } = {}): string {
+  const usage = { input: 10, output: 5, totalTokens: opts.tokens ?? 15 };
+  const message: Record<string, unknown> = {
+    role: 'assistant',
+    content: text ? [{ type: 'text', text }] : [],
+    usage,
+    stopReason: opts.error ? 'error' : 'stop',
+  };
+  if (opts.error) message['errorMessage'] = opts.error;
+  return JSON.stringify({ type: 'message_end', message });
+}
+
+test('parsePiLine maps the documented event shapes', () => {
+  assert.equal(parsePiLine('not json'), null);
+  assert.deepEqual(parsePiLine(SESSION), { kind: 'session', sessionId: 'sess-1' });
+  assert.deepEqual(
+    parsePiLine('{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"hi"}}'),
+    { kind: 'delta', text: 'hi' },
+  );
+  // thinking deltas are not answer text
+  assert.equal(
+    parsePiLine('{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","delta":"hmm"}}')
+      ?.kind,
+    'other',
+  );
+  const final = parsePiLine(assistantEnd('hello', { tokens: 42 }));
+  assert.equal(final?.kind, 'final');
+  assert.equal(final?.text, 'hello');
+  assert.equal(final?.tokens, 42);
+  assert.equal(final?.isError, false);
+  const errored = parsePiLine(assistantEnd('', { error: 'boom' }));
+  assert.equal(errored?.isError, true);
+  assert.equal(errored?.errorText, 'boom');
+  assert.equal(parsePiLine(AGENT_END)?.kind, 'end');
+});
+
+test('parsePiUsageTokens prefers totalTokens, falls back to input+output', () => {
+  assert.equal(parsePiUsageTokens({ input: 10, output: 5, totalTokens: 15 }), 15);
+  assert.equal(parsePiUsageTokens({ input: 10, output: 5 }), 15);
+  assert.equal(parsePiUsageTokens({}), undefined);
+  assert.equal(parsePiUsageTokens('nope'), undefined);
+});
+
+test('PiAdapter streams text_delta as deltas and completes with the text + usage', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+  const { done } = collect(adapter);
+
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'hi' });
+  last().feed([
+    SESSION,
+    '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"Hello "}}',
+    '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"world"}}',
+    assistantEnd('Hello world', { tokens: 99 }),
+    AGENT_END,
+  ]);
+
+  const events = await done;
+  assert.equal(events[0]?.type, 'turn_started');
+  const deltas = events
+    .filter((e) => e.type === 'delta')
+    .map((e) => (e.data as { text: string }).text);
+  assert.deepEqual(deltas, ['Hello ', 'world']);
+  const completed = events.find((e) => e.type === 'turn_completed');
+  assert.equal((completed?.data as { text: string }).text, 'Hello world');
+  const usage = (completed?.data as { usage?: { tokens: number } }).usage;
+  assert.equal(usage?.tokens, 99);
+  // first turn has no --session-id yet; -p --mode json lead the args
+  const args = last().args;
+  assert.deepEqual(args.slice(0, 3), ['-p', '--mode', 'json']);
+  assert.equal(args.includes('--session-id'), false);
+  assert.equal(args[args.length - 1], 'hi');
+});
+
+test('PiAdapter reuses the captured session id with --session-id next turn', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+
+  const first = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'one' });
+  last().feed([SESSION, assistantEnd('a'), AGENT_END]);
+  await first.done;
+
+  const second = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u2', text: 'two' });
+  const argsForSecond = last().args;
+  last().feed([assistantEnd('b'), AGENT_END]);
+  await second.done;
+
+  const idx = argsForSecond.indexOf('--session-id');
+  assert.notEqual(idx, -1);
+  assert.equal(argsForSecond[idx + 1], 'sess-1');
+});
+
+test('PiAdapter passes the model and maps reasoning to --thinking', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+  const { done } = collect(adapter);
+
+  await adapter.sendTurn({
+    threadId: 't1',
+    turnId: 'u1',
+    text: 'hi',
+    service: 'google/gemini-2.5-pro',
+    options: { reasoning: 'xhigh' },
+  });
+  last().feed([SESSION, assistantEnd('ok'), AGENT_END]);
+  await done;
+
+  const args = last().args;
+  assert.equal(args[args.indexOf('--model') + 1], 'google/gemini-2.5-pro');
+  assert.equal(args[args.indexOf('--thinking') + 1], 'xhigh');
+});
+
+test('PiAdapter omits --thinking when no reasoning is set', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+  const { done } = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'hi' });
+  last().feed([SESSION, assistantEnd('ok'), AGENT_END]);
+  await done;
+  assert.equal(last().args.includes('--thinking'), false);
+});
+
+test('PiAdapter maps the permission posture to the right tool flags', async () => {
+  const cases = [
+    { mode: 'acceptEdits' as const, hasTools: false, hasApprove: false },
+    { mode: 'default' as const, hasTools: true, hasApprove: false },
+    { mode: 'bypassPermissions' as const, hasTools: false, hasApprove: true },
+  ];
+  for (const { mode, hasTools, hasApprove } of cases) {
+    const { spawnFn, last } = fakeSpawner();
+    const adapter = new PiAdapter({ binaryPath: 'pi', permissionMode: mode, spawnFn });
+    const { done } = collect(adapter);
+    await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'hi' });
+    last().feed([SESSION, assistantEnd('ok'), AGENT_END]);
+    await done;
+    const args = last().args;
+    assert.equal(args.includes('--tools'), hasTools);
+    if (hasTools) assert.equal(args[args.indexOf('--tools') + 1], 'read,grep,find,ls');
+    assert.equal(args.includes('--approve'), hasApprove);
+  }
+});
+
+test('PiAdapter surfaces an error stopReason as turn_error', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+  const { done } = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'hi' });
+  last().feed([SESSION, assistantEnd('', { error: 'model not found' }), AGENT_END]);
+  const events = await done;
+  const err = events.find((e) => e.type === 'turn_error');
+  assert.equal((err?.data as { text: string }).text, 'model not found');
+});
+
+test('PiAdapter surfaces a plain-text startup error as turn_error', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+  const { done } = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'hi' });
+  // session event then a non-JSON error line, no terminal event before close
+  last().feed([SESSION, 'No API key found for xiaomi.']);
+  const events = await done;
+  const err = events.find((e) => e.type === 'turn_error');
+  assert.match((err?.data as { text: string }).text, /No API key found/);
+});
+
+test('parsePiModelList parses the --list-models table', () => {
+  const table = [
+    'provider      model                    context  max-out  thinking  images',
+    'google        gemini-2.5-pro           1.0M     65.5K    yes       yes',
+    'google        gemini-2.0-flash-lite    1.0M     8.2K     no        yes',
+    'deepseek      deepseek-v4-pro          1M       384K     yes       no',
+    '',
+  ].join('\n');
+  const models = parsePiModelList(table, 'google/gemini-2.5-pro');
+  assert.deepEqual(
+    models.map((m) => m.id),
+    ['google/gemini-2.5-pro', 'google/gemini-2.0-flash-lite', 'deepseek/deepseek-v4-pro'],
+  );
+  // header skipped; displayName is the model, description the provider
+  assert.equal(models[0]?.displayName, 'gemini-2.5-pro');
+  assert.equal(models[0]?.description, 'google');
+  assert.equal(models[0]?.isDefault, true);
+  // thinking==yes advertises the reasoning knob; thinking==no does not
+  assert.equal(models[0]?.options?.[0]?.key, 'reasoning');
+  assert.equal(models[1]?.options, undefined);
+  assert.deepEqual(
+    models[0]?.options?.[0]?.values?.map((v) => v.value),
+    ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'],
+  );
+});

--- a/bridge/test/adapters/pi-adapter.test.ts
+++ b/bridge/test/adapters/pi-adapter.test.ts
@@ -15,6 +15,8 @@ import type { AgentStreamEvent } from '@uxnan/shared';
 interface FakeSpawn {
   args: string[];
   feed(lines: string[]): void;
+  /** Write lines to STDERR (where `pi --list-models` prints its table), then close. */
+  feedStderr(lines: string[]): void;
 }
 
 function fakeSpawner(): {
@@ -24,10 +26,12 @@ function fakeSpawner(): {
   const spawns: FakeSpawn[] = [];
   const spawnFn = (_command: string, args: string[]): SpawnedProcess => {
     const stdout = new PassThrough();
+    const stderr = new PassThrough();
     const emitter = new EventEmitter();
     stdout.on('end', () => emitter.emit('close', 0));
     const proc: SpawnedProcess = {
       stdout,
+      stderr,
       on: (event: string, listener: (...a: unknown[]) => void) => emitter.on(event, listener),
       kill: () => emitter.emit('close', 0),
     } as SpawnedProcess;
@@ -35,6 +39,11 @@ function fakeSpawner(): {
       args,
       feed: (lines) => {
         for (const line of lines) stdout.write(`${line}\n`);
+        stdout.end();
+      },
+      feedStderr: (lines) => {
+        for (const line of lines) stderr.write(`${line}\n`);
+        stderr.end();
         stdout.end();
       },
     });
@@ -251,4 +260,23 @@ test('parsePiModelList parses the --list-models table', () => {
     models[0]?.options?.[0]?.values?.map((v) => v.value),
     ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'],
   );
+});
+
+test('PiAdapter.listModels parses the table pi prints to stderr', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn, defaultModel: 'google/gemini-2.5-pro' });
+  const promise = adapter.listModels();
+  // pi prints the --list-models table to STDERR, not stdout.
+  last().feedStderr([
+    'provider      model                    context  max-out  thinking  images',
+    'google        gemini-2.5-pro           1.0M     65.5K    yes       yes',
+    'deepseek      deepseek-v4-pro          1M       384K     yes       no',
+  ]);
+  const models = await promise;
+  assert.deepEqual(
+    models.map((m) => m.id),
+    ['google/gemini-2.5-pro', 'deepseek/deepseek-v4-pro'],
+  );
+  assert.equal(last().args.includes('--list-models'), true);
+  assert.equal(models[0]?.isDefault, true);
 });

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,15 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **pi agent support.** The `pi` CLI is now a fully wired agent on the bridge,
+  so it appears in the app like the others through the existing data-driven UI
+  (model picker, reasoning-effort knob via `--thinking`, context meter, sign-in
+  status). Added its monochrome logo (`assets/images/agents/pi.svg`, tinted via
+  `currentColor`) and wired `AgentVisuals` (logo/label "pi"/accent). No UI code
+  changes were needed — the app already renders any agent the bridge advertises.
+
 ### Changed
 
 - **Manual "Check sign-in" on the not-signed-in surfaces.** Both the

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -17,6 +17,33 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Model picker grouped by provider + no inline-dropdown jank.** The model
+  picker (`model_picker_sheet.dart`) now groups models under provider headers
+  (M3 list subheaders) for multi-provider agents like pi/OpenCode, flattened
+  into one lazy `ListView.builder` so hundreds of models stay cheap; agents with
+  a single provider (Claude/Codex) render flat without headers. Grouping is a
+  pure domain helper (`groupModelsByProvider` in `agent_model.dart`, unit-tested).
+  The new-conversation dialog's model field no longer builds a giant inline
+  `DropdownMenu` (which stalled for pi's ~326 models) — it's a tappable field
+  that opens the same sheet, showing the selected model and a spinner while the
+  list loads.
+- **Conversation app bar scrolls away for more reading room.** The large app
+  bar drops `snap` (keeps `floating`, stays non-pinned), so it scrolls fully out
+  of the way with the content and returns proportionally on scroll-up instead of
+  snapping the tall header open — more clean space for messages.
+- **Consistent `.large` app-bar title height across screens.** The conversation
+  app bar used a two-line `Column` title (title + connection/"Responding…"
+  status), which sat at a different level/size than the single-line titles on
+  the devices, threads and archived screens. Its title is now a single-line
+  `Text` like the others, and the live connection / responding state moved to a
+  compact dot/spinner indicator in the actions (tooltip carries the label) — so
+  all four `.large` bars align at the same title level and size.
+- **Conversation options strip: coherent spacing + collapsible.** The reasoning
+  (run-option) and approval-mode controls are now one strip above the composer
+  with consistent vertical rhythm (fixes the run-option chip sitting flush
+  against the composer for pi, and the over-large gap when both showed). A
+  `tune` toggle in the composer toolbar collapses/expands the strip
+  (`AnimatedSize`), shown only when there's something to toggle.
 - **Manual "Check sign-in" on the not-signed-in surfaces.** Both the
   new-conversation agent card and the **conversation login banner** now offer a
   **Check sign-in** `TextButton` that re-queries `auth/status` on tap (spinner

--- a/uxnanmobile/assets/images/agents/pi.svg
+++ b/uxnanmobile/assets/images/agents/pi.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <!-- P shape: outer boundary clockwise, inner hole counter-clockwise -->
+  <path fill="currentColor" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <!-- i dot -->
+  <path fill="currentColor" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/uxnanmobile/l10n/app_en.arb
+++ b/uxnanmobile/l10n/app_en.arb
@@ -146,6 +146,8 @@
   "composerSend": "Send",
   "composerAttach": "Attach",
   "composerVoice": "Voice input",
+  "composerOptionsShow": "Show options",
+  "composerOptionsHide": "Hide options",
 
   "newThreadAction": "New conversation",
   "newThreadTitle": "New conversation",

--- a/uxnanmobile/l10n/app_es.arb
+++ b/uxnanmobile/l10n/app_es.arb
@@ -110,6 +110,8 @@
   "composerSend": "Enviar",
   "composerAttach": "Adjuntar",
   "composerVoice": "Entrada de voz",
+  "composerOptionsShow": "Mostrar opciones",
+  "composerOptionsHide": "Ocultar opciones",
 
   "newThreadAction": "Nueva conversación",
   "newThreadTitle": "Nueva conversación",

--- a/uxnanmobile/lib/domain/entities/agent_model.dart
+++ b/uxnanmobile/lib/domain/entities/agent_model.dart
@@ -163,3 +163,51 @@ class AgentModel extends Equatable {
   List<Object?> get props =>
       [id, displayName, description, version, isDefault, options];
 }
+
+/// A provider-labelled group of models, for a sectioned model picker.
+class AgentModelGroup extends Equatable {
+  /// Creates an [AgentModelGroup].
+  const AgentModelGroup({required this.provider, required this.models});
+
+  /// The provider name shown as the section header (e.g. `google`, `opencode`).
+  final String provider;
+
+  /// The models that belong to [provider], in their original order.
+  final List<AgentModel> models;
+
+  @override
+  List<Object?> get props => [provider, models];
+}
+
+/// Groups [models] by provider so the picker can show provider headers over
+/// their models. The provider is the `id` prefix before the first `/` (pi and
+/// OpenCode report `provider/model` ids), falling back to [AgentModel.description]
+/// and then `"Other"`. First-seen order is preserved both across groups and
+/// within each group.
+///
+/// Callers should treat a single returned group as a flat list (no header):
+/// agents like Claude/Codex report bare ids that all collapse into one group.
+List<AgentModelGroup> groupModelsByProvider(List<AgentModel> models) {
+  final order = <String>[];
+  final byProvider = <String, List<AgentModel>>{};
+  for (final model in models) {
+    final provider = providerOfModel(model);
+    byProvider.putIfAbsent(provider, () {
+      order.add(provider);
+      return <AgentModel>[];
+    }).add(model);
+  }
+  return [
+    for (final provider in order)
+      AgentModelGroup(provider: provider, models: byProvider[provider]!),
+  ];
+}
+
+/// The provider a [model] belongs to: the `id` prefix before the first `/`,
+/// else its [AgentModel.description], else `"Other"`.
+String providerOfModel(AgentModel model) {
+  final slash = model.id.indexOf('/');
+  if (slash > 0) return model.id.substring(0, slash);
+  final description = model.description;
+  return description != null && description.isNotEmpty ? description : 'Other';
+}

--- a/uxnanmobile/lib/l10n/app_localizations.dart
+++ b/uxnanmobile/lib/l10n/app_localizations.dart
@@ -704,6 +704,18 @@ abstract class AppLocalizations {
   /// **'Voice input'**
   String get composerVoice;
 
+  /// No description provided for @composerOptionsShow.
+  ///
+  /// In en, this message translates to:
+  /// **'Show options'**
+  String get composerOptionsShow;
+
+  /// No description provided for @composerOptionsHide.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide options'**
+  String get composerOptionsHide;
+
   /// No description provided for @newThreadAction.
   ///
   /// In en, this message translates to:

--- a/uxnanmobile/lib/l10n/app_localizations_en.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_en.dart
@@ -334,6 +334,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get composerVoice => 'Voice input';
 
   @override
+  String get composerOptionsShow => 'Show options';
+
+  @override
+  String get composerOptionsHide => 'Hide options';
+
+  @override
   String get newThreadAction => 'New conversation';
 
   @override

--- a/uxnanmobile/lib/l10n/app_localizations_es.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_es.dart
@@ -335,6 +335,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get composerVoice => 'Entrada de voz';
 
   @override
+  String get composerOptionsShow => 'Mostrar opciones';
+
+  @override
+  String get composerOptionsHide => 'Ocultar opciones';
+
+  @override
   String get newThreadAction => 'Nueva conversación';
 
   @override

--- a/uxnanmobile/lib/presentation/screens/conversation/composer/composer_bar.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/composer/composer_bar.dart
@@ -20,6 +20,9 @@ class ComposerBar extends StatefulWidget {
     this.onModelTap,
     this.enabled = true,
     this.showAttach = true,
+    this.showOptionsToggle = false,
+    this.optionsVisible = true,
+    this.onToggleOptions,
     super.key,
   });
 
@@ -42,6 +45,17 @@ class ComposerBar extends StatefulWidget {
   /// Whether to show the attach button. Hidden for agents that don't advertise
   /// the `images` capability (the picker itself is still FOR-DEV).
   final bool showAttach;
+
+  /// Whether to show the toggle that collapses/expands the run-option and
+  /// approval-mode strip above the composer. Hidden when there's nothing to
+  /// toggle (the agent advertises no run options and no approvals).
+  final bool showOptionsToggle;
+
+  /// Whether the options strip is currently expanded (drives the toggle icon).
+  final bool optionsVisible;
+
+  /// Toggles the options strip. Required when [showOptionsToggle] is true.
+  final VoidCallback? onToggleOptions;
 
   @override
   State<ComposerBar> createState() => _ComposerBarState();
@@ -130,6 +144,21 @@ class _ComposerBarState extends State<ComposerBar> {
                     ),
                     const SizedBox(width: UxnanSpacing.xs),
                   ],
+                  // Collapse/expand the run-option + approval strip above the
+                  // composer, shown only when there's something to toggle.
+                  if (widget.showOptionsToggle) ...[
+                    _RoundIconButton(
+                      icon: widget.optionsVisible
+                          ? Icons.tune_rounded
+                          : Icons.tune_outlined,
+                      tooltip: widget.optionsVisible
+                          ? l10n.composerOptionsHide
+                          : l10n.composerOptionsShow,
+                      selected: widget.optionsVisible,
+                      onPressed: widget.onToggleOptions,
+                    ),
+                    const SizedBox(width: UxnanSpacing.xs),
+                  ],
                   Flexible(
                     child: _ModelChip(
                       model: widget.environment.modelName,
@@ -178,11 +207,16 @@ class _RoundIconButton extends StatelessWidget {
     required this.icon,
     required this.tooltip,
     required this.onPressed,
+    this.selected = false,
   });
 
   final IconData icon;
   final String tooltip;
   final VoidCallback? onPressed;
+
+  /// When true, the button reads as "on" (primary tint over a soft container) —
+  /// used for the options-strip toggle.
+  final bool selected;
 
   @override
   Widget build(BuildContext context) {
@@ -190,7 +224,18 @@ class _RoundIconButton extends StatelessWidget {
     return IconButton(
       tooltip: tooltip,
       visualDensity: VisualDensity.compact,
-      icon: Icon(icon, size: 20, color: colors.onSurfaceVariant),
+      isSelected: selected,
+      style: selected
+          ? IconButton.styleFrom(
+              backgroundColor: colors.secondaryContainer,
+              foregroundColor: colors.onSecondaryContainer,
+            )
+          : null,
+      icon: Icon(
+        icon,
+        size: 20,
+        color: selected ? colors.onSecondaryContainer : colors.onSurfaceVariant,
+      ),
       onPressed: onPressed,
     );
   }

--- a/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
@@ -37,6 +37,9 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
   // FOR-DEV: there is no bridge RPC for the approval/access mode yet, so it is
   // a local per-thread setting (no sampled default — see SessionEnvironment).
   ApprovalMode _approvalMode = ApprovalMode.approveForMe;
+  // Whether the run-option + approval strip above the composer is expanded.
+  // Toggled from the composer's options button.
+  bool _optionsVisible = true;
   final ScrollController _scroll = ScrollController();
   String? _gitCwd;
 
@@ -209,6 +212,14 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
     final cwd = thread?.cwd;
     final snapshot = timelineAsync.value;
 
+    // What the collapsible options strip above the composer holds: the
+    // data-driven run-option knobs and/or the approval-mode control. The
+    // composer's toggle is shown only when there is at least one of them.
+    final showRunOptions = connectedHere && runOptions.isNotEmpty;
+    final showApproval = thread != null &&
+        ref.watch(agentCapabilitiesProvider(thread.agentId)).approvals;
+    final hasOptions = showRunOptions || showApproval;
+
     // Resolve git state for the real workspace once the thread's cwd is known.
     if (connectedHere) _refreshGitFor(cwd);
 
@@ -234,24 +245,27 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
                   parent: AlwaysScrollableScrollPhysics(),
                 ),
                 slivers: [
+                  // Quick-return large app bar: NOT pinned, so it scrolls
+                  // fully away with the content for a clean reading surface;
+                  // `floating` (without `snap`) brings it back proportionally
+                  // as the user scrolls up, instead of snapping the tall
+                  // header open.
                   SliverAppBar.large(
                     floating: true,
-                    snap: true,
-                    title: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          thread?.title ?? l10n.conversationTitle,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        if (activity == ThreadActivity.running)
-                          const _RespondingLabel()
-                        else
-                          _ConnectionLabel(phase: effectivePhase),
-                      ],
+                    // Single-line title (the thread title only) so this bar's
+                    // title sits at the same level and size as the other
+                    // .large bars (devices, threads, archived). The live
+                    // connection / "Responding…" state moved to a compact
+                    // indicator in the actions (no extra height).
+                    title: Text(
+                      thread?.title ?? l10n.conversationTitle,
+                      overflow: TextOverflow.ellipsis,
                     ),
                     actions: [
+                      _StatusIndicator(
+                        phase: effectivePhase,
+                        running: activity == ThreadActivity.running,
+                      ),
                       // One git affordance (was a redundant branch chip + an
                       // upload button): an IconButton — the M3-correct app-bar
                       // action — opens the git sheet; branch in its tooltip.
@@ -290,25 +304,60 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
           ),
           // Sign-in warning: the agent on this PC is not logged in, so turns
           // won't run until the user signs into its CLI on the PC. Kept above
-          // the composer (not in the scrolling list) so it stays visible.
+          // the composer (not in the scrolling list) so it stays visible, and
+          // outside the collapsible strip (it's not dismissible).
           if (requiresLogin && thread != null)
             _LoginRequiredBanner(agentId: thread.agentId),
-          // Per-model run-option knobs (reasoning effort, …) the bridge
-          // advertises for the active model — a generic, data-driven control.
-          if (connectedHere && runOptions.isNotEmpty)
-            _RunOptionsBar(threadId: widget.threadId, options: runOptions),
-          // Access/approval mode lives directly above the composer (its own
-          // affordance, alert-coloured on full access), shown only for agents
-          // that gate tools.
-          if (thread != null &&
-              ref.watch(agentCapabilitiesProvider(thread.agentId)).approvals)
-            _ApprovalBar(mode: _approvalMode, onTap: _editApprovalMode),
+          // Collapsible options strip: the per-model run-option knobs
+          // (reasoning effort, …) the bridge advertises plus the approval mode
+          // (for agents that gate tools). One container with consistent
+          // vertical rhythm so spacing reads the same whether one or both
+          // controls show; AnimatedSize animates the show/hide driven by the
+          // composer toggle.
+          if (hasOptions)
+            AnimatedSize(
+              duration: const Duration(milliseconds: 180),
+              curve: Curves.easeOutCubic,
+              alignment: Alignment.bottomCenter,
+              child: _optionsVisible
+                  ? Padding(
+                      padding: const EdgeInsets.fromLTRB(
+                        UxnanSpacing.lg,
+                        UxnanSpacing.sm,
+                        UxnanSpacing.lg,
+                        UxnanSpacing.sm,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (showRunOptions)
+                            _RunOptionsBar(
+                              threadId: widget.threadId,
+                              options: runOptions,
+                            ),
+                          if (showRunOptions && showApproval)
+                            const SizedBox(height: UxnanSpacing.sm),
+                          if (showApproval)
+                            _ApprovalBar(
+                              mode: _approvalMode,
+                              onTap: _editApprovalMode,
+                            ),
+                        ],
+                      ),
+                    )
+                  : const SizedBox(width: double.infinity),
+            ),
           ComposerBar(
             environment: environment,
             resolvedModel: resolvedModel,
             enabled: connectedHere,
             showAttach: thread != null &&
                 ref.watch(agentCapabilitiesProvider(thread.agentId)).images,
+            showOptionsToggle: hasOptions,
+            optionsVisible: _optionsVisible,
+            onToggleOptions: () =>
+                setState(() => _optionsVisible = !_optionsVisible),
             onModelTap: thread != null ? () => _pickModel(thread) : null,
             onSend: (text) => ref.read(threadManagerProvider).sendUserMessage(
                   widget.threadId,
@@ -360,47 +409,37 @@ class _EmptyState extends StatelessWidget {
   }
 }
 
-/// Header status shown while the agent is producing a turn: a small spinner and
-/// "Responding…", in the primary colour. Replaces the connection label (being
-/// connected is implied) so the user knows a reply is on the way.
-class _RespondingLabel extends StatelessWidget {
-  const _RespondingLabel();
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = Theme.of(context).colorScheme;
-    final l10n = AppLocalizations.of(context);
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SizedBox(
-          width: 10,
-          height: 10,
-          child:
-              CircularProgressIndicator(strokeWidth: 2, color: colors.primary),
-        ),
-        const SizedBox(width: UxnanSpacing.xs),
-        Text(
-          l10n.threadResponding,
-          style: Theme.of(context)
-              .textTheme
-              .bodySmall
-              ?.copyWith(color: colors.primary),
-        ),
-      ],
-    );
-  }
-}
-
-class _ConnectionLabel extends StatelessWidget {
-  const _ConnectionLabel({required this.phase});
+/// Compact live-status indicator in the app-bar actions: a small spinner while
+/// the agent is producing a turn ("Responding…"), otherwise a colour-coded
+/// connection dot. Kept out of the title so this bar's title aligns with the
+/// other `.large` bars; the textual state rides in the tooltip.
+class _StatusIndicator extends StatelessWidget {
+  const _StatusIndicator({required this.phase, required this.running});
 
   final ConnectionPhase phase;
+  final bool running;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final textTheme = Theme.of(context).textTheme;
+    final colors = Theme.of(context).colorScheme;
+
+    if (running) {
+      return Tooltip(
+        message: l10n.threadResponding,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: UxnanSpacing.sm),
+          child: SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: colors.primary,
+            ),
+          ),
+        ),
+      );
+    }
 
     final (label, color) = switch (phase) {
       ConnectionPhase.connected => (
@@ -421,17 +460,16 @@ class _ConnectionLabel extends StatelessWidget {
         ),
     };
 
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Container(
-          width: 7,
-          height: 7,
+    return Tooltip(
+      message: label,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: UxnanSpacing.sm),
+        child: Container(
+          width: 8,
+          height: 8,
           decoration: BoxDecoration(color: color, shape: BoxShape.circle),
         ),
-        const SizedBox(width: UxnanSpacing.xs),
-        Text(label, style: textTheme.bodySmall),
-      ],
+      ),
     );
   }
 }
@@ -605,36 +643,28 @@ class _RunOptionsBar extends ConsumerWidget {
     final visible =
         options.where((o) => o.kind == 'enum' || o.kind == 'toggle').toList();
     if (visible.isEmpty) return const SizedBox.shrink();
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        UxnanSpacing.lg,
-        UxnanSpacing.xs,
-        UxnanSpacing.lg,
-        0,
-      ),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Wrap(
-          spacing: UxnanSpacing.xs,
-          runSpacing: UxnanSpacing.xs,
-          children: [
-            for (final option in visible)
-              if (option.kind == 'toggle')
-                FilterChip(
-                  label: Text(option.label),
-                  selected: selections[option.key] == true,
-                  visualDensity: VisualDensity.compact,
-                  onSelected: (value) =>
-                      notifier.set(threadId, option.key, value),
-                )
-              else
-                _EnumOptionChip(
-                  threadId: threadId,
-                  option: option,
-                  selected: selections[option.key],
-                ),
-          ],
-        ),
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Wrap(
+        spacing: UxnanSpacing.xs,
+        runSpacing: UxnanSpacing.xs,
+        children: [
+          for (final option in visible)
+            if (option.kind == 'toggle')
+              FilterChip(
+                label: Text(option.label),
+                selected: selections[option.key] == true,
+                visualDensity: VisualDensity.compact,
+                onSelected: (value) =>
+                    notifier.set(threadId, option.key, value),
+              )
+            else
+              _EnumOptionChip(
+                threadId: threadId,
+                option: option,
+                selected: selections[option.key],
+              ),
+        ],
       ),
     );
   }
@@ -738,28 +768,20 @@ class _ApprovalBar extends StatelessWidget {
         ),
     };
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        UxnanSpacing.lg,
-        UxnanSpacing.xs,
-        UxnanSpacing.lg,
-        0,
-      ),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: ActionChip(
-          avatar: Icon(
-            icon,
-            size: 18,
-            color: isFull ? colors.onErrorContainer : colors.onSurfaceVariant,
-          ),
-          label: Text(label),
-          labelStyle: isFull ? TextStyle(color: colors.onErrorContainer) : null,
-          backgroundColor: isFull ? colors.errorContainer : null,
-          side: isFull ? BorderSide(color: colors.error) : null,
-          visualDensity: VisualDensity.compact,
-          onPressed: onTap,
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: ActionChip(
+        avatar: Icon(
+          icon,
+          size: 18,
+          color: isFull ? colors.onErrorContainer : colors.onSurfaceVariant,
         ),
+        label: Text(label),
+        labelStyle: isFull ? TextStyle(color: colors.onErrorContainer) : null,
+        backgroundColor: isFull ? colors.errorContainer : null,
+        side: isFull ? BorderSide(color: colors.error) : null,
+        visualDensity: VisualDensity.compact,
+        onPressed: onTap,
       ),
     );
   }

--- a/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
@@ -503,10 +503,9 @@ class _LoginRequiredBanner extends ConsumerWidget {
             UxnanSpacing.sm,
             UxnanSpacing.sm,
           ),
-          // Icon on the left; the right section stacks title → body → action,
-          // all left-aligned (M3 alert-with-action, vertical layout).
+          // Icon on the left (vertically centered — Row's default); the right
+          // section stacks title → body → action, all left-aligned.
           child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               if (loginInProgress)
                 SizedBox(

--- a/uxnanmobile/lib/presentation/screens/conversation/support/model_picker_sheet.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/support/model_picker_sheet.dart
@@ -138,67 +138,144 @@ class _ModelList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final colors = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
     if (models.isEmpty) {
       return Padding(
         padding: const EdgeInsets.all(UxnanSpacing.md),
         child: Text(l10n.modelPickerEmpty),
       );
     }
+    // Group by provider so big multi-provider agents (pi, OpenCode) read as
+    // sections. A single group (Claude/Codex bare ids) renders flat: we skip
+    // the headers and the per-row provider stripping.
+    final groups = groupModelsByProvider(models);
+    final grouped = groups.length > 1;
+    // Flatten to a single lazy list of header (String) + model rows, so even
+    // hundreds of models stay cheap to build.
+    final entries = <Object>[];
+    if (grouped) {
+      for (final group in groups) {
+        entries
+          ..add(group.provider)
+          ..addAll(group.models);
+      }
+    } else {
+      entries.addAll(models);
+    }
     return ListView.builder(
       shrinkWrap: true,
-      itemCount: models.length,
+      itemCount: entries.length,
       itemBuilder: (context, index) {
-        final model = models[index];
-        final selected = model.id == current;
-        // Secondary line: the resolved version (for aliases) and/or the wire id
-        // when it differs from the display name, then any description.
-        final detail = <String>[
-          if (model.version != null && model.version != model.id)
-            model.version!
-          else if (model.id != model.displayName)
-            model.id,
-          if (model.description != null) model.description!,
-        ].join(' · ');
-        return ListTile(
-          dense: true,
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(UxnanRadius.md),
-          ),
-          selected: selected,
-          selectedTileColor: colors.primaryContainer.withValues(alpha: 0.4),
-          title: Row(
-            children: [
-              Flexible(
-                child: Text(
-                  model.displayName,
-                  style: textTheme.bodyMedium,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              if (model.isDefault) ...[
-                const SizedBox(width: UxnanSpacing.sm),
-                _DefaultBadge(label: l10n.modelPickerDefault),
-              ],
-            ],
-          ),
-          subtitle: detail.isEmpty
-              ? null
-              : Text(
-                  detail,
-                  style: UxnanTypography.codeSmall.copyWith(
-                    color: colors.onSurfaceVariant,
-                  ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-          trailing: selected
-              ? Icon(Icons.check_rounded, color: colors.primary, size: 20)
-              : null,
-          onTap: () => Navigator.of(context).pop(model.id),
+        final entry = entries[index];
+        if (entry is String) return _ProviderHeader(provider: entry);
+        final model = entry as AgentModel;
+        return _ModelTile(
+          model: model,
+          grouped: grouped,
+          selected: model.id == current,
         );
       },
+    );
+  }
+}
+
+/// A provider section header (M3 list subheader) over its models.
+class _ProviderHeader extends StatelessWidget {
+  const _ProviderHeader({required this.provider});
+
+  final String provider;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        UxnanSpacing.sm,
+        UxnanSpacing.md,
+        UxnanSpacing.sm,
+        UxnanSpacing.xs,
+      ),
+      child: Text(
+        provider.toUpperCase(),
+        style: textTheme.labelMedium?.copyWith(
+          color: colors.primary,
+          letterSpacing: 0.6,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _ModelTile extends StatelessWidget {
+  const _ModelTile({
+    required this.model,
+    required this.grouped,
+    required this.selected,
+  });
+
+  final AgentModel model;
+  final bool grouped;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final colors = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final slash = model.id.indexOf('/');
+    // Under a provider header, drop the redundant `provider/` prefix when the
+    // display name is just the wire id (OpenCode); pi already shows the bare
+    // model name.
+    final title = grouped && model.displayName == model.id && slash > 0
+        ? model.id.substring(slash + 1)
+        : model.displayName;
+    // Secondary line: the resolved version (for aliases) and/or the wire id
+    // when it differs from the shown title, then any description. The provider
+    // is already in the header when grouped, so it's omitted there.
+    final detail = <String>[
+      if (model.version != null && model.version != model.id)
+        model.version!
+      else if (model.id != title)
+        model.id,
+      if (!grouped && model.description != null) model.description!,
+    ].join(' · ');
+    return ListTile(
+      dense: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(UxnanRadius.md),
+      ),
+      selected: selected,
+      selectedTileColor: colors.primaryContainer.withValues(alpha: 0.4),
+      title: Row(
+        children: [
+          Flexible(
+            child: Text(
+              title,
+              style: textTheme.bodyMedium,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (model.isDefault) ...[
+            const SizedBox(width: UxnanSpacing.sm),
+            _DefaultBadge(label: l10n.modelPickerDefault),
+          ],
+        ],
+      ),
+      subtitle: detail.isEmpty
+          ? null
+          : Text(
+              detail,
+              style: UxnanTypography.codeSmall.copyWith(
+                color: colors.onSurfaceVariant,
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+      trailing: selected
+          ? Icon(Icons.check_rounded, color: colors.primary, size: 20)
+          : null,
+      onTap: () => Navigator.of(context).pop(model.id),
     );
   }
 }

--- a/uxnanmobile/lib/presentation/screens/threads/new_conversation_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/threads/new_conversation_screen.dart
@@ -7,6 +7,7 @@ import 'package:uxnan/domain/entities/project.dart';
 import 'package:uxnan/domain/enums/agent_id.dart';
 import 'package:uxnan/l10n/app_localizations.dart';
 import 'package:uxnan/presentation/providers/application_providers.dart';
+import 'package:uxnan/presentation/screens/conversation/support/model_picker_sheet.dart';
 import 'package:uxnan/presentation/screens/threads/workspace_browser_sheet.dart';
 import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
@@ -228,7 +229,8 @@ class _NewConversationScreenState extends ConsumerState<NewConversationScreen> {
                 controller: _model,
                 enabled: agent != null,
                 models: models,
-                onChanged: (_) => _modelTouched = true,
+                agentId: agent?.agentId,
+                onChanged: (_) => setState(() => _modelTouched = true),
               ),
             ],
           ),
@@ -546,109 +548,94 @@ class _AgentLeading extends StatelessWidget {
   }
 }
 
-/// Model picker. When the bridge reports models for the selected agent it shows
-/// a filterable M3 [DropdownMenu] (the user can still type a custom id); while
-/// loading or when no list is available it falls back to a free-text field.
+/// Model picker. A tappable field that opens the shared [ModelPickerSheet]
+/// (lazy, searchable, grouped by provider) rather than an inline dropdown —
+/// agents like pi/OpenCode report hundreds of models, which made an inline
+/// `DropdownMenu` janky to build. Shows the selected model id (or a hint), with
+/// a spinner while the bridge's model list is still loading.
 class _ModelField extends StatelessWidget {
   const _ModelField({
     required this.controller,
     required this.enabled,
     required this.models,
+    required this.agentId,
     required this.onChanged,
   });
 
   final TextEditingController controller;
   final bool enabled;
   final AsyncValue<List<AgentModel>>? models;
+  final String? agentId;
   final ValueChanged<String> onChanged;
 
-  @override
-  Widget build(BuildContext context) {
-    final list = models?.asData?.value;
-    if (enabled && list != null && list.isNotEmpty) {
-      return DropdownMenu<String>(
-        controller: controller,
-        enableFilter: true,
-        requestFocusOnTap: true,
-        expandedInsets: EdgeInsets.zero,
-        menuHeight: 320,
-        hintText: AppLocalizations.of(context).newThreadModelHint,
-        leadingIcon: const Icon(Icons.auto_awesome_outlined, size: 18),
-        initialSelection: controller.text.isEmpty ? null : controller.text,
-        onSelected: (value) => onChanged(value ?? ''),
-        dropdownMenuEntries: [
-          for (final model in list)
-            DropdownMenuEntry<String>(
-              value: model.id,
-              label: model.displayName,
-            ),
-        ],
-      );
-    }
-    return _ModelTextField(
-      controller: controller,
-      enabled: enabled,
-      loading: models?.isLoading ?? false,
-      onChanged: onChanged,
+  Future<void> _pick(BuildContext context) async {
+    final id = agentId;
+    if (id == null) return;
+    final picked = await ModelPickerSheet.show(
+      context,
+      agentId: id,
+      current: controller.text.isEmpty ? null : controller.text,
     );
+    if (picked == null) return;
+    controller.text = picked;
+    onChanged(picked);
   }
-}
-
-class _ModelTextField extends StatelessWidget {
-  const _ModelTextField({
-    required this.controller,
-    required this.enabled,
-    required this.loading,
-    required this.onChanged,
-  });
-
-  final TextEditingController controller;
-  final bool enabled;
-  final bool loading;
-  final ValueChanged<String> onChanged;
 
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
     final l10n = AppLocalizations.of(context);
-    return Container(
-      decoration: BoxDecoration(
-        color: colors.surfaceContainerHighest,
+    final loading = models?.isLoading ?? false;
+    final hasModel = controller.text.isNotEmpty;
+    final tappable = enabled && agentId != null && !loading;
+
+    return Material(
+      color: colors.surfaceContainerHighest,
+      shape: RoundedRectangleBorder(
         borderRadius: const BorderRadius.all(UxnanRadius.lg),
-        border: Border.all(color: colors.outline),
+        side: BorderSide(color: colors.outline),
       ),
-      padding: const EdgeInsets.symmetric(
-        horizontal: UxnanSpacing.md,
-        vertical: 2,
-      ),
-      child: TextField(
-        controller: controller,
-        enabled: enabled,
-        onChanged: onChanged,
-        style: Theme.of(context).textTheme.bodyMedium,
-        decoration: InputDecoration(
-          isCollapsed: true,
-          border: InputBorder.none,
-          contentPadding: const EdgeInsets.symmetric(vertical: UxnanSpacing.md),
-          icon: Icon(
-            Icons.auto_awesome_outlined,
-            size: 18,
-            color: colors.onSurfaceVariant,
+      child: InkWell(
+        borderRadius: const BorderRadius.all(UxnanRadius.lg),
+        onTap: tappable ? () => _pick(context) : null,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: UxnanSpacing.md,
+            vertical: UxnanSpacing.md,
           ),
-          suffixIconConstraints:
-              const BoxConstraints(maxHeight: 20, maxWidth: 36),
-          suffixIcon: loading
-              ? const Padding(
-                  padding: EdgeInsets.only(right: 10),
-                  child: SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
+          child: Row(
+            children: [
+              Icon(
+                Icons.auto_awesome_outlined,
+                size: 18,
+                color: colors.onSurfaceVariant,
+              ),
+              const SizedBox(width: UxnanSpacing.md),
+              Expanded(
+                child: Text(
+                  hasModel ? controller.text : l10n.newThreadModelHint,
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: hasModel ? null : colors.onSurfaceVariant,
                   ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const SizedBox(width: UxnanSpacing.sm),
+              if (loading)
+                const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
                 )
-              : null,
-          hintText: l10n.newThreadModelHint,
-          hintStyle: TextStyle(color: colors.onSurfaceVariant),
+              else if (enabled && agentId != null)
+                Icon(
+                  Icons.unfold_more_rounded,
+                  size: 20,
+                  color: colors.onSurfaceVariant,
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/uxnanmobile/lib/presentation/widgets/agent_logos.dart
+++ b/uxnanmobile/lib/presentation/widgets/agent_logos.dart
@@ -36,4 +36,7 @@ class AgentLogos {
 
   /// Kilo Code logo (monochrome).
   static const String kilocode = '$_base/kilocode.svg';
+
+  /// pi logo (monochrome — uses `currentColor`).
+  static const String pi = '$_base/pi.svg';
 }

--- a/uxnanmobile/lib/presentation/widgets/agent_visuals.dart
+++ b/uxnanmobile/lib/presentation/widgets/agent_visuals.dart
@@ -16,7 +16,7 @@ class AgentVisuals {
         AgentId.opencode => AgentLogos.opencode,
         AgentId.claudeCode => AgentLogos.claude,
         AgentId.geminiCli => AgentLogos.gemini,
-        AgentId.piAgent => null,
+        AgentId.piAgent => AgentLogos.pi,
         AgentId.custom => null,
       };
 

--- a/uxnanmobile/test/unit/domain/agent_model_test.dart
+++ b/uxnanmobile/test/unit/domain/agent_model_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uxnan/domain/entities/agent_model.dart';
+
+void main() {
+  group('groupModelsByProvider', () {
+    test('groups provider/model ids by their prefix, preserving order', () {
+      final groups = groupModelsByProvider(const [
+        AgentModel(id: 'google/gemini-2.5-pro', displayName: 'gemini-2.5-pro'),
+        AgentModel(id: 'openai/gpt-5', displayName: 'gpt-5'),
+        AgentModel(id: 'google/gemini-flash', displayName: 'gemini-flash'),
+      ]);
+      expect(groups.map((g) => g.provider).toList(), ['google', 'openai']);
+      expect(
+        groups.first.models.map((m) => m.id).toList(),
+        ['google/gemini-2.5-pro', 'google/gemini-flash'],
+      );
+      expect(groups[1].models.single.id, 'openai/gpt-5');
+    });
+
+    test('falls back to description then "Other" when the id has no slash', () {
+      final groups = groupModelsByProvider(const [
+        AgentModel(id: 'opus', displayName: 'opus', description: 'anthropic'),
+        AgentModel(id: 'gpt-5-codex', displayName: 'gpt-5-codex'),
+      ]);
+      expect(groups.map((g) => g.provider).toList(), ['anthropic', 'Other']);
+    });
+
+    test('a single shared provider collapses to one group (flat list)', () {
+      final groups = groupModelsByProvider(const [
+        AgentModel(id: 'opus', displayName: 'opus'),
+        AgentModel(id: 'sonnet', displayName: 'sonnet'),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.single.provider, 'Other');
+      expect(groups.single.models, hasLength(2));
+    });
+
+    test('empty input yields no groups', () {
+      expect(groupModelsByProvider(const []), isEmpty);
+    });
+  });
+
+  group('providerOfModel', () {
+    test('prefers the id prefix before the first slash', () {
+      expect(
+        providerOfModel(
+          const AgentModel(id: 'opencode/glm-5', displayName: 'opencode/glm-5'),
+        ),
+        'opencode',
+      );
+    });
+
+    test('uses description, then "Other", for ids without a slash', () {
+      expect(
+        providerOfModel(
+          const AgentModel(id: 'opus', displayName: 'opus', description: 'x'),
+        ),
+        'x',
+      );
+      expect(
+        providerOfModel(const AgentModel(id: 'codex', displayName: 'codex')),
+        'Other',
+      );
+    });
+  });
+}

--- a/uxnanmobile/test/unit/presentation/agent_visuals_test.dart
+++ b/uxnanmobile/test/unit/presentation/agent_visuals_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uxnan/domain/enums/agent_id.dart';
+import 'package:uxnan/presentation/widgets/agent_logos.dart';
+import 'package:uxnan/presentation/widgets/agent_visuals.dart';
+
+void main() {
+  group('AgentVisuals', () {
+    test('pi has a logo, label and accent color', () {
+      expect(AgentVisuals.logoFor(AgentId.piAgent), AgentLogos.pi);
+      expect(AgentVisuals.labelFor(AgentId.piAgent), 'pi');
+      // colorFor returns a concrete color (compile-time mapping).
+      expect(AgentVisuals.colorFor(AgentId.piAgent), isNotNull);
+    });
+
+    test('the pi wire id round-trips through AgentId', () {
+      expect(AgentId.piAgent.wireId, 'pi-agent');
+      expect(AgentIdParsing.fromWireId('pi-agent'), AgentId.piAgent);
+    });
+
+    test('every known agent has a label', () {
+      for (final id in AgentId.values) {
+        expect(AgentVisuals.labelFor(id), isNotEmpty);
+      }
+    });
+  });
+}


### PR DESCRIPTION
Integrates `@earendil-works/pi-coding-agent` (the `pi` CLI) as a first-class agent across the bridge and the mobile app, plus related model-picker and conversation-screen UX refinements.

## Bridge
- **pi adapter** (`pi-adapter.ts`, `resolve-pi.ts`, registered in `bridge.ts`/`index.ts`): drives `pi -p --mode json` — streamed text, session continuity (`--session-id`), `--model provider/model`, reasoning effort (`--thinking`), tool posture (`permissionMode`), usage and error handling. Auth detected via `~/.pi/agent/auth.json`. Validated against pi 0.79.1.
- **Model discovery fix**: `pi --list-models` prints its table to **stderr**, not stdout — the adapter now reads both, so `agent/models` returns the list (the phone's picker was empty for pi). `SpawnedProcess` gains an optional `stderr` stream.

## Mobile
- **pi visuals**: `AgentId.piAgent` ↔ `pi-agent`, logo/label/accent, `pi.svg` asset.
- **Model picker grouped by provider** (M3 subheaders) for multi-provider agents (pi/OpenCode), flattened into one lazy list; single-provider agents render flat. Pure, unit-tested domain helper `groupModelsByProvider`.
- **New-conversation model field** opens the shared picker sheet instead of a giant inline `DropdownMenu` (which stalled for pi's ~326 models); spinner while loading.
- **Conversation options strip** (reasoning + approval) gets consistent spacing and a composer toggle to collapse/expand it.
- **Consistent `.large` app-bar titles**: the conversation bar uses a single-line title with a compact status indicator in the actions (and drops `snap`, keeps `floating`), aligning all four `.large` bars.

## Verification
- Bridge: `npm test` (incl. new listModels stderr test).
- Mobile: `flutter analyze` clean; `flutter test` 236/236 (incl. new grouping unit tests).

## Optional follow-ups (documented in FOR-DEV, non-blocking)
- Map the resolved model's context window for a `%` context ring (pi reports raw `totalTokens` today).
- Surface pi's `thinking`/tool-call events as structured content if a use case appears.