### PR TITLE
feat(svelte): VS Code-style history branch graph (desktop)

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Changed — history branch graph looks like VS Code
+- **Branch-stable lane colors.** The history graph colored lanes by *column
+  index*, so two unrelated branches that happened to share a column looked like
+  the same branch. Each lane now carries a color id assigned when it's born and
+  kept for its whole life (a reused lane gets a fresh one), so a branch keeps
+  its color even as it shifts columns — matching VS Code. `src/lib/gitGraph.ts`.
+- **Rounded-step connectors + ringed merge nodes.** Branch/merge edges are now
+  drawn as VS Code-style rounded steps (vertical → quarter-arc → horizontal)
+  instead of straight diagonals, and merge commits render as a solid dot with a
+  separate outer ring. `src/lib/components/HistoryPanel.svelte`.
+- The log itself was already correct (git2 `Sort::TOPOLOGICAL | TIME` / CLI
+  `--topo-order`, offset paging, no merge-shortstat parsing) — only the graph's
+  visuals changed. Docs: `architecture/02c-git-worktrees.md` §6.4.
+
 ### Changed — agent notifications: precise, hook-driven, enriched
 - **No more "agent is idle" notifications.** The coarse output-activity inference
   no longer raises any notification or unread badge — it only drives the visual

--- a/uxnandesktop/architecture/02c-git-worktrees.md
+++ b/uxnandesktop/architecture/02c-git-worktrees.md
@@ -351,8 +351,15 @@ worktree activo. Características:
   espera a continuación; el commit ocupa el/los carriles que lo esperaban (el más
   a la izquierda es su nodo, el resto son aristas de merge que colapsan en él), su
   primer padre continúa en el mismo carril y cada padre extra abre/reutiliza otro.
-  Color fijo por índice de carril. El grafo solo se muestra sobre el log sin
-  filtrar (un filtro rompería las cadenas de padres).
+  **Color estable por rama** (estilo VS Code): a cada carril se le asigna un id
+  de color al nacer que conserva toda su vida (un carril reutilizado recibe uno
+  nuevo), de modo que una rama mantiene su color aunque cambie de columna — en
+  vez de colorear por índice de columna, donde ramas distintas que comparten
+  columna se verían iguales. Las aristas de branch/merge se dibujan con
+  **conectores de esquina redondeada** (vertical → arco → horizontal, como VS
+  Code) en lugar de diagonales rectas, y los **merge commits** llevan un punto
+  sólido con un **anillo de contorno separado**. El grafo solo se muestra sobre
+  el log sin filtrar (un filtro rompería las cadenas de padres).
 
 #### Comandos Tauri (historial)
 

--- a/uxnandesktop/package-lock.json
+++ b/uxnandesktop/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "uxnan-desktop",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uxnan-desktop",
-      "version": "0.0.0",
-      "license": "UNLICENSED",
+      "version": "0.0.1",
+      "license": "MPL-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
         "@codemirror/lang-cpp": "^6.0.3",

--- a/uxnandesktop/src/lib/components/HistoryPanel.svelte
+++ b/uxnandesktop/src/lib/components/HistoryPanel.svelte
@@ -31,7 +31,31 @@
   // Graph geometry (kept in lockstep with the row height below).
   const ROW_H = 44;
   const LANE_W = 14;
+  const CURVE_R = 5; // rounded-corner radius for branch/merge bends (VS Code-ish)
   const laneX = (lane: number) => lane * LANE_W + LANE_W / 2;
+
+  // VS Code-style rounded-step connectors (vertical → quarter-arc → horizontal),
+  // instead of straight diagonals. `edgeIn` runs a merging branch down its lane
+  // and bends into the node; `edgeOut` leaves the node and bends down into a
+  // parent lane. A same-lane edge is a plain vertical line.
+  function edgeIn(fromLane: number, toLane: number): string {
+    const x1 = laneX(fromLane);
+    const x2 = laneX(toLane);
+    const my = ROW_H / 2;
+    if (x1 === x2) return `M ${x1} 0 L ${x2} ${my}`;
+    const dir = x2 > x1 ? 1 : -1;
+    const r = Math.min(CURVE_R, Math.abs(x2 - x1), my);
+    return `M ${x1} 0 V ${my - r} Q ${x1} ${my} ${x1 + dir * r} ${my} H ${x2}`;
+  }
+  function edgeOut(fromLane: number, toLane: number): string {
+    const x1 = laneX(fromLane);
+    const x2 = laneX(toLane);
+    const my = ROW_H / 2;
+    if (x1 === x2) return `M ${x1} ${my} L ${x2} ${ROW_H}`;
+    const dir = x2 > x1 ? 1 : -1;
+    const r = Math.min(CURVE_R, Math.abs(x2 - x1), my);
+    return `M ${x1} ${my} H ${x2 - dir * r} Q ${x2} ${my} ${x2} ${my + r} V ${ROW_H}`;
+  }
 
   // The graph is only meaningful over the full, unfiltered log (a filter breaks
   // parent chains), so it's drawn when graph view is on AND no filter is active.
@@ -106,33 +130,52 @@
           stroke-width="1.5"
         />
       {:else if seg.kind === "in"}
-        <line
-          x1={laneX(seg.fromLane)}
-          y1="0"
-          x2={laneX(seg.toLane)}
-          y2={ROW_H / 2}
+        <path
+          d={edgeIn(seg.fromLane, seg.toLane)}
+          fill="none"
           stroke={seg.color}
           stroke-width="1.5"
         />
       {:else}
-        <line
-          x1={laneX(seg.fromLane)}
-          y1={ROW_H / 2}
-          x2={laneX(seg.toLane)}
-          y2={ROW_H}
+        <path
+          d={edgeOut(seg.fromLane, seg.toLane)}
+          fill="none"
           stroke={seg.color}
           stroke-width="1.5"
         />
       {/if}
     {/each}
+    <!-- Node: a halo clears crossing lines; merge commits get a separate outer
+         ring around a solid dot (a gap between them), like VS Code. -->
     <circle
       cx={laneX(rowLayout.nodeLane)}
       cy={ROW_H / 2}
-      r={rowLayout.isMerge ? 4 : 3.5}
-      fill={rowLayout.isMerge ? "var(--background)" : rowLayout.nodeColor}
-      stroke={rowLayout.nodeColor}
-      stroke-width="1.5"
+      r={(rowLayout.isMerge ? 5 : 3.5) + 1.5}
+      fill="var(--background)"
     />
+    {#if rowLayout.isMerge}
+      <circle
+        cx={laneX(rowLayout.nodeLane)}
+        cy={ROW_H / 2}
+        r="5"
+        fill="none"
+        stroke={rowLayout.nodeColor}
+        stroke-width="1.5"
+      />
+      <circle
+        cx={laneX(rowLayout.nodeLane)}
+        cy={ROW_H / 2}
+        r="2.5"
+        fill={rowLayout.nodeColor}
+      />
+    {:else}
+      <circle
+        cx={laneX(rowLayout.nodeLane)}
+        cy={ROW_H / 2}
+        r="3.5"
+        fill={rowLayout.nodeColor}
+      />
+    {/if}
   </svg>
 {/snippet}
 

--- a/uxnandesktop/src/lib/gitGraph.ts
+++ b/uxnandesktop/src/lib/gitGraph.ts
@@ -72,16 +72,25 @@ interface GraphCommit {
 export function computeGraph(commits: GraphCommit[], cap = 8): GraphLayout {
   /** Pending parent hash per lane (null = free). Top-of-row state. */
   const lanes: (string | null)[] = [];
+  /** Branch-stable color id per lane (null = free). A lane keeps its color id
+   *  for its whole life and a reused lane gets a fresh one — so a branch keeps
+   *  one color even when it shifts columns, the way VS Code colors the graph
+   *  (instead of coloring by column index, where unrelated branches sharing a
+   *  column would look like the same branch). */
+  const laneColors: (number | null)[] = [];
   const rows: GraphRow[] = [];
   let maxLanes = 1;
+  let nextColor = 0;
 
-  const color = (lane: number) => GRAPH_COLORS[lane % GRAPH_COLORS.length];
+  const colorOf = (id: number | null) =>
+    GRAPH_COLORS[(id ?? 0) % GRAPH_COLORS.length];
 
   /** First free lane (reused in place), else a new one, else the capped last. */
   const firstFree = (): number => {
     for (let i = 0; i < lanes.length; i++) if (lanes[i] === null) return i;
     if (lanes.length < cap) {
       lanes.push(null);
+      laneColors.push(null);
       return lanes.length - 1;
     }
     return cap - 1;
@@ -94,48 +103,90 @@ export function computeGraph(commits: GraphCommit[], cap = 8): GraphLayout {
 
     const nodeLane = incoming.length > 0 ? incoming[0] : firstFree();
 
-    // Snapshot the top-of-row state before mutating (used to draw passing lanes).
+    // Snapshot the top-of-row state before mutating (used to draw passing lanes
+    // in their own colors).
     const topLanes = lanes.slice();
+    const topColors = laneColors.slice();
+
+    // The node's color: continue the incoming branch's color if a child was
+    // waiting for it, otherwise a brand-new branch tip → a fresh color.
+    let nodeColorId = laneColors[nodeLane];
+    if (nodeColorId == null) nodeColorId = nextColor++;
 
     // The node consumes every lane that was waiting for it.
-    for (const idx of incoming) lanes[idx] = null;
+    for (const idx of incoming) {
+      lanes[idx] = null;
+      laneColors[idx] = null;
+    }
 
-    // First parent continues straight down in the node's lane; no parent (a root
-    // commit) frees the lane.
+    // First parent continues straight down in the node's lane, keeping the
+    // node's color; a root commit (no parents) frees the lane.
     const parents = c.parents;
-    lanes[nodeLane] = parents.length > 0 ? parents[0] : null;
+    if (parents.length > 0) {
+      lanes[nodeLane] = parents[0];
+      laneColors[nodeLane] = nodeColorId;
+    } else {
+      lanes[nodeLane] = null;
+      laneColors[nodeLane] = null;
+    }
 
-    // Each extra parent (a merge) reuses a lane already waiting for it, or opens
-    // a new one.
-    const extraParentLanes: number[] = [];
+    // Each extra parent (a merge) reuses a lane already waiting for it (keeping
+    // that branch's color), or opens a new lane with a fresh color.
+    const extraParents: { lane: number; colorId: number }[] = [];
     for (let p = 1; p < parents.length; p++) {
       const ph = parents[p];
       let lane = lanes.findIndex((h) => h === ph);
+      let colorId: number;
       if (lane === -1) {
         lane = firstFree();
         lanes[lane] = ph;
+        colorId = nextColor++;
+        laneColors[lane] = colorId;
+      } else {
+        colorId = laneColors[lane] ?? nextColor++;
+        laneColors[lane] = colorId;
       }
-      extraParentLanes.push(lane);
+      extraParents.push({ lane, colorId });
     }
 
-    // --- Build the row's drawn segments. ---
+    // --- Build the row's drawn segments (each in its branch's color). ---
     const segments: GraphSegment[] = [];
     // Top-half edges: each lane active above either arrives at the node (it was
     // waiting for this commit) or passes straight through.
     for (let i = 0; i < topLanes.length; i++) {
       if (topLanes[i] === null) continue;
       if (incoming.includes(i)) {
-        segments.push({ fromLane: i, toLane: nodeLane, color: color(i), kind: "in" });
+        segments.push({
+          fromLane: i,
+          toLane: nodeLane,
+          color: colorOf(topColors[i]),
+          kind: "in",
+        });
       } else {
-        segments.push({ fromLane: i, toLane: i, color: color(i), kind: "through" });
+        segments.push({
+          fromLane: i,
+          toLane: i,
+          color: colorOf(topColors[i]),
+          kind: "through",
+        });
       }
     }
     // Bottom-half edges leaving the node toward its parents.
     if (parents.length > 0) {
-      segments.push({ fromLane: nodeLane, toLane: nodeLane, color: color(nodeLane), kind: "out" });
+      segments.push({
+        fromLane: nodeLane,
+        toLane: nodeLane,
+        color: colorOf(nodeColorId),
+        kind: "out",
+      });
     }
-    for (const lane of extraParentLanes) {
-      segments.push({ fromLane: nodeLane, toLane: lane, color: color(lane), kind: "out" });
+    for (const { lane, colorId } of extraParents) {
+      segments.push({
+        fromLane: nodeLane,
+        toLane: lane,
+        color: colorOf(colorId),
+        kind: "out",
+      });
     }
 
     const activeNow = lanes.reduce((m, h, i) => (h !== null ? i + 1 : m), 0);
@@ -144,7 +195,7 @@ export function computeGraph(commits: GraphCommit[], cap = 8): GraphLayout {
 
     rows.push({
       nodeLane,
-      nodeColor: color(nodeLane),
+      nodeColor: colorOf(nodeColorId),
       segments,
       lanes: laneCount,
       isMerge: parents.length > 1,


### PR DESCRIPTION
## Summary

Brings the desktop **History tab** branch graph in line with VS Code (the same
visual treatment we just did for the mobile graph). The log layer was already
correct — git2 `Sort::TOPOLOGICAL | TIME` / CLI `--topo-order`, offset paging,
no merge-shortstat parsing — so **only the graph's visuals changed**.

## Affected component(s)

- [ ] `shared`
- [ ] `bridge`
- [ ] `relay`
- [x] `uxnandesktop` — Tauri desktop app
- [ ] `uxnanmobile`
- [x] Cross-cutting / tooling / docs

## Type of change

- [x] `feat` — VS Code-style graph visuals
- [x] `chore` — package-lock metadata sync
- [x] `docs` — architecture/02c + CHANGELOG

## What changed

- **Branch-stable lane colors** (`src/lib/gitGraph.ts`): lanes were colored by
  *column index*, so two unrelated branches sharing a column looked like one.
  Each lane now carries a color id assigned at birth and kept for its whole life
  (a reused lane gets a fresh one), so a branch keeps its color across column
  shifts — like VS Code.
- **Rounded-step connectors + ringed merge nodes**
  (`src/lib/components/HistoryPanel.svelte`): branch/merge edges are drawn as
  VS Code-style rounded steps (vertical → quarter-arc → horizontal) instead of
  straight diagonals; merge commits render as a solid dot with a separate outer
  ring (with a halo that clears crossing lines).
- **`chore(build)`**: re-derived `uxnandesktop/package-lock.json` so its
  metadata (version 0.0.1, license MPL-2.0) matches `package.json`.

## How was it tested?

1. `cd uxnandesktop && npm run check` (svelte-kit sync + svelte-check) → 0
   errors, 0 warnings.
2. Manual, on the History tab of this repo (reviewed with the maintainer):
   commits and graph render correctly, lanes keep their color across columns,
   merge nodes are ringed, connectors are rounded — close to VS Code.

## Checklist

- [x] Lint/check passes for the touched component (`svelte-check`).
- [ ] Tests added/updated — no frontend test harness exists yet (tracked in
      `FOR-DEV.md`); the graph algorithm is pure and was verified manually.
- [x] `CHANGELOG.md` updated.
- [x] Docs / `architecture/` updated (`02c-git-worktrees.md` §6.4).
- [x] Commits follow Conventional Commits.
- [ ] Not a `uxnanmobile` release.
- [x] No `shared` contract change.
