### PR TITLE
feat(ui): NE mobile UI tweaks — floating composer, stronger app-bar veil, file-tree colours, keyboard fix

### DIFF
--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -61,6 +61,32 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
     `AlertDialog`s. Reused by the editor.
 
 ### Changed
+- **Floating composer over a scroll veil (conversation + git screens).** The
+  message composer and the git commit bar no longer sit on a solid surface
+  band. They now float over the timeline / file list — which scrolls *under*
+  them — backed by a `NeComposerVeil`: a vertical surface gradient that is
+  transparent at the top (so content shows through as it scrolls past) and
+  solid at the very bottom, mirroring the top bar's veil. The scroll reserves a
+  bottom spacer equal to the composer's live height (measured via a new
+  `MeasureHeight` widget) so the last message/card still rests just above the
+  pill, and the conversation's jump-to-latest button is lifted by the same
+  amount.
+  - `presentation/widgets/measure_size.dart` (new), `widgets/ne_top_bar.dart`
+    (`NeComposerVeil`), `screens/conversation/conversation_screen.dart`,
+    `screens/conversation/git/git_screen.dart`.
+- **Stronger Neural Expressive app-bar scroll veil.** The transparent top bar's
+  gradient is more present (top alpha `0.75 → 0.92`, mid `0.45 → 0.62`) so the
+  back/actions read confidently against busy content, while still dissolving to
+  fully transparent at the lower edge (never a solid band).
+  - `presentation/widgets/ne_top_bar.dart`.
+- **File browser conveys git state by name colour, not status dots.** The small
+  decorative grey type-dots are gone; each row's leading glyph is now the
+  file-type icon and the **name + icon colour** carries the git state —
+  tracked-unchanged files read as `onSurface`, **untracked** ones as a muted
+  grey (`onSurfaceVariant`, previously the untracked blue), and
+  added/modified/deleted/renamed in their git colour (only an actual change
+  bumps the weight). New shared `gitStatusColor` helper.
+  - `presentation/screens/conversation/files/widgets/file_tree_tile.dart`.
 - **Custom themes can now be single-brightness (light-only / dark-only) or
   dual.** A `CustomTheme` authors at least one side; the other, when needed for
   rendering, is derived from the authored side's key colors
@@ -104,6 +130,12 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
   for the slim screen. Full suite green; `flutter analyze` clean.
 
 ### Fixed
+- **File browser path bar no longer rises like a composer when a keyboard
+  shows.** The browser pins its body (`resizeToAvoidBottomInset: false`) so the
+  read-only bottom path bar stays anchored, and it drops focus when returning
+  from the file viewer so any soft keyboard left over from the viewer's inline
+  editor dismisses instead of shoving the path bar upward.
+  - `presentation/screens/conversation/files/file_browser_screen.dart`.
 - **Markdown preview no longer stretches tables vertically.** The file viewer's
   Markdown body now uses `IntrinsicColumnWidth` (was the framework default
   `FlexColumnWidth`, which squeezed every column to fit the viewport and wrapped

--- a/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
@@ -575,9 +575,8 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
                           vertical: UxnanSpacing.sm,
                         ),
                         child: TextButton.icon(
-                          onPressed: () => ref
-                              .read(threadManagerProvider)
-                              .loadMoreHistory(),
+                          onPressed: () =>
+                              ref.read(threadManagerProvider).loadMoreHistory(),
                           icon: const Icon(Icons.history_rounded, size: 18),
                           label: Text(l10n.conversationLoadEarlier),
                         ),
@@ -690,8 +689,8 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
                         if (ref.read(scrollToBottomOnSendProvider)) {
                           _forceScrollOnSend = true;
                         }
-                        final options = ref
-                            .read(threadRunOptionsProvider(widget.threadId));
+                        final options =
+                            ref.read(threadRunOptionsProvider(widget.threadId));
                         final attachments = List<ImageContent>.of(_attachments);
                         ref.read(threadManagerProvider).sendUserMessage(
                               widget.threadId,

--- a/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
@@ -32,6 +32,7 @@ import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
 import 'package:uxnan/presentation/widgets/agent_visuals.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
+import 'package:uxnan/presentation/widgets/measure_size.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 
 /// The active conversation: a Neural Expressive layout — a transparent top bar
@@ -71,6 +72,13 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
   /// Whether the "jump to latest" button is shown — true once the user has
   /// scrolled up far enough that the newest messages are off-screen.
   bool _showJumpToBottom = false;
+
+  /// Measured height of the floating bottom chrome (sign-in/cwd banners, the
+  /// diff+context info bar, attachments and the composer pill). The timeline
+  /// reserves a matching bottom spacer so the last message rests just above the
+  /// pill while content scrolls under its translucent veil; the jump-to-latest
+  /// button is lifted by the same amount.
+  double _bottomChromeHeight = 0;
 
   /// Whether the initial scroll position has been restored for this open.
   /// Guards the one-time restore so later timeline updates don't re-yank the
@@ -251,6 +259,14 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
       final max = _scroll.position.maxScrollExtent;
       if (max - _scroll.offset > 1) _scroll.jumpTo(max);
     });
+  }
+
+  /// Records the measured height of the floating bottom chrome so the timeline
+  /// reserves matching bottom padding (and the jump button clears the pill).
+  /// Ignores sub-pixel jitter to avoid a rebuild loop.
+  void _onBottomChromeHeight(double height) {
+    if (!mounted || (height - _bottomChromeHeight).abs() < 0.5) return;
+    setState(() => _bottomChromeHeight = height);
   }
 
   /// Opens the git actions screen (branch state, changed files, commit/push)
@@ -441,7 +457,6 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final colors = Theme.of(context).colorScheme;
     final timelineAsync = ref.watch(activeTimelineProvider);
     final thread = ref.watch(threadByIdProvider(widget.threadId));
     // This thread lives on a specific PC; live actions (send, git) only work
@@ -528,174 +543,171 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
 
     return Scaffold(
       body: Stack(
+        // Expand so the timeline gets tight full-screen constraints and the
+        // top bar / composer overlays keep the full row width.
+        fit: StackFit.expand,
         children: [
-          Column(
-            children: [
-              Expanded(
-                child: Stack(
+          // The streaming timeline fills the whole screen and scrolls *under*
+          // both the transparent top bar and the floating composer (reserved
+          // for by a bottom spacer of the composer's measured height).
+          // Tapping the message area dismisses the keyboard; dragging scrolls.
+          GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () => FocusScope.of(context).unfocus(),
+            child: CustomScrollView(
+              controller: _scroll,
+              physics: const BouncingScrollPhysics(
+                parent: AlwaysScrollableScrollPhysics(),
+              ),
+              slivers: [
+                // Spacer so the first content sits below the transparent top
+                // bar (it overlays the scroll).
+                SliverToBoxAdapter(child: SizedBox(height: topInset)),
+                // "Load earlier" header when the rendered window does not yet
+                // cover the whole local history.
+                if (snapshot != null &&
+                    snapshot.messages.isNotEmpty &&
+                    snapshot.hasMore)
+                  SliverToBoxAdapter(
+                    child: Center(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: UxnanSpacing.sm,
+                        ),
+                        child: TextButton.icon(
+                          onPressed: () => ref
+                              .read(threadManagerProvider)
+                              .loadMoreHistory(),
+                          icon: const Icon(Icons.history_rounded, size: 18),
+                          label: Text(l10n.conversationLoadEarlier),
+                        ),
+                      ),
+                    ),
+                  ),
+                if (snapshot == null)
+                  const SliverFillRemaining(
+                    child: Center(child: CircularProgressIndicator()),
+                  )
+                else if (snapshot.messages.isEmpty)
+                  const SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: _EmptyState(),
+                  )
+                else
+                  SliverPadding(
+                    padding: EdgeInsets.fromLTRB(
+                      contentInset,
+                      UxnanSpacing.sm,
+                      contentInset,
+                      UxnanSpacing.lg,
+                    ),
+                    sliver: SliverList.builder(
+                      itemCount: snapshot.messages.length,
+                      itemBuilder: (context, index) => MessageBubble(
+                        message: snapshot.messages[index],
+                      ),
+                    ),
+                  ),
+                // Reserve room for the floating composer + its banners so the
+                // last message rests just above the pill instead of behind it.
+                SliverToBoxAdapter(
+                  child: SizedBox(height: _bottomChromeHeight),
+                ),
+              ],
+            ),
+          ),
+          // Jump-to-latest button: appears (with a small spring) when the user
+          // has scrolled up, sitting just above the floating composer chrome.
+          Positioned(
+            right: UxnanSpacing.lg,
+            bottom: _bottomChromeHeight + UxnanSpacing.md,
+            child: _JumpToBottomButton(
+              visible: _showJumpToBottom,
+              onTap: _scrollToBottom,
+            ),
+          ),
+          // The floating bottom chrome — sign-in / cwd banners, the diff+context
+          // info bar, attachments, and the composer pill — painted over a
+          // gradient veil (transparent at the top, so the timeline shows
+          // through as it scrolls under it; solid at the very bottom). Its
+          // measured height feeds the scroll's bottom spacer above.
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: MeasureHeight(
+              onChange: _onBottomChromeHeight,
+              child: NeComposerVeil(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    // Tapping the message area dismisses the keyboard (unfocus
-                    // the composer); dragging still scrolls.
-                    GestureDetector(
-                      behavior: HitTestBehavior.translucent,
-                      onTap: () => FocusScope.of(context).unfocus(),
-                      child: CustomScrollView(
-                        controller: _scroll,
-                        physics: const BouncingScrollPhysics(
-                          parent: AlwaysScrollableScrollPhysics(),
-                        ),
-                        slivers: [
-                          // Spacer so the first content sits below the
-                          // transparent top bar (it overlays the scroll).
-                          SliverToBoxAdapter(child: SizedBox(height: topInset)),
-                          // "Load earlier" header when the rendered window does
-                          // not yet cover the whole local history.
-                          if (snapshot != null &&
-                              snapshot.messages.isNotEmpty &&
-                              snapshot.hasMore)
-                            SliverToBoxAdapter(
-                              child: Center(
-                                child: Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    vertical: UxnanSpacing.sm,
-                                  ),
-                                  child: TextButton.icon(
-                                    onPressed: () => ref
-                                        .read(threadManagerProvider)
-                                        .loadMoreHistory(),
-                                    icon: const Icon(
-                                      Icons.history_rounded,
-                                      size: 18,
-                                    ),
-                                    label: Text(l10n.conversationLoadEarlier),
-                                  ),
-                                ),
-                              ),
-                            ),
-                          if (snapshot == null)
-                            const SliverFillRemaining(
-                              child: Center(child: CircularProgressIndicator()),
-                            )
-                          else if (snapshot.messages.isEmpty)
-                            const SliverFillRemaining(
-                              hasScrollBody: false,
-                              child: _EmptyState(),
-                            )
-                          else
-                            SliverPadding(
-                              padding: EdgeInsets.fromLTRB(
-                                contentInset,
-                                UxnanSpacing.sm,
-                                contentInset,
-                                UxnanSpacing.lg,
-                              ),
-                              sliver: SliverList.builder(
-                                itemCount: snapshot.messages.length,
-                                itemBuilder: (context, index) => MessageBubble(
-                                  message: snapshot.messages[index],
-                                ),
-                              ),
-                            ),
-                        ],
+                    // Sign-in / vanished-cwd warnings stay above the composer
+                    // (not in the scrolling list) so they remain visible.
+                    if (_cwdMissing)
+                      const _Centered(child: _CwdMissingBanner()),
+                    if (requiresLogin && thread != null)
+                      _Centered(
+                        child: _LoginRequiredBanner(agentId: thread.agentId),
                       ),
-                    ),
-                    // Bottom scroll veil mirroring the top bar's: the last
-                    // messages fade into the surface just above the composer.
-                    Positioned(
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      child: IgnorePointer(
-                        child: Container(
-                          height: UxnanSpacing.xl,
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: [
-                                colors.surface.withValues(alpha: 0),
-                                colors.surface,
-                              ],
-                            ),
-                          ),
+                    if (lastEdits != null || environment.showContext)
+                      _Centered(
+                        child: _ComposerInfoBar(
+                          edits: lastEdits,
+                          showContext: environment.showContext,
+                          hasContext: environment.hasContext,
+                          percent: environment.contextPercent,
+                          tokenLabel: environment.contextTokensLabel,
+                          mode: contextMode,
                         ),
                       ),
-                    ),
-                    // Jump-to-latest button: appears (with a small spring) over
-                    // the last messages when the user has scrolled up, so the
-                    // bottom of a long/streaming conversation is one tap away.
-                    Positioned(
-                      right: UxnanSpacing.lg,
-                      bottom: UxnanSpacing.md,
-                      child: _JumpToBottomButton(
-                        visible: _showJumpToBottom,
-                        onTap: _scrollToBottom,
+                    if (_attachments.isNotEmpty)
+                      _Centered(
+                        child: _AttachmentStrip(
+                          attachments: _attachments,
+                          onRemove: _removeAttachment,
+                        ),
                       ),
+                    ComposerBar(
+                      enabled: connectedHere && !_cwdMissing,
+                      hasAttachments: _attachments.isNotEmpty,
+                      // While the agent is producing a turn, Send becomes
+                      // Stop — cancels the turn (without closing the thread).
+                      running: running,
+                      onStop: () => ref
+                          .read(threadManagerProvider)
+                          .cancelTurn(widget.threadId),
+                      onPlus: hasTurnTools
+                          ? () => _openTurnTools(
+                                runOptions,
+                                showAttach: showAttach,
+                                showApproval: showApproval,
+                              )
+                          : null,
+                      onSend: (text) {
+                        // Honor the scroll-to-latest-on-send setting: arm a
+                        // forced scroll so the user sees their message even if
+                        // scrolled up.
+                        if (ref.read(scrollToBottomOnSendProvider)) {
+                          _forceScrollOnSend = true;
+                        }
+                        final options = ref
+                            .read(threadRunOptionsProvider(widget.threadId));
+                        final attachments = List<ImageContent>.of(_attachments);
+                        ref.read(threadManagerProvider).sendUserMessage(
+                              widget.threadId,
+                              text,
+                              options: options,
+                              attachments: attachments,
+                            );
+                        if (_attachments.isNotEmpty) {
+                          setState(_attachments.clear);
+                        }
+                      },
                     ),
                   ],
                 ),
               ),
-              // Sign-in warning: the agent isn't logged in on this PC, so
-              // turns won't run until the user signs into its CLI there. Kept
-              // above the composer (not in the scrolling list) so it stays
-              // visible.
-              if (_cwdMissing) const _Centered(child: _CwdMissingBanner()),
-              if (requiresLogin && thread != null)
-                _Centered(child: _LoginRequiredBanner(agentId: thread.agentId)),
-              if (lastEdits != null || environment.showContext)
-                _Centered(
-                  child: _ComposerInfoBar(
-                    edits: lastEdits,
-                    showContext: environment.showContext,
-                    hasContext: environment.hasContext,
-                    percent: environment.contextPercent,
-                    tokenLabel: environment.contextTokensLabel,
-                    mode: contextMode,
-                  ),
-                ),
-              if (_attachments.isNotEmpty)
-                _Centered(
-                  child: _AttachmentStrip(
-                    attachments: _attachments,
-                    onRemove: _removeAttachment,
-                  ),
-                ),
-              ComposerBar(
-                enabled: connectedHere && !_cwdMissing,
-                hasAttachments: _attachments.isNotEmpty,
-                // While the agent is producing a turn, Send becomes Stop —
-                // cancels the turn (without closing the thread).
-                running: running,
-                onStop: () =>
-                    ref.read(threadManagerProvider).cancelTurn(widget.threadId),
-                onPlus: hasTurnTools
-                    ? () => _openTurnTools(
-                          runOptions,
-                          showAttach: showAttach,
-                          showApproval: showApproval,
-                        )
-                    : null,
-                onSend: (text) {
-                  // Honor the scroll-to-latest-on-send setting: arm a forced
-                  // scroll so the user sees their message even if scrolled up.
-                  if (ref.read(scrollToBottomOnSendProvider)) {
-                    _forceScrollOnSend = true;
-                  }
-                  final options =
-                      ref.read(threadRunOptionsProvider(widget.threadId));
-                  final attachments = List<ImageContent>.of(_attachments);
-                  ref.read(threadManagerProvider).sendUserMessage(
-                        widget.threadId,
-                        text,
-                        options: options,
-                        attachments: attachments,
-                      );
-                  if (_attachments.isNotEmpty) {
-                    setState(_attachments.clear);
-                  }
-                },
-              ),
-            ],
+            ),
           ),
           // Transparent NE top bar overlaid above the scrolling content.
           Positioned(

--- a/uxnanmobile/lib/presentation/screens/conversation/files/file_browser_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/files/file_browser_screen.dart
@@ -88,6 +88,13 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
     final anyExpanded = _anyExpanded(rootAsync.value);
 
     return Scaffold(
+      // The browser has no text input of its own — the persistent path bar at
+      // the bottom is read-only chrome, not a composer. If a stray soft
+      // keyboard lingers (e.g. when returning from the file viewer), it must
+      // NOT shove the path bar upward as if it were an input. Pinning the body
+      // (no bottom-inset resize) keeps the path bar anchored; we also drop
+      // focus when returning from the viewer so the keyboard dismisses.
+      resizeToAvoidBottomInset: false,
       body: Stack(
         // StackFit.expand keeps the bar at the full row width — the
         // default loose fit sizes the stack to its non-Positioned child
@@ -287,20 +294,25 @@ class _FileBrowserScreenState extends ConsumerState<FileBrowserScreen> {
                   node: entry.node,
                   depth: entry.depth,
                   showExtension: showExtension,
-                  onTap: () {
+                  onTap: () async {
                     if (entry.node.isDir) {
                       unawaited(
                         manager.toggleDirectory(widget.cwd, entry.node.path),
                       );
                     } else {
-                      unawaited(
-                        FileViewerScreen.push(
-                          context,
-                          cwd: widget.cwd,
-                          path: entry.node.path,
-                          node: entry.node,
-                        ),
+                      await FileViewerScreen.push(
+                        context,
+                        cwd: widget.cwd,
+                        path: entry.node.path,
+                        node: entry.node,
                       );
+                      // Returning from the viewer can leave a soft keyboard up
+                      // (e.g. after using its inline editor); drop focus so it
+                      // dismisses and the read-only path bar never reads as a
+                      // composer.
+                      if (context.mounted) {
+                        FocusManager.instance.primaryFocus?.unfocus();
+                      }
                     }
                   },
                 );

--- a/uxnanmobile/lib/presentation/screens/conversation/files/widgets/file_tree_tile.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/files/widgets/file_tree_tile.dart
@@ -5,40 +5,29 @@ import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
 
-/// Visual treatment for a tree tile (icon + accent color) by [GitFileStatus].
+/// The name/icon color for a file or folder by its [GitFileStatus].
 ///
-/// The color follows the rest of the app's git chrome: added/modified/
-/// renamed/unstaged use the same `UxnanColors` tokens as the diff view in
-/// `GitScreen`; untracked gets the untracked blue; tracked (no change) is the
-/// neutral on-surface-variant tone. Untracked files share the untracked color
-/// so the eye picks them up immediately.
-({IconData icon, Color color}) gitFileStatusVisuals(GitFileStatus? status) {
-  switch (status) {
-    case GitFileStatus.added:
-      return (icon: Icons.add_circle_outline, color: UxnanColors.gitAdded);
-    case GitFileStatus.modified:
-      return (icon: Icons.edit_outlined, color: UxnanColors.gitModified);
-    case GitFileStatus.deleted:
-      return (icon: Icons.remove_circle_outline, color: UxnanColors.gitDeleted);
-    case GitFileStatus.renamed:
-      return (
-        icon: Icons.drive_file_move_outline,
-        color: UxnanColors.gitModified
-      );
-    case GitFileStatus.untracked:
-      return (icon: Icons.fiber_new_outlined, color: UxnanColors.gitUntracked);
-    case null:
-      return (
-        icon: Icons.insert_drive_file_outlined,
-        color: UxnanColors.onSurfaceMuted
-      );
-  }
+/// Communicates git state through colour, not extra glyphs:
+/// - tracked, unchanged (`null`) → [ColorScheme.onSurface] (the regular,
+///   confident text tone);
+/// - **untracked** → [ColorScheme.onSurfaceVariant] — a distinguishable muted
+///   grey so files git isn't tracking read as clearly de-emphasised;
+/// - added/modified/renamed/deleted → the matching `UxnanColors` git token
+///   (same palette as the diff view in `GitScreen`).
+Color gitStatusColor(GitFileStatus? status, ColorScheme colors) {
+  return switch (status) {
+    GitFileStatus.added => UxnanColors.gitAdded,
+    GitFileStatus.modified => UxnanColors.gitModified,
+    GitFileStatus.renamed => UxnanColors.gitModified,
+    GitFileStatus.deleted => UxnanColors.gitDeleted,
+    GitFileStatus.untracked => colors.onSurfaceVariant,
+    null => colors.onSurface,
+  };
 }
 
-/// Returns the icon for a directory or file extension (best-effort). The icon
-/// is purely decorative — the file's git status is painted separately as a
-/// leading dot — so the file type is communicated by glyph and the git state
-/// by color.
+/// Returns the icon for a directory or file extension (best-effort). The file
+/// type is communicated by the glyph; the git state is communicated by the
+/// glyph + name colour (see [gitStatusColor]).
 ({IconData icon}) fileTypeVisuals({
   required String name,
   required FileEntryType type,
@@ -166,9 +155,12 @@ const _codeExts = [
   '.tf', //
 ];
 
-/// A single row in the file browser: a leading icon, a name (optionally with
-/// the git status painted as the name color), the path, an optional git
-/// status pill on the right, and a trailing chevron for directories.
+/// A single row in the file browser: a leading file-type icon, the name, its
+/// path, and a trailing chevron for directories. Git state is conveyed purely
+/// through the name + icon colour (see [gitStatusColor]) — tracked-unchanged
+/// files read as [ColorScheme.onSurface], untracked ones as a muted grey, and
+/// changed files in their git colour — so the row stays uncluttered (no extra
+/// status dots or pills).
 ///
 /// Stateless — the parent owns expansion / selection state and passes the
 /// derived booleans. Tap fires [onTap], long-press [onLongPress] when given.
@@ -208,29 +200,20 @@ class FileTreeTile extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
     final isDir = node.isDir;
     final status = node.gitStatus;
-    final visuals = gitFileStatusVisuals(status);
     final typeVisuals = fileTypeVisuals(name: node.basename, type: node.type);
     final displayName = node.displayName(showExtension: showExtension);
     final indent = depth * 16.0;
 
-    // Name color reflects git status when set; otherwise the regular text
-    // color. Untracked files get the untracked color so they pop without a
-    // bold weight change.
-    final nameColor = switch (status) {
-      GitFileStatus.added => UxnanColors.gitAdded,
-      GitFileStatus.modified => UxnanColors.gitModified,
-      GitFileStatus.deleted => UxnanColors.gitDeleted,
-      GitFileStatus.renamed => UxnanColors.gitModified,
-      GitFileStatus.untracked => UxnanColors.gitUntracked,
-      null => colors.onSurface,
-    };
-
-    // The leading icon mirrors the git status (added/edited/removed/) for
-    // files; for directories we keep the folder icon regardless of status.
-    final leadingIcon = isDir ? Icons.folder_outlined : visuals.icon;
-    final leadingColor = isDir
-        ? (status == null ? colors.onSurfaceVariant : visuals.color)
-        : visuals.color;
+    // Git state is carried by colour: tracked-unchanged → onSurface, untracked
+    // → a muted grey, changed → the git colour. The name takes that colour
+    // directly; the leading file-type icon takes it too, except a neutral
+    // (unchanged) file keeps a slightly softer icon tone than its name.
+    final statusColor = gitStatusColor(status, colors);
+    final iconColor = status == null ? colors.onSurfaceVariant : statusColor;
+    // Only an actual git *change* (added/modified/deleted/renamed) bumps the
+    // weight; untracked stays at the normal weight so it reads as quiet grey.
+    final emphasised =
+        status != null && status != GitFileStatus.untracked;
 
     return InkWell(
       onTap: onTap,
@@ -243,28 +226,13 @@ class FileTreeTile extends StatelessWidget {
         child: Row(
           children: [
             SizedBox(width: indent),
+            // The leading glyph communicates the file *type*; its colour
+            // communicates the git state.
             Icon(
-              leadingIcon,
+              typeVisuals.icon,
               size: 20,
-              color: leadingColor,
+              color: iconColor,
               semanticLabel: isDir ? 'Folder' : status?.name ?? 'File',
-            ),
-            const SizedBox(width: UxnanSpacing.sm),
-            // The leading dot: a small filled circle in the file-type color.
-            // Decorative — it groups similar files at a glance and gives the
-            // git status icon extra prominence.
-            Container(
-              width: 6,
-              height: 6,
-              decoration: BoxDecoration(
-                color: typeVisuals == const (icon: Icons.image_outlined) ||
-                        typeVisuals ==
-                            const (icon: Icons.description_outlined) ||
-                        typeVisuals == const (icon: Icons.menu_book_outlined)
-                    ? colors.onSurfaceVariant.withValues(alpha: 0.5)
-                    : colors.onSurfaceVariant.withValues(alpha: 0.25),
-                shape: BoxShape.circle,
-              ),
             ),
             const SizedBox(width: UxnanSpacing.sm),
             Expanded(
@@ -275,9 +243,9 @@ class FileTreeTile extends StatelessWidget {
                   Text(
                     displayName,
                     style: textTheme.bodyMedium?.copyWith(
-                      color: nameColor,
+                      color: statusColor,
                       fontWeight:
-                          status == null ? FontWeight.w400 : FontWeight.w500,
+                          emphasised ? FontWeight.w500 : FontWeight.w400,
                     ),
                     overflow: TextOverflow.ellipsis,
                   ),

--- a/uxnanmobile/lib/presentation/screens/conversation/files/widgets/file_tree_tile.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/files/widgets/file_tree_tile.dart
@@ -212,8 +212,7 @@ class FileTreeTile extends StatelessWidget {
     final iconColor = status == null ? colors.onSurfaceVariant : statusColor;
     // Only an actual git *change* (added/modified/deleted/renamed) bumps the
     // weight; untracked stays at the normal weight so it reads as quiet grey.
-    final emphasised =
-        status != null && status != GitFileStatus.untracked;
+    final emphasised = status != null && status != GitFileStatus.untracked;
 
     return InkWell(
       onTap: onTap,

--- a/uxnanmobile/lib/presentation/screens/conversation/git/git_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/git/git_screen.dart
@@ -13,6 +13,7 @@ import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
+import 'package:uxnan/presentation/widgets/measure_size.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 
 /// Full-screen Material 3 source-control surface for a thread's workspace.
@@ -72,6 +73,11 @@ class _GitScreenState extends ConsumerState<GitScreen> {
   bool _showDetails = false;
   bool _busy = false;
 
+  /// Measured height of the floating commit composer so the file list reserves
+  /// a matching bottom spacer and the last card rests just above it while
+  /// content scrolls under its translucent veil.
+  double _bottomChromeHeight = 0;
+
   @override
   void initState() {
     super.initState();
@@ -110,6 +116,14 @@ class _GitScreenState extends ConsumerState<GitScreen> {
     _diffs.clear();
     await ref.read(gitActionManagerProvider).refreshStatus(cwd);
     if (mounted) setState(() {});
+  }
+
+  /// Records the measured height of the floating commit composer so the file
+  /// list reserves matching bottom padding. Ignores sub-pixel jitter to avoid a
+  /// rebuild loop.
+  void _onBottomChromeHeight(double height) {
+    if (!mounted || (height - _bottomChromeHeight).abs() < 0.5) return;
+    setState(() => _bottomChromeHeight = height);
   }
 
   /// Pull-to-refresh handler: forwards to [_refresh] with the screen's `cwd`.
@@ -754,7 +768,6 @@ class _GitScreenState extends ConsumerState<GitScreen> {
         ? null
         : ref.watch(threadByIdProvider(threadId))?.worktreePath;
 
-    final colors = Theme.of(context).colorScheme;
     final topInset = NeTopBar.preferredHeight(context);
     return Scaffold(
       body: Stack(
@@ -766,140 +779,116 @@ class _GitScreenState extends ConsumerState<GitScreen> {
         // bar's Row.
         fit: StackFit.expand,
         children: [
-          Column(
-            children: [
-              Expanded(
-                child: Stack(
-                  children: [
-                    GestureDetector(
-                      behavior: HitTestBehavior.translucent,
-                      onTap: () => FocusScope.of(context).unfocus(),
-                      child: RefreshIndicator(
-                        onRefresh: _pullToRefresh,
-                        child: CustomScrollView(
-                          // Bouncing + always-scrollable matches `NeScaffold`
-                          // and the file browser so the screen feels native
-                          // on iOS and the user can drag-to-refresh even when
-                          // the content fits the viewport.
-                          physics: const BouncingScrollPhysics(
-                            parent: AlwaysScrollableScrollPhysics(),
+          // The changed-files list fills the screen and scrolls *under* the
+          // floating commit composer (reserved for by a bottom spacer of its
+          // measured height) and the transparent top bar.
+          GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () => FocusScope.of(context).unfocus(),
+            child: RefreshIndicator(
+              onRefresh: _pullToRefresh,
+              child: CustomScrollView(
+                // Bouncing + always-scrollable matches `NeScaffold` and the
+                // file browser so the screen feels native on iOS and the user
+                // can drag-to-refresh even when the content fits the viewport.
+                physics: const BouncingScrollPhysics(
+                  parent: AlwaysScrollableScrollPhysics(),
+                ),
+                slivers: [
+                  // Spacer so first content clears the overlaid bar.
+                  SliverToBoxAdapter(child: SizedBox(height: topInset)),
+                  if (state == null)
+                    SliverFillRemaining(
+                      hasScrollBody: false,
+                      child: _NoRepository(connecting: widget.cwd != null),
+                    )
+                  else ...[
+                    SliverToBoxAdapter(child: _BranchSummary(state: state)),
+                    if (files.isEmpty)
+                      const SliverToBoxAdapter(child: _CleanState())
+                    else ...[
+                      SliverToBoxAdapter(
+                        child: _SelectionBar(
+                          total: files.length,
+                          selected: _selectedPaths(files).length,
+                          onSelectAll: () => setState(_deselected.clear),
+                          onDeselectAll: () => setState(
+                            () => _deselected.addAll(files.map((f) => f.path)),
                           ),
-                          slivers: [
-                            // Spacer so first content clears the overlaid bar.
-                            SliverToBoxAdapter(
-                              child: SizedBox(height: topInset),
-                            ),
-                            if (state == null)
-                              SliverFillRemaining(
-                                hasScrollBody: false,
-                                child: _NoRepository(
-                                  connecting: widget.cwd != null,
-                                ),
-                              )
-                            else ...[
-                              SliverToBoxAdapter(
-                                child: _BranchSummary(state: state),
-                              ),
-                              if (files.isEmpty)
-                                const SliverToBoxAdapter(child: _CleanState())
-                              else ...[
-                                SliverToBoxAdapter(
-                                  child: _SelectionBar(
-                                    total: files.length,
-                                    selected: _selectedPaths(files).length,
-                                    onSelectAll: () =>
-                                        setState(_deselected.clear),
-                                    onDeselectAll: () => setState(
-                                      () => _deselected
-                                          .addAll(files.map((f) => f.path)),
-                                    ),
-                                    onDiscardSelected: _busy
-                                        ? null
-                                        : () => _discard(state, all: false),
-                                  ),
-                                ),
-                                SliverList.builder(
-                                  itemCount: files.length,
-                                  itemBuilder: (context, index) {
-                                    final file = files[index];
-                                    return _FileCard(
-                                      file: file,
-                                      selected: _isSelected(file.path),
-                                      expanded: _isExpanded(file.path),
-                                      onSelectedChanged: (value) =>
-                                          setState(() {
-                                        if (value) {
-                                          _deselected.remove(file.path);
-                                        } else {
-                                          _deselected.add(file.path);
-                                        }
-                                      }),
-                                      onExpandedChanged: (value) =>
-                                          setState(() {
-                                        if (value) {
-                                          _expanded.add(file.path);
-                                        } else {
-                                          _expanded.remove(file.path);
-                                        }
-                                      }),
-                                      onDiscard: _busy
-                                          ? null
-                                          : () => _discardOne(state, file.path),
-                                      diff: widget.cwd == null ||
-                                              !_isExpanded(file.path)
-                                          ? null
-                                          : _diffFor(widget.cwd!, file.path),
-                                    );
-                                  },
-                                ),
-                                const SliverToBoxAdapter(
-                                  child: SizedBox(height: UxnanSpacing.lg),
-                                ),
-                              ],
-                            ],
-                          ],
+                          onDiscardSelected:
+                              _busy ? null : () => _discard(state, all: false),
                         ),
                       ),
-                    ),
-                    Positioned(
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      child: IgnorePointer(
-                        child: Container(
-                          height: UxnanSpacing.xl,
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: [
-                                colors.surface.withValues(alpha: 0),
-                                colors.surface,
-                              ],
-                            ),
-                          ),
-                        ),
+                      SliverList.builder(
+                        itemCount: files.length,
+                        itemBuilder: (context, index) {
+                          final file = files[index];
+                          return _FileCard(
+                            file: file,
+                            selected: _isSelected(file.path),
+                            expanded: _isExpanded(file.path),
+                            onSelectedChanged: (value) => setState(() {
+                              if (value) {
+                                _deselected.remove(file.path);
+                              } else {
+                                _deselected.add(file.path);
+                              }
+                            }),
+                            onExpandedChanged: (value) => setState(() {
+                              if (value) {
+                                _expanded.add(file.path);
+                              } else {
+                                _expanded.remove(file.path);
+                              }
+                            }),
+                            onDiscard: _busy
+                                ? null
+                                : () => _discardOne(state, file.path),
+                            diff: widget.cwd == null || !_isExpanded(file.path)
+                                ? null
+                                : _diffFor(widget.cwd!, file.path),
+                          );
+                        },
                       ),
-                    ),
+                    ],
                   ],
+                  // Reserve room for the floating commit composer so the last
+                  // card rests just above it instead of behind it.
+                  SliverToBoxAdapter(
+                    child: SizedBox(height: _bottomChromeHeight),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          // The floating commit composer over a gradient veil — transparent at
+          // the top so the file list shows through as it scrolls under it,
+          // solid at the very bottom. Its measured height feeds the scroll
+          // spacer above so the last card never hides behind it.
+          if (state != null)
+            Positioned(
+              left: 0,
+              right: 0,
+              bottom: 0,
+              child: MeasureHeight(
+                onChange: _onBottomChromeHeight,
+                child: NeComposerVeil(
+                  child: _CommitBar(
+                    state: state,
+                    title: _title,
+                    description: _description,
+                    coAuthor: _coAuthor,
+                    showDetails: _showDetails,
+                    busy: _busy,
+                    onToggleDetails: () =>
+                        setState(() => _showDetails = !_showDetails),
+                    onCommit: () => _commit(state),
+                    onPush: () => _push(state),
+                    onUndoCommit: () => _undoCommit(state),
+                  ),
                 ),
               ),
-              if (state != null)
-                _CommitBar(
-                  state: state,
-                  title: _title,
-                  description: _description,
-                  coAuthor: _coAuthor,
-                  showDetails: _showDetails,
-                  busy: _busy,
-                  onToggleDetails: () =>
-                      setState(() => _showDetails = !_showDetails),
-                  onCommit: () => _commit(state),
-                  onPush: () => _push(state),
-                  onUndoCommit: () => _undoCommit(state),
-                ),
-            ],
-          ),
+            ),
           Positioned(
             top: 0,
             left: 0,

--- a/uxnanmobile/lib/presentation/widgets/measure_size.dart
+++ b/uxnanmobile/lib/presentation/widgets/measure_size.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+/// Reports its child's rendered **height** to [onChange] after every layout in
+/// which it changes.
+///
+/// Used to let a floating bottom chrome (the composer pill + its banners) tell
+/// the scroll view behind it how much bottom padding to reserve, so content can
+/// scroll *under* the translucent composer veil while the last item still rests
+/// just above the pill. The callback is fired from a post-frame callback (never
+/// synchronously during layout) so a `setState` in the parent is safe.
+class MeasureHeight extends SingleChildRenderObjectWidget {
+  /// Creates a [MeasureHeight] that wraps [child] and reports its height.
+  const MeasureHeight({
+    required this.onChange,
+    required Widget super.child,
+    super.key,
+  });
+
+  /// Called with the child's height whenever it changes between layouts.
+  final ValueChanged<double> onChange;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderMeasureHeight(onChange);
+
+  @override
+  void updateRenderObject(BuildContext context, RenderObject renderObject) {
+    (renderObject as _RenderMeasureHeight).onChange = onChange;
+  }
+}
+
+class _RenderMeasureHeight extends RenderProxyBox {
+  _RenderMeasureHeight(this.onChange);
+
+  ValueChanged<double> onChange;
+  double? _lastHeight;
+
+  @override
+  void performLayout() {
+    super.performLayout();
+    final height = size.height;
+    if (_lastHeight != height) {
+      _lastHeight = height;
+      // Defer: mutating parent state synchronously during layout throws.
+      SchedulerBinding.instance.addPostFrameCallback((_) => onChange(height));
+    }
+  }
+}

--- a/uxnanmobile/lib/presentation/widgets/ne_top_bar.dart
+++ b/uxnanmobile/lib/presentation/widgets/ne_top_bar.dart
@@ -43,23 +43,22 @@ class NeTopBar extends StatelessWidget {
     return Container(
       padding: EdgeInsets.only(top: topInset),
       decoration: BoxDecoration(
-        // A subtle scroll veil: the surface is mostly transparent
-        // (peaks at 0.75 alpha) so the content underneath reads through
-        // the bar instead of looking like a solid app-bar band. The top
-        // is just opaque enough to give the back / actions a stable
-        // background; the bottom dissolves quickly into the surface.
-        // Matches the conversation + file browser + git screen chrome
-        // exactly — same alpha curve everywhere so no screen reads as a
-        // solid app-bar band over its content.
+        // A scroll veil: a vertical surface gradient so the content
+        // underneath reads through the bar instead of looking like a solid
+        // app-bar band. The top is strong enough to give the back / actions
+        // a confident, legible background (peaks at 0.92 alpha — noticeably
+        // more present than a faint veil, but never a fully solid band); the
+        // bottom dissolves into the surface so scrolling content shows
+        // through the lower edge.
         gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
           colors: [
-            colors.surface.withValues(alpha: 0.75),
-            colors.surface.withValues(alpha: 0.45),
+            colors.surface.withValues(alpha: 0.92),
+            colors.surface.withValues(alpha: 0.62),
             colors.surface.withValues(alpha: 0),
           ],
-          stops: const [0, 0.5, 1],
+          stops: const [0, 0.55, 1],
         ),
       ),
       child: SizedBox(
@@ -75,6 +74,41 @@ class NeTopBar extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// A bottom "scroll veil" that backs a **floating composer** (the conversation
+/// composer pill, the git commit bar): a vertical surface gradient — fully
+/// transparent at the top, fading to the solid surface at the bottom — that
+/// mirrors the [NeTopBar]'s top veil. Overlay it at the bottom of the screen
+/// over a full-height scroll view (padded by its measured height) so the
+/// timeline scrolls *under* the translucent upper edge and the composer reads
+/// as a floating pill instead of a solid app-bar-style band.
+class NeComposerVeil extends StatelessWidget {
+  /// Creates a [NeComposerVeil] wrapping the floating chrome [child].
+  const NeComposerVeil({required this.child, super.key});
+
+  /// The floating chrome (banners + composer pill) painted over the veil.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            colors.surface.withValues(alpha: 0),
+            colors.surface.withValues(alpha: 0.7),
+            colors.surface,
+          ],
+          stops: const [0, 0.45, 1],
+        ),
+      ),
+      child: child,
     );
   }
 }


### PR DESCRIPTION
Neural Expressive UI tweaks in `uxnanmobile/`, reviewed on-device against the live app. **No contract / behaviour-API changes — UI only.**

## Changes

### 1 · Stronger NE app-bar scroll veil
`ne_top_bar.dart` — the transparent top bar's gradient is more present (top alpha `0.75 → 0.92`, mid `0.45 → 0.62`) so the back/actions stay legible over busy content, while still dissolving to fully transparent at the lower edge (never a solid band).

### 2 · Floating composer over a scroll veil (conversation + git screens)
The message composer and the git commit bar no longer sit on a solid surface band — they **float** over the timeline / file list, which now scrolls *under* them, backed by a new `NeComposerVeil` (surface gradient: transparent at the top, solid at the bottom, mirroring the top bar). The scroll reserves a bottom spacer equal to the composer's **live** height — measured by a new `MeasureHeight` widget — so the last message/card still rests just above the pill, and the conversation's jump-to-latest button is lifted to match.
- new `presentation/widgets/measure_size.dart`, `widgets/ne_top_bar.dart` (`NeComposerVeil`), `conversation_screen.dart`, `git/git_screen.dart`.

### 3 · File browser path bar no longer rises like a composer (fix)
A soft keyboard left over from the file viewer's inline editor could shove the read-only bottom path bar upward. Pin the body (`resizeToAvoidBottomInset: false`) so it stays anchored, and drop focus when returning from the viewer so any stray keyboard dismisses.
- `files/file_browser_screen.dart`.

### 4 · File tree conveys git state by name colour, not status dots
The decorative grey type-dots are gone; the leading glyph is now the file-type icon and the **name + icon colour** carries the git state — tracked-unchanged → `onSurface`, **untracked → muted grey** (`onSurfaceVariant`, previously the untracked blue), changed → its git colour (only an actual change bumps the weight). New shared `gitStatusColor` helper; removed the now-unused `gitFileStatusVisuals`.
- `files/widgets/file_tree_tile.dart`.

## Verification
- `flutter analyze` (affected dirs): no issues.
- `flutter test` `file_tree_tile_test.dart`: all pass.
- On-device review of the floating composer / git commit bar (keyboard, scroll-under, banners) pending merge.

## Notes
- Docs: `uxnanmobile/CHANGELOG.md` updated under `[Unreleased]`.
- Not in scope: an in-browser file search was considered and intentionally dropped (the bridge has no recursive file-search RPC; a loaded-tree-only search would be too limited).