### PR TITLE
fix(git): history graph missing commits + phantom lanes (bridge log + mobile graph)

### DIFF
--- a/architecture/02a-system-architecture.md
+++ b/architecture/02a-system-architecture.md
@@ -1601,10 +1601,16 @@ async function handleGitCreateBranch({ cwd, name }) { ... }
 async function handleGitCreateWorktree({ cwd, branch, path, managed }) { ... }
 async function handleGitStackedPublish({ cwd, message, remote, branch }) { ... }
 async function handleGitLog({ cwd, limit, cursor, ref }) {
-  // git log --format=...%x1e --decorate=full -z --shortstat -n (limit+1) [cursor^|ref]
-  // Paginación por cursor: cursor^ excluye el cursor y devuelve los commits
-  // estrictamente más antiguos. Devuelve {commits, hasMore, nextCursor}.
+  // git log <ref|HEAD> --topo-order --format=...%x1e --decorate=full -z
+  //   --shortstat -n (limit+1) --skip <offset>
+  // Orden TOPOLÓGICO (no por fecha) → grafo limpio, padres justo tras el hijo.
+  // Paginación por OFFSET: `cursor` es un token opaco (= nº de commits a saltar);
+  //   nextCursor = offset+limit. (El antiguo `cursor^` saltaba el 2º padre de un
+  //   merge y PERDÍA commits en un DAG.) Devuelve {commits, hasMore, nextCursor}.
   // %D (--decorate=full) → refs[] por commit (HEAD/ramas/remotas/tags).
+  // Parser robusto: un merge no emite --shortstat, así que el record siguiente
+  //   empieza con el terminador -z sin stat — se quita el NUL líder antes de
+  //   separar campos (si no, se descartaba el commit posterior a un merge).
   // Repo fresco (sin HEAD) → {commits:[], hasMore:false} (no error).
 }
 async function handleGitCommitShow({ cwd, sha }) {

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — git/log dropped commits & produced a tangled graph
+- **`git/log` no longer loses commits or invents lanes on a branchy history.**
+  Three coupled fixes in `src/git/git-service.ts`:
+  - **Topological order** (`--topo-order`) instead of git's default date order,
+    so a commit's parents immediately follow it — the phone's swimlane graph
+    stays clean (no lanes dangling across unrelated commits → no phantom lanes)
+    and matches `git log --graph` / VS Code.
+  - **Offset pagination** (`--skip <n>`, `cursor` = an opaque offset token)
+    replacing the previous `<cursor>^` (first-parent) scheme, which skipped a
+    merge's second-parent history across page boundaries and silently dropped
+    real commits.
+  - **Merge-safe shortstat parsing.** Merge (and empty) commits emit no
+    `--shortstat`, so the record after a merge began with a bare `-z` NUL
+    terminator; the parser assumed a `\n<stat>\n` prefix, mis-split the fields
+    and dropped that commit. It now strips the leading NUL before splitting.
+  - Tests: a merge-DAG pagination test asserting no commit is dropped.
+
 ### Added — richer git history (refs + commit detail)
 - **`git/log` now decorates commits with refs.** `GitService.log` runs with
   `--decorate=full` and a `%D` field, parsed into `GitCommit.refs[]`

--- a/bridge/src/git/git-service.ts
+++ b/bridge/src/git/git-service.ts
@@ -92,6 +92,11 @@ export class GitService {
     options: { limit?: number; cursor?: string; ref?: string } = {},
   ): Promise<GitLogResult> {
     const limit = Math.max(1, Math.min(options.limit ?? 50, 500));
+    // `cursor` is an opaque pagination token: the offset (commit count) to skip.
+    // Offset paging over a *topologically ordered* log is the only correct way
+    // to page a DAG — the previous `<cursor>^` (first-parent) scheme silently
+    // dropped a merge's second-parent history across page boundaries.
+    const offset = Math.max(0, Math.trunc(Number(options.cursor ?? 0)) || 0);
     // Fetch one extra commit so we can tell `hasMore` without a second git
     // invocation (the extra is dropped from the result).
     const fetchLimit = limit + 1;
@@ -110,6 +115,12 @@ export class GitService {
     ].join('%x00');
     const args = [
       'log',
+      options.ref ?? 'HEAD',
+      // Topological order so a commit's parents immediately follow it: the
+      // phone's swimlane graph stays clean (no lanes left dangling across
+      // unrelated commits, which produced phantom lanes) and matches the
+      // VS Code / `git log --graph` layout.
+      '--topo-order',
       `--format=${format}%x1e`,
       // Full ref names so `%D` is unambiguous (refs/heads vs refs/remotes vs
       // refs/tags) — a local branch named `feat/x` won't be mistaken for a
@@ -119,20 +130,27 @@ export class GitService {
       '--shortstat',
       '-n',
       String(fetchLimit),
-      // Cursor: when set, start from the cursor's parent (`<cursor>^`) so
-      // the cursor itself is excluded and we get strictly older commits.
-      // The `^` notation is a shorthand for `~1` and works for both
-      // regular and merge commits.
-      options.cursor ? `${options.cursor}^` : (options.ref ?? 'HEAD'),
+      '--skip',
+      String(offset),
     ];
     try {
       const { stdout } = await runGit(cwd, args);
-      return parseLogOutput(stdout, limit);
+      const { commits, hasMore } = parseLogOutput(stdout, limit);
+      return {
+        commits,
+        hasMore,
+        // Next page = skip everything shown so far. Stable across calls because
+        // topo-order is deterministic for a fixed repo state.
+        ...(hasMore ? { nextCursor: String(offset + limit) } : {}),
+      };
     } catch (err) {
       // A fresh repo (no commits yet) has no HEAD — `git log HEAD` exits
       // non-zero. That's not an error from the caller's perspective: it
       // just means there's nothing to list.
-      if (err instanceof GitCommandError && /unknown revision|bad revision/i.test(err.stderr)) {
+      if (
+        err instanceof GitCommandError &&
+        /unknown revision|bad revision|does not have any commits/i.test(err.stderr)
+      ) {
         return { commits: [], hasMore: false };
       }
       throw err;
@@ -640,22 +658,39 @@ function autoStashLabel(branch: string): string {
  * fields. We pair them by deferring the shortstat attachment by one record.
  */
 function parseLogOutput(stdout: string, limit: number): GitLogResult {
-  // Trim the trailing 0x1E so the last record isn't empty, then split.
-  const records = stdout.replace(/\x1e+$/, '').split('\x1e');
-  // Each entry holds the parsed commit (without stats) and the shortstat
-  // that belongs to it. We populate the shortstat retroactively when the
-  // next record provides it.
+  // Split into records by our 0x1E separator. Layout per commit:
+  //   <commit fields, NUL-separated>\x1e[<this commit's shortstat>]<NUL>...
+  // so after splitting, record 0 is the first commit's fields, and every later
+  // record is `<previous commit's shortstat>\x00<this commit's fields>`. The
+  // shortstat is EMPTY for commits git emits none for — notably merge commits
+  // (and empty commits). The previous parser assumed a `\x00\n<stat>\n` prefix
+  // was always present, so the record right after a merge began with a bare
+  // `\x00`, the field split shifted by one, `sha` came out empty, and that
+  // commit was silently dropped — which lost real commits once `--topo-order`
+  // put merges inline. This parser instead splits at the first NUL.
+  const records = stdout.split('\x1e');
+  // Each entry holds the parsed commit (without stats) and the shortstat that
+  // belongs to it (populated retroactively from the next record's prefix).
   const parsed: { commit: Omit<GitCommit, 'stats'>; shortstat: string }[] = [];
   for (const rawRecord of records) {
-    if (!rawRecord.trim()) continue;
-    // Peel off a leading `\x00\n<shortstat>\n` (present on every record
-    // except the first). The shortstat belongs to the PREVIOUS commit.
-    let shortstat = '';
+    // Layout: each commit is `<fields…>%x1e` then the `-z` NUL terminator, then
+    // (only when git emits one) `\n<shortstat>\n`. So after splitting on %x1e,
+    // record 0 is the first commit's fields, and every later record begins with
+    // the previous commit's NUL terminator, then optionally that commit's
+    // shortstat, then this commit's fields. Merges (and empty commits) emit NO
+    // shortstat — we must still strip the leading NUL, otherwise the field
+    // split shifts and the commit right after a merge is dropped.
     let record = rawRecord;
-    const shortstatMatch = rawRecord.match(/^\x00\n(.*?)\n([\s\S]*)$/);
-    if (shortstatMatch) {
-      shortstat = shortstatMatch[1] ?? '';
-      record = shortstatMatch[2] ?? '';
+    let shortstat = '';
+    if (record.startsWith('\x00')) record = record.slice(1);
+    const statMatch = record.match(/^\n([^\n]*)\n([\s\S]*)$/);
+    if (statMatch) {
+      shortstat = statMatch[1] ?? '';
+      record = statMatch[2] ?? '';
+    }
+    // The shortstat (when present) belongs to the PREVIOUS commit.
+    if (shortstat && parsed.length > 0) {
+      parsed[parsed.length - 1]!.shortstat = shortstat;
     }
     const parts = record.split('\x00');
     const [
@@ -671,12 +706,7 @@ function parseLogOutput(stdout: string, limit: number): GitLogResult {
       decorationRaw,
       messageRaw,
     ] = parts;
-    if (!sha) continue;
-    // Attach the shortstat from THIS record to the PREVIOUS commit (it
-    // appeared after that commit in the git output).
-    if (parsed.length > 0 && shortstat) {
-      parsed[parsed.length - 1]!.shortstat = shortstat;
-    }
+    if (!sha || !sha.trim()) continue;
     const parents = parentsRaw ? parentsRaw.trim().split(/\s+/).filter(Boolean) : [];
     const message = messageRaw ?? '';
     // Message: first line is the title, the rest (after a blank line) is
@@ -728,12 +758,9 @@ function parseLogOutput(stdout: string, limit: number): GitLogResult {
   });
   const hasMore = commits.length > limit;
   const trimmed = hasMore ? commits.slice(0, limit) : commits;
-  const nextCursor = hasMore ? trimmed[trimmed.length - 1]?.sha : undefined;
-  return {
-    commits: trimmed,
-    hasMore,
-    ...(nextCursor ? { nextCursor } : {}),
-  };
+  // `nextCursor` is added by `GitService.log` (offset-based); the parser only
+  // reports the page contents + whether a further page exists.
+  return { commits: trimmed, hasMore };
 }
 
 /**

--- a/bridge/test/git/git-service.test.ts
+++ b/bridge/test/git/git-service.test.ts
@@ -382,6 +382,44 @@ test('log paginates by cursor and reports hasMore + nextCursor', async () => {
   await rmrf(dir);
 });
 
+test('log pages a merge DAG without dropping any commit', async () => {
+  const dir = await newRepo();
+  await writeFile(join(dir, 'a.txt'), 'a');
+  await git.commit(dir, 'A (root)');
+  await git.createBranch(dir, 'feature');
+  await git.checkout(dir, 'feature');
+  await writeFile(join(dir, 'b.txt'), 'b');
+  await git.commit(dir, 'B (feature)');
+  await git.checkout(dir, 'main');
+  await writeFile(join(dir, 'c.txt'), 'c');
+  await git.commit(dir, 'C (main)');
+  // Merge feature into main, forcing a real merge commit (two parents).
+  await runGit(dir, ['merge', '--no-ff', '-m', 'M (merge feature)', 'feature']);
+
+  // Page through the whole history two at a time and collect every SHA.
+  const seen = new Set<string>();
+  const titles: string[] = [];
+  let cursor: string | undefined;
+  for (let guard = 0; guard < 10; guard++) {
+    const page = await git.log(dir, { limit: 2, ...(cursor ? { cursor } : {}) });
+    for (const c of page.commits) {
+      seen.add(c.sha);
+      titles.push(c.messageTitle);
+    }
+    if (!page.hasMore) break;
+    cursor = page.nextCursor;
+  }
+
+  // All four commits (A, B, C, merge) must appear exactly once — the old
+  // `<cursor>^` paging dropped the merge's second-parent (B) across the page
+  // boundary.
+  assert.equal(seen.size, 4);
+  assert.equal(titles.length, 4);
+  assert.ok(titles.some((t) => t.startsWith('M (merge')));
+  assert.ok(titles.some((t) => t.startsWith('B (feature)')));
+  await rmrf(dir);
+});
+
 test('log returns an empty list on a fresh repo with no commits', async () => {
   const dir = await newRepo();
   const log = await git.log(dir);

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "uxnan-monorepo",
       "version": "0.0.0",
-      "license": "UNLICENSED",
+      "license": "MPL-2.0",
       "workspaces": [
         "shared",
         "bridge",
@@ -24,8 +24,8 @@
     },
     "bridge": {
       "name": "uxnan-bridge",
-      "version": "0.1.0",
-      "license": "UNLICENSED",
+      "version": "0.0.1",
+      "license": "MPL-2.0",
       "dependencies": {
         "@uxnan/shared": "*",
         "ajv": "^8.17.1",
@@ -2611,8 +2611,8 @@
     },
     "relay": {
       "name": "uxnan-relay",
-      "version": "0.1.0",
-      "license": "UNLICENSED",
+      "version": "0.0.1",
+      "license": "MPL-2.0",
       "dependencies": {
         "@uxnan/shared": "*",
         "ws": "^8.18.0"
@@ -2632,8 +2632,8 @@
     },
     "shared": {
       "name": "@uxnan/shared",
-      "version": "0.1.0",
-      "license": "UNLICENSED",
+      "version": "0.0.1",
+      "license": "MPL-2.0",
       "dependencies": {
         "ajv": "^8.17.1"
       },

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Changed
+- **`git/log` pagination is now an opaque offset cursor** (`models/git.ts`):
+  `GitLogParams.cursor` / `GitLogResult.nextCursor` are documented as an opaque
+  token (an offset over a topologically-ordered log) instead of a commit SHA —
+  the bridge switched off the `<cursor>^` scheme that dropped commits across
+  merge boundaries. Wire shape is unchanged (still a `string`).
+
 ### Added
 - **Git commit refs + a `git/commitShow` method** (`models/git.ts`,
   `jsonrpc/methods.ts`, `jsonrpc/method-registry.ts`): `GitCommit.refs?:

--- a/shared/src/models/git.ts
+++ b/shared/src/models/git.ts
@@ -141,14 +141,18 @@ export interface GitCommit {
 }
 
 /**
- * A page of commits for a repository. Cursor-based pagination: when
- * `hasMore` is true the next page starts at `nextCursor` (a commit SHA)
- * — pass it as `GitLogParams.cursor` to fetch the previous page.
+ * A page of commits for a repository, newest-first in topological order.
+ * Pagination is by opaque cursor: when `hasMore` is true, pass `nextCursor`
+ * back as `GitLogParams.cursor` to fetch the next (older) page.
  */
 export interface GitLogResult {
   commits: GitCommit[];
   hasMore: boolean;
-  /** SHA to pass as `cursor` on the next call. Undefined when `hasMore` is false. */
+  /**
+   * Opaque pagination token to pass back as `GitLogParams.cursor` for the next
+   * page. Undefined when `hasMore` is false. (Currently an offset over a
+   * topologically-ordered log — treat it as opaque.)
+   */
   nextCursor?: string;
 }
 
@@ -158,8 +162,9 @@ export interface GitLogParams {
   /** Max commits to return. Defaults to 50 on the bridge. */
   limit?: number;
   /**
-   * Cursor for pagination. When set, returns commits strictly older than
-   * this SHA (exclusive). Omit for the first (newest) page.
+   * Opaque pagination cursor from the previous result's `nextCursor`. Omit for
+   * the first (newest) page. Paging is offset-based over a topologically
+   * ordered log, so no commit is skipped across a merge boundary.
    */
   cursor?: string;
   /**

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- **Consistent circular floating scroll buttons.** The git history's
+  back-to-top button was M3's default rounded-square `FloatingActionButton`,
+  while the conversation's scroll-to-bottom button is a circle; NE's action
+  language is circular, so both now share one widget
+  (`presentation/widgets/ne_circular_button.dart`, `secondaryContainer`).
 - **Commit detail: per-file expandable diffs.** The commit detail screen no
   longer shows one big combined diff under the file list; each touched file is
   now its own collapsible card (collapsed by default) that reveals **just that

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,18 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **Commit detail: per-file expandable diffs.** The commit detail screen no
+  longer shows one big combined diff under the file list; each touched file is
+  now its own collapsible card (collapsed by default) that reveals **just that
+  file's diff** when tapped — mirroring the clean per-file cards of the
+  version-control screen. The combined `git/commitShow` diff is split per file
+  client-side (keyed by new/old path). `NeSurface` was hoisted from
+  `git_screen.dart` into `presentation/widgets/ne_surface.dart` for reuse.
+  - `presentation/screens/conversation/git/git_commit_detail_screen.dart`,
+    `presentation/widgets/ne_surface.dart` (new), new l10n
+    `gitHistoryNoTextDiff` / `gitHistoryBinaryDiff`.
+
 ### Fixed
 - **Git history graph: no more ref-chip overflow, cleaner lanes.** In graph
   mode each row now shows a single width-capped primary ref chip (branch > tag

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,19 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Git history graph: no more ref-chip overflow, cleaner lanes.** In graph
+  mode each row now shows a single width-capped primary ref chip (branch > tag
+  > HEAD > remote) plus a `+N` marker instead of every chip inline, so a tip
+  with several refs (e.g. `HEAD`/`main`/`origin/main`) can no longer overflow
+  the row; `CommitRefChip` ellipsizes when width-capped. The graph connectors
+  are now VS Code-style rounded steps (vertical → arc → vertical) instead of
+  swoopy S-curves. (The missing-commits / phantom-lane problem itself is fixed
+  bridge-side — `git/log` now uses topological order + offset pagination + a
+  merge-safe parser; this page just consumes the corrected, opaque cursor.)
+  - `presentation/screens/conversation/git/git_history_screen.dart`,
+    `widgets/commit_ref_chip.dart`; regression widget test for the overflow.
+
 ### Added
 - **Redesigned git history + full commit detail.** The history screen is now a
   single clean, flat list (no card chrome — matches the file browser) with two

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -24,6 +24,14 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
     `gitHistoryNoTextDiff` / `gitHistoryBinaryDiff`.
 
 ### Fixed
+- **Git history graph: pass-through lanes no longer draw diagonal "hooks".** A
+  lane just crossing a row was routed to `outgoing.indexOf(occupant)`, which —
+  when the same parent occupied two lanes (a commit with multiple children,
+  common around merges) — returned the *first* lane, so the other lane bent
+  sideways every row. Pass-through lanes now draw a straight vertical in their
+  own column (lanes are never compacted), matching VS Code / the desktop graph.
+  - `presentation/screens/conversation/git/git_history_screen.dart`
+    (`_GraphPainter`).
 - **Git history graph: no more ref-chip overflow, cleaner lanes.** In graph
   mode each row now shows a single width-capped primary ref chip (branch > tag
   > HEAD > remote) plus a `+N` marker instead of every chip inline, so a tip

--- a/uxnanmobile/l10n/app_en.arb
+++ b/uxnanmobile/l10n/app_en.arb
@@ -458,6 +458,8 @@
   "gitHistoryDiffSection": "Diff",
   "gitHistoryDiffTruncated": "Diff truncated — too large to show in full.",
   "gitHistoryNoFileChanges": "No file changes in this commit.",
+  "gitHistoryNoTextDiff": "No textual changes.",
+  "gitHistoryBinaryDiff": "Binary file — no text diff.",
   "gitHistoryRenamedFrom": "from {oldPath}",
   "@gitHistoryRenamedFrom": {
     "description": "Secondary label on a renamed file in the commit detail, showing the previous path.",

--- a/uxnanmobile/l10n/app_es.arb
+++ b/uxnanmobile/l10n/app_es.arb
@@ -346,6 +346,8 @@
   "gitHistoryDiffSection": "Diff",
   "gitHistoryDiffTruncated": "Diff truncado — demasiado grande para mostrarlo completo.",
   "gitHistoryNoFileChanges": "Este commit no cambió archivos.",
+  "gitHistoryNoTextDiff": "Sin cambios de texto.",
+  "gitHistoryBinaryDiff": "Archivo binario — sin diff de texto.",
   "gitHistoryRenamedFrom": "desde {oldPath}",
   "gitHistoryDetailLoadFailed": "No se pudo cargar este commit",
   "gitHistoryEmpty": "Aún no hay commits",

--- a/uxnanmobile/lib/l10n/app_localizations.dart
+++ b/uxnanmobile/lib/l10n/app_localizations.dart
@@ -1964,6 +1964,18 @@ abstract class AppLocalizations {
   /// **'No file changes in this commit.'**
   String get gitHistoryNoFileChanges;
 
+  /// No description provided for @gitHistoryNoTextDiff.
+  ///
+  /// In en, this message translates to:
+  /// **'No textual changes.'**
+  String get gitHistoryNoTextDiff;
+
+  /// No description provided for @gitHistoryBinaryDiff.
+  ///
+  /// In en, this message translates to:
+  /// **'Binary file — no text diff.'**
+  String get gitHistoryBinaryDiff;
+
   /// Secondary label on a renamed file in the commit detail, showing the previous path.
   ///
   /// In en, this message translates to:

--- a/uxnanmobile/lib/l10n/app_localizations_en.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_en.dart
@@ -1000,6 +1000,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get gitHistoryNoFileChanges => 'No file changes in this commit.';
 
   @override
+  String get gitHistoryNoTextDiff => 'No textual changes.';
+
+  @override
+  String get gitHistoryBinaryDiff => 'Binary file — no text diff.';
+
+  @override
   String gitHistoryRenamedFrom(String oldPath) {
     return 'from $oldPath';
   }

--- a/uxnanmobile/lib/l10n/app_localizations_es.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_es.dart
@@ -1002,6 +1002,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get gitHistoryNoFileChanges => 'Este commit no cambió archivos.';
 
   @override
+  String get gitHistoryNoTextDiff => 'Sin cambios de texto.';
+
+  @override
+  String get gitHistoryBinaryDiff => 'Archivo binario — sin diff de texto.';
+
+  @override
   String gitHistoryRenamedFrom(String oldPath) {
     return 'desde $oldPath';
   }

--- a/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
@@ -32,6 +32,7 @@ import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
 import 'package:uxnan/presentation/widgets/agent_visuals.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
+import 'package:uxnan/presentation/widgets/ne_circular_button.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 
 /// The active conversation: a Neural Expressive layout — a transparent top bar
@@ -1216,7 +1217,6 @@ class _JumpToBottomButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = Theme.of(context).colorScheme;
     final l10n = AppLocalizations.of(context);
     return IgnorePointer(
       ignoring: !visible,
@@ -1227,27 +1227,10 @@ class _JumpToBottomButton extends StatelessWidget {
         child: AnimatedOpacity(
           opacity: visible ? 1 : 0,
           duration: const Duration(milliseconds: 140),
-          child: Tooltip(
-            message: l10n.conversationScrollToBottom,
-            child: Material(
-              color: colors.secondaryContainer,
-              shape: const CircleBorder(),
-              elevation: 3,
-              shadowColor: colors.shadow,
-              clipBehavior: Clip.antiAlias,
-              child: InkWell(
-                onTap: onTap,
-                child: SizedBox(
-                  width: 44,
-                  height: 44,
-                  child: Icon(
-                    Icons.keyboard_arrow_down_rounded,
-                    color: colors.onSecondaryContainer,
-                    size: 26,
-                  ),
-                ),
-              ),
-            ),
+          child: NeCircularButton(
+            icon: Icons.keyboard_arrow_down_rounded,
+            tooltip: l10n.conversationScrollToBottom,
+            onTap: onTap,
           ),
         ),
       ),

--- a/uxnanmobile/lib/presentation/screens/conversation/git/git_commit_detail_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/git/git_commit_detail_screen.dart
@@ -11,6 +11,7 @@ import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
 import 'package:uxnan/presentation/widgets/expressive_progress.dart';
+import 'package:uxnan/presentation/widgets/ne_surface.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 
 /// Full-screen detail for a single commit, backed by `git/commitShow`.
@@ -145,26 +146,22 @@ class _GitCommitDetailScreenState extends ConsumerState<GitCommitDetailScreen> {
         ),
       );
     } else if (details != null) {
-      slivers
-        ..add(SliverToBoxAdapter(child: _FilesSection(files: details.files)))
-        ..add(
-          SliverToBoxAdapter(
-            child: _DiffSection(
-              diff: details.diff,
-              truncated: details.diffTruncated,
-            ),
+      slivers.add(
+        SliverToBoxAdapter(
+          child: _FilesSection(
+            files: details.files,
+            diffByPath: _splitDiffByPath(details.diff),
+            diffTruncated: details.diffTruncated,
           ),
-        );
+        ),
+      );
     }
 
     slivers.add(
       const SliverToBoxAdapter(child: SizedBox(height: UxnanSpacing.xxl)),
     );
 
-    return NeScaffold(
-      title: l10n.gitHistoryDetailsTitle,
-      slivers: slivers,
-    );
+    return NeScaffold(title: l10n.gitHistoryDetailsTitle, slivers: slivers);
   }
 }
 
@@ -257,8 +254,9 @@ class _Header extends StatelessWidget {
                 Expanded(
                   child: Text(
                     commit.sha,
-                    style: UxnanTypography.codeSmall
-                        .copyWith(color: colors.onSurfaceVariant),
+                    style: UxnanTypography.codeSmall.copyWith(
+                      color: colors.onSurfaceVariant,
+                    ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -276,8 +274,9 @@ class _Header extends StatelessWidget {
             const SizedBox(height: UxnanSpacing.md),
             Text(
               l10n.gitHistoryDetailsParents(commit.parents.length),
-              style: textTheme.labelMedium
-                  ?.copyWith(color: colors.onSurfaceVariant),
+              style: textTheme.labelMedium?.copyWith(
+                color: colors.onSurfaceVariant,
+              ),
             ),
             const SizedBox(height: UxnanSpacing.xs),
             Wrap(
@@ -328,10 +327,22 @@ class _Header extends StatelessWidget {
   }
 }
 
-/// The "N files changed" section: one row per file with status + per-file +/-.
+/// The "N files changed" section: one expandable card per file (collapsed by
+/// default), each revealing that file's own diff — mirroring the clean,
+/// per-file cards of the version-control (`GitScreen`) screen.
 class _FilesSection extends StatelessWidget {
-  const _FilesSection({required this.files});
+  const _FilesSection({
+    required this.files,
+    required this.diffByPath,
+    required this.diffTruncated,
+  });
   final List<GitCommitFile> files;
+
+  /// The commit's unified diff split per file, keyed by path (new and old).
+  final Map<String, String> diffByPath;
+
+  /// Whether the commit's overall diff was capped by the bridge.
+  final bool diffTruncated;
 
   @override
   Widget build(BuildContext context) {
@@ -358,176 +369,233 @@ class _FilesSection extends StatelessWidget {
             ),
           ),
           const SizedBox(height: UxnanSpacing.xs),
-          for (final file in files) _CommitFileRow(file: file),
+          for (final file in files)
+            Padding(
+              padding: const EdgeInsets.only(bottom: UxnanSpacing.xs),
+              child: _CommitFileCard(
+                file: file,
+                diff: diffByPath[file.path] ??
+                    (file.oldPath != null ? diffByPath[file.oldPath!] : null),
+              ),
+            ),
+          if (diffTruncated) ...[
+            const SizedBox(height: UxnanSpacing.xs),
+            Text(
+              l10n.gitHistoryDiffTruncated,
+              style: textTheme.bodySmall?.copyWith(
+                color: colors.onSurfaceVariant,
+              ),
+            ),
+          ],
         ],
       ),
     );
   }
 }
 
-/// A single file row in the commit detail.
-class _CommitFileRow extends StatelessWidget {
-  const _CommitFileRow({required this.file});
+/// A collapsible card for one file touched by the commit: a tappable header
+/// (status icon, name, rename/dir, per-file +/-, chevron) that reveals that
+/// file's own colored diff. Collapsed by default — mirrors the version-control
+/// screen's file cards.
+class _CommitFileCard extends StatefulWidget {
+  const _CommitFileCard({required this.file, this.diff});
   final GitCommitFile file;
+  final String? diff;
+
+  @override
+  State<_CommitFileCard> createState() => _CommitFileCardState();
+}
+
+class _CommitFileCardState extends State<_CommitFileCard> {
+  bool _expanded = false;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final colors = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
+    final file = widget.file;
     final (icon, color) = _statusVisual(file.status);
     final segments = file.path.split('/');
     final name = segments.isEmpty ? file.path : segments.last;
     final dir = segments.length > 1
         ? segments.sublist(0, segments.length - 1).join('/')
         : null;
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: UxnanSpacing.xs),
-      child: Row(
+    final subtitle =
+        file.oldPath != null ? l10n.gitHistoryRenamedFrom(file.oldPath!) : dir;
+
+    return NeSurface(
+      outlined: true,
+      padding: EdgeInsets.zero,
+      child: Column(
         children: [
-          Icon(icon, size: 18, color: color),
-          const SizedBox(width: UxnanSpacing.sm),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  name,
-                  style: textTheme.bodyMedium?.copyWith(color: color),
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if (file.oldPath != null)
-                  Text(
-                    l10n.gitHistoryRenamedFrom(file.oldPath!),
-                    style: UxnanTypography.codeSmall
-                        .copyWith(color: colors.onSurfaceVariant),
-                    overflow: TextOverflow.ellipsis,
-                  )
-                else if (dir != null)
-                  Text(
-                    dir,
-                    style: UxnanTypography.codeSmall
-                        .copyWith(color: colors.onSurfaceVariant),
-                    overflow: TextOverflow.ellipsis,
+          InkWell(
+            onTap: () => setState(() => _expanded = !_expanded),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: UxnanSpacing.md,
+                vertical: UxnanSpacing.sm,
+              ),
+              child: Row(
+                children: [
+                  Icon(icon, size: 18, color: color),
+                  const SizedBox(width: UxnanSpacing.sm),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          name,
+                          style: textTheme.titleSmall?.copyWith(
+                            color: color,
+                            fontWeight: FontWeight.w500,
+                          ),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        if (subtitle != null)
+                          Text(
+                            subtitle,
+                            style: UxnanTypography.codeSmall.copyWith(
+                              color: colors.onSurfaceVariant,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                      ],
+                    ),
                   ),
-              ],
+                  const SizedBox(width: UxnanSpacing.sm),
+                  if (file.binary)
+                    Text(
+                      'bin',
+                      style: UxnanTypography.codeSmall.copyWith(
+                        color: colors.onSurfaceVariant,
+                      ),
+                    )
+                  else ...[
+                    if (file.additions > 0)
+                      Text(
+                        '+${file.additions}',
+                        style: UxnanTypography.codeSmall.copyWith(
+                          color: UxnanColors.gitAdded,
+                        ),
+                      ),
+                    if (file.deletions > 0) ...[
+                      const SizedBox(width: UxnanSpacing.xs),
+                      Text(
+                        '−${file.deletions}',
+                        style: UxnanTypography.codeSmall.copyWith(
+                          color: UxnanColors.gitDeleted,
+                        ),
+                      ),
+                    ],
+                  ],
+                  const SizedBox(width: UxnanSpacing.xs),
+                  Icon(
+                    _expanded
+                        ? Icons.expand_less_rounded
+                        : Icons.expand_more_rounded,
+                    size: 20,
+                    color: colors.onSurfaceVariant,
+                  ),
+                ],
+              ),
             ),
           ),
-          const SizedBox(width: UxnanSpacing.sm),
-          if (file.binary)
-            Text(
-              'bin',
-              style: UxnanTypography.codeSmall
-                  .copyWith(color: colors.onSurfaceVariant),
-            )
-          else ...[
-            if (file.additions > 0)
-              Text(
-                '+${file.additions}',
-                style: UxnanTypography.codeSmall
-                    .copyWith(color: UxnanColors.gitAdded),
-              ),
-            if (file.deletions > 0) ...[
-              const SizedBox(width: UxnanSpacing.xs),
-              Text(
-                '−${file.deletions}',
-                style: UxnanTypography.codeSmall
-                    .copyWith(color: UxnanColors.gitDeleted),
-              ),
-            ],
-          ],
+          if (_expanded) _DiffLines(diff: widget.diff, binary: file.binary),
         ],
       ),
     );
   }
 }
 
-/// The full unified diff for the commit, colored and horizontally scrollable.
-class _DiffSection extends StatelessWidget {
-  const _DiffSection({required this.diff, required this.truncated});
-  final String diff;
-  final bool truncated;
+/// The colored, horizontally-scrollable diff body for one file. Drops the noisy
+/// per-file header lines (the filename is already the card title) and keeps the
+/// hunks + +/- content.
+class _DiffLines extends StatelessWidget {
+  const _DiffLines({required this.diff, required this.binary});
+  final String? diff;
+  final bool binary;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final colors = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
-    final lines = diff.split('\n');
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        UxnanSpacing.lg,
-        UxnanSpacing.md,
-        UxnanSpacing.lg,
-        UxnanSpacing.lg,
+    final lines = _renderableLines(diff ?? '');
+    final empty = lines.isEmpty;
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: colors.surfaceContainerHighest,
+        border: Border(top: BorderSide(color: colors.outlineVariant)),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            l10n.gitHistoryDiffSection,
-            style: textTheme.labelLarge?.copyWith(
-              color: colors.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-          const SizedBox(height: UxnanSpacing.xs),
-          ClipRRect(
-            borderRadius: const BorderRadius.all(UxnanRadius.md),
-            child: ColoredBox(
-              color: colors.surfaceContainerHigh,
-              child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child: IntrinsicWidth(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      for (final line in lines)
-                        ColoredBox(
-                          color: _lineColor(line),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: UxnanSpacing.md,
-                              vertical: 1,
-                            ),
-                            child: Text(
-                              line.isEmpty ? ' ' : line,
-                              style: UxnanTypography.codeBody.copyWith(
-                                color: _isMeta(line)
-                                    ? colors.onSurfaceVariant
-                                    : null,
-                              ),
+      child: empty
+          ? Padding(
+              padding: const EdgeInsets.all(UxnanSpacing.md),
+              child: Text(
+                binary ? l10n.gitHistoryBinaryDiff : l10n.gitHistoryNoTextDiff,
+                style: textTheme.bodySmall?.copyWith(
+                  color: colors.onSurfaceVariant,
+                ),
+              ),
+            )
+          : SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: IntrinsicWidth(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    for (final line in lines)
+                      ColoredBox(
+                        color: _lineColor(line),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: UxnanSpacing.md,
+                            vertical: 1,
+                          ),
+                          child: Text(
+                            line.isEmpty ? ' ' : line,
+                            style: UxnanTypography.codeBody.copyWith(
+                              color: line.startsWith('@@')
+                                  ? colors.onSurfaceVariant
+                                  : null,
                             ),
                           ),
                         ),
-                    ],
-                  ),
+                      ),
+                  ],
                 ),
               ),
             ),
-          ),
-          if (truncated) ...[
-            const SizedBox(height: UxnanSpacing.sm),
-            Text(
-              l10n.gitHistoryDiffTruncated,
-              style:
-                  textTheme.bodySmall?.copyWith(color: colors.onSurfaceVariant),
-            ),
-          ],
-        ],
-      ),
     );
   }
 
-  bool _isMeta(String line) =>
-      line.startsWith('diff --git ') ||
-      line.startsWith('index ') ||
-      line.startsWith('--- ') ||
-      line.startsWith('+++ ') ||
-      line.startsWith('new file mode ') ||
-      line.startsWith('deleted file mode ') ||
-      line.startsWith('rename ') ||
-      line.startsWith('similarity index ');
+  /// Keeps hunk headers + content; drops `diff --git`, `index`, `---`/`+++`,
+  /// mode and rename metadata (redundant with the card title).
+  List<String> _renderableLines(String diff) {
+    final result = <String>[];
+    for (final line in diff.split('\n')) {
+      if (line.startsWith('diff --git ') ||
+          line.startsWith('index ') ||
+          line.startsWith('--- ') ||
+          line.startsWith('+++ ') ||
+          line.startsWith('new file mode ') ||
+          line.startsWith('deleted file mode ') ||
+          line.startsWith('old mode ') ||
+          line.startsWith('new mode ') ||
+          line.startsWith('rename from ') ||
+          line.startsWith('rename to ') ||
+          line.startsWith('similarity index ') ||
+          line.startsWith('Binary files ')) {
+        continue;
+      }
+      result.add(line);
+    }
+    while (result.isNotEmpty && result.last.trim().isEmpty) {
+      result.removeLast();
+    }
+    return result;
+  }
 
   Color _lineColor(String line) {
     if (line.startsWith('@@')) {
@@ -541,6 +609,39 @@ class _DiffSection extends StatelessWidget {
     }
     return Colors.transparent;
   }
+}
+
+/// Splits a commit's combined unified diff into per-file chunks, keyed by both
+/// the new and old path (so renames/deletes resolve). Each chunk starts at a
+/// `diff --git a/<old> b/<new>` line.
+Map<String, String> _splitDiffByPath(String diff) {
+  final map = <String, String>{};
+  final lines = diff.split('\n');
+  final header = RegExp(r'^diff --git a/(.*) b/(.*)$');
+  var start = -1;
+  String? aPath;
+  String? bPath;
+  void flush(int end) {
+    if (start < 0) return;
+    final chunk = lines.sublist(start, end).join('\n');
+    final a = aPath;
+    final b = bPath;
+    if (b != null && b.isNotEmpty) map[b] = chunk;
+    if (a != null && a.isNotEmpty) map[a] = chunk;
+  }
+
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    if (line.startsWith('diff --git ')) {
+      flush(i);
+      start = i;
+      final m = header.firstMatch(line);
+      aPath = m?.group(1);
+      bPath = m?.group(2);
+    }
+  }
+  flush(lines.length);
+  return map;
 }
 
 /// A label/value metadata row.
@@ -568,9 +669,7 @@ class _MetaRow extends StatelessWidget {
               ),
             ),
           ),
-          Expanded(
-            child: SelectableText(value, style: textTheme.bodyMedium),
-          ),
+          Expanded(child: SelectableText(value, style: textTheme.bodyMedium)),
         ],
       ),
     );
@@ -617,15 +716,15 @@ class _InlineError extends StatelessWidget {
     GitFileStatus.modified => (Icons.edit_outlined, UxnanColors.gitModified),
     GitFileStatus.deleted => (
         Icons.remove_circle_outline,
-        UxnanColors.gitDeleted
+        UxnanColors.gitDeleted,
       ),
     GitFileStatus.renamed => (
         Icons.drive_file_move_outline,
-        UxnanColors.gitModified
+        UxnanColors.gitModified,
       ),
     GitFileStatus.untracked => (
         Icons.fiber_new_outlined,
-        UxnanColors.gitUntracked
+        UxnanColors.gitUntracked,
       ),
   };
 }

--- a/uxnanmobile/lib/presentation/screens/conversation/git/git_history_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/git/git_history_screen.dart
@@ -17,10 +17,10 @@ import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 /// flat list (no card chrome — matches the file browser's surface). The app
 /// bar carries two `IconSurface` toggles:
 ///
-///   - **Graph** — overlays a continuous, colored VS Code / GitKraken-style
-///     lane graph on the left of each row. Rows are flush (no gaps) so the
-///     lines connect seamlessly across the whole list, with bezier curves at
-///     branch/merge points.
+///   - **Graph** — overlays a continuous, colored VS Code-style swimlane graph
+///     on the left of each row. Fixed-height rows keep the dots aligned in
+///     lanes; lines connect across rows with rounded-step connectors and a
+///     branch-stable color per lane; merge nodes get a separate outer ring.
 ///   - **Compact** — a denser row layout.
 ///
 /// Backed by `git/log` (cursor pagination, 50/page) with **infinite scroll**
@@ -39,11 +39,7 @@ class GitHistoryScreen extends ConsumerStatefulWidget {
   final String? ref;
 
   /// Pushes the screen onto the navigator.
-  static Future<void> push(
-    BuildContext context, {
-    String? cwd,
-    String? ref,
-  }) {
+  static Future<void> push(BuildContext context, {String? cwd, String? ref}) {
     return Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (_) => GitHistoryScreen(cwd: cwd, ref: ref),
@@ -127,9 +123,9 @@ class _GitHistoryScreenState extends ConsumerState<GitHistoryScreen> {
       _error = null;
     });
     try {
-      final result = await ref.read(gitActionManagerProvider).log(
-            GitLogParams(cwd: cwd, limit: _pageSize, ref: _viewingRef),
-          );
+      final result = await ref
+          .read(gitActionManagerProvider)
+          .log(GitLogParams(cwd: cwd, limit: _pageSize, ref: _viewingRef));
       if (!mounted) return;
       setState(() {
         _commits = result.commits;
@@ -154,9 +150,9 @@ class _GitHistoryScreenState extends ConsumerState<GitHistoryScreen> {
       _error = null;
     });
     try {
-      final result = await ref.read(gitActionManagerProvider).log(
-            GitLogParams(cwd: cwd, limit: _pageSize, ref: _viewingRef),
-          );
+      final result = await ref
+          .read(gitActionManagerProvider)
+          .log(GitLogParams(cwd: cwd, limit: _pageSize, ref: _viewingRef));
       if (!mounted) return;
       setState(() {
         _commits = result.commits;
@@ -179,9 +175,9 @@ class _GitHistoryScreenState extends ConsumerState<GitHistoryScreen> {
     if (cwd == null || cursor == null || _pageLoading || !_hasMore) return;
     setState(() => _pageLoading = true);
     try {
-      final result = await ref.read(gitActionManagerProvider).log(
-            GitLogParams(cwd: cwd, limit: _pageSize, cursor: cursor),
-          );
+      final result = await ref
+          .read(gitActionManagerProvider)
+          .log(GitLogParams(cwd: cwd, limit: _pageSize, cursor: cursor));
       if (!mounted) return;
       setState(() {
         _commits = [..._commits, ...result.commits];
@@ -233,10 +229,8 @@ class _GitHistoryScreenState extends ConsumerState<GitHistoryScreen> {
       isScrollControlled: true,
       showDragHandle: true,
       backgroundColor: Theme.of(context).colorScheme.surfaceContainerHigh,
-      builder: (_) => _BranchPickerSheet(
-        branches: branches,
-        selectedRef: _viewingRef,
-      ),
+      builder: (_) =>
+          _BranchPickerSheet(branches: branches, selectedRef: _viewingRef),
     );
     if (picked == null || !mounted) return;
     // `_RefChoice(ref: null)` means "back to HEAD".
@@ -474,12 +468,34 @@ class _CommitGraphRow extends StatelessWidget {
                       ),
                       const SizedBox(width: UxnanSpacing.xs),
                     ],
-                    for (final ref in row.commit.refs)
-                      Padding(
-                        padding: const EdgeInsets.only(right: UxnanSpacing.xs),
-                        child: CommitRefChip(refData: ref, dense: true),
+                    // A single, width-capped primary ref chip (+ "+N" when
+                    // there are more) so a tip with several refs can't overflow
+                    // the row. The full set shows in the list view and detail.
+                    if (row.commit.refs.isNotEmpty) ...[
+                      Flexible(
+                        flex: 0,
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(
+                            maxWidth: compact ? 100 : 130,
+                          ),
+                          child: CommitRefChip(
+                            refData: _primaryRef(row.commit.refs),
+                            dense: true,
+                          ),
+                        ),
                       ),
-                    Flexible(
+                      if (row.commit.refs.length > 1) ...[
+                        const SizedBox(width: UxnanSpacing.xs),
+                        Text(
+                          '+${row.commit.refs.length - 1}',
+                          style: textTheme.labelSmall?.copyWith(
+                            color: colors.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                      const SizedBox(width: UxnanSpacing.xs),
+                    ],
+                    Expanded(
                       child: Text(
                         row.commit.messageTitle,
                         maxLines: 1,
@@ -608,8 +624,9 @@ class _ShaBadge extends StatelessWidget {
       ),
       child: Text(
         shortSha,
-        style:
-            UxnanTypography.codeSmall.copyWith(color: colors.onSurfaceVariant),
+        style: UxnanTypography.codeSmall.copyWith(
+          color: colors.onSurfaceVariant,
+        ),
       ),
     );
   }
@@ -625,8 +642,10 @@ class _MergeBadge extends StatelessWidget {
     final colors = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
     return Container(
-      padding:
-          const EdgeInsets.symmetric(horizontal: UxnanSpacing.sm, vertical: 2),
+      padding: const EdgeInsets.symmetric(
+        horizontal: UxnanSpacing.sm,
+        vertical: 2,
+      ),
       decoration: BoxDecoration(
         color: colors.tertiaryContainer,
         borderRadius: const BorderRadius.all(UxnanRadius.sm),
@@ -709,8 +728,9 @@ class _CenteredState extends StatelessWidget {
             const SizedBox(height: UxnanSpacing.sm),
             Text(
               body!,
-              style: textTheme.bodyMedium
-                  ?.copyWith(color: colors.onSurfaceVariant),
+              style: textTheme.bodyMedium?.copyWith(
+                color: colors.onSurfaceVariant,
+              ),
               textAlign: TextAlign.center,
             ),
           ],
@@ -796,10 +816,7 @@ class _ViewingRefBanner extends StatelessWidget {
 /// Bottom sheet that lists the current HEAD plus the local and remote branches
 /// so the user can view the history from any ref (read-only — no checkout).
 class _BranchPickerSheet extends StatelessWidget {
-  const _BranchPickerSheet({
-    required this.branches,
-    required this.selectedRef,
-  });
+  const _BranchPickerSheet({required this.branches, required this.selectedRef});
 
   final GitBranchList branches;
   final String? selectedRef;
@@ -1098,17 +1115,29 @@ class _GraphPainter extends CustomPainter {
     ..style = PaintingStyle.stroke
     ..strokeCap = StrokeCap.round;
 
-  /// A straight vertical when the columns match, otherwise a smooth S-curve
-  /// (vertical tangents at both ends) — the rounded VS Code connector.
+  /// VS Code-style connector: a straight vertical when the columns match,
+  /// otherwise vertical → quarter-arc → short horizontal → quarter-arc →
+  /// vertical (the crisp rounded "step" at the row midpoint). Assumes
+  /// `from.dy <= to.dy` (all connectors run top→down in a row).
   void _connect(Canvas canvas, Paint paint, Offset from, Offset to) {
     if ((from.dx - to.dx).abs() < 0.5) {
       canvas.drawLine(from, to, paint);
       return;
     }
+    final dir = to.dx > from.dx ? 1.0 : -1.0;
     final midY = (from.dy + to.dy) / 2;
+    final r = [
+      5.0,
+      (to.dx - from.dx).abs() / 2,
+      (to.dy - from.dy).abs() / 2,
+    ].reduce((a, b) => a < b ? a : b);
     final path = Path()
       ..moveTo(from.dx, from.dy)
-      ..cubicTo(from.dx, midY, to.dx, midY, to.dx, to.dy);
+      ..lineTo(from.dx, midY - r)
+      ..quadraticBezierTo(from.dx, midY, from.dx + dir * r, midY)
+      ..lineTo(to.dx - dir * r, midY)
+      ..quadraticBezierTo(to.dx, midY, to.dx, midY + r)
+      ..lineTo(to.dx, to.dy);
     canvas.drawPath(path, paint);
   }
 
@@ -1199,6 +1228,23 @@ List<Color> _lanePalette(ColorScheme colors) => [
       UxnanColors.warning,
       UxnanColors.gitDeleted,
     ];
+
+/// Picks the most useful ref to show in the dense graph row: a local branch
+/// first, then a tag, then HEAD, then a remote branch.
+GitRef _primaryRef(List<GitRef> refs) {
+  const order = [
+    GitRefType.branch,
+    GitRefType.tag,
+    GitRefType.head,
+    GitRefType.remoteBranch,
+  ];
+  for (final type in order) {
+    for (final ref in refs) {
+      if (ref.type == type) return ref;
+    }
+  }
+  return refs.first;
+}
 
 /// Compact relative date — "just now", "5m", "2h", "3d", "Mar 4", "2022".
 String _relativeDate(DateTime when) {

--- a/uxnanmobile/lib/presentation/screens/conversation/git/git_history_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/git/git_history_screen.dart
@@ -1161,15 +1161,18 @@ class _GraphPainter extends CustomPainter {
           Offset(centerX, dotY),
         );
       } else {
-        final k = row.outgoing.indexOf(occ);
-        if (k != -1) {
-          _connect(
-            canvas,
-            _stroke(row.incomingColors[j]),
-            Offset(_laneX(j), 0),
-            Offset(_laneX(k), h),
-          );
-        }
+        // A pass-through lane continues in its *own* column (lanes are never
+        // compacted, so `outgoing[j]` is still this occupant) — draw a straight
+        // vertical. Using `outgoing.indexOf(occ)` was wrong: when the same
+        // parent occupies two lanes (a commit with multiple children, common
+        // around merges) it returned the *first* lane, so the other lane drew a
+        // diagonal "hook" every row instead of a clean vertical.
+        _connect(
+          canvas,
+          _stroke(row.incomingColors[j]),
+          Offset(_laneX(j), 0),
+          Offset(_laneX(j), h),
+        );
       }
     }
 

--- a/uxnanmobile/lib/presentation/screens/conversation/git/git_history_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/git/git_history_screen.dart
@@ -11,6 +11,7 @@ import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
 import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
+import 'package:uxnan/presentation/widgets/ne_circular_button.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 
 /// Full-screen commit history for the workspace's git repo — a single, clean,
@@ -283,10 +284,10 @@ class _GitHistoryScreenState extends ConsumerState<GitHistoryScreen> {
       scrollController: _scrollController,
       onRefresh: _initialLoading ? null : _refresh,
       floatingActionButton: _showBackToTop
-          ? FloatingActionButton.small(
+          ? NeCircularButton(
+              icon: Icons.keyboard_arrow_up_rounded,
               tooltip: l10n.gitHistoryBackToTop,
-              onPressed: _backToTop,
-              child: const Icon(Icons.keyboard_arrow_up_rounded),
+              onTap: _backToTop,
             )
           : null,
       actions: [

--- a/uxnanmobile/lib/presentation/screens/conversation/git/git_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/git/git_screen.dart
@@ -13,6 +13,7 @@ import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
+import 'package:uxnan/presentation/widgets/ne_surface.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 
 /// Full-screen Material 3 source-control surface for a thread's workspace.
@@ -527,11 +528,7 @@ class _GitScreenState extends ConsumerState<GitScreen> {
     if (confirmed != true || !mounted) return;
     await _guard(
       () => ref.read(gitActionManagerProvider).discard(
-            GitDiscardParams(
-              cwd: cwd,
-              paths: paths,
-              threadId: widget.threadId,
-            ),
+            GitDiscardParams(cwd: cwd, paths: paths, threadId: widget.threadId),
           ),
       l10n.gitDiscardSuccess,
       cwd,
@@ -646,9 +643,9 @@ class _GitScreenState extends ConsumerState<GitScreen> {
     final l10n = AppLocalizations.of(context);
     if (cwd == null) return;
     await _guard(
-      () => ref.read(gitActionManagerProvider).pull(
-            GitPullParams(cwd: cwd, threadId: widget.threadId),
-          ),
+      () => ref
+          .read(gitActionManagerProvider)
+          .pull(GitPullParams(cwd: cwd, threadId: widget.threadId)),
       l10n.gitPullSuccess,
       cwd,
     );
@@ -810,8 +807,9 @@ class _GitScreenState extends ConsumerState<GitScreen> {
                                     onSelectAll: () =>
                                         setState(_deselected.clear),
                                     onDeselectAll: () => setState(
-                                      () => _deselected
-                                          .addAll(files.map((f) => f.path)),
+                                      () => _deselected.addAll(
+                                        files.map((f) => f.path),
+                                      ),
                                     ),
                                     onDiscardSelected: _busy
                                         ? null
@@ -951,10 +949,7 @@ class _GitScreenState extends ConsumerState<GitScreen> {
                     tooltip: l10n.gitHistoryButton,
                     onPressed: _busy
                         ? null
-                        : () => GitHistoryScreen.push(
-                              context,
-                              cwd: widget.cwd,
-                            ),
+                        : () => GitHistoryScreen.push(context, cwd: widget.cwd),
                   ),
                 if (state != null)
                   _OverflowMenu(
@@ -1045,18 +1040,12 @@ class _OverflowMenu extends StatelessWidget {
         PopupMenuItem(
           enabled: !busy,
           onTap: onNewBranch,
-          child: _MenuRow(
-            icon: Icons.add_rounded,
-            label: l10n.gitNewBranch,
-          ),
+          child: _MenuRow(icon: Icons.add_rounded, label: l10n.gitNewBranch),
         ),
         PopupMenuItem(
           enabled: !busy,
           onTap: onCreatePr,
-          child: _MenuRow(
-            icon: Icons.merge_rounded,
-            label: l10n.gitCreatePr,
-          ),
+          child: _MenuRow(icon: Icons.merge_rounded, label: l10n.gitCreatePr),
         ),
         PopupMenuItem(
           enabled: !busy,
@@ -1645,9 +1634,7 @@ class _BorderlessField extends StatelessWidget {
         border: InputBorder.none,
         enabledBorder: InputBorder.none,
         focusedBorder: InputBorder.none,
-        contentPadding: const EdgeInsets.symmetric(
-          vertical: UxnanSpacing.sm,
-        ),
+        contentPadding: const EdgeInsets.symmetric(vertical: UxnanSpacing.sm),
         hintText: hint,
         hintStyle: TextStyle(color: colors.onSurfaceVariant),
       ),
@@ -1704,11 +1691,7 @@ class _NoRepository extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Icon(
-            Icons.source_outlined,
-            size: 40,
-            color: colors.onSurfaceVariant,
-          ),
+          Icon(Icons.source_outlined, size: 40, color: colors.onSurfaceVariant),
           const SizedBox(height: UxnanSpacing.md),
           Text(l10n.gitNoRepository, style: textTheme.titleSmall),
           const SizedBox(height: UxnanSpacing.xs),
@@ -1990,8 +1973,9 @@ class _PrDialog extends StatefulWidget {
 }
 
 class _PrDialogState extends State<_PrDialog> {
-  late final TextEditingController _title =
-      TextEditingController(text: widget.initialTitle);
+  late final TextEditingController _title = TextEditingController(
+    text: widget.initialTitle,
+  );
   final TextEditingController _body = TextEditingController();
   String? _error;
   late String? _head = _headOptions.isEmpty ? null : _headOptions.first;
@@ -2228,46 +2212,6 @@ class _BranchField extends StatelessWidget {
 // `presentation/widgets/` tree.
 // ---------------------------------------------------------------------------
 
-/// A rounded NE surface used in place of M3's `Card.filled` / `Card.outlined`.
-/// Filled by default on `surfaceContainerHigh`; the `outlined` flag adds a thin
-/// `outlineVariant` border so cards nested inside other surfaces remain
-/// legible. No drop shadow — NE is flat by design.
-class NeSurface extends StatelessWidget {
-  /// Creates a [NeSurface].
-  const NeSurface({
-    required this.child,
-    this.outlined = false,
-    this.padding = const EdgeInsets.all(UxnanSpacing.md),
-    super.key,
-  });
-
-  /// The widget this surface wraps.
-  final Widget child;
-
-  /// Whether to draw a thin `outlineVariant` border (use when the card sits
-  /// on a background that matches `surfaceContainerHigh`).
-  final bool outlined;
-
-  /// Padding applied to [child].
-  final EdgeInsetsGeometry padding;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = Theme.of(context).colorScheme;
-    return Material(
-      color: colors.surfaceContainerHigh,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(20),
-        side: outlined
-            ? BorderSide(color: colors.outlineVariant)
-            : BorderSide.none,
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: Padding(padding: padding, child: child),
-    );
-  }
-}
-
 /// An M3-style checkbox rendered as a circular NE surface so the gesture
 /// ripple matches the rest of the screen. `null` renders an indeterminate
 /// (mixed) state — partial selection across the list.
@@ -2341,12 +2285,7 @@ class _NeSelectionSurface extends StatelessWidget {
               width: 24,
               height: 24,
               child: Center(
-                child: Icon(
-                  icon,
-                  size: 18,
-                  color: fg,
-                  semanticLabel: tooltip,
-                ),
+                child: Icon(icon, size: 18, color: fg, semanticLabel: tooltip),
               ),
             ),
           ),

--- a/uxnanmobile/lib/presentation/screens/conversation/git/widgets/commit_ref_chip.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/git/widgets/commit_ref_chip.dart
@@ -34,10 +34,16 @@ class CommitRefChip extends StatelessWidget {
         children: [
           Icon(icon, size: dense ? 11 : 13, color: fg),
           const SizedBox(width: UxnanSpacing.xs),
-          Text(
-            refData.name,
-            style: (dense ? textTheme.labelSmall : textTheme.labelMedium)
-                ?.copyWith(color: fg, fontWeight: FontWeight.w600),
+          // Flexible + ellipsis so the chip truncates inside a width-capped
+          // slot (e.g. the dense graph row) instead of overflowing its row.
+          Flexible(
+            child: Text(
+              refData.name,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: (dense ? textTheme.labelSmall : textTheme.labelMedium)
+                  ?.copyWith(color: fg, fontWeight: FontWeight.w600),
+            ),
           ),
         ],
       ),

--- a/uxnanmobile/lib/presentation/widgets/ne_circular_button.dart
+++ b/uxnanmobile/lib/presentation/widgets/ne_circular_button.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+/// Neural Expressive **circular action button** — a filled
+/// `secondaryContainer` circle with a single glyph, used for the floating
+/// scroll shortcuts (scroll-to-bottom in the conversation, back-to-top in the
+/// git history). NE's action language is circular (like `IconSurface`), so this
+/// replaces M3's default rounded-square `FloatingActionButton.small` to keep
+/// every floating action consistent across the app.
+class NeCircularButton extends StatelessWidget {
+  /// Creates a [NeCircularButton].
+  const NeCircularButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+    this.size = 44,
+    this.iconSize = 26,
+    super.key,
+  });
+
+  /// The glyph shown centered in the circle.
+  final IconData icon;
+
+  /// Tooltip + accessibility label.
+  final String tooltip;
+
+  /// Tap handler.
+  final VoidCallback onTap;
+
+  /// Diameter of the circle.
+  final double size;
+
+  /// Glyph size.
+  final double iconSize;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: tooltip,
+      child: Material(
+        color: colors.secondaryContainer,
+        shape: const CircleBorder(),
+        elevation: 3,
+        shadowColor: colors.shadow,
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: SizedBox(
+            width: size,
+            height: size,
+            child: Icon(
+              icon,
+              color: colors.onSecondaryContainer,
+              size: iconSize,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/uxnanmobile/lib/presentation/widgets/ne_surface.dart
+++ b/uxnanmobile/lib/presentation/widgets/ne_surface.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:uxnan/presentation/theme/spacing.dart';
+
+/// Neural Expressive **surface card**: a rounded `surfaceContainerHigh` panel
+/// with optional thin outline, used for the git change cards and the commit
+/// detail's per-file cards. Clips its child so nested content (e.g. a diff
+/// body) follows the rounded corners.
+class NeSurface extends StatelessWidget {
+  /// Creates a [NeSurface].
+  const NeSurface({
+    required this.child,
+    this.outlined = false,
+    this.padding = const EdgeInsets.all(UxnanSpacing.md),
+    super.key,
+  });
+
+  /// The widget this surface wraps.
+  final Widget child;
+
+  /// Whether to draw a thin `outlineVariant` border (use when the card sits
+  /// on a background that matches `surfaceContainerHigh`).
+  final bool outlined;
+
+  /// Padding applied to [child].
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Material(
+      color: colors.surfaceContainerHigh,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: outlined
+            ? BorderSide(color: colors.outlineVariant)
+            : BorderSide.none,
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(padding: padding, child: child),
+    );
+  }
+}

--- a/uxnanmobile/test/widget/presentation/git_history_screen_test.dart
+++ b/uxnanmobile/test/widget/presentation/git_history_screen_test.dart
@@ -129,7 +129,47 @@ Map<String, dynamic> _commitToJson(GitCommit c) => {
       'committerTimestamp': c.committerTimestamp,
       'messageTitle': c.messageTitle,
       'messageBody': c.messageBody,
+      if (c.refs.isNotEmpty)
+        'refs': [
+          for (final r in c.refs) {'name': r.name, 'type': r.type.name},
+        ],
     };
+
+/// A commit decorated with several refs (HEAD + branch + remote) — used to
+/// check the graph row doesn't overflow on a narrow screen.
+List<GitCommit> _decoratedCommits() => [
+      const GitCommit(
+        sha: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        shortSha: 'a1b2c3d',
+        parents: ['0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f'],
+        authorName: 'Luis',
+        authorEmail: 'luis@example.com',
+        authorTimestamp: 1735689600,
+        committerName: 'Luis',
+        committerEmail: 'luis@example.com',
+        committerTimestamp: 1735689600,
+        messageTitle: 'feat: a commit with a long title that should ellipsize',
+        messageBody: '',
+        refs: [
+          GitRef(name: 'HEAD', type: GitRefType.head),
+          GitRef(name: 'main', type: GitRefType.branch),
+          GitRef(name: 'origin/main', type: GitRefType.remoteBranch),
+        ],
+      ),
+      const GitCommit(
+        sha: '0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f',
+        shortSha: '0f0f0f0',
+        parents: [],
+        authorName: 'Luis',
+        authorEmail: 'luis@example.com',
+        authorTimestamp: 1735603200,
+        committerName: 'Luis',
+        committerEmail: 'luis@example.com',
+        committerTimestamp: 1735603200,
+        messageTitle: 'chore: initial commit',
+        messageBody: '',
+      ),
+    ];
 
 /// Wraps [child] in a [ProviderScope] that overrides the git providers with
 /// the supplied stubs.
@@ -230,6 +270,35 @@ void main() {
     // still render (now with the lane gutter).
     expect(find.byIcon(Icons.account_tree_rounded), findsOneWidget);
     expect(find.text('feat: history view'), findsOneWidget);
+  });
+
+  testWidgets('graph rows with several refs do not overflow when narrow',
+      (tester) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final manager = _stubManager(commits: _decoratedCommits());
+    addTearDown(manager.dispose);
+
+    await tester.pumpWidget(
+      _wrap(
+        manager: manager,
+        child: const GitHistoryScreen(cwd: '/repo'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Enable the graph overlay (gutter + ref chips compete for width here).
+    await tester.tap(find.byIcon(Icons.account_tree_outlined));
+    await tester.pumpAndSettle();
+
+    // No RenderFlex overflow was thrown during layout/paint.
+    expect(tester.takeException(), isNull);
+    // The primary ref ("main") chip renders, with a "+2" overflow marker.
+    expect(find.text('main'), findsOneWidget);
+    expect(find.text('+2'), findsOneWidget);
   });
 
   testWidgets('toggles compact density', (tester) async {

--- a/uxnanmobile/test/widget/presentation/git_history_screen_test.dart
+++ b/uxnanmobile/test/widget/presentation/git_history_screen_test.dart
@@ -86,7 +86,13 @@ GitActionManager _stubManager({
                 'deletions': 1,
               },
             ],
-            'diff': '--- a/lib/main.dart\n+++ b/lib/main.dart\n+new line\n',
+            'diff': 'diff --git a/lib/main.dart b/lib/main.dart\n'
+                'index 1111111..2222222 100644\n'
+                '--- a/lib/main.dart\n'
+                '+++ b/lib/main.dart\n'
+                '@@ -1,1 +1,2 @@\n'
+                ' context\n'
+                '+new line\n',
           },
         );
       }
@@ -367,9 +373,14 @@ void main() {
     expect(find.text('Commit details'), findsOneWidget);
     expect(find.byTooltip('Copy SHA'), findsOneWidget);
     expect(find.text('Copy message'), findsOneWidget);
-    // The file list + diff from git/commitShow render (the row shows the
-    // basename; the directory is a separate muted line).
+    // The file card from git/commitShow renders (basename as the card title);
+    // its diff is collapsed by default…
     expect(find.text('main.dart'), findsOneWidget);
+    expect(find.textContaining('new line'), findsNothing);
+
+    // …and reveals that file's own diff when the card is expanded.
+    await tester.tap(find.text('main.dart'));
+    await tester.pumpAndSettle();
     expect(find.textContaining('new line'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

Fixes the git history graph on mobile: it was **missing commits** and drawing
**phantom/extra lanes** on a branchy history, plus a few graph/detail polish
items. Root causes were in the bridge's `git/log`; the rest is mobile UI.

## Affected component(s)

- [x] `shared` — `git/log` cursor semantics (docs only; wire shape unchanged)
- [x] `bridge` — `git/log` ordering + pagination + parsing
- [ ] `relay`
- [ ] `uxnandesktop`
- [x] `uxnanmobile` — git history graph + commit detail
- [x] Cross-cutting / tooling / docs

## Type of change

- [x] `fix` — bug fixes (missing commits, phantom lanes, diagonal hooks, overflow)
- [x] `feat` — per-file expandable diffs, branch/ref picker (landed earlier on
      this branch)
- [x] `chore` / `docs`

## What changed

**bridge + shared — `git/log` was dropping commits / tangling the graph**
- **Topological order** (`--topo-order`) instead of git's default date order, so
  parents immediately follow children (no lanes dangling across unrelated
  commits → no phantom lanes).
- **Offset pagination** (`--skip`; `cursor` is now an opaque offset token)
  replacing `<cursor>^`, which skipped a merge's second-parent history across
  page boundaries and dropped real commits.
- **Merge-safe shortstat parsing**: merge/empty commits emit no `--shortstat`,
  so the record after a merge began with a bare `-z` NUL; the parser mis-split
  and dropped that commit. It now strips the leading NUL first.
- Merge-DAG pagination test (no commit dropped).

**uxnanmobile — graph + detail**
- **Pass-through lanes draw straight** (no diagonal "hooks"): they used
  `outgoing.indexOf`, which collapsed duplicate-occupant lanes to the first.
- VS Code-style graph (fixed-height rows, branch-stable colors, rounded-step
  connectors, ringed merge nodes) and **ref-chip overflow** fix (single capped
  primary chip + `+N`).
- **Per-file expandable diffs** in the commit detail (collapsed cards, each with
  its own diff) — mirrors the version-control screen; `NeSurface` hoisted to a
  shared widget.
- **Circular floating scroll buttons** unified with the conversation FAB
  (`NeCircularButton`).
- `chore(build)`: sync root `package-lock.json` metadata (MPL-2.0 / 0.0.1).

## How was it tested?

1. `cd bridge && npx tsc && node --test dist/test/git/git-service.test.js` →
   25 pass (incl. the new merge-DAG pagination test).
2. `shared` + `bridge` + `relay` `tsc` clean.
3. `cd uxnanmobile && flutter analyze` → no issues; `dart format` clean.
4. `flutter test` on the touched suites incl. `git_history_screen_test.dart`
   (8 widget tests: list, empty, error, graph toggle, narrow-screen ref overflow,
   compact, branch picker, full detail with per-file diff expand) → all pass.
5. Manual, on-device against the rebuilt bridge (reviewed with the maintainer):
   full history loads + pages, graph lanes/colors correct (no hooks/phantom
   lanes), commit detail shows per-file diffs.

## Checklist

- [x] Lint/format pass for the touched components.
- [x] Tests added/updated, and the suite passes.
- [x] `CHANGELOG.md` updated for shared, bridge, and mobile.
- [x] Docs / `architecture/` updated (`02a` handleGitLog + history UI, `02b`
      cursor note).
- [x] Commits follow Conventional Commits.
- [ ] Not a `uxnanmobile` release.
- [x] `shared` cursor-semantics change — bridge + mobile consume it (opaque
      cursor; wire shape unchanged).
