### PR TITLE
docs: restructure READMEs, refresh component docs, and translate the design guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,13 +315,32 @@ Match the change to the docs it touches (a single change often hits several rows
 | Behavior / API / a feature in one component | that component's **`CHANGELOG.md`** (`[Unreleased]`, [Keep a Changelog](https://keepachangelog.com/)) — **always, without exception** — plus its **`README.md`** and **`docs/`** if how it's installed / configured / used / run / tested / connected changed |
 | A cross-component contract (a `shared/` JSON-RPC method, E2EE message, notification, or model field) | the **`shared/`** types + validators, **`architecture/02a`/`02b`**, and the **`CHANGELOG.md` of every consumer** you touched this cycle (see *Cross-monorepo* below) |
 | Direction / an architecture decision (even spec-only, no code) | the affected **`architecture/`** page(s) **and** the executive summary at the top of that doc — see **§4 Spec drift control** |
-| Implementation state (a phase / feature flips planned → done, or done → reworked) | the matching **`architecture/00-index.md`** / **`04-technical-reference.md`** status table |
-| Finished a deferred item (100% + validated) | **remove** it from `FOR-DEV.md` / `FOR-HUMAN.md` — see *completion lifecycle* below |
+| Implementation state in a component (a feature / phase flips planned → done, or done → reworked) | that component's **`FOR-DEV.md` `## Status`** — the home for per-component "what's working today / what's left" (see *Where status lives* below). Also refresh the matching **`architecture/00-index.md`** / **`04-technical-reference.md`** status table when a spec-level phase flips |
+| Finished a deferred item (100% + validated) | **remove** it from `FOR-DEV.md` / `FOR-HUMAN.md` — see *completion lifecycle* below — and fold the now-shipped capability into that `FOR-DEV.md`'s `## Status` |
 | Deferred new work / left a stub / found a missing human asset | **add** a `FOR-DEV.md` / `FOR-HUMAN.md` entry **and** the inline `FOR-DEV:` / `FOR-HUMAN:` marker at its site |
 
 Verify the docs the same way you verify code: re-read what you wrote against the
 real current state (counts, file names, flags, agent lists, paths). A doc that
 cites a number, a file, or a flag that no longer matches the code is drift.
+
+#### Where status lives (README vs FOR-DEV)
+
+Keep the two audiences separate so neither doc rots:
+
+- **`README.md` (per component **and** the root `README.md`/`README.es.md`) is the
+  user-facing front door.** It explains *what the thing is and does* and carries
+  only a **brief, current snapshot** of status — never the exhaustive
+  feature-by-feature inventory. When state changes, update the snapshot only if the
+  one-line summary is now wrong.
+- **`FOR-DEV.md` `## Status` is the developer-facing home for detailed
+  implementation status** — what's working today, what's partial, what's left. This
+  is where the granular "DONE / pending" detail belongs, sitting directly above the
+  pending-work list it contextualizes. Every component's `FOR-DEV.md` opens with a
+  `## Status` section; keep it current as features land (and as items are removed
+  per the *completion lifecycle*).
+- **`architecture/` status tables** stay the spec-level record of which phases /
+  subsystems are built (see §4 Spec drift control). They track the *spec*, not the
+  prose; the per-component lived status is `FOR-DEV.md`.
 
 #### Counts, enumerations & links (easy to miss)
 
@@ -333,8 +352,9 @@ cites a number, a file, or a flag that no longer matches the code is drift.
   `N methods` count in `shared/README.md`, `bridge/README.md`, the root
   `README.md` / `README.es.md`, **and** `architecture/02b` (the `METHOD_NAMES`
   count *and* the method list); new tests bump the `N passing` / `N bridge + …`
-  counts in the affected README(s). Re-derive the number from the code (`grep -c`
-  the registry / `test(`), don't trust the old one.
+  counts wherever they're cited — the affected component's `FOR-DEV.md` `## Status`
+  and any `README.md` / `docs/` page that still quotes a count. Re-derive the number
+  from the code (`grep -c` the registry / `test(`), don't trust the old one.
 - **Never reference a git-ignored / local-only file from a tracked file.** Anything
   in `.git/info/exclude` (e.g. the local `*_MVP.md` snapshots, scratch/runbook
   notes) is the maintainer's local context and won't exist on a fresh clone —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,39 @@ Keep the two audiences separate so neither doc rots:
   notes) is the maintainer's local context and won't exist on a fresh clone —
   tracked docs, workflows and config must stand on their own without pointing at it.
 
+#### The docs track the code — re-verify them when the code moves (easy to miss)
+
+`README.md` and especially the `docs/` guides are **not** prose that ages
+gracefully on its own: they hard-code concrete facts pulled straight from the
+source, and each of those facts is a small contract that silently breaks the
+moment the code it mirrors changes. Whenever you touch code that any doc or README
+describes, **re-derive the affected facts from the source in the same change set**
+— don't trust what the doc already says. The facts that have bitten us, with where
+they live:
+
+- **CLI commands, flags & npm scripts** — the `bin`/`scripts` in each
+  `package.json`, the Tauri/Flutter commands. If you rename a script or change a
+  flag, grep the component's `README.md` + `docs/` for it.
+- **Config keys, enum values & identifiers** — field names and defaults in the
+  config type (e.g. `daemon-config.ts`), and **canonical id unions** like
+  `AgentId` (`gemini-cli`/`pi-agent`, *not* `gemini`/`pi`). A doc that lists ids
+  or config fields must match the union/interface exactly.
+- **Env var names, file names & paths** — e.g. `UXNAN_HOOK_URL` / `UXNAN_AGENT_ID`,
+  `~/.uxnan/daemon-config.json`, `~/.uxnan/checkpoints.json`. Copy them from the
+  code, never from memory.
+- **Default values & ports** — e.g. `DEFAULT_LAN_PORT`, `checkpointMaxPerProject`.
+  Quote the constant's real value.
+- **"Which agents / which features" claims** — e.g. "3 adapters wired" or "next
+  agent is X". When an agent or capability lands, the prose that enumerates them
+  (in `docs/agents.md`, `docs/testing.md`, etc.) is part of the same change.
+- **Behavior described in a doc-comment** — a `/** … */` that explains a fallback,
+  a posture, or a scope must match what the code actually does (these drift the
+  fastest, because nothing compiles them against reality).
+
+Same rule as the rest of §2: this verification lands in the **same change set** as
+the code, and a doc/comment that cites a command, key, id, path, value, or
+behavior that no longer matches the source is drift — treat it as a bug.
+
 #### Cross-monorepo functionality (read this twice)
 
 Many features span monorepos — a bridge method the mobile app renders, an E2EE step

--- a/README.es.md
+++ b/README.es.md
@@ -4,107 +4,156 @@
 ![Monorepo](https://img.shields.io/badge/MONOREPO-5_PROYECTOS-blue?style=for-the-badge)
 ![E2EE](https://img.shields.io/badge/E2EE-AES--256--GCM-0a0a0a?style=for-the-badge&logo=letsencrypt&logoColor=white)
 ![Platforms](https://img.shields.io/badge/PLATAFORMAS-Android_%7C_iOS_%7C_Windows_%7C_macOS_%7C_Linux-lightgrey?style=for-the-badge)
+![License](https://img.shields.io/badge/LICENCIA-MPL--2.0-2ea44f?style=for-the-badge)
 
 > [Read in English](README.md)
 
-Uxnan (pronunciado /uʃ.nan/) es un ecosistema de herramientas que construyo para resolver un problema muy concreto que tengo como desarrollador: **controlar agentes de codificación con IA desde cualquier lugar, sin que mi hardware se convierta en un cuello de botella.**
+Uxnan (pronunciado /uʃ.nan/) es un ecosistema de herramientas que construyo para
+resolver un problema muy concreto que tengo como desarrollador: **controlar
+agentes de codificación con IA desde cualquier lugar, sin que mi hardware se
+convierta en un cuello de botella.**
 
 ## Por qué existe este proyecto
 
-Trabajo con agentes de codificación CLI (Claude Code, Codex CLI, OpenCode, Gemini CLI, pi-agent) todos los días. Son herramientas extraordinarias, pero el flujo de trabajo actual tiene fricciones reales:
+Trabajo con agentes de codificación CLI (Claude Code, Codex CLI, OpenCode, Gemini
+CLI, pi-agent) todos los días. Son herramientas extraordinarias, pero el flujo de
+trabajo actual tiene fricciones reales:
 
-- **Cuando me alejo de la PC**, pierdo visibilidad total sobre lo que el agente está haciendo. No puedo revisar su progreso, aprobar cambios o enviar nuevas instrucciones desde el teléfono.
-- **Las soluciones de escritorio existentes son excelentes**, pero muchas asumen hardware de gama alta. En mi setup actual, correr un IDE pesado + múltiples agentes + un entorno Electron consume más recursos de los que puedo permitirme.
-- **No existe una herramienta móvil agnóstica a proveedor** que funcione con cualquier agente, no solo con uno en particular.
+- **Cuando me alejo de la PC**, pierdo visibilidad total sobre lo que el agente
+  está haciendo. No puedo revisar su progreso, aprobar cambios o enviar nuevas
+  instrucciones desde el teléfono.
+- **Las soluciones de escritorio existentes son excelentes**, pero muchas asumen
+  hardware de gama alta. En mi setup actual, correr un IDE pesado + múltiples
+  agentes + un entorno Electron consume más recursos de los que puedo
+  permitirme.
+- **No existe una herramienta móvil agnóstica a proveedor** que funcione con
+  cualquier agente, no solo con uno en particular.
 
-Uxnan nace para resolver exactamente eso. No es un agente — es el **plano de control** para los agentes que ya uso.
+Uxnan nace para resolver exactamente eso. No es un agente — es el **plano de
+control** para los agentes que ya uso.
+
+## Cómo encaja todo
+
+El teléfono nunca habla con un intermediario en la nube en claro. Se empareja con
+el **bridge** que corre en tu PC y se conecta **primero de forma directa** —por
+tu LAN o tu red Tailscale— y solo cae a un **relay** opcional y self-hosted
+cuando estás fuera de casa. Sea cual sea la ruta, cada byte va cifrado de extremo
+a extremo; el relay solo ve sobres sellados.
+
+```text
+   📱 uxnanmobile                  💻 tu PC
+   (app Flutter)                   ┌──────────────────────────────┐
+        │                          │  bridge  ──▶  CLIs de agentes │
+        │   E2EE (X25519 +         │  (daemon)     claude · codex  │
+        ├──── Ed25519 + ──────────▶│               opencode · pi   │
+        │     AES-256-GCM)         │               gemini          │
+        │                          └──────────────────────────────┘
+        │                                      ▲
+        └──── relay (opcional, ─────────────────┘
+              self-hosted, solo fuera de la LAN —
+              reenvía sobres sellados, no ve nada)
+
+   uxnandesktop — una app de escritorio aparte, ligera, para correr y revisar
+   esos mismos agentes en la propia PC. shared — los contratos que ambos hablan.
+```
 
 ## Qué hace cada componente
 
-### `uxnanmobile/` — App Móvil (Flutter, Android + iOS)
+Uxnan es un solo repositorio con cinco proyectos. Cada uno tiene su propio README
+con la historia completa; aquí va la versión corta y a dónde ir después.
+
+### 📱 [`uxnanmobile/`](uxnanmobile/README.md) — la app móvil
 
 ![Flutter](https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white)
 ![Dart](https://img.shields.io/badge/Dart-0175C2?style=for-the-badge&logo=dart&logoColor=white)
 ![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white)
 ![iOS](https://img.shields.io/badge/iOS-000000?style=for-the-badge&logo=apple&logoColor=white)
-![SQLite](https://img.shields.io/badge/SQLite-003B57?style=for-the-badge&logo=sqlite&logoColor=white)
 
-App Flutter que funciona como control remoto de los agentes corriendo en mi PC. Desde el teléfono puedo ver conversaciones en tiempo real, enviar instrucciones, adjuntar imágenes, dictar por voz, hacer commit+push, revisar diffs y recibir notificaciones cuando un agente termina una tarea.
+Una app Flutter (Android + iOS) que convierte tu teléfono en un control remoto de
+los agentes en tu PC. Mira las conversaciones llegar en tiempo real, envía
+instrucciones, adjunta imágenes, dicta por voz, revisa diffs, haz commit y push,
+y recibe una notificación en cuanto un agente termina — todo sobre el canal
+cifrado y bridge-first.
 
-La conexión es E2EE real y es **bridge-first**: el teléfono prueba primero las direcciones directas LAN/Tailscale del bridge, y cae al relay self-hosted solo para acceso fuera de la LAN. El relay, cuando se usa, solo ve envelopes E2EE opacos.
+→ **[Lee el README de la app móvil](uxnanmobile/README.md)**
 
-> Especificación técnica completa: [`architecture/`](architecture/00-index.md)
-
-### `uxnandesktop/` — App de Escritorio (ADE, Tauri 2 + Rust + Svelte 5)
+### 🖥️ [`uxnandesktop/`](uxnandesktop/README.md) — la app de escritorio
 
 ![Rust](https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white)
 ![Tauri](https://img.shields.io/badge/Tauri_2-FFC131?style=for-the-badge&logo=tauri&logoColor=000000)
 ![Svelte](https://img.shields.io/badge/Svelte_5-FF3E00?style=for-the-badge&logo=svelte&logoColor=white)
-![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
 ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white)
 ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=white)
 
-Un **Agent Development Environment** ligero construido con Tauri 2, Rust y Svelte 5. A diferencia de las alternativas basadas en Electron que consumen 200-500 MB de RAM solo por existir, este ADE usa el webview nativo del OS y apunta a 30-100 MB de RAM.
+Un **Agent Development Environment** ligero construido con Tauri 2, Rust y Svelte
+5. A diferencia de las alternativas basadas en Electron que consumen 200-500 MB
+de RAM solo por existir, este ADE usa el webview nativo del OS y apunta a 30-100
+MB de RAM.
 
-La idea central: cada tarea vive en su propio git worktree con su propio agente corriendo en un pseudoterminal independiente. Puedo tener 5 agentes trabajando en paralelo sin que uno bloquee a otro, cambiar entre ellos con un click (sin `git stash`, sin `git checkout`), y revisar los cambios de cada uno en un visor de diffs integrado (CodeMirror 6, unificado + lado a lado, staging por hunk) antes de hacer commit.
+La idea central: cada tarea vive en su propio git worktree con su propio agente
+corriendo en un pseudoterminal independiente. Puedo tener 5 agentes trabajando en
+paralelo sin que uno bloquee a otro, cambiar entre ellos con un click (sin `git
+stash`, sin `git checkout`), y revisar los cambios de cada uno en un visor de
+diffs integrado (CodeMirror 6, unificado + lado a lado, staging por hunk) antes
+de hacer commit.
 
-No integra el SDK de ningún agente. Es terminal-centrico: cualquier agente CLI funciona sin modificación. **Las Fases 0-5 + la pista cross-cutting (S) están completas** — el ADE es alpha-funcional como app standalone. La única fase restante es la **Fase 6 (bridge embebido / pairing móvil)**, que es *opcional para uso standalone*.
+No integra el SDK de ningún agente. Es terminal-centrico: cualquier agente CLI
+funciona sin modificación.
 
-> Especificación técnica completa: [`uxnandesktop/architecture/`](uxnandesktop/architecture/00-index.md)
+→ **[Lee el README de la app de escritorio](uxnandesktop/README.md)**
 
-### `bridge/` — Daemon Bridge (Node.js, corre en la PC)
+### 🌉 [`bridge/`](bridge/README.md) — el daemon en tu PC
 
 ![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
 ![JSON RPC](https://img.shields.io/badge/JSON--RPC_2.0-000000?style=for-the-badge&logo=json&logoColor=white)
 ![WebSocket](https://img.shields.io/badge/WebSocket-010101?style=for-the-badge&logo=socketdotio&logoColor=white)
 
-El **daemon de plano de control local** que conecta la app móvil con los agentes locales. Implementa el lado bridge del protocolo E2EE (X25519 + HKDF + Ed25519 + AES-256-GCM), lanza el **CLI local oficial** de cada agente sobre stdio (sin API / SDK / keys de proveedor), y expone una interfaz JSON-RPC unificada (60 métodos + 8 notificaciones de streaming) hacia el teléfono.
+El corazón del producto. Un pequeño daemon Node.js que corre en tu PC, mantiene
+la conexión cifrada de extremo a extremo con tu teléfono (protocolo E2EE: X25519
++ HKDF + Ed25519 + AES-256-GCM) y maneja a los agentes por ti, lanzando el **CLI
+local oficial** de cada uno tal como lo harías en una terminal. Sin API de
+proveedor, sin SDK, sin keys: cada agente corre bajo la cuenta con la que ya
+iniciaste sesión.
 
-Funciona en dos modos:
-- **Standalone** (por defecto): se instala por separado para quienes solo quieren el control remoto desde el móvil sin instalar la app de escritorio.
-- **Embebido**: la app de escritorio lo integra como proceso hijo (Fase 6 de `uxnandesktop/`, *opcional para standalone*).
+**Agentes reales cableados:** OpenCode, Claude Code, Codex, pi, Gemini CLI.
 
-**Agentes reales cableados:** OpenCode, Claude Code, Codex, pi, Gemini CLI. Cada uno corre el CLI oficial en el `cwd` del thread con `shell:false`; el bridge parsea su formato nativo de stream y emite eventos estructurados `stream/content/block` (comando / diff / tool) más `stream/thinking/delta` (razonamiento). **Aider** es el único que no está cableado todavía (receta en `bridge/FOR-DEV.md`).
+→ **[Lee el README del bridge](bridge/README.md)**
 
-> Especificación del bridge: [`architecture/02a-system-architecture.md`](architecture/02a-system-architecture.md) (sección 5.8)
-> Integración con desktop: [`uxnandesktop/architecture/02e-bridge-integration.md`](uxnandesktop/architecture/02e-bridge-integration.md)
-
-### `relay/` — Servidor Relay (Node.js, **opcional / self-hosted**)
+### 🔁 [`relay/`](relay/README.md) — el salto opcional fuera de la LAN
 
 ![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
 ![E2EE](https://img.shields.io/badge/E2EE_OPACO-0a0a0a?style=for-the-badge&logo=letsencrypt&logoColor=white)
 
-Relay WebSocket stateless que reenvía **envelopes E2EE opacos** entre el teléfono y el bridge cuando no están en la misma red LAN/Tailscale. Solo ve frames cifrados — nunca plaintext, keys, código ni diffs.
+Un relay WebSocket diminuto y stateless que puedes self-hostear para cuando tu
+teléfono y tu PC no están en la misma red. Reenvía **sobres E2EE sellados** y
+nada más — nunca ve tu código, tus diffs, tus keys ni una línea de texto plano.
+La mayoría del tiempo ni lo necesitas.
 
-El relay es ahora **opcional y self-hosted**: las rutas primarias del producto son **LAN-direct** y **Tailscale-direct** (cero hosting, cero credenciales). El relay es el fallback off-LAN hospedado para quien quiera correr el suyo. Las notificaciones push las envía **el bridge directamente** (FCM HTTP v1, `firebase-admin` lazy) y funcionan sobre cualquier transporte; los endpoints `/push/*` del relay quedan como fallback hospedado.
+→ **[Lee el README del relay](relay/README.md)**
 
-> Especificación del relay: [`architecture/02a-system-architecture.md`](architecture/02a-system-architecture.md) (sección 5.10)
-
-### `shared/` — Contratos Compartidos (TypeScript, ESM, Node ≥18)
+### 📦 [`shared/`](shared/README.md) — el lenguaje común
 
 ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
 ![JSON Schema](https://img.shields.io/badge/JSON_Schema-000000?style=for-the-badge&logo=json&logoColor=white)
 
-La única fuente de verdad para los **contratos JSON-RPC + E2EE** que consumen el bridge y el relay (la app móvil mantiene equivalentes Dart sincronizados a mano). Exports autoritativos:
+La única fuente de verdad para los **contratos JSON-RPC + E2EE** que habla cada
+parte de Uxnan. El bridge y el relay lo consumen directo; la app móvil mantiene
+equivalentes en Dart sincronizados a mano. Si dos componentes necesitan ponerse
+de acuerdo en la forma de un mensaje, se ponen de acuerdo aquí.
 
-- **JSON-RPC**: tipos de envelope + constructores, códigos de error (`-32000..-32008` + estándar), registro de métodos tipado (locked en build-time contra `METHOD_NAMES`).
-- **E2EE**: mensajes de handshake, transcript builder, `SecureEnvelope`, `PairingPayload` v2 (con `hosts: string[]` para direccionamiento directo).
-- **Modelos de dominio** (thread/turn/message, git, workspace, project, auth, session, approval) y **contratos de agente** (`IAgentAdapter`, `AgentCapabilities`, `AgentConfig`).
-- **Validación**: validadores basados en Ajv para requests, responses, envelopes E2EE, payloads de pairing y payloads de push.
+- **JSON-RPC**: tipos de envelope + constructores, códigos de error
+  (`-32000..-32008` + estándar), registro de métodos tipado (locked en
+  build-time contra `METHOD_NAMES`).
+- **E2EE**: mensajes de handshake, transcript builder, `SecureEnvelope`,
+  `PairingPayload` v2 (con `hosts: string[]` para direccionamiento directo).
+- **Modelos de dominio** (thread/turn/message, git, workspace, project, auth,
+  session, approval) y **contratos de agente** (`IAgentAdapter`,
+  `AgentCapabilities`, `AgentConfig`).
+- **Validación**: validadores basados en Ajv para requests, responses, envelopes
+  E2EE, payloads de pairing y payloads de push.
 
-> Contratos JSON-RPC: [`architecture/02b-contracts-and-requirements.md`](architecture/02b-contracts-and-requirements.md) (sección 1)
-
-## Stack
-
-| Componente | Tecnología |
-|---|---|
-| App móvil | Flutter / Dart, Riverpod 3.x (manual), Material Design 3 (+ Neural Expressive), drift (SQLite) |
-| App desktop | Rust, Tauri 2, Svelte 5 (Runes), shadcn-svelte, Tailwind v4, xterm.js, CodeMirror 6 |
-| Bridge | Node.js (TypeScript, ESM, Node ≥18) |
-| Relay | Node.js (TypeScript, ESM, Node ≥18) — opcional / self-hosted |
-| Contratos compartidos | TypeScript (ESM, Node ≥18), validadores Ajv |
-| Seguridad | X25519 + Ed25519 + AES-256-GCM + HKDF-SHA256 |
+→ **[Lee el README de los contratos compartidos](shared/README.md)**
 
 ## Seguridad
 
@@ -113,33 +162,84 @@ La única fuente de verdad para los **contratos JSON-RPC + E2EE** que consumen e
 ![AES-256-GCM](https://img.shields.io/badge/AES--256--GCM-Cifrado-2ea44f?style=for-the-badge)
 ![HKDF-SHA256](https://img.shields.io/badge/HKDF--SHA256-Derivación_de_Claves-2ea44f?style=for-the-badge)
 
-Toda la comunicación entre la app móvil y la PC pasa por un canal E2EE real. El relay, cuando se usa, es solo transporte y nunca ve texto plano. Las claves de sesión se derivan mediante intercambio de claves efímeras X25519, autenticadas con firmas de identidad Ed25519, y usadas para cifrado simétrico AES-256-GCM. Los payloads del bridge están sanitizados: `auth/status` es per-agente, nunca devuelve tokens y detecta el login solo por la existencia de archivos de auth conocidos.
+Aquí la privacidad no es una función, es el cimiento. Todo lo que viaja entre el
+teléfono y la PC pasa por un canal cifrado de extremo a extremo real: las claves
+de sesión salen de un intercambio efímero X25519, las identidades se autentican
+con firmas Ed25519 y el tráfico se sella con AES-256-GCM. El relay, cuando
+siquiera interviene, es puro transporte y jamás sostiene una clave. Las
+respuestas del bridge también van sanitizadas — el estado de sesión, por ejemplo,
+se reporta por agente y **nunca** devuelve un token.
 
-## Estado actual
+Si encuentras una vulnerabilidad, por favor no abras un issue público — revisa
+[`SECURITY.md`](SECURITY.md).
+
+## Estado
 
 ![Phase](https://img.shields.io/badge/PHASE-ALPHA_(MVP_en_progreso)-orange?style=for-the-badge)
 
-El MVP móvil corre end-to-end contra el bridge con **5 agentes reales** (OpenCode, Claude Code, Codex, pi, Gemini CLI). El ADE de escritorio es alpha-funcional como app standalone. Estado por componente:
+Uxnan está en **alpha**, y el ciclo central ya funciona de extremo a extremo.
+Desde el teléfono puedo emparejarme con el bridge y mantener una conversación
+real en streaming con **cinco agentes** —OpenCode, Claude Code, Codex, pi y
+Gemini CLI— sobre el canal cifrado. La app de escritorio es alpha-funcional por
+sí sola. Las notificaciones push están vivas en Android (iOS depende de assets de
+Apple).
 
-| Componente | Estado |
-|---|---|
-| `uxnanmobile/` | **MVP cableado (Android alpha-ready).** Pairing QR + por código manual + trusted reconnect, transporte E2EE (LAN/Tailscale-direct + fallback relay), conversación en streaming con **turnos estructurados del agente** (work log, changed files, thinking — todo intercalado), threads por PC con **status multi-PC truthful connection-targeted**, **selector de modelos estructurado** (nombres legibles, badge default, versión resuelta del alias, per-model run-option knobs), **medidor de uso de contexto persistido** (%, gated en `reportsContextUsage`), **dictado voz→texto**, **adjuntar imágenes** (galería + cámara), **stop-the-turn** mid-run, **sign-in status per-agente** (`auth/status`), **aprobación interactiva** (Approve / Reject / "always allow this session"), **Remove device**, acciones por thread (rename / archive / delete / copy id), **folder browser** (`workspace/browseDirs`), **indicador relay-vs-directo**, **deep-link de notificaciones**, **pantalla Git completa** (diff per-file, switch de rama con auto-stash, smart PR, undo-commit), settings + preferencias de notificación + scroll-on-send, **copy personalizado en push** + supresión en foreground, registro FCM (gated). iOS pendiente de assets FOR-HUMAN. |
-| `bridge/` | **Implementado.** Transporte E2EE (LAN `http+ws` + relay opcional), **5 agentes reales cableados** (OpenCode, Claude Code, Codex, pi, Gemini CLI) + per-thread/project agent+model, **descubrimiento estructurado `AgentModel[]`**, **token usage per-turn**, **thinking + structured commands/tools/diffs** para cada agente, **intake de aprobación interactiva** (Echo demo + Claude Code opt-in `PreToolUse` hook), **adjuntar imágenes** (file-path CLI-agnóstico), **folder browsing plug-and-play** (`workspace/browseDirs`), **pins de agent/model per-proyecto**, **`auth/status` sanitizado per-agente**, git + workspace + **checkpoints con restore verdadero + retention pruning**, **fallback on-disk `turn/list` history** (Claude/Codex/OpenCode/pi JSONL/JSON stores), **FCM push directo desde el bridge** (persistido, target per-phone, prune-on-untrust), **manual-code pairing** (`GET /pair/resolve?code=`) + **descubrimiento mDNS** (`_uxnan._tcp.local`), autostart por OS, file logging. **Aider** es el último agente planeado (FOR-DEV). |
-| `relay/` | **Implementado — ahora OPCIONAL / self-hosted.** Relay de envelopes E2EE por `sessionId`, rate limiting per-IP, peer-close + manejo de stale-socket, endpoints de push (`/push/register|notify`, FCM, gated en creds) como **fallback** (el bridge es la ruta primaria de push). |
-| `shared/` | **Implementado.** Contratos JSON-RPC + E2EE, **60 métodos** + 8 notificaciones de streaming, validadores Ajv, `PairingPayload` v2 (relay opcional + hosts), per-model run-option knobs, image attachments, aprobación interactiva. |
-| `uxnandesktop/` | **Alpha-funcional (standalone).** Tauri 2 + Rust + Svelte 5 ADE. **Fases 0-5 + cross-cutting (S) completas.** Shell de tres paneles redimensionable, persistencia JSON atómica (5 backups rotativos + migraciones secuenciales), terminales PTY (xterm WebGL + DOM fallback) con tabs + splits anidados + reordenar/mover tabs entre regiones + ciclo MRU con `Ctrl+Tab` + ring buffer de salida en backend + protocolo de teclado Kitty/CSI-u, git worktrees con workspaces de terminal per-worktree, git status/diff/stage/commit/push/pull (watcher 3s focus-paused, visor de diffs CodeMirror 6, staging por hunk), **Layer 1 HTTP hook server** (axum: `working/blocked/waiting/done` preciso, cache persistente) + Layer 2 terminal-title (OSC) + Layer 3 process-tree, notificaciones nativas en idle, logos personalizados por agente, override de agente per-worktree, i18n completa EN/ES, design tokens, registro de agentes + manual + auto-launch, paleta de worktrees (Ctrl/Cmd+P), listas virtualizadas, keep-awake opt-in (Windows). Fase 6 (bridge embebido / pairing móvil) es la única fase restante, *opcional para uso standalone*. |
+Aquí va la foto rápida; el estado detallado y siempre al día de cada proyecto
+vive en su propio `FOR-DEV.md`:
 
-**Las notificaciones push** están code-complete y **Android está live**; la entrega en iOS está pendiente de una APNs key (macOS + Apple Developer). **El push lo envía directamente el bridge** (FCM HTTP v1) sobre cualquier transporte — LAN directo, Tailscale o relay — así que funciona sin un relay hospedado. Los endpoints `/push/*` del relay quedan como fallback hospedado opcional.
+| Proyecto | Cómo está | Detalle |
+|---|---|---|
+| [`uxnanmobile/`](uxnanmobile/README.md) | MVP cableado, Android alpha-ready; iOS pendiente de assets de Apple | [estado](uxnanmobile/FOR-DEV.md) |
+| [`uxnandesktop/`](uxnandesktop/README.md) | Alpha-funcional como app standalone | [estado](uxnandesktop/FOR-DEV.md) |
+| [`bridge/`](bridge/README.md) | Implementado; 5 agentes reales cableados | [estado](bridge/FOR-DEV.md) |
+| [`relay/`](relay/README.md) | Implementado; opcional / self-hosted | [estado](relay/FOR-DEV.md) |
+| [`shared/`](shared/README.md) | Implementado; contratos bloqueados en CI | [README](shared/README.md) |
 
-**iOS** no está alpha-ready todavía: el Podfile se genera en el primer build en macOS, la APNs key debe subirse a Firebase, y las usage strings de `Info.plist` (cámara, micrófono, red local, photo library) están pendientes — ver `uxnanmobile/FOR-HUMAN.md`.
+Es software temprano, sin usuarios ni datos de producción todavía, así que las
+cosas aún pueden cambiar donde una idea mejor lo justifique.
 
-El progreso por componente vive en cada `CHANGELOG.md`; lo pendiente en cada
-`FOR-DEV.md`. La documentación operativa por componente (instalación,
-configuración, agentes, testing, deploy) vive en [`bridge/docs/`](bridge/docs/),
-[`relay/docs/`](relay/docs/), [`uxnanmobile/docs/`](uxnanmobile/docs/), y
-[`uxnandesktop/docs/`](uxnandesktop/docs/). El proyecto aplica
-[`AGENTS.md` → "Spec drift control"](AGENTS.md): cada `DONE` en cualquier
-`FOR-DEV.md` se refleja en `architecture/` en el mismo conjunto de cambios.
+## Apoya el proyecto
+
+Uxnan es gratis y de código abierto, hecho en abierto y en mi tiempo libre. Si te
+resulta útil y quieres ayudar a que siga avanzando, un café ayuda muchísimo — y
+de verdad se agradece. 🙏
+
+<p align="center">
+  <a href="https://sink.gamas.workers.dev/buymeacoffee">
+    <img src="https://raw.githubusercontent.com/luisgamas/buttons-design/main/buy_me_a_coffe/buy_me_a_coffe_fill.png" width="200" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://sink.gamas.workers.dev/paypal-donations">
+    <img src="https://raw.githubusercontent.com/luisgamas/buttons-design/main/paypal/paypal_fill.png" width="200" alt="Donate via PayPal" />
+  </a>
+  <a href="https://sink.gamas.workers.dev/github-sponsor">
+    <img src="https://raw.githubusercontent.com/luisgamas/buttons-design/main/github_sponsor/github_sponsor_fill.png" width="200" alt="Sponsor on GitHub" />
+  </a>
+</p>
+
+## Para colaboradores y desarrolladores
+
+Si quieres compilar, correr o contribuir a Uxnan, todo lo que necesitas vive
+fuera del README para que la documentación de arriba se mantenga enfocada:
+
+- **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — cómo preparar el entorno, los
+  controles de calidad y cómo abrir un buen PR.
+- **[`AGENTS.md`](AGENTS.md)** — la única fuente de verdad para convenciones,
+  reglas de arquitectura y cómo se mantiene sincronizada la documentación. Léelo
+  antes de cualquier cambio no trivial.
+- **Docs por proyecto** — cada proyecto guarda guías enfocadas en su propio
+  `docs/` y un `CHANGELOG.md`: [`bridge/docs/`](bridge/docs/) ·
+  [`relay/docs/`](relay/docs/) · [`uxnanmobile/docs/`](uxnanmobile/docs/) ·
+  [`uxnandesktop/docs/`](uxnandesktop/docs/).
+- **La especificación** — los documentos de arquitectura son la fuente de verdad
+  del comportamiento entre componentes:
+  [`architecture/`](architecture/00-index.md) (móvil, bridge, relay, shared) y
+  [`uxnandesktop/architecture/`](uxnandesktop/architecture/00-index.md)
+  (escritorio).
+- **Releases y versionado** — [`VERSIONS.md`](VERSIONS.md).
+
+## Licencia
+
+Uxnan se publica bajo la [Mozilla Public License 2.0](LICENSE).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,108 +4,151 @@
 ![Monorepo](https://img.shields.io/badge/MONOREPO-5_PROJECTS-blue?style=for-the-badge)
 ![E2EE](https://img.shields.io/badge/E2EE-AES--256--GCM-0a0a0a?style=for-the-badge&logo=letsencrypt&logoColor=white)
 ![Platforms](https://img.shields.io/badge/PLATFORMS-Android_%7C_iOS_%7C_Windows_%7C_macOS_%7C_Linux-lightgrey?style=for-the-badge)
+![License](https://img.shields.io/badge/LICENSE-MPL--2.0-2ea44f?style=for-the-badge)
 
 > [Leer en español](README.es.md)
 
-Uxnan (pronounced /uʃ.nan/) is a toolkit I'm building to solve a very specific problem I have as a developer: **controlling AI coding agents from anywhere, without my hardware becoming the bottleneck.**
+Uxnan (pronounced /uʃ.nan/) is a toolkit I'm building to solve a very specific
+problem I have as a developer: **controlling AI coding agents from anywhere,
+without my hardware becoming the bottleneck.**
 
 ## Why this project exists
 
-I work with CLI coding agents (Claude Code, Codex CLI, OpenCode, Gemini CLI, pi-agent) every day. They're extraordinary tools, but the current workflow has real friction:
+I work with CLI coding agents (Claude Code, Codex CLI, OpenCode, Gemini CLI,
+pi-agent) every day. They're extraordinary tools, but the current workflow has
+real friction:
 
-- **When I step away from my PC**, I lose all visibility into what the agent is doing. I can't check its progress, approve changes, or send new instructions from my phone.
-- **Existing desktop solutions are excellent**, but many assume high-end hardware. On my current setup, running a heavy IDE + multiple agents + an Electron environment consumes more resources than I can afford.
-- **There's no provider-agnostic mobile tool** that works with any agent, not just one in particular.
+- **When I step away from my PC**, I lose all visibility into what the agent is
+  doing. I can't check its progress, approve changes, or send new instructions
+  from my phone.
+- **Existing desktop solutions are excellent**, but many assume high-end
+  hardware. On my current setup, running a heavy IDE + multiple agents + an
+  Electron environment consumes more resources than I can afford.
+- **There's no provider-agnostic mobile tool** that works with any agent, not
+  just one in particular.
 
-Uxnan was born to solve exactly that. It's not an agent — it's the **control plane** for the agents I already use.
+Uxnan was born to solve exactly that. It's not an agent — it's the **control
+plane** for the agents I already use.
+
+## How it fits together
+
+The phone never talks to a cloud middleman in the clear. It pairs with the
+**bridge** running on your PC and connects to it **directly first** — over your
+LAN or your Tailscale network — and only falls back to an optional, self-hosted
+**relay** when you're away from home. Whatever the path, every byte is
+end-to-end encrypted; the relay only ever sees sealed envelopes.
+
+```text
+   📱 uxnanmobile                  💻 your PC
+   (Flutter app)                   ┌──────────────────────────────┐
+        │                          │  bridge  ──▶  agent CLIs      │
+        │   E2EE (X25519 +         │  (daemon)     claude · codex  │
+        ├──── Ed25519 + ──────────▶│               opencode · pi   │
+        │     AES-256-GCM)         │               gemini          │
+        │                          └──────────────────────────────┘
+        │                                      ▲
+        └──── relay (optional, ────────────────┘
+              self-hosted, off-LAN only —
+              forwards sealed envelopes, sees nothing)
+
+   uxnandesktop — a separate, lightweight desktop app to run & review the same
+   agents on the PC itself. shared — the contracts both ends speak.
+```
 
 ## What each component does
 
-### `uxnanmobile/` — Mobile App (Flutter, Android + iOS)
+Uxnan is a single repository with five projects. Each one has its own README with
+the full story; here's the short version and where to go next.
+
+### 📱 [`uxnanmobile/`](uxnanmobile/README.md) — the mobile app
 
 ![Flutter](https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white)
 ![Dart](https://img.shields.io/badge/Dart-0175C2?style=for-the-badge&logo=dart&logoColor=white)
 ![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white)
 ![iOS](https://img.shields.io/badge/iOS-000000?style=for-the-badge&logo=apple&logoColor=white)
-![SQLite](https://img.shields.io/badge/SQLite-003B57?style=for-the-badge&logo=sqlite&logoColor=white)
-![Material Design](https://img.shields.io/badge/Material_Design_3-757575?style=for-the-badge&logo=materialdesign&logoColor=white)
 
-A Flutter app that works as a remote control for agents running on my PC. From my phone I can watch conversations in real time, send instructions, attach images, dictate via voice, commit+push, review diffs, and receive notifications when an agent finishes a task.
+A Flutter app (Android + iOS) that turns your phone into a remote control for the
+agents on your PC. Watch conversations stream in real time, send instructions,
+attach images, dictate by voice, review diffs, commit and push, and get a
+notification the moment an agent finishes — all over the encrypted, bridge-first
+channel.
 
-The connection is end-to-end encrypted (E2EE) and is **bridge-first**: the phone tries the bridge's direct LAN/Tailscale addresses first, and falls back to a self-hosted relay only for off-LAN access. The relay — when used — only ever sees opaque E2EE envelopes.
+→ **[Read the mobile app README](uxnanmobile/README.md)**
 
-> Full technical specification: [`architecture/`](architecture/00-index.md)
-
-### `uxnandesktop/` — Desktop App (ADE, Tauri 2 + Rust + Svelte 5)
+### 🖥️ [`uxnandesktop/`](uxnandesktop/README.md) — the desktop app
 
 ![Rust](https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white)
 ![Tauri](https://img.shields.io/badge/Tauri_2-FFC131?style=for-the-badge&logo=tauri&logoColor=000000)
 ![Svelte](https://img.shields.io/badge/Svelte_5-FF3E00?style=for-the-badge&logo=svelte&logoColor=white)
-![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
 ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white)
 ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white)
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=white)
 
-A lightweight **Agent Development Environment** built with Tauri 2, Rust, and Svelte 5. Unlike Electron-based alternatives that consume 200-500 MB of RAM just by existing, this ADE uses the native OS webview and targets 30-100 MB of RAM.
+A lightweight **Agent Development Environment** built with Tauri 2, Rust and
+Svelte 5. Unlike Electron-based alternatives that consume 200-500 MB of RAM just
+by existing, this ADE uses the OS's native webview and targets 30-100 MB of RAM.
 
-The core idea: each task lives in its own git worktree with its own agent running in an independent pseudoterminal. I can have 5 agents working in parallel without one blocking another, switch between them with a click (no `git stash`, no `git checkout`), and review each one's changes in an integrated diff viewer (CodeMirror 6, unified + side-by-side, hunk-level staging) before committing.
+The core idea: each task lives in its own git worktree with its own agent running
+in an independent pseudoterminal. I can have 5 agents working in parallel without
+one blocking another, switch between them with a click (no `git stash`, no `git
+checkout`), and review each one's changes in an integrated diff viewer
+(CodeMirror 6, unified + side-by-side, hunk-level staging) before committing.
 
-It doesn't integrate any agent's SDK. It's terminal-centric: any CLI agent works without modification. **Phases 0–5 + the cross-cutting track (S) are complete** — the ADE is alpha-functional as a standalone app. The only remaining phase is **Phase 6 (embedded bridge / mobile pairing)**, which is *optional for standalone use*.
+It doesn't integrate any agent's SDK. It's terminal-centric: any CLI agent works
+without modification.
 
-> Full technical specification: [`uxnandesktop/architecture/`](uxnandesktop/architecture/00-index.md)
+→ **[Read the desktop app README](uxnandesktop/README.md)**
 
-### `bridge/` — Bridge Daemon (Node.js, runs on the PC)
+### 🌉 [`bridge/`](bridge/README.md) — the daemon on your PC
 
 ![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
 ![JSON RPC](https://img.shields.io/badge/JSON--RPC_2.0-000000?style=for-the-badge&logo=json&logoColor=white)
 ![WebSocket](https://img.shields.io/badge/WebSocket-010101?style=for-the-badge&logo=socketdotio&logoColor=white)
 
-The **local control-plane daemon** that connects the mobile app to local agents. It implements the bridge side of the E2EE protocol (X25519 + HKDF + Ed25519 + AES-256-GCM), spawns each agent's **official local CLI** over stdio (no provider API / SDK / keys), and exposes a unified JSON-RPC interface (60 methods + 8 streaming notifications) to the phone.
+The heart of the product. A small Node.js daemon that runs on your PC, holds the
+end-to-end-encrypted connection to your phone (E2EE protocol: X25519 + HKDF +
+Ed25519 + AES-256-GCM), and drives the agents on your behalf by launching each
+one's **official local CLI** exactly as you would in a terminal. No provider API,
+no SDK, no keys: every agent runs under the account you already signed it in
+with.
 
-It works in two modes:
-- **Standalone** (default): installed separately for those who only want mobile remote control without installing the desktop app.
-- **Embedded**: the desktop app integrates it as a child process (Phase 6 of `uxnandesktop/`, *optional for standalone*).
+**Real agents wired:** OpenCode, Claude Code, Codex, pi, Gemini CLI.
 
-**Real agents wired:** OpenCode, Claude Code, Codex, pi, Gemini CLI. Each runs the official CLI in the thread's cwd with `shell:false`; the bridge parses its native stream format and emits structured `stream/content/block` events (command / diff / tool) plus `stream/thinking/delta` (reasoning). **Aider** is the only one not yet wired (recipe in `bridge/FOR-DEV.md`).
+→ **[Read the bridge README](bridge/README.md)**
 
-> Bridge specification: [`architecture/02a-system-architecture.md`](architecture/02a-system-architecture.md) (section 5.8)
-> Desktop integration: [`uxnandesktop/architecture/02e-bridge-integration.md`](uxnandesktop/architecture/02e-bridge-integration.md)
-
-### `relay/` — Relay Server (Node.js, **optional / self-hosted**)
+### 🔁 [`relay/`](relay/README.md) — the optional off-LAN hop
 
 ![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
 ![E2EE](https://img.shields.io/badge/E2EE_OPAQUE-0a0a0a?style=for-the-badge&logo=letsencrypt&logoColor=white)
 
-A stateless WebSocket relay that forwards **opaque E2EE envelopes** between the phone and the bridge when they're not on the same LAN/Tailscale network. It only ever sees encrypted frames — never plaintext, keys, code, or diffs.
+A tiny, stateless WebSocket relay you can self-host for when your phone and PC
+aren't on the same network. It forwards **sealed E2EE envelopes** and nothing
+else — it never sees your code, your diffs, your keys, or a line of plaintext.
+Most of the time you won't need it at all.
 
-The relay is now **optional and self-hosted**: the product's primary paths are **LAN-direct** and **Tailscale-direct** (zero hosting, zero credentials). The relay is the hosted off-LAN fallback for users who want to run their own. Push notifications are sent **by the bridge directly** (FCM HTTP v1, lazy `firebase-admin`) and work on any transport; the relay's `/push/*` endpoints stay as a hosted fallback.
+→ **[Read the relay README](relay/README.md)**
 
-> Relay specification: [`architecture/02a-system-architecture.md`](architecture/02a-system-architecture.md) (section 5.10)
-
-### `shared/` — Shared Contracts (TypeScript, ESM, Node >=18)
+### 📦 [`shared/`](shared/README.md) — the common language
 
 ![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
 ![JSON Schema](https://img.shields.io/badge/JSON_Schema-000000?style=for-the-badge&logo=json&logoColor=white)
 
-The single source of truth for **JSON-RPC + E2EE contracts** consumed by the bridge and the relay (the mobile app keeps hand-synced Dart equivalents). Authoritative exports:
+The single source of truth for the **JSON-RPC + E2EE contracts** that every part
+of Uxnan speaks. The bridge and relay consume it directly; the mobile app keeps
+hand-synced Dart equivalents. If two components ever need to agree on a message
+shape, they agree here.
 
-- **JSON-RPC** envelope types + constructors, error codes (`-32000..-32008` + standard), typed method registry (compile-time-locked to `METHOD_NAMES`).
-- **E2EE** handshake messages, transcript builder, `SecureEnvelope`, `PairingPayload` v2 (with `hosts: string[]` for direct addressing).
-- **Domain models** (thread/turn/message, git, workspace, project, auth, session, approval) and **agent contracts** (`IAgentAdapter`, `AgentCapabilities`, `AgentConfig`).
-- **Validation**: Ajv-backed validators for requests, responses, E2EE envelopes, pairing payloads, push payloads.
+- **JSON-RPC**: envelope types + constructors, error codes (`-32000..-32008` +
+  standard), typed method registry (build-time-locked to `METHOD_NAMES`).
+- **E2EE**: handshake messages, transcript builder, `SecureEnvelope`,
+  `PairingPayload` v2 (with `hosts: string[]` for direct addressing).
+- **Domain models** (thread/turn/message, git, workspace, project, auth, session,
+  approval) and **agent contracts** (`IAgentAdapter`, `AgentCapabilities`,
+  `AgentConfig`).
+- **Validation**: Ajv-backed validators for requests, responses, E2EE envelopes,
+  pairing payloads and push payloads.
 
-> JSON-RPC contracts: [`architecture/02b-contracts-and-requirements.md`](architecture/02b-contracts-and-requirements.md) (section 1)
-
-## Stack
-
-| Component | Technology |
-|---|---|
-| Mobile app | Flutter / Dart, Riverpod 3.x (manual), Material Design 3 (+ Neural Expressive), drift (SQLite) |
-| Desktop app | Rust, Tauri 2, Svelte 5 (Runes), shadcn-svelte, Tailwind v4, xterm.js, CodeMirror 6 |
-| Bridge | Node.js (TypeScript, ESM, Node >=18) |
-| Relay | Node.js (TypeScript, ESM, Node >=18) — optional / self-hosted |
-| Shared contracts | TypeScript (ESM, Node >=18), Ajv validators |
-| Security | X25519 + Ed25519 + AES-256-GCM + HKDF-SHA256 |
+→ **[Read the shared contracts README](shared/README.md)**
 
 ## Security
 
@@ -114,41 +157,84 @@ The single source of truth for **JSON-RPC + E2EE contracts** consumed by the bri
 ![AES-256-GCM](https://img.shields.io/badge/AES--256--GCM-Encryption-2ea44f?style=for-the-badge)
 ![HKDF-SHA256](https://img.shields.io/badge/HKDF--SHA256-Key_Derivation-2ea44f?style=for-the-badge)
 
-All communication between the mobile app and the PC goes through a real E2EE channel. The relay — when used — is transport-only and never sees plaintext. Session keys are derived via X25519 ephemeral key exchange, authenticated with Ed25519 identity signatures, and used for AES-256-GCM symmetric encryption. Bridge payloads are sanitized: `auth/status` is per-agent, never returns tokens, and detects login only by the existence of well-known auth files.
+Here privacy isn't a feature, it's the foundation. Everything that travels
+between the phone and the PC goes through a real end-to-end encrypted channel:
+session keys come from an X25519 ephemeral exchange, identities are authenticated
+with Ed25519 signatures, and traffic is sealed with AES-256-GCM. The relay, when
+it's even involved, is pure transport and never holds a key. Bridge responses are
+sanitized too — sign-in status, for example, is reported per agent and **never**
+returns a token.
 
-## Current status
+If you find a vulnerability, please don't open a public issue — see
+[`SECURITY.md`](SECURITY.md).
+
+## Status
 
 ![Phase](https://img.shields.io/badge/PHASE-ALPHA_(MVP_in_progress)-orange?style=for-the-badge)
 
-The mobile MVP runs end-to-end against the bridge with **5 real agents** (OpenCode, Claude Code, Codex, pi, Gemini CLI). The desktop ADE is alpha-functional as a standalone app. Per-component status:
+Uxnan is in **alpha**, and the core loop already works end to end. From the phone
+I can pair with the bridge and hold a real, streaming conversation with **five
+agents** — OpenCode, Claude Code, Codex, pi and Gemini CLI — over the encrypted
+channel. The desktop app is alpha-functional on its own. Push notifications are
+live on Android (iOS depends on Apple assets).
 
-| Component | Status |
-|---|---|
-| `uxnanmobile/` | **MVP wired (Android alpha-ready).** QR pairing + manual-code pairing + trusted reconnect, E2EE transport (LAN/Tailscale-direct + relay fallback), streaming conversation with **structured agent turns** (work log, changed files, thinking — all interleaved), per-PC threads with **connection-targeted multi-PC status**, **structured model picker** (readable names, default badge, alias resolved version, per-model run-option knobs), **persisted context-usage meter** (%, gated on `reportsContextUsage`), **voice->text dictation**, **image attachments** (photo library + camera), **stop-the-turn** mid-run, **per-agent sign-in status** (`auth/status`), **interactive approval** (Approve / Reject / "always allow this session"), **Remove device**, per-thread actions (rename / archive / delete / copy id), **folder browser** (`workspace/browseDirs`), **relay-vs-direct transport indicator**, **notification deep-link**, full **Git screen** (per-file diff, branch switch with auto-stash, smart PR, undo-commit), settings + notification preferences + scroll-on-send, **personalized push copy** + foreground suppression, FCM push registration (gated). iOS pending FOR-HUMAN assets. |
-| `bridge/` | **Implemented.** E2EE transport (LAN `http+ws` + optional relay), **5 real agents wired** (OpenCode, Claude Code, Codex, pi, Gemini CLI) + per-thread/project agent+model, **structured `AgentModel[]` discovery**, **per-turn token usage**, **thinking + structured commands/tools/diffs** for every agent, **interactive approval intake** (Echo demo + Claude Code opt-in `PreToolUse` hook), **image attachments** (CLI-agnostic file-path), **plug-and-play folder browsing** (`workspace/browseDirs`), **per-project agent/model pins**, **sanitized per-agent `auth/status`**, git + workspace + **checkpoints with true worktree restore + retention pruning**, **on-disk `turn/list` history fallback** (Claude/Codex/OpenCode/pi JSONL/JSON stores), **direct FCM push from the bridge** (persisted, per-phone target, prune-on-untrust), **manual-code pairing** (`GET /pair/resolve?code=`) + **mDNS discovery** (`_uxnan._tcp.local`), autostart per OS, file logging. **Aider** is the last planned agent (FOR-DEV). |
-| `relay/` | **Implemented — now OPTIONAL / self-hosted.** E2EE envelope relay by `sessionId`, per-IP rate limiting, peer-close + stale-socket handling, **CSWSH `Origin` check on upgrades**, push endpoints (`/push/register|notify`, FCM, gated on creds) with **atomic state persistence** to `~/.uxnan/relay-state.json` (token registry + dedupe window with TTL 7d + cap 10k) as a **fallback** (the bridge is the primary push path). |
-| `shared/` | **Implemented.** JSON-RPC + E2EE contracts, **60 methods** + 8 streaming notifications, Ajv validators, `PairingPayload` v2 (relay optional + hosts), per-model run-option knobs, image attachments, interactive approval. |
-| `uxnandesktop/` | **Alpha-functional (standalone).** Tauri 2 + Rust + Svelte 5 ADE. **Phases 0-5 + cross-cutting (S) complete.** Three-panel resizable shell, atomic JSON persistence (5 rotating backups + sequential migrations), PTY terminals (xterm WebGL + DOM fallback) with tabs + nested splits + drag-reorder/move tabs across regions + `Ctrl+Tab` MRU + a backend output ring buffer + Kitty/CSI-u keyboard protocol, git worktrees with per-worktree terminal workspaces, git status/diff/stage/commit/push/pull (3s focus-paused watcher, CodeMirror 6 diff viewer, hunk-level staging), **Layer 1 HTTP hook server** (axum: precise `working/blocked/waiting/done`, persistent cache) + Layer 2 terminal-title (OSC) + Layer 3 process-tree, native idle notifications, custom agent logos, per-worktree agent override, full EN/ES i18n, design tokens, agents registry + manual + auto-launch, worktree palette (Ctrl/Cmd+P), virtualized lists, opt-in keep-awake (Windows). Phase 6 (embedded bridge / mobile pairing) is the only remaining phase, *optional for standalone use*. |
+Here's the quick snapshot; the detailed, always-current state for each project
+lives in its own `FOR-DEV.md`:
 
-**Push notifications** are code-complete and **Android is live**; iOS delivery is
-pending an APNs key (macOS + Apple Developer). **Push is sent directly by the
-bridge** (FCM HTTP v1) on any transport — direct LAN, Tailscale, or relay — so
-it works without a hosted relay. The relay's `/push/*` endpoints remain as an
-optional hosted fallback.
+| Project | Where it stands | Details |
+|---|---|---|
+| [`uxnanmobile/`](uxnanmobile/README.md) | MVP wired, Android alpha-ready; iOS pending Apple assets | [status](uxnanmobile/FOR-DEV.md) |
+| [`uxnandesktop/`](uxnandesktop/README.md) | Alpha-functional as a standalone app | [status](uxnandesktop/FOR-DEV.md) |
+| [`bridge/`](bridge/README.md) | Implemented; 5 real agents wired | [status](bridge/FOR-DEV.md) |
+| [`relay/`](relay/README.md) | Implemented; optional / self-hosted | [status](relay/FOR-DEV.md) |
+| [`shared/`](shared/README.md) | Implemented; contracts locked in CI | [README](shared/README.md) |
 
-**iOS** is not yet alpha-ready: the Podfile is generated on the first macOS
-build, the APNs key must be uploaded to Firebase, and `Info.plist` usage
-strings (camera, mic, local network, photo library) are pending — see
-`uxnanmobile/FOR-HUMAN.md`.
+This is early software, with no users and no production data yet, so things can
+still change where a better idea justifies it.
 
-Per-component progress lives in each `CHANGELOG.md`; pending work in each
-`FOR-DEV.md`. Per-component docs (install, config, agents, testing, deploy)
-live in [`bridge/docs/`](bridge/docs/), [`relay/docs/`](relay/docs/),
-[`uxnanmobile/docs/`](uxnanmobile/docs/), and
-[`uxnandesktop/docs/`](uxnandesktop/docs/). The project applies
-[`AGENTS.md` -> "Spec drift control"](AGENTS.md): every `DONE` in any
-`FOR-DEV.md` is reflected in `architecture/` in the same change set.
+## Support the project
+
+Uxnan is free and open source, built in the open in my own time. If it's useful
+to you and you'd like to help it keep moving, a coffee goes a long way — and it's
+genuinely appreciated. 🙏
+
+<p align="center">
+  <a href="https://sink.gamas.workers.dev/buymeacoffee">
+    <img src="https://raw.githubusercontent.com/luisgamas/buttons-design/main/buy_me_a_coffe/buy_me_a_coffe_fill.png" width="200" alt="Buy Me a Coffee" />
+  </a>
+  <a href="https://sink.gamas.workers.dev/paypal-donations">
+    <img src="https://raw.githubusercontent.com/luisgamas/buttons-design/main/paypal/paypal_fill.png" width="200" alt="Donate via PayPal" />
+  </a>
+  <a href="https://sink.gamas.workers.dev/github-sponsor">
+    <img src="https://raw.githubusercontent.com/luisgamas/buttons-design/main/github_sponsor/github_sponsor_fill.png" width="200" alt="Sponsor on GitHub" />
+  </a>
+</p>
+
+## For contributors & developers
+
+If you want to build, run, or contribute to Uxnan, everything you need lives off
+the README so the documentation above stays focused:
+
+- **[`CONTRIBUTING.md`](CONTRIBUTING.md)** — how to set up, the quality gates, and
+  how to open a good PR.
+- **[`AGENTS.md`](AGENTS.md)** — the single source of truth for conventions,
+  architecture rules, and how the docs stay in sync. Read it before any
+  non-trivial change.
+- **Per-project docs** — each project keeps task-focused guides in its own
+  `docs/` and a `CHANGELOG.md`: [`bridge/docs/`](bridge/docs/) ·
+  [`relay/docs/`](relay/docs/) · [`uxnanmobile/docs/`](uxnanmobile/docs/) ·
+  [`uxnandesktop/docs/`](uxnandesktop/docs/).
+- **The specification** — the architecture documents are the source of truth for
+  cross-component behavior: [`architecture/`](architecture/00-index.md) (mobile,
+  bridge, relay, shared) and
+  [`uxnandesktop/architecture/`](uxnandesktop/architecture/00-index.md)
+  (desktop).
+- **Releases & versioning** — [`VERSIONS.md`](VERSIONS.md).
+
+## License
+
+Uxnan is released under the [Mozilla Public License 2.0](LICENSE).
 
 ---
 
-*Uxnan — a name with no relation to or derivation from any existing product.*
+*Uxnan — a name with no relation to, or derivation from, any existing product.*

--- a/bridge/FOR-DEV.md
+++ b/bridge/FOR-DEV.md
@@ -13,9 +13,54 @@ only a human can provide.)
 
 The bridge is **alpha-functional** on its primary path (LAN/Tailscale-direct,
 standalone). It builds clean and the suite is green (bridge 357, shared 29, relay
-27). Nothing below blocks LAN/Tailscale-direct use. The only items that gate a
+27). Nothing below blocks LAN/Tailscale-direct use; the only items that gate a
 **public npm release** are the *Packaging* first-publish steps and real-device
 push validation (FOR-HUMAN).
+
+**Implemented (DONE):**
+
+- **E2EE transport** — relay `mac` client + direct-LAN `http+ws` server,
+  handshake, AES-256-GCM channel, byte-for-byte compatible with the mobile app;
+  background reconnect loop; stable pairing session; mDNS discovery
+  (`_uxnan._tcp.local`); manual-code pairing (`GET /pair/resolve?code=`).
+- **OS-keychain identity persistence** + single-instance lock.
+- **Real Git + Workspace handlers** — path-traversal-safe; working-tree
+  checkpoints with **true restore** + retention pruning; `git/revert`,
+  `git/deleteBranch`, `git/removeWorktree`, `workspace/exists`,
+  `workspace/browseDirs`.
+- **Conversation engine** — threads / turns + streaming, per-thread
+  `Message.blocks` / `Message.thinking` / `Message.usage`.
+- **5 real agents wired** — OpenCode (default), Claude Code, Codex, pi, and
+  Gemini CLI. Each spawns its **official local CLI** over stdio with
+  `shell:false`, parses the native stream, and emits structured
+  `stream/content/block` events (command / diff / tool) plus
+  `stream/thinking/delta` (reasoning). **Aider** is the only remaining agent
+  (recipe below).
+- **Per-thread agent/project selection** + per-project agent/model pins
+  (`projectAgents` config); per-model run-option knobs advertised on
+  `agent/models`; per-turn token usage on `stream/turn/completed`.
+- **Full thread lifecycle** — `thread/rename|archive|unarchive|delete`.
+- **Plug-and-play folder browsing** — `workspace/browseDirs` with a
+  `browseRoots` config.
+- **Direct FCM push from the bridge** — primary path, persisted across restarts,
+  per-phone target, prune-on-untrust. `firebase-admin` is an `optionalDependency`
+  (no creds = silent no-op; foreground local notifications still work).
+- **Sanitized per-agent `auth/status`** — never tokens; login detected by
+  auth-file existence only.
+- **Interactive approval intake** — Echo demo + Claude Code opt-in `PreToolUse`
+  hook + Codex via the `codex app-server` turn protocol + Gemini `BeforeTool`
+  hook; all routed through one `requestApproval` round-trip, validated
+  end-to-end.
+- **Image attachments** — CLI-agnostic file-path, sandbox-safe.
+- **On-disk `turn/list` history fallback** for Claude / Codex / OpenCode / pi /
+  Gemini JSONL/JSON stores.
+- **Bridge control** — `bridge/status` (real `relayConnected`),
+  `bridge/removeTrustedDevice` (revokes + drops session + prunes push
+  registration), `bridge/trustedDevices`, `bridge/connectedPhones`,
+  `bridge/generatePairingQr`.
+- **Autostart** (`install-service` / `uninstall-service` per platform, never
+  elevated), file logging with secret redaction, and the
+  `start`/`stop`/`status`/`qr`/`code`/`install-service` CLI.
 
 ## Transport & connectivity
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,95 +1,111 @@
 # uxnan-bridge
 
-Local control-plane daemon that connects the Uxnan mobile app to the developer's
-PC over an end-to-end-encrypted channel. It runs Git, reads the workspace, and
-drives AI coding agents on behalf of the phone, routing JSON-RPC methods to
-per-domain handlers.
+![Node.js](https://img.shields.io/badge/Node.js-%E2%89%A518-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-ESM-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
+![JSON RPC](https://img.shields.io/badge/JSON--RPC_2.0-60_methods-000000?style=for-the-badge&logo=json&logoColor=white)
+![E2EE](https://img.shields.io/badge/E2EE-AES--256--GCM-0a0a0a?style=for-the-badge&logo=letsencrypt&logoColor=white)
+![Platforms](https://img.shields.io/badge/Windows_%7C_macOS_%7C_Linux-lightgrey?style=for-the-badge)
 
-> **Status: ALPHA-FUNCTIONAL on the primary path (LAN/Tailscale-direct, bridge-
-> direct push).** The bridge is the **heart of the product** — the product is
-> bridge-first: the mobile app pairs with the bridge and tries direct LAN/
-> Tailscale addresses first; the relay is an optional, self-hosted off-LAN
-> fallback. Background push is sent **by the bridge** (FCM HTTP v1) over any
-> transport, so the phone keeps getting notifications whether the bridge is
-> reached via direct LAN, Tailscale, or relay.
->
-> **DONE:**
-> - **E2EE transport** (relay `mac` client + direct-LAN `http+ws` server,
->   handshake, AES-256-GCM channel, byte-for-byte compatible with the mobile
->   app; background reconnect loop; stable pairing session; mDNS discovery
->   `_uxnan._tcp.local`; manual-code pairing `GET /pair/resolve?code=`).
-> - **OS-keychain identity persistence** + single-instance lock.
-> - **Real Git + Workspace handlers** (path-traversal-safe, working-tree
->   checkpoints with **true restore** + retention pruning, `git/revert`,
->   `git/deleteBranch`, `git/removeWorktree`, `workspace/exists`,
->   `workspace/browseDirs`).
-> - **Conversation engine** (threads/turns + streaming, per-thread
->   `Message.blocks`/`Message.thinking`/`Message.usage`).
-> - **5 real agents wired:** OpenCode (default), Claude Code, Codex, pi, and
->   **Gemini CLI**. Each spawns its **official local CLI** over stdio with
->   `shell:false`, parses the native stream, and emits structured
->   `stream/content/block` events (command / diff / tool) plus
->   `stream/thinking/delta` (reasoning). **Aider** is the only remaining
->   agent (recipe in [`FOR-DEV.md`](FOR-DEV.md)).
-> - **Per-thread agent/project selection** + per-project agent/model pins
->   (`projectAgents` config); per-model run-option knobs advertised on
->   `agent/models`; per-turn token usage on `stream/turn/completed`.
-> - **Full thread lifecycle** (`thread/rename|archive|unarchive|delete`).
-> - **Plug-and-play folder browsing** (`workspace/browseDirs`) with
->   `browseRoots` config.
-> - **Direct FCM push from the bridge** (primary path, persisted across
->   restarts, per-phone target, prune-on-untrust). `firebase-admin` is an
->   `optionalDependency` — no creds = silent no-op, foreground local
->   notifications still work.
-> - **Sanitized per-agent `auth/status`** (never tokens, login detected by
->   auth-file existence only).
-> - **Interactive approval intake** (Echo demo + Claude Code opt-in
->   `PreToolUse` hook + Codex via the `codex app-server` turn protocol
->   — `applyPatchApproval` / `execCommandApproval` elicitations routed
->   through the same `requestApproval` round-trip; all validated
->   end-to-end).
-> - **Image attachments** (CLI-agnostic file-path, sandbox-safe).
-> - **On-disk `turn/list` history fallback** for Claude/Codex/OpenCode/pi/Gemini
->   JSONL/JSON stores.
-> - **Bridge control:** `bridge/status` (real `relayConnected`),
->   `bridge/removeTrustedDevice` (revokes + drops session + prunes push
->   registration), `bridge/trustedDevices`, `bridge/connectedPhones`,
->   `bridge/generatePairingQr`.
-> - **Autostart** (`install-service`/`uninstall-service` per platform,
->   never elevated), file logging with secret redaction, CLI
->   (`start`/`stop`/`status`/`qr`/`code`/`install-service`).
->
-> **PENDING that matters for a public release (not LAN alpha):** Aider
-> adapter, packaging + `npm publish` (pin `@uxnan/shared`), real-device push
-> validation. **Optional / blocked-on-mobile:** seq catch-up + key rotation
-> (await a mobile trigger), desktop embedded IPC (desktop Phase 6), Aider in
-> the history reader (no per-session log shipped), log size-rotation. See
-> [`FOR-DEV.md`](./FOR-DEV.md).
->
-> **How the bridge talks to agents:** it spawns each agent's **official local
-> CLI** (`opencode`, `claude`, `codex`, `pi`, `gemini`) as a child process
-> and drives it over stdio — exactly as you would in a terminal. It does
-> **not** use any provider HTTP API, API key, or language SDK; each CLI runs
-> under the account/subscription you already authenticated it with. Prompts
-> are passed as argv elements with `shell:false` (no shell injection). See
-> [`FOR-HUMAN.md`](./FOR-HUMAN.md) for the per-agent install/login
-> prerequisites.
+The local control-plane daemon that connects the [Uxnan](../README.md) mobile app
+to your PC over an end-to-end-encrypted channel. It is the **heart of the
+product**: it holds the secure connection to your phone, runs Git and reads your
+workspace on request, and drives the AI coding agents on your behalf, routing
+JSON-RPC methods to per-domain handlers.
 
-## Docs
+The product is **bridge-first**. The mobile app pairs with the bridge and tries
+its direct LAN / Tailscale addresses first; the [relay](../relay/README.md) is an
+optional, self-hosted off-LAN fallback. Background push notifications are sent
+**by the bridge itself** (FCM HTTP v1) over any transport, so the phone keeps
+receiving them whether it reached the bridge directly or through a relay.
 
-Detailed docs live in [`docs/`](./docs/):
-[installation & autostart](./docs/installation.md) ·
-[configuration](./docs/configuration.md) ·
-[connectivity (LAN/Tailscale/relay)](./docs/connectivity.md) ·
-[how agents are driven](./docs/agents.md) ·
-[testing](./docs/testing.md) ·
-[packaging & deploy](./docs/deploy.md) ·
-[push notifications](./docs/push-notifications.md).
+> **Status:** alpha-functional on the primary path (LAN/Tailscale-direct,
+> bridge-direct push), with **five real agents wired**. The detailed breakdown of
+> what is built and what remains lives in [`FOR-DEV.md`](FOR-DEV.md); the release
+> history is in [`CHANGELOG.md`](CHANGELOG.md).
 
-## Install (later, as a global package)
+## Why the bridge matters
+
+The bridge is small on purpose, but it is where the design decisions that make
+Uxnan distinct actually live:
+
+- **One bridge, many projects.** You start the bridge **once**, from a single
+  location of your choosing, and it gives the phone access to **all** the projects
+  underneath it — Git repositories or plain folders alike. There is no need to
+  launch a separate process per project: the phone browses the configured roots
+  (`workspace/browseDirs`, constrained by the `browseRoots` setting) and roots a
+  new conversation anywhere it is allowed to look.
+- **Provider-agnostic, with no keys to hand over.** For each agent the bridge
+  spawns that agent's **official local CLI** and talks to it over stdio. It never
+  uses a provider HTTP API, API key, or language SDK. Each CLI runs under the
+  account or subscription you already authenticated on the machine, and the bridge
+  only orchestrates it.
+- **Effortless discovery.** A freshly started bridge advertises itself on the
+  local network over mDNS (`_uxnan._tcp.local`), so the phone can find it without
+  typing an address. Pairing is by QR (which carries the bridge's direct
+  `host:port` list) or by a short manual code (`GET /pair/resolve?code=`) when a
+  camera is not convenient.
+- **The transports it brings up.** On start, the bridge runs a direct LAN
+  `http + ws` server (which also serves Tailscale addresses transparently) and,
+  optionally, maintains a relay pairing session for off-LAN reach. The phone
+  chooses the best available path; you do not have to.
+- **End-to-end encryption is not optional.** Every byte to and from the phone is
+  sealed with the documented E2EE protocol (X25519 + HKDF + Ed25519 +
+  AES-256-GCM). Responses are sanitized before they leave the machine — for
+  example, `auth/status` reports sign-in per agent and **never** returns a token.
+
+<details>
+<summary><b>Diagram — one bridge serving many projects over several transports</b></summary>
+
+```mermaid
+flowchart LR
+  phone["📱 uxnanmobile"]
+
+  subgraph disc["Discovery & pairing"]
+    mdns["mDNS · _uxnan._tcp.local"]
+    qr["QR (direct hosts)"]
+    code["Manual code · /pair/resolve"]
+  end
+
+  subgraph pc["💻 your PC"]
+    bridge["uxnan-bridge<br/>(single instance)"]
+    subgraph roots["browseRoots"]
+      p1["project-a (git)"]
+      p2["project-b (git)"]
+      p3["scripts/ (plain folder)"]
+    end
+    clis["Official local CLIs<br/>opencode · claude · codex · pi · gemini"]
+  end
+
+  phone -- "E2EE" --> disc
+  disc --> bridge
+  phone -- "LAN / Tailscale (direct)" --> bridge
+  phone -- "relay (optional, off-LAN)" --> bridge
+  bridge --> p1
+  bridge --> p2
+  bridge --> p3
+  bridge --> clis
+```
+
+</details>
+
+## How the bridge drives agents
+
+This is the mechanism behind "provider-agnostic": the bridge spawns each agent's
+official local CLI — `opencode`, `claude`, `codex`, `pi`, `gemini` — as a child
+process and drives it over stdio, exactly as you would in a terminal. Prompts are
+passed as `argv` elements with `shell:false` (no shell injection), in the thread's
+working directory. The bridge parses each CLI's native stream and re-emits it as
+structured events — `stream/content/block` (command / diff / tool) plus
+`stream/thinking/delta` (reasoning) — so the phone renders the same shape no
+matter which agent is running.
+
+See [`FOR-HUMAN.md`](FOR-HUMAN.md) for the per-agent install / login
+prerequisites, and [`docs/agents.md`](docs/agents.md) for the details.
+
+## Install
 
 ```bash
-npm install -g uxnan-bridge
+npm install -g uxnan-bridge   # (planned — published as a global package)
 ```
 
 ## CLI
@@ -109,42 +125,56 @@ secret-redaction pass) and to stderr. Autostart at login is configured by the
 platform scripts under `scripts/`.
 
 The Ed25519 identity is stored in the OS keychain (Windows Credential Manager /
-macOS Keychain / Linux Secret Service) via `@napi-rs/keyring`. If no keychain
-is available the bridge still runs with an in-memory identity (not persisted
-across restarts).
+macOS Keychain / Linux Secret Service) via `@napi-rs/keyring`. With no keychain
+available, the bridge still runs with an in-memory identity (not persisted across
+restarts).
+
+## Docs
+
+Task-focused guides live in [`docs/`](docs/):
+[installation & autostart](docs/installation.md) ·
+[configuration](docs/configuration.md) ·
+[connectivity (LAN / Tailscale / relay)](docs/connectivity.md) ·
+[how agents are driven](docs/agents.md) ·
+[testing](docs/testing.md) ·
+[packaging & deploy](docs/deploy.md) ·
+[push notifications](docs/push-notifications.md).
 
 ## Architecture
 
-- **Contracts:** consumes [`@uxnan/shared`](../shared) for JSON-RPC and E2EE
-  types and runtime validators. The bridge exposes **60 JSON-RPC methods +
-  8 streaming notifications** (see `shared/src/jsonrpc/`). The mobile app
-  keeps manually-synced Dart equivalents of the same shapes.
-- **State:** non-secret JSON under `~/.uxnan/` (atomic writes): `daemon-config.json`,
-  `pairing-session.json`, `threads.json`, `trusted-phones.json`,
-  `push-state.json`, `agent-cache/`, `logs/`. The Ed25519 identity is a
-  secret and is kept in a `SecretStore`, never written in plaintext.
-- **Routing:** `HandlerRouter.dispatchRaw()` validates the envelope and
-  routes to registered handlers; errors map to JSON-RPC error codes
-  (`-32000..-32008` + standard).
-- **Agents:** `IAgentAdapter` per agent (OpenCode / Claude Code / Codex /
-  pi / Gemini CLI); `AgentManager` orchestrates streaming and broadcasts
-  `stream/*` notifications to connected phones.
-- **Push:** `PushService` (persisted by relay `sessionId`) delivers FCM
-  HTTP v1 directly via `createBridgePushSender` (lazy `firebase-admin`),
-  with the relay `/push/notify` as a fallback.
+- **Contracts.** Consumes [`@uxnan/shared`](../shared/README.md) for JSON-RPC and
+  E2EE types and runtime validators. The bridge exposes **60 JSON-RPC methods +
+  8 streaming notifications** (see `shared/src/jsonrpc/`); the mobile app keeps
+  manually-synced Dart equivalents of the same shapes.
+- **State.** Non-secret JSON under `~/.uxnan/` (atomic writes) —
+  `daemon-config.json`, `pairing-session.json`, `threads.json`,
+  `trusted-phones.json`, `push-state.json`, `agent-cache/`, `logs/`. The Ed25519
+  identity is a secret kept in a `SecretStore`, never written in plaintext.
+- **Routing.** `HandlerRouter.dispatchRaw()` validates the envelope and routes to
+  registered handlers; errors map to JSON-RPC error codes (`-32000..-32008` +
+  standard).
+- **Agents.** An `IAgentAdapter` per agent (OpenCode / Claude Code / Codex / pi /
+  Gemini CLI); `AgentManager` orchestrates streaming and broadcasts `stream/*`
+  notifications to connected phones.
+- **Push.** `PushService` (persisted by relay `sessionId`) delivers FCM HTTP v1
+  directly via `createBridgePushSender` (lazy `firebase-admin`), with the relay
+  `/push/notify` as a fallback.
 
-See `architecture/02a-system-architecture.md` §5.8 and
-`uxnandesktop/architecture/02e-bridge-integration.md`.
+The cross-component specification is `architecture/02a-system-architecture.md`
+§5.8 and
+[`uxnandesktop/architecture/02e-bridge-integration.md`](../uxnandesktop/architecture/02e-bridge-integration.md).
 
 ## Develop
 
 ```bash
-# from the repo root (workspaces):
+# from the repo root (npm workspaces):
 npm run build      # build @uxnan/shared then uxnan-bridge
-npm test           # build + run all node:test suites (357 bridge + 29 shared + 27 relay)
+npm test           # build + run all node:test suites
 npm run typecheck  # tsc --noEmit across packages
 npm run format     # prettier --write
 ```
 
-Requires Node ≥18. ESM-only. Test runner uses `--test-concurrency=1` on
-Windows (see CHANGELOG for why).
+Requires Node ≥ 18. ESM-only. The test runner uses `--test-concurrency=1` on
+Windows (see [`CHANGELOG.md`](CHANGELOG.md) for why). What is implemented versus
+still pending — including the recipe for wiring the next agent — is tracked in
+[`FOR-DEV.md`](FOR-DEV.md).

--- a/bridge/docs/agents.md
+++ b/bridge/docs/agents.md
@@ -1,5 +1,9 @@
 # Bridge — how agents are driven
 
+![Agents](https://img.shields.io/badge/wired_agents-5-2ea44f?style=for-the-badge)
+![Transport](https://img.shields.io/badge/driven_via-official_local_CLI-339933?style=for-the-badge&logo=gnometerminal&logoColor=white)
+![No keys](https://img.shields.io/badge/no_API_%7C_no_SDK_%7C_no_keys-0a0a0a?style=for-the-badge)
+
 ## Execution model (no provider API, no SDK, no keys)
 
 For each agent, the bridge spawns that vendor's **official local CLI** as a child
@@ -73,7 +77,7 @@ exposes both, so users get plug-and-play "latest" *and* explicit version control
   Ids equal to an alias are dropped (the alias is the canonical "latest" entry).
 
 ```jsonc
-// ~/.uxnan/config.json
+// ~/.uxnan/daemon-config.json
 {
   "agents": {
     "claude-code": {

--- a/bridge/docs/configuration.md
+++ b/bridge/docs/configuration.md
@@ -1,5 +1,8 @@
 # Bridge — configuration
 
+![Config](https://img.shields.io/badge/file-~%2F.uxnan%2Fdaemon--config.json-0a0a0a?style=for-the-badge&logo=json&logoColor=white)
+![Optional](https://img.shields.io/badge/every_field-has_a_default-2ea44f?style=for-the-badge)
+
 The daemon reads `~/.uxnan/daemon-config.json`. Every field has a default, so the
 file is optional; create it to override. Defaults live in
 [`../src/daemon-config.ts`](../src/daemon-config.ts).
@@ -9,7 +12,7 @@ file is optional; create it to override. Defaults live in
 | Field | Default | Purpose |
 |---|---|---|
 | `relayUrl` | built-in default (placeholder) | WebSocket URL of the relay (remote/off-LAN fallback). The built-in default is a **placeholder** — set this to **your own** self-hosted relay's `wss://…` URL *before* you flip `relayEnabled`, so turning the relay on is a one-line change with nothing else to wire. |
-| `relayEnabled` | `false` | **Off by default** — the bridge is LAN/Tailscale-direct (no hosting) and the pairing QR carries only the direct `hosts`. The relay is **optional and self-hosted**: pre-set `relayUrl` to your relay, then flip this to `true` and re-pair (or regenerate the QR) — the QR then carries your `relay` as a fallback after the direct `hosts`. Needed only for off-LAN access without a mesh VPN, and for **background push** (FCM). See [`connectivity.md`](./connectivity.md), [`../../relay/docs/deploy.md`](../../relay/docs/deploy.md) and [`../../relay/docs/push-notifications.md`](../../relay/docs/push-notifications.md). |
+| `relayEnabled` | `false` | **Off by default** — the bridge is LAN/Tailscale-direct (no hosting) and the pairing QR carries only the direct `hosts`. The relay is **optional and self-hosted**: pre-set `relayUrl` to your relay, then flip this to `true` and re-pair (or regenerate the QR) — the QR then carries your `relay` as a fallback after the direct `hosts`. Needed only for off-LAN access without a mesh VPN, and for **background push** (FCM). See [`connectivity.md`](./connectivity.md), [`push-notifications.md`](./push-notifications.md) and [`../../relay/docs/deploy.md`](../../relay/docs/deploy.md). |
 | `lanEnabled` | `true` | Serve the LAN WebSocket so the phone can connect directly. Its non-internal IPv4s (LAN + Tailscale `100.x`) are advertised as `hosts` in the pairing QR. |
 | `lanPort` | built-in default | LAN server port. |
 | `mdnsEnabled` | `true` | Advertise the bridge on the LAN via mDNS/Bonjour (`_uxnan._tcp`) so the phone can **discover** it for manual-code pairing without typing the host. Effective only when `lanEnabled`. Best-effort — a failed bind (UDP 5353 busy) degrades silently; pairing still works by QR or by typing the host. |
@@ -27,15 +30,18 @@ file is optional; create it to override. Defaults live in
 
 ### Per-agent overrides (`agents.<id>`)
 
-`<id>` is one of `opencode`, `claude-code`, `codex`.
+`<id>` is one of the wired agent ids: `opencode`, `claude-code`, `codex`,
+`gemini-cli`, `pi-agent`. These are the canonical `AgentId` values — note
+`gemini-cli` and `pi-agent` (not `gemini` / `pi`). The same id strings are used
+for `defaultAgent` and `projectAgents[].agentId`.
 
 | Field | Purpose |
 |---|---|
 | `binaryPath` | Absolute path to the agent CLI (else auto-resolved). |
 | `model` | Default model for that agent (an alias like `opus`, or an exact id). |
-| `models` | Extra explicit models to show in the picker **alongside** the ones the agent reports itself. Each entry is a bare id string or `{ id, displayName?, description? }`. For **Claude Code** this pins concrete versions (e.g. `claude-opus-4-7`) next to the auto-updating `opus`/`sonnet`/`haiku` aliases — see [agents.md](./agents.md#claude-code-models-latest-aliases--pinned-versions). Ignored by agents that enumerate their own models (OpenCode, Codex). |
-| `permissionMode` | Headless posture for agents that gate tools: `acceptEdits` (default — edits auto-apply), `default` (read-only/no-edit), `bypassPermissions` (full autonomy). Maps to each CLI's flag (Claude `--permission-mode`/`--dangerously-skip-permissions`; Codex `-s workspace-write`/`read-only`/`--dangerously-bypass-approvals-and-sandbox`). |
-| `interactiveApprovals` | **Claude Code only**, opt-in (default false; requires `lanEnabled`). When true, every tool the agent runs prompts you **on the phone** (Approve / Reject) before it executes — the bridge injects a `PreToolUse` hook that holds the tool until you answer (5-min timeout → deny). Overrides `permissionMode` for Claude (it forces `--permission-mode default` so the hook is the gate). Leave it off for unattended runs. |
+| `models` | Extra explicit models to show in the picker **alongside** the ones the agent reports itself. Each entry is a bare id string or `{ id, displayName?, description? }`. For **Claude Code** this pins concrete versions (e.g. `claude-opus-4-7`) next to the auto-updating `opus`/`sonnet`/`haiku` aliases — see [agents.md](./agents.md#claude-code-models-latest-aliases--pinned-versions). Currently consumed only by the Claude Code adapter; ignored by agents that enumerate their own models (OpenCode, Codex, pi, Gemini CLI). |
+| `permissionMode` | Headless posture for agents that gate tools: `acceptEdits` (default — edits auto-apply), `default` (read-only/no-edit), `bypassPermissions` (full autonomy). Mapped to each CLI's own flags — Claude (`--permission-mode` / `--dangerously-skip-permissions`), Codex (`-s workspace-write` / `read-only` / `--dangerously-bypass-approvals-and-sandbox`), Gemini (`--approval-mode auto_edit` / `plan` / `yolo`), and pi (its built-in tool posture / `--tools` / `--approve`). OpenCode does not gate tools, so it ignores this field. |
+| `interactiveApprovals` | Opt-in interactive tool approvals for **Claude Code and Gemini CLI** (default false; requires `lanEnabled`). When true, every tool the agent runs prompts you **on the phone** (Approve / Reject) before it executes: the bridge injects a `PreToolUse` hook for Claude (and a `BeforeTool` hook for Gemini) that holds the tool until you answer (5-min timeout → deny). For Claude it overrides `permissionMode` (forcing `--permission-mode default` so the hook is the gate). Leave it off for unattended runs. |
 
 ### Per-project agent/model pins (`projectAgents`)
 
@@ -47,7 +53,7 @@ optional default model for it.
 | Field | Purpose |
 |---|---|
 | `cwd` | Absolute project directory the pin applies to (matched by resolved path). |
-| `agentId` | Agent the project defaults to (`opencode` / `claude-code` / `codex`). |
+| `agentId` | Agent the project defaults to (`opencode` / `claude-code` / `codex` / `gemini-cli` / `pi-agent`). |
 | `model` | Optional default model for that agent. |
 
 When the phone starts a thread (`thread/start`) **without** an explicit

--- a/bridge/docs/connectivity.md
+++ b/bridge/docs/connectivity.md
@@ -1,5 +1,9 @@
 # Connectivity — how the phone reaches the bridge
 
+![LAN](https://img.shields.io/badge/LAN-direct-2ea44f?style=for-the-badge)
+![Tailscale](https://img.shields.io/badge/Tailscale-direct_(recommended_off--LAN)-blue?style=for-the-badge&logo=tailscale&logoColor=white)
+![Relay](https://img.shields.io/badge/relay-optional_%2F_self--hosted-lightgrey?style=for-the-badge)
+
 The phone and bridge always speak the **same E2EE protocol**; only the *transport*
 to reach the bridge differs. The pairing QR advertises the available transports and
 the phone picks one. There are three modes — pick by where you need to use it.

--- a/bridge/docs/deploy.md
+++ b/bridge/docs/deploy.md
@@ -1,14 +1,23 @@
 # Bridge — packaging & deployment
 
+![Install](https://img.shields.io/badge/install-npm_i_-g_uxnan--bridge-339933?style=for-the-badge&logo=npm&logoColor=white)
+![Autostart](https://img.shields.io/badge/autostart-per_OS,_never_elevated-2ea44f?style=for-the-badge)
+
 The bridge is software the **user installs on their PC**. The relay is a separate,
-**hosted** service (see [`../../relay/docs/deploy.md`](../../relay/docs/deploy.md)).
+**optional / self-hosted** service (see
+[`../../relay/docs/deploy.md`](../../relay/docs/deploy.md)).
 
 ## Run modes
 
-- **LAN-only (zero hosting):** if the phone and PC share a network, the phone
+- **LAN-direct (zero hosting):** if the phone and PC share a network, the phone
   connects directly to the bridge's LAN server — no relay to deploy. Simplest start.
-- **Remote (off-LAN):** needs a reachable relay; the relay URL is baked into the
-  pairing QR / `relayUrl` config. Hosting options are in the relay deploy doc.
+- **Tailscale-direct (zero hosting, recommended off-LAN):** with both devices on
+  the same tailnet, the bridge's `100.x` address is advertised in the pairing QR
+  and the phone reaches it directly from anywhere — still no relay.
+- **Self-hosted relay (optional):** only for off-LAN access without a mesh VPN. Set
+  `relayEnabled: true` and point `relayUrl` at your own relay; the QR then carries
+  it as a fallback after the direct `hosts`. Hosting options are in the relay
+  deploy doc.
 
 ## Publishing the bridge (npm)
 

--- a/bridge/docs/installation.md
+++ b/bridge/docs/installation.md
@@ -1,5 +1,9 @@
 # Bridge — installation & autostart
 
+![Node.js](https://img.shields.io/badge/Node.js-%E2%89%A518-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![Platforms](https://img.shields.io/badge/Windows_%7C_macOS_%7C_Linux-lightgrey?style=for-the-badge)
+![Autostart](https://img.shields.io/badge/autostart-at_logon,_never_elevated-2ea44f?style=for-the-badge)
+
 How to install, run, and auto-start the uxnan bridge daemon on a PC.
 
 ## Prerequisites

--- a/bridge/docs/push-notifications.md
+++ b/bridge/docs/push-notifications.md
@@ -1,5 +1,10 @@
 # Push & local notifications — setup, testing, multi-account
 
+![Android](https://img.shields.io/badge/Android-LIVE-3DDC84?style=for-the-badge&logo=android&logoColor=white)
+![iOS](https://img.shields.io/badge/iOS-pending_APNs-000000?style=for-the-badge&logo=apple&logoColor=white)
+![Push](https://img.shields.io/badge/delivery-bridge--direct_FCM-FFCA28?style=for-the-badge&logo=firebase&logoColor=black)
+![Gated](https://img.shields.io/badge/code--complete-gated_on_creds-orange?style=for-the-badge)
+
 How notifications work in Uxnan, how to **activate** them from scratch against
 your own Firebase account, how to **test** they work, and which files are safe to
 commit. Push is **code-complete and gated**: everything builds and runs without
@@ -36,7 +41,7 @@ Two independent surfaces, both already wired in the app:
 
 Default — **the bridge delivers directly** (no relay):
 
-```
+```text
 agent turn ends ─► bridge (PushService.onTurnEnd)
                      │  createBridgePushSender → FCM HTTP v1
                      │  (firebase-admin, service account on the bridge)
@@ -47,7 +52,7 @@ agent turn ends ─► bridge (PushService.onTurnEnd)
 Optional fallback — **a self-hosted relay delivers** (only when the bridge holds
 no FCM credential and `relayEnabled: true`):
 
-```
+```text
 agent turn ends ─► bridge ──POST /push/notify──► relay (PushRegistry → FCM sender)
                                                    │  FCM HTTP v1 (service account on the relay)
                                                    ▼
@@ -278,16 +283,18 @@ credential in place: it delivers directly. With no credential it logs
 |---|---|---|
 | `firebase-service-account.json` | **Secret — admin private key.** Grants the ability to send FCM (and other Admin SDK calls) for your project. | **Never.** Keep it in `~/.uxnan/` per machine. To use another PC, generate a fresh key there (or copy it over a secure channel). Rotate/revoke in GCP IAM if leaked. |
 | `*.p8` (APNs key) | **Secret.** | **Never.** |
-| `android/app/google-services.json` | **Low.** Client config (project id, app id, an API key). It already ships inside your APK, so it isn't a true secret — but the API key should be restricted in the GCP console. | Optional. **Currently gitignored.** In a **private** repo it's acceptable to commit for zero-setup clones; otherwise leave it out and re-fetch with `firebase apps:sdkconfig`. |
+| `android/app/google-services.json` | **Low.** Client config (project id, app id, an API key). It already ships inside your APK, so it isn't a true secret — but the API key should be restricted in the GCP console. | **Currently gitignored, and recommended to keep that way** (the project is open source). Re-fetch it locally with `firebase apps:sdkconfig`; it is per-deployment anyway, so committing one user's config helps no one else. |
 | `ios/Runner/GoogleService-Info.plist` | **Low** (same as above, for iOS). | Same as `google-services.json`. |
 
 **Bottom line:** the **service-account key never goes in git** (it stays on this
-PC and is re-created per machine). The two **client config files are low-risk**;
-they're gitignored by default, but since this repo is private you *may* commit
-them if you'd rather every clone work without re-downloading. They are trivial to
-regenerate either way (`firebase apps:sdkconfig …`), so re-downloading on a new PC
-is a one-line command — you never lose anything by keeping them out of git.
+PC and is re-created per machine). The two **client config files are low-risk**,
+and since the project is open source they stay **gitignored by default** — each
+deployment uses its own Firebase project, so committing one machine's config would
+not help anyone else. They are trivial to regenerate (`firebase apps:sdkconfig …`),
+so re-creating them on a new PC is a one-line command — you never lose anything by
+keeping them out of git.
 
-> Want the two client files committed (private repo, convenience)? Un-ignore just
-> those two lines in `.gitignore` while keeping `firebase-service-account.json`
-> and `*.p8` ignored. Ask and it can be flipped.
+> If you specifically wanted those two client files committed for convenience
+> (e.g. in a **private** fork), you would un-ignore just those two lines in
+> `.gitignore` while keeping `firebase-service-account.json` and `*.p8` ignored.
+> For the public project, leaving them out is the safer default.

--- a/bridge/docs/testing.md
+++ b/bridge/docs/testing.md
@@ -1,5 +1,8 @@
 # Bridge — testing & validation
 
+![Runner](https://img.shields.io/badge/runner-node%3Atest-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![Concurrency](https://img.shields.io/badge/--test--concurrency-1_(Windows)-blue?style=for-the-badge)
+
 How to run the automated tests and validate the parts they can't fully cover on a
 dev machine (real-device E2EE, real agent CLIs, push). Relay-specific testing is in
 [`../../relay/docs/testing.md`](../../relay/docs/testing.md).
@@ -28,8 +31,9 @@ Covered: JSON-RPC contracts + validators; E2EE crypto/handshake/replay; pairing
 payload; relay forwarding/rate-limit/health; daemon state, identity (keychain via a
 fake backend), lock file; the **autostart** plan per platform; git + workspace +
 **directory browsing** + checkpoints (real git in temp repos); conversation store;
-the AgentManager + echo agent end-to-end; the OpenCode/Claude Code/Codex adapter
-parsers + streaming against fake spawns; and router-level wiring/error mapping.
+the AgentManager + echo agent end-to-end; the OpenCode / Claude Code / Codex / pi /
+Gemini adapter parsers + streaming against fake spawns; and router-level
+wiring/error mapping.
 
 ### Environment notes / known flakes (Windows)
 - **Serialized runner:** several suites boot a full bridge or spawn real child
@@ -69,13 +73,14 @@ pairing QR = Base64 of the UTF-8 JSON.
 ## 3. Validating agent adapters
 
 - **Echo:** fully tested; use it for the streaming path with no creds.
-- **OpenCode / Claude Code / Codex (wired):** see [`agents.md`](./agents.md) for how
-  each is driven. To run for real, set a working `model` (and `permissionMode`) in
-  `agents.<id>` + a real project dir, then drive a turn from the app and watch the
-  streamed deltas. Capture a CLI stream directly with stdin closed, e.g.
-  `cmd /c "<cli> ... < NUL"` (these CLIs hang on an open stdin pipe). Adapter unit
-  tests live in `test/adapters/`.
-- **Next (Gemini):** follow the recipe in [`../FOR-DEV.md`](../FOR-DEV.md).
+- **OpenCode / Claude Code / Codex / pi / Gemini CLI (all wired):** see
+  [`agents.md`](./agents.md) for how each is driven. To run for real, set a working
+  `model` (and `permissionMode`) in `agents.<id>` + a real project dir, then drive a
+  turn from the app and watch the streamed deltas. Capture a CLI stream directly
+  with stdin closed, e.g. `cmd /c "<cli> ... < NUL"` (these CLIs hang on an open
+  stdin pipe). Adapter unit tests live in `test/adapters/`.
+- **Next (Aider):** the only remaining planned adapter — follow the recipe in
+  [`../FOR-DEV.md`](../FOR-DEV.md).
 
 ## 4. Push notifications (implemented, gated)
 

--- a/bridge/src/daemon-config.ts
+++ b/bridge/src/daemon-config.ts
@@ -53,10 +53,11 @@ export interface AgentSettings {
    */
   permissionMode?: AgentPermissionMode;
   /**
-   * Opt-in interactive tool approvals (Claude Code only): inject a `PreToolUse`
-   * hook (via `--settings`) so every tool round-trips to the bridge and the user
-   * approves/rejects it on the phone (`turn/send { approvalResponse }`). Requires
-   * `lanEnabled` (the hook calls the bridge's local HTTP endpoint). Default false.
+   * Opt-in interactive tool approvals (Claude Code and Gemini CLI): inject a
+   * pre-tool hook (Claude's `PreToolUse`, Gemini's `BeforeTool`) so every tool
+   * round-trips to the bridge and the user approves/rejects it on the phone
+   * (`turn/send { approvalResponse }`). Requires `lanEnabled` (the hook calls the
+   * bridge's local HTTP endpoint). Default false.
    */
   interactiveApprovals?: boolean;
 }
@@ -105,7 +106,9 @@ export interface DaemonConfig {
    * Absolute base directories the phone may BROWSE under via `workspace/browseDirs`
    * (descend into sub-folders, pick any directory as a thread's cwd) without
    * escaping the root. Empty → falls back to {@link workspaceRoots}, then the
-   * user's home directory. Set this to e.g. your `Documents` folder.
+   * bridge's launch directory (`process.cwd()`) — so an unconfigured install
+   * browses from wherever the bridge was started. Set this to e.g. your
+   * `Documents` folder.
    */
   browseRoots: string[];
   /** Per-agent settings keyed by {@link AgentId}. */

--- a/relay/FOR-DEV.md
+++ b/relay/FOR-DEV.md
@@ -2,7 +2,7 @@
 
 Deferred developer work for the relay. (Human-only assets are in `relay/FOR-HUMAN.md`.)
 
-## Context
+## Status
 
 The relay is **optional and self-hosted**. The product's primary paths are
 LAN-direct and Tailscale-direct to the bridge; push is now sent **bridge-direct**
@@ -10,9 +10,17 @@ LAN-direct and Tailscale-direct to the bridge; push is now sent **bridge-direct*
 optional push fallback — alpha-functional, 27 tests green, shipped via `npm`
 through the same CI matrix as the bridge.
 
-The implemented surface (envelope relay, `/health`, per-IP rate limiting,
-reconnection/peer-close, CSWSH defense, `/push/register|notify` with atomic
-persistence + dedupe) is documented in `relay/README.md` and `relay/docs/`.
+**Implemented (DONE):**
+
+- **E2EE envelope relay** — one `mac` + `iphone` per `sessionId`, forwarding every
+  frame unchanged; `GET /health`.
+- **Per-IP rate limiting** and reconnection support (peer-close + stale-socket
+  handling).
+- **CSWSH `Origin` check** on WebSocket upgrades.
+- **Push endpoints** (`/push/register|notify`, FCM, gated on creds) with **atomic
+  state persistence** to `~/.uxnan/relay-state.json` — token registry + dedupe
+  window, TTL 7d + cap 10k — as a **fallback** (the bridge is the primary push
+  path).
 
 **Closed — do not rebuild:** `/trusted-session/resolve` (manual-code pairing moved
 to the bridge's `GET /pair/resolve?code=`) and an APNs-direct sender (the decision

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,34 +1,60 @@
 # uxnan-relay
 
-WebSocket relay that forwards **opaque E2EE envelopes** between the Uxnan mobile
-app and the bridge. It only ever sees encrypted frames — never plaintext, keys,
-code, or diffs. The envelope-forwarding path is stateless; the **optional** push
-fallback persists a small token/dedupe file (`~/.uxnan/relay-state.json`).
+![Node.js](https://img.shields.io/badge/Node.js-%E2%89%A518-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-ESM-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
+![WebSocket](https://img.shields.io/badge/WebSocket-stateless-010101?style=for-the-badge&logo=socketdotio&logoColor=white)
+![E2EE](https://img.shields.io/badge/sees-only_sealed_envelopes-0a0a0a?style=for-the-badge&logo=letsencrypt&logoColor=white)
+![Role](https://img.shields.io/badge/role-optional_%2F_self--hosted-blue?style=for-the-badge)
 
-> **Status: ALPHA-FUNCTIONAL — OPTIONAL / self-hosted.**
->
-> The product is **bridge-first**: the primary paths are LAN-direct and
-> Tailscale-direct (zero hosting, zero credentials). The relay is the
-> hosted off-LAN fallback for users who want to run their own.
-> **Push notifications are sent by the bridge directly** (FCM HTTP v1, lazy
-> `firebase-admin`); the relay's `/push/*` endpoints stay as a hosted
-> fallback. See `bridge/FOR-DEV.md` → *Direct FCM from the bridge*.
->
-> **DONE:** E2EE envelope relay (one `mac`+`iphone` per `sessionId`),
-> `GET /health`, per-IP rate limiting, reconnection support (peer-close +
-> stale-socket handling), **CSWSH `Origin` check on upgrades**, push
-> endpoints (`/push/register|notify`, FCM, gated on creds) with
-> **atomic state persistence** to `~/.uxnan/relay-state.json` (token registry
-> + dedupe window, with TTL 7d + cap 10k).
->
-> **PENDING — relay-only / optional** (does not block the bridge-first
-> product): multi-session `mac`, auth-on-forwarding (only for a
-> hosted/public relay). See [`FOR-DEV.md`](FOR-DEV.md).
+A small, stateless WebSocket relay that forwards **opaque E2EE envelopes** between
+the [Uxnan](../README.md) mobile app and the [bridge](../bridge/README.md) when
+the two aren't on the same network. It only ever sees encrypted frames — never
+plaintext, keys, code, or diffs. The envelope-forwarding path is stateless; the
+**optional** push fallback persists a small token/dedupe file
+(`~/.uxnan/relay-state.json`).
 
-> **`mac` / `iphone` are ROLES, not platforms.** `mac` = the PC/bridge side
-> (runs on Windows, macOS or Linux); `iphone` = the mobile app side (Android or
-> iOS). The names come from the protocol spec and are fixed by the wire contract
-> with the mobile app — they do not restrict the operating system.
+> **Status:** alpha-functional — and **optional / self-hosted**. The product is
+> bridge-first (LAN-direct and Tailscale-direct need zero hosting and zero
+> credentials); the relay is just the hosted off-LAN fallback for people who want
+> to run their own. Push notifications are sent **by the bridge directly** now —
+> the relay's `/push/*` endpoints stay only as a fallback. What's built and
+> what's left is in [`FOR-DEV.md`](FOR-DEV.md); history in
+> [`CHANGELOG.md`](CHANGELOG.md).
+
+> **`mac` / `iphone` are ROLES, not platforms.** `mac` = the PC/bridge side (runs
+> on Windows, macOS or Linux); `iphone` = the mobile app side (Android or iOS).
+> The names come from the protocol spec and are fixed by the wire contract with
+> the mobile app — they do not restrict the operating system.
+
+## When you actually need it
+
+Most of the time, you do not. When your phone and PC share a network — the same
+Wi-Fi, or a Tailscale tailnet — the app reaches the bridge **directly**, with no
+relay, no hosting, and no credentials. The relay exists for the one case the
+direct paths cannot cover: reaching your PC from **outside** that network. In that
+case you self-host this relay, and it simply shuttles sealed envelopes between the
+two sides. Because everything is already end-to-end encrypted, the relay is a dumb
+pipe by design — it can route or drop traffic, but it can never read it.
+
+<details>
+<summary><b>Diagram — how the relay pairs two sides by session, seeing nothing</b></summary>
+
+```mermaid
+sequenceDiagram
+  participant P as 📱 iphone (app)
+  participant R as 🔁 relay
+  participant B as 🌉 mac (bridge)
+  B->>R: connect (x-role: mac, x-session-id)
+  P->>R: connect (x-role: iphone, x-session-id)
+  Note over R: pair the two sockets sharing a sessionId
+  P->>R: sealed E2EE envelope
+  R->>B: same envelope, forwarded unchanged
+  B->>R: sealed E2EE envelope
+  R->>P: same envelope, forwarded unchanged
+  Note over R: never sees plaintext, keys, code, or diffs
+```
+
+</details>
 
 ## Run
 
@@ -47,26 +73,26 @@ A client connects via WebSocket presenting:
 
 The relay pairs the `mac` and `iphone` sockets that share a `sessionId` and
 forwards every frame from one to the other unchanged. `GET /health` returns
-`{"ok":true}`.
-
-See `architecture/02a-system-architecture.md` §5.10.
-
-## Develop
-
-```bash
-# from the repo root (workspaces):
-npm run build && npm test
-```
-
-Requires Node ≥18. ESM-only. The relay consumes `@uxnan/shared` for the
-JSON-RPC envelope types; the bridge-side `relay-e2e.test.ts` exercises the
-full end-to-end (relay + bridge + a fake phone over a real WebSocket).
+`{"ok":true}`. The full cross-component spec is
+`architecture/02a-system-architecture.md` §5.10.
 
 ## Docs
 
-See [`docs/`](./docs/): [deployment & hosting](./docs/deploy.md) (LAN-only vs
-Cloudflare Tunnel / Fly.io / Workers) · [testing](./docs/testing.md).
+See [`docs/`](docs/): [deployment & hosting](docs/deploy.md) (LAN-only vs
+Cloudflare Tunnel / Fly.io / Workers) · [testing](docs/testing.md).
 
 Push notifications are **bridge-first** now (the relay is only an optional
 delivery fallback) — see
 [`bridge/docs/push-notifications.md`](../bridge/docs/push-notifications.md).
+
+## Develop
+
+```bash
+# from the repo root (npm workspaces):
+npm run build && npm test
+```
+
+Requires Node ≥ 18. ESM-only. The relay consumes
+[`@uxnan/shared`](../shared/README.md) for the JSON-RPC envelope types; the
+bridge-side `relay-e2e.test.ts` exercises the full end-to-end (relay + bridge + a
+fake phone over a real WebSocket).

--- a/relay/docs/deploy.md
+++ b/relay/docs/deploy.md
@@ -1,5 +1,9 @@
 # Relay — deployment & hosting
 
+![Role](https://img.shields.io/badge/role-optional_%2F_self--hosted-blue?style=for-the-badge)
+![Hosting](https://img.shields.io/badge/start-LAN--only,_zero_infra-2ea44f?style=for-the-badge)
+![TLS](https://img.shields.io/badge/TLS-terminate_at_tunnel%2Fproxy-0a0a0a?style=for-the-badge&logo=letsencrypt&logoColor=white)
+
 The relay is a small WebSocket server that forwards **opaque E2EE envelopes**
 between the phone and the bridge by `sessionId`. It never sees plaintext, keys,
 code, or diffs — only encrypted frames. The envelope-forwarding path is
@@ -64,7 +68,7 @@ uxnan-relay 8787          # or: RELAY_PORT=8787 uxnan-relay
 
 ## Push notifications (gated)
 
-The relay exposes `POST /push/register` + `POST /push/notify` (Phase 6). Real
+The relay exposes `POST /push/register` + `POST /push/notify`. Real
 delivery is **gated** on a Firebase service account (`UXNAN_FCM_SERVICE_ACCOUNT`);
 without it the sender is a no-op. Setup: [`../FOR-HUMAN.md`](../FOR-HUMAN.md).
 The bridge is the **primary** push path — the relay's `/push/*` endpoints are

--- a/relay/docs/testing.md
+++ b/relay/docs/testing.md
@@ -1,5 +1,8 @@
 # Relay — testing
 
+![Runner](https://img.shields.io/badge/runner-node%3Atest-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![Coverage](https://img.shields.io/badge/forwarding_%7C_rate--limit_%7C_CSWSH_%7C_push-tested-2ea44f?style=for-the-badge)
+
 ## Automated
 
 ```bash

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,15 +1,49 @@
 # @uxnan/shared
 
-Shared JSON-RPC and E2EE contracts for the Uxnan ecosystem. Consumed as a local
-workspace dependency by the **bridge** and the **relay**. The mobile app keeps
-manually-synced Dart equivalents (see
+![TypeScript](https://img.shields.io/badge/TypeScript-ESM-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-%E2%89%A518-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![JSON Schema](https://img.shields.io/badge/validation-Ajv-000000?style=for-the-badge&logo=json&logoColor=white)
+![Contracts](https://img.shields.io/badge/60_methods_%7C_8_notifications-blue?style=for-the-badge)
+
+Shared JSON-RPC and E2EE contracts for the [Uxnan](../README.md) ecosystem — the
+single source of truth every component agrees on. Consumed as a local workspace
+dependency by the **[bridge](../bridge/README.md)** and the
+**[relay](../relay/README.md)**; the mobile app keeps manually-synced Dart
+equivalents (see
 [`architecture/02b-contracts-and-requirements.md`](../architecture/02b-contracts-and-requirements.md)
 §1 for the canonical contract list).
 
-> **Status:** implemented. **60 JSON-RPC methods** + **8 streaming
-> notifications**, lock-step in build-time with the `METHOD_NAMES` array and
+> **Status:** implemented and stable — **60 JSON-RPC methods** + **8 streaming
+> notifications**, kept lock-step at build time with the `METHOD_NAMES` array and
 > the `StreamNotification` enum (a compile-time assertion in
-> `src/jsonrpc/method-registry.ts` fails the build on any drift).
+> `src/jsonrpc/method-registry.ts` fails the build on any drift). Changes are
+> recorded in [`CHANGELOG.md`](CHANGELOG.md).
+
+## Why it exists
+
+Three independent codebases — a Node.js bridge, a Node.js relay, and a Flutter app
+— have to agree on exactly the same messages on the wire. Rather than letting each
+one drift its own way, every shape lives here once: the request and response
+envelopes, the streaming notifications, the E2EE handshake, the pairing payload,
+and the domain and agent models. The bridge and relay import this package
+directly; the mobile app mirrors it in Dart. When a contract changes, it changes
+here first, and the build refuses to pass if the registry and the spec disagree.
+
+<details>
+<summary><b>Diagram — one contract, three consumers</b></summary>
+
+```mermaid
+flowchart TB
+  shared["@uxnan/shared<br/>JSON-RPC + E2EE contracts"]
+  bridge["uxnan-bridge<br/>(imports directly)"]
+  relay["uxnan-relay<br/>(imports directly)"]
+  mobile["uxnanmobile<br/>(hand-synced Dart mirror)"]
+  shared --> bridge
+  shared --> relay
+  shared -. mirrored .-> mobile
+```
+
+</details>
 
 ## What's inside
 

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -19,6 +19,35 @@ backend tests + 19 frontend Vitest unit tests (pure logic); **no Svelte componen
 or E2E tests yet**. macOS is **unvalidated** (developed on Windows; CI is
 `{ubuntu, windows}`). **Phase 6 (embedded bridge / mobile pairing) is NOT started.**
 
+**Built (DONE), in detail:**
+
+- **Three-panel resizable shell** with atomic JSON persistence (5 rotating
+  backups + sequential schema migrations).
+- **PTY terminals** (`portable-pty 0.9`, xterm WebGL + DOM fallback) — tabs +
+  nested splits that never remount on split, drag-to-reorder / move tabs across
+  regions, `Ctrl+Tab` MRU cycling, a backend output ring buffer that restores a
+  recreated pane's scrollback, and the Kitty/CSI-u keyboard protocol.
+- **Git worktrees** — per-worktree terminal workspaces, hierarchical Projects
+  tree, in-app directory picker, worktree palette (Ctrl/Cmd+P), squash-merged
+  branch cleanup on removal, WSL repos routed through `wsl.exe`.
+- **Full git review** — status / diff / stage / commit / push / pull with a 3 s
+  focus-paused Tokio watcher, CodeMirror 6 diff viewer, hunk-level staging,
+  side-by-side toggle, visual image diffs, and optional AI commit-message
+  generation via a local CLI agent.
+- **Agent monitoring (Phase 4)** — Layer 1 local HTTP hook server (`axum`, precise
+  `working/blocked/waiting/done` + persistent cache) + Layer 2 terminal-title
+  (OSC) + Layer 3 process-tree detection; colored status dots, unread/done badges,
+  custom agent logos, per-worktree agent override.
+- **Multi-agent orchestration** (spec `02d` §3) — a console (status bar, shown with
+  ≥2 live agents) routing a message to all agents, one type (fan-out), or a
+  coordinator's workers, with backpressure + an in-memory coordinator→workers task
+  graph.
+- **Cross-cutting (S)** — Settings (theme + terminal profiles w/ OS templates),
+  design tokens, full EN/ES i18n + Language picker, agents registry + install
+  detection + manual + auto-launch, per-agent env vars, a configurable agent
+  launch shell (Command Prompt by default on Windows), virtualized lists
+  (`@tanstack/svelte-virtual`), opt-in keep-awake (Windows).
+
 ## Phase 6 — Bridge integration (embedded bridge / mobile pairing) ☐
 
 **Goal:** let the desktop act as the mobile bridge (single-install). The standalone

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -8,56 +8,118 @@ Built with **Rust + Tauri 2** (backend) and **Svelte 5 / SvelteKit + Tailwind
 CSS v4 + shadcn-svelte** (frontend). Terminals use xterm.js; diffs use
 CodeMirror 6.
 
+![Rust](https://img.shields.io/badge/Rust-000000?style=for-the-badge&logo=rust&logoColor=white)
+![Tauri](https://img.shields.io/badge/Tauri_2-FFC131?style=for-the-badge&logo=tauri&logoColor=000000)
+![Svelte](https://img.shields.io/badge/Svelte_5-FF3E00?style=for-the-badge&logo=svelte&logoColor=white)
+![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS_v4-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
+![RAM](https://img.shields.io/badge/RAM-~30%E2%80%93100_MB-2ea44f?style=for-the-badge)
+![i18n](https://img.shields.io/badge/i18n-EN_%7C_ES-blue?style=for-the-badge)
+![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white)
+![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=white)
+
 > Part of the [Uxnan](../) monorepo. The full specification is the source of
 > truth — start at [`architecture/00-index.md`](architecture/00-index.md).
 > The engineering roadmap and deferred work live in [`FOR-DEV.md`](FOR-DEV.md);
 > human-provided assets in [`FOR-HUMAN.md`](FOR-HUMAN.md).
 
-## Status
+## Why it helps, even in alpha
 
-**ALPHA-FUNCTIONAL (standalone).** **Phases 0–5 + the cross-cutting track (S)
-are complete.** The ADE is ready for alpha release as a standalone app
-(manage repos / worktrees, multiplexed terminals, launch + monitor agents, full
-git review with hunk staging & diffs, settings / i18n / theming). The only
-remaining roadmap phase is **Phase 6 (bridge integration / mobile pairing)**,
-which is *optional for standalone use* — required only if you want the ADE to
-also act as the mobile bridge (otherwise, install `uxnan-bridge` standalone).
+Uxnan Desktop is for developers who want a clear, multi-agent workflow without
+paying the resource cost of a full IDE or an Electron shell. Because it renders
+through the operating system's native webview instead of bundling its own browser,
+it targets **30–100 MB of RAM** where comparable Electron applications routinely
+sit at **200–500 MB**. That difference is the point: it is meant to be a practical
+choice on low-to-moderate-resource machines, not only on high-end workstations,
+while still offering an intuitive interface for running and reviewing several
+agents at once.
 
-Highlights of what ships today:
-- Three-panel resizable shell with atomic JSON persistence (5 rotating
-  backups + sequential schema migrations).
-- PTY terminals (`portable-pty 0.9`, xterm WebGL + DOM fallback) with tabs
-  + nested splits that never remount on split, drag-to-reorder / move tabs
-  across regions, `Ctrl+Tab` MRU cycling, a backend output ring buffer that
-  restores a recreated pane's scrollback, and the Kitty/CSI-u keyboard protocol.
-- Git worktrees with per-worktree terminal workspaces, hierarchical
-  Projects tree, in-app directory picker, worktree palette
-  (Ctrl/Cmd+P), squash-merged branch cleanup on removal, and WSL repos
-  routed through `wsl.exe`.
-- Full git review (status / diff / stage / commit / push / pull with a
-  3 s focus-paused Tokio watcher, CodeMirror 6 diff viewer, hunk-level
-  staging, side-by-side toggle, visual image diffs, and optional AI
-  commit-message generation via a local CLI agent).
-- **Agent monitoring** (Phase 4) — three layers: Layer 1 local HTTP hook
-  server (`axum` with precise `working/blocked/waiting/done` and persistent
-  cache) + Layer 2 terminal-title (OSC) + Layer 3 process-tree detection.
-  Colored status dots, unread/done badges, custom agent logos, per-worktree
-  agent override.
-- **Multi-agent orchestration** (spec `02d` §3) — a console (status bar, shown
-  with ≥2 live agents) that routes a message to all agents, to one type
-  (fan-out), or to a coordinator's workers, with **backpressure** (each agent
-  gets its next message only once it's free) and an in-memory coordinator→workers
-  task graph.
-- Cross-cutting (S): Settings (theme + terminal profiles w/ OS templates),
-  design tokens, full **i18n (EN/ES)** + Language picker, agents
-  registry + install detection + manual + auto-launch, **per-agent env vars** and
-  a **configurable agent launch shell** (Command Prompt by default on Windows).
-- Virtualized lists (`@tanstack/svelte-virtual`), opt-in keep-awake
-  (Windows).
+It is deliberately **not an IDE**. It is an orchestration, monitoring, and
+change-review layer, and any CLI agent works inside it without modification.
 
-Pre-release gaps before distributing builds: branded icons + signing/
-updater keys (`FOR-HUMAN.md`) and a CI/CD pipeline (see `FOR-DEV.md` →
-*CI/CD — release builds*).
+## What it does
+
+The application is **alpha-functional as a standalone app**. The capabilities
+available today are:
+
+- **Parallel, isolated agents.** Every task gets its own git worktree, its own
+  terminal workspace, and its own agent, so one agent's work never collides with
+  another's, and switching between them is a single click rather than a `git
+  stash` / `git checkout` cycle.
+- **A full terminal multiplexer.** Tabs, nested splits, drag-to-reorder and the
+  ability to move tabs across panes, `Ctrl+Tab` MRU cycling, WebGL rendering, and
+  scrollback that survives recreating a pane — built on `portable-pty` and
+  xterm.js.
+- **Integrated Git review.** Status, stage, commit, push and pull, with a unified
+  or side-by-side diff viewer (CodeMirror 6), **hunk-level staging**, visual image
+  diffs, squash-merged branch cleanup on worktree removal, WSL repositories routed
+  through `wsl.exe`, and optional **AI-generated commit messages** drafted by a
+  local CLI agent from your staged diff.
+- **Agent monitoring.** Three layers — a precise local hook server, terminal-title
+  inference, and process-tree detection — drive colored status dots, unread / done
+  badges, and native idle notifications, so you always know whether an agent is
+  working, blocked, waiting, or done.
+- **Multi-agent orchestration.** With two or more live agents, a console routes a
+  message to all of them, to one agent type (fan-out), or to a coordinator's
+  workers, applying backpressure so no agent receives a new message before it is
+  free.
+- **Personalization and internationalization.** Full custom theming with design
+  tokens and light/dark modes, terminal profiles, per-agent launch settings and
+  environment variables, a configurable launch shell, and a completely translated
+  interface in **English and Spanish**.
+
+<details>
+<summary><b>Diagram — the three-panel ADE, a worktree per task, layered monitoring</b></summary>
+
+```mermaid
+flowchart TB
+  subgraph shell["Three-panel ADE shell"]
+    sidebar["Projects & worktrees<br/>(sidebar)"]
+    center["Terminals · diffs · files<br/>(center, splits + tabs)"]
+    agents["Agents & orchestration<br/>(status panel)"]
+  end
+
+  subgraph work["A worktree per task"]
+    w1["worktree A<br/>terminal + agent"]
+    w2["worktree B<br/>terminal + agent"]
+    w3["worktree C<br/>terminal + agent"]
+  end
+
+  subgraph mon["Agent monitoring (3 layers)"]
+    l1["Layer 1 — local hook server (axum)"]
+    l2["Layer 2 — terminal-title (OSC)"]
+    l3["Layer 3 — process-tree detection"]
+  end
+
+  sidebar --> work
+  work --> center
+  work --> mon
+  mon --> agents
+```
+
+</details>
+
+## Platform support
+
+Uxnan Desktop is cross-platform by construction — Tauri 2 targets Windows, macOS
+and Linux — but **all current testing has been carried out directly on Windows**.
+
+- **Windows** — actively developed and tested; this is the validated platform
+  today.
+- **Linux** — expected to work and built in CI, but not yet exercised end-to-end
+  by the maintainer. If you run it on Linux, your feedback and recommendations are
+  genuinely welcome; please open an issue or a discussion so the experience can be
+  hardened.
+- **macOS** — supported by the toolchain, but no maintainer builds are produced
+  yet and the platform is unvalidated. Until a signed build exists, macOS users
+  can build it themselves by following
+  [release builds & packaging](docs/build.md).
+
+The only remaining roadmap phase is **Phase 6 (bridge integration / mobile
+pairing)**, which is *optional for standalone use* — required only if you want the
+ADE to double as the mobile bridge (otherwise install `uxnan-bridge` separately).
+The detailed implementation status (phases, test counts, pre-release gaps) lives
+in [`FOR-DEV.md`](FOR-DEV.md).
 
 ## Docs
 
@@ -126,7 +188,7 @@ makes `pnpm install` no-op here).
 cd uxnandesktop
 npm install            # frontend deps
 npm run check          # svelte-check (type check)
-npm test               # Vitest unit tests (pure logic — 19 passing)
+npm test               # Vitest unit tests (pure logic)
 npm run build          # build the SPA → build/  (required by `cargo build`'s generate_context!)
 npm run tauri dev      # run the desktop app (compiles Rust on first run)
 ```
@@ -134,7 +196,7 @@ npm run tauri dev      # run the desktop app (compiles Rust on first run)
 Backend (from `src-tauri/`):
 
 ```bash
-cargo test             # unit tests (98 passing)
+cargo test             # backend unit tests
 cargo clippy --all-targets
 cargo fmt
 ```

--- a/uxnandesktop/docs/agent-hooks.md
+++ b/uxnandesktop/docs/agent-hooks.md
@@ -1,5 +1,10 @@
 # Agent hooks — precise agent states
 
+![States](https://img.shields.io/badge/states-working_%7C_blocked_%7C_waiting_%7C_done-2ea44f?style=for-the-badge)
+![Server](https://img.shields.io/badge/hook_server-127.0.0.1_(loopback)-0a0a0a?style=for-the-badge)
+![Claude](https://img.shields.io/badge/Claude_Code-auto--installed-D97757?style=for-the-badge)
+![Others](https://img.shields.io/badge/other_agents-generic_wrapper-blue?style=for-the-badge)
+
 The ADE infers a coarse **working / idle** state from terminal output with no
 setup. To get **precise** states — `working`, `blocked`, `waiting`, `done` — an
 agent must actively report them to the ADE's local **hook server** (Layer 1 of

--- a/uxnandesktop/docs/agent-launch.md
+++ b/uxnandesktop/docs/agent-launch.md
@@ -1,5 +1,9 @@
 # Agent launch & configuration
 
+![Shell](https://img.shields.io/badge/default_launch_shell-cmd_on_Windows-0a0a0a?style=for-the-badge)
+![Env](https://img.shields.io/badge/per--agent-env_vars-2ea44f?style=for-the-badge)
+![Quoting](https://img.shields.io/badge/arguments-shell--aware_quoting-blue?style=for-the-badge)
+
 How to register CLI coding agents in the ADE and tune **how** they launch:
 per-agent **environment variables**, the **shell** they run in (Command Prompt by
 default on Windows), **auto-launch** when you create a worktree, and the

--- a/uxnandesktop/docs/architecture.md
+++ b/uxnandesktop/docs/architecture.md
@@ -1,5 +1,9 @@
 # Desktop — architecture orientation
 
+![Backend](https://img.shields.io/badge/backend-Rust_%2B_Tauri_2-000000?style=for-the-badge&logo=tauri&logoColor=FFC131)
+![Frontend](https://img.shields.io/badge/frontend-Svelte_5_runes-FF3E00?style=for-the-badge&logo=svelte&logoColor=white)
+![Spec](https://img.shields.io/badge/source_of_truth-architecture%2F-blue?style=for-the-badge)
+
 A short map of how the code is organized and where it sits in the Uxnan
 monorepo. The **authoritative specification** is in
 [`../architecture/`](../architecture/00-index.md) — this file is a quick
@@ -17,7 +21,7 @@ change-review layer, **not** an IDE.
 The system keeps three sources of truth in sync (spec §1 of
 `architecture/02a-system-architecture.md`):
 
-```
+```text
 Rust backend (Tauri core)  ──Tauri commands (invoke) + events (emit/listen)──►  Svelte webview
    repos/worktrees, PTY,                                                          UI state, layout,
    git2+CLI, persistence,                                                         active selection
@@ -44,8 +48,10 @@ Rust backend (Tauri core)  ──Tauri commands (invoke) + events (emit/listen)�
 | `commands.rs` | The `#[tauri::command]` surface. |
 | `error.rs` | `AppError` (internal) + serializable `CommandError`. |
 
-Phase 1+ adds `pty`, `git`, and agent-hook modules — see
-[`../FOR-DEV.md`](../FOR-DEV.md).
+Later phases add the runtime modules that are all present today — `pty.rs`,
+`git.rs` / `gitfast.rs`, `hooks.rs` / `agent_hooks.rs`, `procscan.rs`, `browse.rs`,
+`fs.rs` / `fswatch.rs`, `power.rs` and `which.rs`. The full file-by-file layout is
+in [`../README.md`](../README.md); remaining work is in [`../FOR-DEV.md`](../FOR-DEV.md).
 
 ## Frontend (`src/`)
 

--- a/uxnandesktop/docs/build.md
+++ b/uxnandesktop/docs/build.md
@@ -1,5 +1,9 @@
 # Desktop — release builds & packaging
 
+![Bundler](https://img.shields.io/badge/build-tauri_build-FFC131?style=for-the-badge&logo=tauri&logoColor=000000)
+![Targets](https://img.shields.io/badge/installers-Windows_%7C_macOS_%7C_Linux-lightgrey?style=for-the-badge)
+![Per_OS](https://img.shields.io/badge/cross--compile-build_on_each_OS-0a0a0a?style=for-the-badge)
+
 How to compile Uxnan Desktop for distribution. For day-to-day debug runs see
 [`development.md`](development.md).
 

--- a/uxnandesktop/docs/design-tokens.md
+++ b/uxnandesktop/docs/design-tokens.md
@@ -1,5 +1,8 @@
 # Desktop — design tokens (sizing & emphasis)
 
+![Source](https://img.shields.io/badge/tokens-src%2Flib%2Fdesign.ts-blue?style=for-the-badge)
+![Style](https://img.shields.io/badge/Tailwind-class_strings_by_role-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
+
 A small, reusable scale that keeps the UI visually consistent and lets us tune
 density from one place. The tokens are Tailwind class strings grouped by **role**
 in [`src/lib/design.ts`](../src/lib/design.ts); apply them with `cn(...)`.

--- a/uxnandesktop/docs/development.md
+++ b/uxnandesktop/docs/development.md
@@ -1,5 +1,10 @@
 # Desktop — development & running in debug
 
+![Node.js](https://img.shields.io/badge/Node.js-%E2%89%A518-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![Rust](https://img.shields.io/badge/Rust-stable-000000?style=for-the-badge&logo=rust&logoColor=white)
+![Package manager](https://img.shields.io/badge/use-npm,_not_pnpm-CB3837?style=for-the-badge&logo=npm&logoColor=white)
+![Dev server](https://img.shields.io/badge/Vite-localhost%3A1420-646CFF?style=for-the-badge&logo=vite&logoColor=white)
+
 How to set up, run, and iterate on Uxnan Desktop locally. For release builds see
 [`build.md`](build.md); for the verification gates see [`testing.md`](testing.md).
 
@@ -66,7 +71,7 @@ npm run check:watch   # re-run on change
 
 ## Project layout (where things live)
 
-```
+```text
 uxnandesktop/
 ├── src/                      # SvelteKit frontend (SPA)
 │   ├── app.css               # Tailwind v4 + shadcn-svelte tokens

--- a/uxnandesktop/docs/i18n.md
+++ b/uxnandesktop/docs/i18n.md
@@ -1,5 +1,9 @@
 # Desktop — internationalization (i18n)
 
+![Languages](https://img.shields.io/badge/languages-EN_%7C_ES-blue?style=for-the-badge)
+![Source](https://img.shields.io/badge/source_of_truth-en.ts-2ea44f?style=for-the-badge)
+![Type-safe](https://img.shields.io/badge/missing_key-fails_to_compile-CB3837?style=for-the-badge&logo=typescript&logoColor=white)
+
 The UI is multilingual. **English is the source of truth**; Spanish ships too.
 The active language follows the device by default and can be changed in
 **Settings → Language**.

--- a/uxnandesktop/docs/orchestration.md
+++ b/uxnandesktop/docs/orchestration.md
@@ -1,5 +1,9 @@
 # Multi-agent orchestration
 
+![Routing](https://img.shields.io/badge/route-all_%7C_by_type_%7C_workers-2ea44f?style=for-the-badge)
+![Backpressure](https://img.shields.io/badge/delivery-backpressured-blue?style=for-the-badge)
+![Scope](https://img.shields.io/badge/needs-%E2%89%A52_live_agents-lightgrey?style=for-the-badge)
+
 Run several CLI agents at once and **drive them from one place**: send a message
 to every agent, to all agents of one type, or to a coordinator's workers — and
 let the ADE deliver it to each one **only when it's free** (backpressure), so a

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -1,5 +1,9 @@
 # Desktop — testing & verification
 
+![Backend](https://img.shields.io/badge/backend-cargo_test_%2B_clippy_%2B_fmt-000000?style=for-the-badge&logo=rust&logoColor=white)
+![Frontend](https://img.shields.io/badge/frontend-svelte--check_%2B_Vitest-FF3E00?style=for-the-badge&logo=svelte&logoColor=white)
+![UI](https://img.shields.io/badge/UI-verified_on--device-2ea44f?style=for-the-badge)
+
 The quality gates to run before considering a change done (AGENTS.md requires
 compile + tests + lint/format clean, and a real UI flow for UI changes).
 

--- a/uxnandesktop/docs/theming.md
+++ b/uxnandesktop/docs/theming.md
@@ -1,5 +1,9 @@
 # Theming & appearance
 
+![Built-in](https://img.shields.io/badge/built--in-System_%7C_Light_%7C_Dark_%7C_Midnight_%7C_Latte-blue?style=for-the-badge)
+![Custom](https://img.shields.io/badge/custom-create_%7C_import_%7C_export-2ea44f?style=for-the-badge)
+![Terminal](https://img.shields.io/badge/terminal-own_override_layer-0a0a0a?style=for-the-badge)
+
 Uxnan Desktop ships built-in themes (System, Light, Dark, Midnight, Latte) and
 lets you create, import and export your own. A theme covers the **whole app** —
 every surface color plus the title / body / mono fonts. The terminal has its own

--- a/uxnanmobile/FOR-DEV.md
+++ b/uxnanmobile/FOR-DEV.md
@@ -4,9 +4,73 @@ Deferred implementation work (code the team/agent will do later). Distinct from
 `FOR-HUMAN.md` (assets only a human can provide). Search the codebase for
 `FOR-DEV:` to jump to the exact deferral sites.
 
-> Convention defined in the root `AGENTS.md` → "Pending developer work". The
-> implemented surface is documented in [`README.md`](README.md) + [`docs/`](docs/);
-> this file tracks only what's left.
+> Convention defined in the root `AGENTS.md` → "Pending developer work".
+> [`README.md`](README.md) carries the user-facing snapshot; the detailed status
+> below is the developer record of what's working, and the rest of this file
+> tracks what's left.
+
+## Status
+
+**MVP wired — Android alpha-ready.** All core modules are implemented and
+connected to live bridge data, validated on-device against a real bridge.
+
+**Built (DONE):**
+
+- **E2EE crypto + secure transport** (X25519 + Ed25519 + HKDF + AES-256-GCM,
+  handshake, seq/replay, outbound buffer, reconnect loop).
+- **Pairing & onboarding** — `OnboardingScreen`, `QrScannerScreen`,
+  `MyDevicesScreen`, **`ManualCodeScreen`** (bridge-first manual-code pairing,
+  `GET /pair/resolve?code=`, host typed or via mDNS discover).
+- **Direct LAN/Tailscale transport** — `DirectTransportSelector` tries each direct
+  `hosts` entry from the QR first, falls back to the relay.
+- **Multi-PC connection-targeting** — all live actions target the PC we actually
+  hold a channel to; browsing is read-only. `bridge/status` consumed (Relay /
+  Direct transport indicator).
+- **Live streaming conversations** that survive leaving/re-entering the screen
+  (per-thread in-memory buffers + `turn/list` re-sync) with a per-thread
+  **"Responding…"** activity indicator.
+- **Structured agent turns** — assistant replies without a bubble, consecutive
+  text merged, collapsible **Work log (N)**, collapsible **Changed files (N) ·
+  +a −d** with per-file diffs, **Copy response**, **Last edits** strip above the
+  composer; **Thinking** section (settings-gated, default off).
+- **New conversation flow** — `project/list` + `agent/list` + `agent/models` +
+  **folder browser** (`workspace/browseDirs`) to root a thread anywhere.
+- **Structured model picker** (readable names, default badge, Claude alias
+  "(latest)" + pinned versions + resolved-version row, `thread/setModel`).
+- **Per-model run-option knobs** (data-driven: `enum` / `toggle`, generic
+  renderer).
+- **Context-usage indicator** (percentage when the model window is known, raw
+  token count otherwise; **0 baseline** for agents with `reportsContextUsage`).
+- **Per-agent sign-in status** (`auth/status`) — banner above the composer, red
+  dot in the threads list, "Check sign-in" in the new-conversation card,
+  auto-refresh on app resume.
+- **Interactive approval** (Approve / Reject / "always allow this session") with a
+  spring `AnimatedSize` morph; validated end-to-end against Echo, Claude Code
+  (`PreToolUse` hook), Codex (`app-server`) and Gemini (`BeforeTool` hook).
+  OpenCode/pi have no headless pre-tool channel yet.
+- **Composer** — bottom-anchored bar; **stop-the-turn** mid-run; **voice → text**
+  (`speech_to_text`); **image attachments** (photo library / camera, downscaled to
+  2048 px / q85, image-only message allowed, gated by the agent's `images`
+  capability).
+- **Per-PC threads** (`Thread.deviceId`) with per-agent filter chips, search /
+  sort / density, archived-thread screen, per-thread actions (rename / archive /
+  unarchive / delete / copy id), **Remove device** (unpair), **Copy thread ID**
+  for CLI resume.
+- **Full Git** — full-screen `GitScreen` (per-file `git/diff`, branch switch with
+  auto-stash, smart PR dialog, undo-commit, `git/revert`, `git/deleteBranch`,
+  `git/removeWorktree`, etc.).
+- **FCM push** (gated) — Android LIVE; deep-link to conversation; **personalized
+  copy** + foreground suppression; per-channel notification preferences (Replies /
+  Errors).
+- **Settings** — theme mode (System/Light/Dark) + a **custom-theme library** with a
+  dedicated Theme Manager (single/dual-brightness themes, live-preview grid,
+  multi-select bulk delete/export, JSON import/export); language (EN/ES, follows
+  device or picker); notification preferences.
+- **i18n** — full app translated (EN + ES) via `flutter gen-l10n`.
+
+iOS is **not yet built** (the Podfile is generated on the first macOS build) and is
+blocked on the Apple assets in [`FOR-HUMAN.md`](FOR-HUMAN.md). Everything still
+pending is below.
 
 ## FOR-DEV: keep the R8 keep rules complete (release minification is ON)
 

--- a/uxnanmobile/README.md
+++ b/uxnanmobile/README.md
@@ -1,13 +1,84 @@
 # uxnanmobile
 
-Flutter mobile client (Android + iOS) for **Uxnan** — a remote control for AI
-coding agents running on a PC, over an end-to-end encrypted channel.
+Flutter mobile client (Android + iOS) for **[Uxnan](../README.md)** — a remote
+control for the AI coding agents running on your PC, over an end-to-end encrypted
+channel. It is the part of the ecosystem you carry with you: the bridge does the
+work on the PC, and this app is how you watch it, steer it, and review it from
+anywhere.
+
+![Flutter](https://img.shields.io/badge/Flutter-02569B?style=for-the-badge&logo=flutter&logoColor=white)
+![Dart](https://img.shields.io/badge/Dart-0175C2?style=for-the-badge&logo=dart&logoColor=white)
+![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white)
+![iOS](https://img.shields.io/badge/iOS-000000?style=for-the-badge&logo=apple&logoColor=white)
+![Riverpod](https://img.shields.io/badge/Riverpod_3.x-0553B1?style=for-the-badge&logo=flutter&logoColor=white)
+![Material 3](https://img.shields.io/badge/Material_Design_3-757575?style=for-the-badge&logo=materialdesign&logoColor=white)
+![E2EE](https://img.shields.io/badge/E2EE-AES--256--GCM-0a0a0a?style=for-the-badge&logo=letsencrypt&logoColor=white)
+![License](https://img.shields.io/badge/LICENSE-MPL--2.0-2ea44f?style=for-the-badge)
 
 > **Status: Android ALPHA-READY. iOS pending FOR-HUMAN assets** (APNs key,
-> `Info.plist` usage strings, signing; first build requires macOS).
+> `Info.plist` usage strings, signing; the first build requires macOS).
 >
 > Full technical specification: [`../architecture/`](../architecture/00-index.md).
 > The architecture docs are the source of truth; this app implements them.
+
+## What sets it apart
+
+There is no shortage of "control your agent from your phone" tools. Uxnan takes a
+deliberately different set of positions, and most of them are felt directly from
+this app:
+
+- **Provider-agnostic, real multi-agent support.** It is not tied to a single
+  vendor. Five real agents are wired today — OpenCode, Claude Code, Codex, pi and
+  Gemini CLI — and you select the agent and model per conversation.
+- **Strong encryption that is never optional.** Every message to and from the PC
+  travels through a real end-to-end encrypted channel (X25519 + Ed25519 +
+  AES-256-GCM + HKDF). There is no "plaintext mode".
+- **Fully open source.** The entire ecosystem, this app included, is released
+  under the [MPL-2.0](../LICENSE) license. Nothing about how it connects to your
+  machine is hidden.
+- **One bridge, every project.** The bridge is started **once**, from a single
+  location on your PC, and from the app you can open a conversation in **any**
+  project beneath it — Git repositories or plain folders alike — without
+  relaunching anything per project. A built-in folder browser (`workspace/
+  browseDirs`) lets you root a new conversation wherever the bridge allows.
+- **Effortless connection.** Pairing is as simple as scanning a QR, and the app
+  can also **discover nearby bridges** automatically over mDNS or accept a short
+  manual code — no addresses to memorize, no compile-time configuration. A
+  transport indicator always tells you whether you are connected **directly** (LAN
+  / Tailscale) or **through the relay**.
+- **Parity with the bridge's main capabilities.** Streaming conversations with
+  structured agent turns, interactive approvals, model and reasoning-effort
+  selection, a live context-usage indicator, per-agent sign-in status, voice and
+  image input, and a full Git screen are all available from the phone.
+- **Full custom theming.** Beyond system light/dark, a dedicated Theme Manager
+  lets you build, preview, import and export your own themes (single- or
+  dual-brightness), so the app genuinely looks the way you want.
+
+<details>
+<summary><b>Diagram — the phone, one bridge, and every project under it</b></summary>
+
+```mermaid
+flowchart LR
+  app["📱 uxnanmobile<br/>(this app)"]
+
+  subgraph pc["💻 your PC"]
+    bridge["uxnan-bridge<br/>(started once)"]
+    p1["project-a (git)"]
+    p2["project-b (git)"]
+    p3["notes/ (plain folder)"]
+    a1["agents<br/>opencode · claude · codex · pi · gemini"]
+  end
+
+  app -- "QR · mDNS · manual code" --> bridge
+  app == "E2EE · LAN / Tailscale (direct)" ==> bridge
+  app -. "E2EE · relay (off-LAN)" .-> bridge
+  bridge --> p1
+  bridge --> p2
+  bridge --> p3
+  bridge --> a1
+```
+
+</details>
 
 ## Stack
 
@@ -73,73 +144,23 @@ Configuration is injected at compile time with `--dart-define` (spec 03 §3.3):
 ```bash
 dart format lib test
 flutter analyze            # must report 0 issues (no warnings)
-flutter test               # unit + widget tests (441 passing)
+flutter test               # unit + widget tests
 ```
 
 ## Status
 
-**MVP wired (Android alpha-ready).** All core modules are implemented and
+**MVP wired — Android alpha-ready.** Every core module is implemented and
 connected to live bridge data, validated on-device against a real bridge:
+pairing + E2EE transport, live streaming conversations with structured agent
+turns, the model picker and run-option knobs, context-usage and sign-in
+indicators, interactive approvals, voice and image input, per-PC threads, a full
+Git screen, and Android push.
 
-- **E2EE crypto + secure transport** (X25519 + Ed25519 + HKDF + AES-256-GCM,
-  handshake, seq/replay, outbound buffer, reconnect loop).
-- **Pairing & onboarding** — `OnboardingScreen`, `QrScannerScreen`,
-  `MyDevicesScreen`, **`ManualCodeScreen`** (bridge-first manual-code
-  pairing, `GET /pair/resolve?code=`, host typed or via mDNS discover).
-- **Direct LAN/Tailscale transport** — `DirectTransportSelector` tries each
-  direct `hosts` entry from the QR first, falls back to the relay.
-- **Multi-PC connection-targeting** — all live actions target the PC we
-  actually hold a channel to; browsing is read-only. `bridge/status`
-  consumed (Relay / Direct transport indicator).
-- **Live streaming conversations** that survive leaving/re-entering the
-  screen (per-thread in-memory buffers + `turn/list` re-sync) with a
-  per-thread **"Responding…"** activity indicator.
-- **Structured agent turns** — assistant replies without a bubble,
-  consecutive text merged, collapsible **Work log (N)**, collapsible
-  **Changed files (N) · +a −d** with per-file diffs, **Copy response**,
-  **Last edits** strip above the composer; **Thinking** section
-  (settings-gated, default off).
-- **New conversation flow** — `project/list` + `agent/list` + `agent/models`
-  + **folder browser** (`workspace/browseDirs`) to root a thread anywhere.
-- **Structured model picker** (readable names, default badge, Claude alias
-  "(latest)" + pinned versions + resolved-version row, `thread/setModel`).
-- **Per-model run-option knobs** (data-driven: `enum` / `toggle`,
-  generic renderer).
-- **Context-usage indicator** (percentage when the model window is known,
-  raw token count otherwise; **0 baseline** for agents with
-  `reportsContextUsage`).
-- **Per-agent sign-in status** (`auth/status`) — banner above the composer,
-  red dot in the threads list, "Check sign-in" in new-conversation card,
-  auto-refresh on app resume.
-- **Interactive approval** (Approve / Reject / "always allow this session")
-  with a spring `AnimatedSize` morph; validated end-to-end against Echo,
-  Claude Code (`PreToolUse` hook), Codex (`app-server`) and Gemini
-  (`BeforeTool` hook). OpenCode/pi have no headless pre-tool channel yet.
-- **Composer** — bottom-anchored bar; **stop-the-turn** mid-run; **voice
-  → text** (`speech_to_text`); **image attachments** (photo library /
-  camera, downscaled to 2048 px / q85, image-only message allowed,
-  gated by the agent's `images` capability).
-- **Per-PC threads** (`Thread.deviceId`) with per-agent filter chips,
-  search / sort / density, archived-thread screen, per-thread actions
-  (rename / archive / unarchive / delete / copy id), **Remove device**
-  (unpair), **Copy thread ID** for CLI resume.
-- **Full Git** — full-screen `GitScreen` (per-file `git/diff`,
-  branch switch with auto-stash, smart PR dialog, undo-commit,
-  `git/revert`, `git/deleteBranch`, `git/removeWorktree`, etc.).
-- **FCM push** (gated) — Android LIVE; deep-link to conversation;
-  **personalized copy** + foreground suppression; per-channel
-  notification preferences (Replies / Errors).
-- **Settings** — theme mode (System/Light/Dark) + a **custom-theme library**
-  with a dedicated Theme Manager (single/dual-brightness themes, live-preview
-  grid, multi-select bulk delete/export, JSON import/export); language (EN/ES,
-  follows device or picker); notification preferences.
-- **i18n** — full app translated (EN + ES) via `flutter gen-l10n`.
-
-Remaining/deferred work (Bug A relink latency, OpenCode/pi interactive approvals
-— a bridge-side gap, automated integration test, and all iOS work) is tracked in
-[`FOR-DEV.md`](FOR-DEV.md); the pending iOS/Apple
-assets are in [`FOR-HUMAN.md`](FOR-HUMAN.md). See [`CHANGELOG.md`](CHANGELOG.md)
-for the full history.
+The detailed, always-current feature inventory and what's left (Bug A relink
+latency, OpenCode/pi interactive approvals — a bridge-side gap — the automated
+integration test, and all iOS work) lives in [`FOR-DEV.md`](FOR-DEV.md); pending
+iOS/Apple assets are in [`FOR-HUMAN.md`](FOR-HUMAN.md); the full history is in
+[`CHANGELOG.md`](CHANGELOG.md).
 
 ## Documentation
 

--- a/uxnanmobile/docs/README.md
+++ b/uxnanmobile/docs/README.md
@@ -1,5 +1,9 @@
 # uxnanmobile — developer docs
 
+![Flutter](https://img.shields.io/badge/Flutter-Android_%7C_iOS-02569B?style=for-the-badge&logo=flutter&logoColor=white)
+![Architecture](https://img.shields.io/badge/Clean_Architecture-Riverpod_3.x-0553B1?style=for-the-badge)
+![Spec](https://img.shields.io/badge/source_of_truth-architecture%2F-blue?style=for-the-badge)
+
 Reference documentation for working **inside** the Flutter app. This is the
 as-built developer guide; the canonical product/design spec lives in the
 monorepo's [`architecture/`](../../architecture/00-index.md) (PRD + SRS) and
@@ -19,5 +23,7 @@ Related files (not in `docs/`):
 - [`../FOR-DEV.md`](../FOR-DEV.md) — pending developer work (greppable `FOR-DEV:`).
 - [`../FOR-HUMAN.md`](../FOR-HUMAN.md) — assets only a human can provide.
 - [`../../AGENTS.md`](../../AGENTS.md) — monorepo-wide agent guidelines.
-- [`../../TESTING.md`](../../TESTING.md) — testing for the **Node** side
-  (`bridge`/`relay`/`shared`); the mobile testing guide is [testing.md](testing.md).
+- Node-side testing (`bridge` / `relay` / `shared`) lives in each component's docs
+  — [`../../bridge/docs/testing.md`](../../bridge/docs/testing.md) and
+  [`../../relay/docs/testing.md`](../../relay/docs/testing.md); the mobile testing
+  guide is [testing.md](testing.md).

--- a/uxnanmobile/docs/architecture.md
+++ b/uxnanmobile/docs/architecture.md
@@ -1,5 +1,9 @@
 # Architecture (as built)
 
+![Layers](https://img.shields.io/badge/Clean_Architecture-core_%E2%86%92_domain_%E2%86%92_app_%E2%86%92_infra_%E2%86%92_ui-0553B1?style=for-the-badge)
+![State](https://img.shields.io/badge/Riverpod_3.x-manual_DI-blue?style=for-the-badge)
+![Persistence](https://img.shields.io/badge/drift-SQLite-003B57?style=for-the-badge&logo=sqlite&logoColor=white)
+
 A developer-oriented map of the actual code. The canonical design is the
 monorepo [`architecture/`](../../architecture/00-index.md) spec — when this doc
 and the spec disagree, the spec wins (the project is ALPHA; code follows spec).
@@ -12,7 +16,7 @@ codegen). Local persistence: **drift** (SQLite). UI: **Material 3**.
 
 Clean Architecture under `lib/`, with a strict dependency direction:
 
-```
+```text
 presentation ─▶ application ─▶ domain ◀─ infrastructure
      └──────────────▶ domain ◀──────────────┘
                        core (no deps)

--- a/uxnanmobile/docs/conventions.md
+++ b/uxnanmobile/docs/conventions.md
@@ -1,5 +1,9 @@
 # Conventions
 
+![State](https://img.shields.io/badge/Riverpod_3.x-manual,_no_codegen-0553B1?style=for-the-badge)
+![UI](https://img.shields.io/badge/Material_3-design_tokens_%2B_skills-757575?style=for-the-badge&logo=materialdesign&logoColor=white)
+![Security](https://img.shields.io/badge/security-non--negotiable-2ea44f?style=for-the-badge&logo=letsencrypt&logoColor=white)
+
 The working agreement for anyone (human or agent) touching `uxnanmobile`. These
 extend the monorepo [`../../AGENTS.md`](../../AGENTS.md); where a Flutter skill's
 generic default conflicts with the [`architecture/`](../../architecture/00-index.md)

--- a/uxnanmobile/docs/neural-expressive-design.md
+++ b/uxnanmobile/docs/neural-expressive-design.md
@@ -1,282 +1,279 @@
-# Guía de Ingeniería de UI — Neural Expressive & Material 3 Expressive para Flutter
-## Sistema de Diseño para la Era de la Inteligencia Artificial · Revisión 2.0
+# UI Engineering Guide — Neural Expressive & Material 3 Expressive for Flutter
+## Design System for the Age of Artificial Intelligence · Revision 2.0
 
-> **Nota de revisión:** Esta versión corrige errores técnicos de la v1.0, incorpora
-> información verificada del redesign real de Gemini (I/O 2026) y de las especificaciones
-> oficiales de M3 Expressive (I/O 2025), y extiende la guía con cobertura completa de
-> breakpoints responsivos (Compact → Extra-Large) y patrones de layout canónicos.
+> **Revision note:** This version corrects technical errors from v1.0, incorporates
+> verified information from the real Gemini redesign (I/O 2026) and from the official
+> M3 Expressive specifications (I/O 2025), and extends the guide with full coverage
+> of responsive breakpoints (Compact → Extra-Large) and canonical layout patterns.
 
 ---
 
-## Índice de Contenido
+## Table of Contents
 
-1. [Introducción y Contexto Real](#1-introducción-y-contexto-real)
-2. [Pilares del Sistema de Diseño](#2-pilares-del-sistema-de-diseño)
-   - [Sistema de Movimiento basado en Física de Resortes](#21-sistema-de-movimiento-basado-en-física-de-resortes)
-   - [Sistema de Formas y Geometría Expresiva](#22-sistema-de-formas-y-geometría-expresiva)
-   - [Sistema Tipográfico](#23-sistema-tipográfico)
-   - [Sistema de Color HCT](#24-sistema-de-color-hct)
-3. [Breakpoints y Clases de Ventana Responsivos](#3-breakpoints-y-clases-de-ventana-responsivos)
-4. [Especificaciones de Componentes](#4-especificaciones-de-componentes)
-   - [Scaffold y Layout Principal](#41-scaffold-y-layout-principal)
+1. [Introduction and Real Context](#1-introduction-and-real-context)
+2. [Pillars of the Design System](#2-pillars-of-the-design-system)
+   - [Spring-Physics-Based Motion System](#21-spring-physics-based-motion-system)
+   - [Shape and Expressive Geometry System](#22-shape-and-expressive-geometry-system)
+   - [Typographic System](#23-typographic-system)
+   - [HCT Color System](#24-hct-color-system)
+3. [Responsive Breakpoints and Window Classes](#3-responsive-breakpoints-and-window-classes)
+4. [Component Specifications](#4-component-specifications)
+   - [Scaffold and Main Layout](#41-scaffold-and-main-layout)
    - [AppBar / Header](#42-appbar--header)
-   - [Campo de Entrada Flotante (Prompt Pill)](#43-campo-de-entrada-flotante-prompt-pill)
+   - [Floating Input Field (Prompt Pill)](#43-floating-input-field-prompt-pill)
    - [Navigation Drawer / Sidebar](#44-navigation-drawer--sidebar)
-   - [Botones Expresivos y Grupos](#45-botones-expresivos-y-grupos)
-   - [Tarjetas y Listas](#46-tarjetas-y-listas)
-   - [Indicadores de Progreso](#47-indicadores-de-progreso)
-   - [Interfaz de Voz Inline](#48-interfaz-de-voz-inline)
-5. [Matriz de Decisión de Componentes](#5-matriz-de-decisión-de-componentes)
-6. [Implementación en Flutter](#6-implementación-en-flutter)
-   - [Tokens de Movimiento M3E](#61-tokens-de-movimiento-m3e)
+   - [Expressive Buttons and Groups](#45-expressive-buttons-and-groups)
+   - [Cards and Lists](#46-cards-and-lists)
+   - [Progress Indicators](#47-progress-indicators)
+   - [Inline Voice Interface](#48-inline-voice-interface)
+5. [Component Decision Matrix](#5-component-decision-matrix)
+6. [Implementation in Flutter](#6-implementation-in-flutter)
+   - [M3E Motion Tokens](#61-m3e-motion-tokens)
    - [Breakpoint Helper](#62-breakpoint-helper)
-   - [Widget: Tarjeta Expresiva con Radios Dinámicos](#63-widget-tarjeta-expresiva-con-radios-dinámicos)
-   - [Widget: Navigation Drawer Responsivo](#64-widget-navigation-drawer-responsivo)
-   - [Widget: Pill Input Flotante](#65-widget-pill-input-flotante)
-   - [Widget: Indicador de Carga Poligonal (Shape Morphing)](#66-widget-indicador-de-carga-poligonal-shape-morphing)
-7. [Gobernanza, Accesibilidad y Rendimiento](#7-gobernanza-accesibilidad-y-rendimiento)
+   - [Widget: Expressive Card with Dynamic Radii](#63-widget-expressive-card-with-dynamic-radii)
+   - [Widget: Responsive Navigation Drawer](#64-widget-responsive-navigation-drawer)
+   - [Widget: Floating Pill Input](#65-widget-floating-pill-input)
+   - [Widget: Polygonal Loading Indicator (Shape Morphing)](#66-widget-polygonal-loading-indicator-shape-morphing)
+7. [Governance, Accessibility, and Performance](#7-governance-accessibility-and-performance)
 
 ---
 
-## 1. Introducción y Contexto Real
+## 1. Introduction and Real Context
 
-### 1.1 Qué es Neural Expressive (y qué NO es)
+### 1.1 What Neural Expressive Is (and What It Is NOT)
 
-**Neural Expressive** es el lenguaje de diseño visual que Google desplegó globalmente el
-**19 de mayo de 2026** en Google I/O, rediseñando de raíz la app de Gemini en Android,
-iOS y web. El vicepresidente de Gemini, Josh Woodward, lo describió como "un lenguaje
-vibrante, dinámico y completamente reimaginado, construido específicamente para la era
-de la IA".
+**Neural Expressive** is the visual design language that Google rolled out globally on
+**May 19, 2026** at Google I/O, fundamentally redesigning the Gemini app on Android,
+iOS, and web. Gemini Vice President Josh Woodward described it as "a vibrant, dynamic,
+and completely reimagined language, built specifically for the age of AI."
 
-Es importante delimitar su alcance real:
+It is important to delimit its real scope:
 
-- ✅ **Es:** Un lenguaje de diseño *específico de Gemini*, construido **sobre** Material 3
-  Expressive (M3E), que adapta sus principios al contexto de interfaces conversacionales con IA.
-- ✅ **Es:** Una filosofía de presentación de información: las respuestas de IA no deben
-  ser "paredes de texto", sino *objetos editoriales diseñados* con jerarquía visual clara.
-- ❌ **No es:** Un sistema independiente de M3E. Es una capa de aplicación encima de M3E.
-- ❌ **No es:** Exclusivamente el efecto de vidrio o gradientes pulsantes. Esos son
-  componentes opcionales de *estado* (procesamiento del modelo); no son la estructura base.
-- ❌ **No es:** Solo estética. Su objetivo principal es **reducción de carga cognitiva** y
-  **localización más rápida de información crítica**.
+- ✅ **It is:** A design language *specific to Gemini*, built **on top of** Material 3
+  Expressive (M3E), which adapts its principles to the context of conversational AI interfaces.
+- ✅ **It is:** A philosophy of information presentation: AI responses should not be
+  "walls of text," but rather *designed editorial objects* with clear visual hierarchy.
+- ❌ **It is not:** A system independent of M3E. It is an application layer on top of M3E.
+- ❌ **It is not:** Exclusively the glass effect or pulsing gradients. Those are optional
+  *state* components (model processing); they are not the base structure.
+- ❌ **It is not:** Only aesthetics. Its primary goal is **reducing cognitive load** and
+  **faster localization of critical information**.
 
-**Material 3 Expressive (M3E)** fue anunciado en Google I/O 2025 y desplegado en
-dispositivos Pixel con Android 16 en septiembre de 2025. Es la evolución (no reemplazo)
-de Material You (M3), con foco en motion física, componentes expresivos y tipografía
-variable. Neural Expressive es la implementación de M3E en el producto Gemini.
+**Material 3 Expressive (M3E)** was announced at Google I/O 2025 and rolled out on
+Pixel devices with Android 16 in September 2025. It is the evolution (not replacement)
+of Material You (M3), with a focus on physics-based motion, expressive components, and
+variable typography. Neural Expressive is the implementation of M3E in the Gemini product.
 
-### 1.2 El Principio Fundamental: Del Chat-Log al Objeto Editorial
+### 1.2 The Fundamental Principle: From Chat-Log to Editorial Object
 
-La premisa central de Neural Expressive: **la respuesta de la IA es un objeto de diseño,
-no un flujo de texto**. Esto implica:
+The central premise of Neural Expressive: **the AI response is a design object,
+not a stream of text**. This implies:
 
-1. La información más crítica ocupa la parte superior con tipografía enfatizada (grande,
-   bold, aislada visualmente).
-2. El contenido de soporte se presenta en tarjetas, líneas de tiempo o visualizaciones
-   inline, no en párrafos planos.
-3. La interfaz *comunica estado*: cuando el modelo procesa, la UI se mueve de forma
-   que refleja esa actividad cognitiva (el "glowbar" pulsante de Gemini es un ejemplo).
+1. The most critical information occupies the top with emphasized typography (large,
+   bold, visually isolated).
+2. Supporting content is presented in cards, timelines, or inline visualizations,
+   not in flat paragraphs.
+3. The interface *communicates state*: when the model processes, the UI moves in a way
+   that reflects that cognitive activity (Gemini's pulsing "glowbar" is an example).
 
-### 1.3 Tu Contexto de Uso (Sin Efecto Vidrio)
+### 1.3 Your Usage Context (Without the Glass Effect)
 
-Esta guía asume que implementas **los principios estructurales y de composición** de
-Neural Expressive con **materiales sólidos y limpios**, sin reproducir los efectos de
-gradiente/glow propios del branding de Gemini. El resultado es una UI moderna, aireada
-y de bajo ruido visual, perfecta para cualquier app conversacional, productividad o
-dashboard.
+This guide assumes you implement **the structural and compositional principles** of
+Neural Expressive with **solid, clean materials**, without reproducing the
+gradient/glow effects specific to Gemini's branding. The result is a modern, airy UI
+with low visual noise, perfect for any conversational, productivity, or dashboard app.
 
 ---
 
-## 2. Pilares del Sistema de Diseño
+## 2. Pillars of the Design System
 
-### 2.1 Sistema de Movimiento basado en Física de Resortes
+### 2.1 Spring-Physics-Based Motion System
 
-M3E reemplaza por completo las curvas de Bézier por un motor de **física de resortes
-amortiguados**. Esto permite animaciones que se interrumpen y redirigen naturalmente,
-reflejando la inercia y masa de objetos reales.
+M3E completely replaces Bézier curves with a **damped spring physics** engine. This
+enables animations that interrupt and redirect naturally, reflecting the inertia and
+mass of real objects.
 
-Un resorte se define por dos parámetros:
-- **Stiffness (k):** Qué tan rígido/rápido es el resorte. Mayor k = animación más rápida.
-- **Damping Ratio (ζ):** Qué tan rápido se amortiguan las oscilaciones. `ζ = 1.0` = sin
-  rebote (amortiguación crítica). `ζ < 1.0` = rebote visible y elástico.
+A spring is defined by two parameters:
+- **Stiffness (k):** How rigid/fast the spring is. Higher k = faster animation.
+- **Damping Ratio (ζ):** How quickly oscillations are damped. `ζ = 1.0` = no
+  bounce (critical damping). `ζ < 1.0` = visible, elastic bounce.
 
-#### Tabla de Tokens Oficiales M3E
+#### Table of Official M3E Tokens
 
-| Token | Stiffness (k) | Damping (ζ) | Comportamiento | Uso Recomendado |
+| Token | Stiffness (k) | Damping (ζ) | Behavior | Recommended Use |
 |:------|:------------:|:-----------:|:---------------|:----------------|
-| `effectsFast` | 3800 | 1.00 | ~150 ms, sin rebote | Switches, checkboxes, feedback táctil micro |
-| `effectsDefault` | 1600 | 1.00 | ~300 ms, sin rebote | Transiciones de color, fade de menús |
-| `effectsSlow` | 800 | 1.00 | ~500 ms, sin rebote | Aparición de ilustraciones, fondos |
-| `spatialFast` | 1400 | 0.90 | Rápido, overshoot leve (~10%) | Icon surfaces, chips de filtro, feedback de botones |
-| `spatialDefault` | 700 | 0.90 | Orgánico, overshoot ~10% | Bottom sheets, paneles, drawer *apertura* |
-| `spatialSlow` | 300 | 0.90 | Dramático, alta inercia | Hero animations, contenedores a pantalla completa |
-| `bouncySpatial` | 400 | 0.40 | Gran rebote (~40% overshoot) | FAB menu, chips pequeños, pickers — **SOLO elementos pequeños** |
-| `snappySpatial` | 1000 | 0.75 | Rápido con rebote leve | Drag de tarjetas, carruseles |
+| `effectsFast` | 3800 | 1.00 | ~150 ms, no bounce | Switches, checkboxes, micro tactile feedback |
+| `effectsDefault` | 1600 | 1.00 | ~300 ms, no bounce | Color transitions, menu fades |
+| `effectsSlow` | 800 | 1.00 | ~500 ms, no bounce | Illustration appearance, backgrounds |
+| `spatialFast` | 1400 | 0.90 | Fast, slight overshoot (~10%) | Icon surfaces, filter chips, button feedback |
+| `spatialDefault` | 700 | 0.90 | Organic, ~10% overshoot | Bottom sheets, panels, drawer *opening* |
+| `spatialSlow` | 300 | 0.90 | Dramatic, high inertia | Hero animations, full-screen containers |
+| `bouncySpatial` | 400 | 0.40 | Large bounce (~40% overshoot) | FAB menu, small chips, pickers — **SMALL elements ONLY** |
+| `snappySpatial` | 1000 | 0.75 | Fast with slight bounce | Card drag, carousels |
 
-> ⚠️ **Corrección crítica de v1.0:** Los valores de damping en la tabla son **ratios**
-> (0.0–1.0), no valores absolutos. La clase `SpringDescription` de Flutter usa el damping
-> *crítico* calculado como `2 * sqrt(stiffness * mass)`, por lo que el parámetro `damping`
-> en Flutter **no es el mismo** que el `dampingRatio` de M3. Ver sección 6.1 para
-> la implementación correcta.
+> ⚠️ **Critical correction from v1.0:** The damping values in the table are **ratios**
+> (0.0–1.0), not absolute values. Flutter's `SpringDescription` class uses *critical*
+> damping calculated as `2 * sqrt(stiffness * mass)`, so the `damping` parameter
+> in Flutter **is not the same** as M3's `dampingRatio`. See section 6.1 for
+> the correct implementation.
 
-> ⚠️ **Error de v1.0 — Drawer con `bouncySpatial`:** La física `bouncySpatial` (k=400,
-> ζ=0.40) **nunca debe usarse en el drawer**. Un overshoot del 40% en una superficie
-> grande como el drawer se percibe como un bucle de apertura/cierre involuntario, no como
-> elasticidad expresiva. Reglas correctas:
-> - **Apertura del drawer:** `spatialDefault` (k=700, ζ=0.90) — ~320 ms, overshoot mínimo.
-> - **Cierre del drawer:** `spatialFast` (k=1400, ζ=0.90) — ~240 ms, decisivo y limpio.
-> - `bouncySpatial` queda reservado para elementos de ≤ 56 dp.
+> ⚠️ **v1.0 error — Drawer with `bouncySpatial`:** The `bouncySpatial` physics (k=400,
+> ζ=0.40) **must never be used on the drawer**. A 40% overshoot on a large surface
+> like the drawer is perceived as an involuntary open/close loop, not as
+> expressive elasticity. Correct rules:
+> - **Drawer opening:** `spatialDefault` (k=700, ζ=0.90) — ~320 ms, minimal overshoot.
+> - **Drawer closing:** `spatialFast` (k=1400, ζ=0.90) — ~240 ms, decisive and clean.
+> - `bouncySpatial` is reserved for elements of ≤ 56 dp.
 
-#### Esquema Expressive vs Standard
+#### Expressive vs Standard Scheme
 
-M3E define dos *motion schemes* aplicables globalmente:
+M3E defines two *motion schemes* applicable globally:
 
-- **Expressive (recomendado):** Springs con ligero overshoot. Para momentos hero, FABs,
-  transiciones de pantalla principal. Es el esquema por defecto de Gemini.
-- **Standard:** Springs con amortiguación crítica, sin rebote. Para apps de alta densidad
-  de información o contextos más formales (dashboards, herramientas de productividad).
+- **Expressive (recommended):** Springs with slight overshoot. For hero moments, FABs,
+  main-screen transitions. It is Gemini's default scheme.
+- **Standard:** Springs with critical damping, no bounce. For high-information-density
+  apps or more formal contexts (dashboards, productivity tools).
 
-Puedes mezclarlos: usa Expressive en momentos de impacto y Standard en transiciones
-funcionales de bajo perfil.
+You can mix them: use Expressive in impactful moments and Standard in low-profile
+functional transitions.
 
 ---
 
-### 2.2 Sistema de Formas y Geometría Expresiva
+### 2.2 Shape and Expressive Geometry System
 
-M3E expande la biblioteca morfológica a **35 figuras** (polígonos, estrellas, pétalos
-asimétricos). La regla clave: **la forma no tiene semántica funcional fija**. Una forma
-ondulada no significa "cargando" obligatoriamente; puede ser una máscara decorativa para
-un avatar.
+M3E expands the morphological library to **35 figures** (polygons, stars, asymmetric
+petals). The key rule: **shape has no fixed functional semantics**. A wavy shape
+does not necessarily mean "loading"; it can be a decorative mask for an avatar.
 
-#### Radios de Esquina por Categoría de Contenedor
+#### Corner Radii by Container Category
 
-| Rol del Token | dp | Uso típico |
+| Token Role | dp | Typical Use |
 |:---|:---:|:---|
-| `shape.none` | 0 | Separadores, divisores |
-| `shape.extraSmall` | 4 | Chips internos, badges |
-| `shape.small` | 8 | Buttons compactos, tooltips |
-| `shape.medium` | 12 | Cards internas, text fields |
-| `shape.large` | 16 | Cards principales, bottom sheets |
-| `shape.extraLarge` | 28 | Modal dialogs, FABs expandidos |
-| `shape.full` | 50%+ | Pills, avatares, icon surfaces |
+| `shape.none` | 0 | Separators, dividers |
+| `shape.extraSmall` | 4 | Internal chips, badges |
+| `shape.small` | 8 | Compact buttons, tooltips |
+| `shape.medium` | 12 | Internal cards, text fields |
+| `shape.large` | 16 | Main cards, bottom sheets |
+| `shape.extraLarge` | 28 | Modal dialogs, expanded FABs |
+| `shape.full` | 50%+ | Pills, avatars, icon surfaces |
 
-#### Principio de Tensión Visual
+#### Visual Tension Principle
 
-Combina formas redondeadas y angulares en el mismo layout para crear "tensión"
-compositiva que dirige la mirada. Ejemplo: una tarjeta con `shape.large` (16 dp) junto
-a un botón con `shape.full` (pill) crea contraste expresivo sin ruido visual.
+Combine rounded and angular shapes in the same layout to create compositional
+"tension" that directs the gaze. Example: a card with `shape.large` (16 dp) next
+to a button with `shape.full` (pill) creates expressive contrast without visual noise.
 
-#### Radios Dinámicos en Listas (Dynamic Corner Cards)
+#### Dynamic Radii in Lists (Dynamic Corner Cards)
 
-Para listas agrupadas, los radios se ajustan según posición para comunicar cohesión:
+For grouped lists, the radii adjust according to position to communicate cohesion:
 
-```
-Primer elemento:   topLeft=24, topRight=24, bottomLeft=4, bottomRight=4
-Elementos medios:  todos los radios = 4 dp
-Último elemento:   topLeft=4, topRight=4, bottomLeft=24, bottomRight=24
-Elemento único:    todos los radios = 24 dp
-Gap entre items:   3 dp (no 8 dp — el gap pequeño refuerza la cohesión visual del grupo)
+```text
+First item:    topLeft=24, topRight=24, bottomLeft=4, bottomRight=4
+Middle items:  all radii = 4 dp
+Last item:     topLeft=4, topRight=4, bottomLeft=24, bottomRight=24
+Single item:   all radii = 24 dp
+Gap between items: 3 dp (not 8 dp — the small gap reinforces the group's visual cohesion)
 ```
 
 ---
 
-### 2.3 Sistema Tipográfico
+### 2.3 Typographic System
 
-**Google Sans Flex** opera como fuente variable primaria en el ecosistema Gemini/M3E.
-Sus tres ejes de variación:
+**Google Sans Flex** operates as the primary variable font in the Gemini/M3E
+ecosystem. Its three axes of variation:
 
-1. **Weight (100–1000):** La información más crítica en el contexto de respuesta IA
-   se renderiza con weights altos (700–900) en la parte superior del contenido. El
-   cuerpo del texto usa weights medios (400–500).
-2. **Optical Size:** Ajusta automáticamente el tracking y el contraste de astas para
-   mantener legibilidad desde 11 sp (microcopy) hasta 57+ sp (display hero).
-3. **Grade / Softness:** Suaviza terminales de letras para connotar calidez vs rigor
-   intelectual según el contexto del contenido.
+1. **Weight (100–1000):** The most critical information in the AI-response context
+   is rendered with high weights (700–900) at the top of the content. The
+   body text uses medium weights (400–500).
+2. **Optical Size:** Automatically adjusts the tracking and stroke contrast to
+   maintain legibility from 11 sp (microcopy) up to 57+ sp (display hero).
+3. **Grade / Softness:** Softens letter terminals to connote warmth vs intellectual
+   rigor according to the content context.
 
-#### Escala Tipográfica Neural Expressive
+#### Neural Expressive Typographic Scale
 
-| Estilo | Size | Weight | Uso en app AI |
+| Style | Size | Weight | Use in AI app |
 |:-------|:----:|:------:|:--------------|
-| `displayLarge` | 57 sp | 400 | Pantalla de bienvenida, splash |
-| `displayMedium` | 45 sp | 400 | Greeting central ("¿En qué puedo ayudarte?") |
-| `headlineLarge` | 32 sp | 700 | Resumen crítico al inicio de respuesta IA |
-| `headlineMedium` | 28 sp | 600 | Títulos de secciones en respuesta editorial |
-| `titleLarge` | 22 sp | 500 | Nombres de conversaciones en el drawer |
-| `titleMedium` | 16 sp | 500–600 | Headers de tarjetas, labels de navegación |
-| `bodyLarge` | 16 sp | 400 | Cuerpo principal de respuesta IA |
-| `bodyMedium` | 14 sp | 400 | Contenido secundario, metadatos |
-| `labelLarge` | 14 sp | 500 | Texto de botones |
-| `labelMedium` | 12 sp | 500 | Labels de chips, badges |
+| `displayLarge` | 57 sp | 400 | Welcome screen, splash |
+| `displayMedium` | 45 sp | 400 | Central greeting ("How can I help you?") |
+| `headlineLarge` | 32 sp | 700 | Critical summary at the start of an AI response |
+| `headlineMedium` | 28 sp | 600 | Section titles in an editorial response |
+| `titleLarge` | 22 sp | 500 | Conversation names in the drawer |
+| `titleMedium` | 16 sp | 500–600 | Card headers, navigation labels |
+| `bodyLarge` | 16 sp | 400 | Main body of an AI response |
+| `bodyMedium` | 14 sp | 400 | Secondary content, metadata |
+| `labelLarge` | 14 sp | 500 | Button text |
+| `labelMedium` | 12 sp | 500 | Chip labels, badges |
 
 ---
 
-### 2.4 Sistema de Color HCT
+### 2.4 HCT Color System
 
-El espacio de color **HCT (Hue, Chroma, Tone)** es la base del dynamic color de M3.
-Para implementaciones con materiales sólidos (tu caso), los roles clave:
+The **HCT (Hue, Chroma, Tone)** color space is the foundation of M3's dynamic color.
+For implementations with solid materials (your case), the key roles:
 
-| Rol de Color | Uso Principal |
+| Color Role | Primary Use |
 |:-------------|:--------------|
-| `surface` | Fondo de pantalla principal |
-| `surfaceContainer` | Fondos de cards internas |
-| `surfaceContainerHigh` | Icon surfaces en AppBar, backgrounds de items seleccionados |
-| `surfaceContainerHighest` | Input fields, chips activos |
-| `onSurface` | Texto e iconos primarios |
-| `onSurfaceVariant` | Texto e iconos secundarios |
-| `primary` | Acciones principales, botones primarios |
-| `primaryContainer` | Background de elementos de selección activa |
-| `secondaryContainer` | Item seleccionado en navigation drawer |
-| `outline` | Bordes de cards, separadores |
-| `outlineVariant` | Bordes sutiles, divisores de lista |
+| `surface` | Main screen background |
+| `surfaceContainer` | Internal card backgrounds |
+| `surfaceContainerHigh` | Icon surfaces in the AppBar, backgrounds of selected items |
+| `surfaceContainerHighest` | Input fields, active chips |
+| `onSurface` | Primary text and icons |
+| `onSurfaceVariant` | Secondary text and icons |
+| `primary` | Primary actions, primary buttons |
+| `primaryContainer` | Background of active selection elements |
+| `secondaryContainer` | Selected item in the navigation drawer |
+| `outline` | Card borders, separators |
+| `outlineVariant` | Subtle borders, list dividers |
 
-> **Gradiente de marca (opcional):** Los gradientes de Neural Expressive (índigo→púrpura→
-> amarillo luminiscente) son opcionales para apps que quieran ese efecto. Para apps de
-> materiales sólidos, usa `primary` y `primaryContainer` del sistema dinámico de M3.
+> **Brand gradient (optional):** The Neural Expressive gradients (indigo→purple→
+> luminescent yellow) are optional for apps that want that effect. For solid-material
+> apps, use `primary` and `primaryContainer` from M3's dynamic system.
 
 ---
 
-## 3. Breakpoints y Clases de Ventana Responsivos
+## 3. Responsive Breakpoints and Window Classes
 
-M3E define **cinco breakpoints** oficiales (actualizados de las tres originales de M3):
+M3E defines **five** official breakpoints (updated from M3's original three):
 
-| Breakpoint | Ancho | Dispositivos Típicos | Navegación | Layout |
+| Breakpoint | Width | Typical Devices | Navigation | Layout |
 |:-----------|:-----:|:---------------------|:-----------|:-------|
-| **Compact** | < 600 dp | Teléfonos en portrait | Bottom NavBar | 1 pane |
-| **Medium** | 600–839 dp | Tablets portrait, foldables cerrados | Navigation Rail | 1–2 panes |
-| **Expanded** | 840–1199 dp | Tablets landscape, foldables abiertos | Drawer permanente / Rail expandido | 2 panes |
-| **Large** | 1200–1599 dp | Laptops, monitores pequeños | Drawer permanente | 2–3 panes |
-| **Extra-Large** | ≥ 1600 dp | Monitores grandes, TV | Drawer permanente ancho | 3+ panes |
+| **Compact** | < 600 dp | Phones in portrait | Bottom NavBar | 1 pane |
+| **Medium** | 600–839 dp | Portrait tablets, closed foldables | Navigation Rail | 1–2 panes |
+| **Expanded** | 840–1199 dp | Landscape tablets, open foldables | Permanent drawer / expanded rail | 2 panes |
+| **Large** | 1200–1599 dp | Laptops, small monitors | Permanent drawer | 2–3 panes |
+| **Extra-Large** | ≥ 1600 dp | Large monitors, TV | Wide permanent drawer | 3+ panes |
 
-### Reglas de Navegación por Breakpoint
+### Navigation Rules by Breakpoint
 
+```text
+Compact  → Bottom NavigationBar (3–5 destinations)
+Medium   → Navigation Rail (collapsed, no labels or with short labels)
+Expanded → Permanent Standard Navigation Drawer (320 dp, pinned)
+Large    → Permanent Standard Navigation Drawer (320 dp)
+Extra-L  → Permanent Standard Navigation Drawer (can expand to 400 dp)
 ```
-Compact  → Bottom NavigationBar (3–5 destinos)
-Medium   → Navigation Rail (colapsada, sin labels o con labels cortos)
-Expanded → Standard Navigation Drawer permanente (320 dp, pineado)
-Large    → Standard Navigation Drawer permanente (320 dp)
-Extra-L  → Standard Navigation Drawer permanente (puede expandirse a 400 dp)
-```
 
-### Márgenes de Contenido por Breakpoint
+### Content Margins by Breakpoint
 
-| Breakpoint | Margin lateral | Max content width |
+| Breakpoint | Lateral margin | Max content width |
 |:-----------|:--------------:|:-----------------:|
 | Compact | 16 dp | 100% |
 | Medium | 24 dp | 100% |
-| Expanded | 24 dp | 840 dp (centrado) |
-| Large | 32 dp | 1040 dp (centrado) |
-| Extra-Large | 32 dp | 1200 dp (centrado) |
+| Expanded | 24 dp | 840 dp (centered) |
+| Large | 32 dp | 1040 dp (centered) |
+| Extra-Large | 32 dp | 1200 dp (centered) |
 
-### Diagramas de Layout por Breakpoint
+### Layout Diagrams by Breakpoint
 
-```
-COMPACT (< 600 dp) — Teléfono Portrait
+```text
+COMPACT (< 600 dp) — Phone Portrait
 ┌─────────────────────────┐
 │ [≡ Model▾]    [tmp] [👤] │  ← Header 56 dp
 ├─────────────────────────┤
 │                         │
 │    [Logo / Gemini]      │  ← Greeting area
-│  "¿En qué te ayudo?"   │
+│  "How can I help?"      │
 │                         │
 │                         │
 │  ┌─────────────────┐    │
@@ -291,13 +288,13 @@ MEDIUM (600–839 dp) — Tablet Portrait
 │      │ [Model▾]      [tmp] [👤] │  ← Header
 │ Rail │                          │
 │      │   [Logo]                 │
-│ [🏠] │  "¿En qué te ayudo?"    │
+│ [🏠] │  "How can I help?"       │
 │ [💬] │                          │
 │ [📚] │  ┌──────────────────┐   │
 │      │  │ ➕  [input]   🎙️ │   │  ← Pill input
 │      │  └──────────────────┘   │
 └──────┴──────────────────────────┘
-Rail: 80 dp ancho, iconos sin labels (o 136 dp con labels)
+Rail: 80 dp wide, icons without labels (or 136 dp with labels)
 
 EXPANDED (840–1199 dp) — Tablet Landscape / Foldable
 ┌────────────┬────────────────────┐
@@ -305,8 +302,8 @@ EXPANDED (840–1199 dp) — Tablet Landscape / Foldable
 │  320 dp    │  [Model▾]  [👤]   │
 │  (pinned)  │                    │
 │ [New Chat] │  [Logo]            │
-│ [Search]   │ "¿En qué te       │
-│ [Library]  │  ayudo?"          │
+│ [Search]   │ "How can I        │
+│ [Library]  │  help?"           │
 │ [Settings] │                    │
 │            │  ┌──────────────┐  │
 │  ─────     │  │ ➕ [input] 🎙│  │
@@ -316,241 +313,241 @@ EXPANDED (840–1199 dp) — Tablet Landscape / Foldable
 
 ---
 
-## 4. Especificaciones de Componentes
+## 4. Component Specifications
 
-### 4.1 Scaffold y Layout Principal
+### 4.1 Scaffold and Main Layout
 
-El Scaffold en Neural Expressive se estructura en capas:
+The Scaffold in Neural Expressive is structured in layers:
 
+```text
+Layer 1 (base):     Surface — screen background, solid color
+Layer 2 (content):  Scroll area — responses, chat, content
+Layer 3 (overlay):  Floating pill input — absolute position over the content
+Layer 4 (chrome):   Transparent AppBar with veil — always on top
+Layer 5 (nav):      Bottom NavBar / Rail / Drawer (depending on breakpoint)
 ```
-Layer 1 (base):     Surface — fondo de pantalla, color sólido
-Layer 2 (content):  Área de scroll — respuestas, chat, contenido
-Layer 3 (overlay):  Pill input flotante — posición absoluta sobre el content
-Layer 4 (chrome):   AppBar transparente con velo — siempre encima
-Layer 5 (nav):      Bottom NavBar / Rail / Drawer (según breakpoint)
-```
 
-**AppBar con velo (gradiente de scroll):**
-El AppBar es transparente. Cuando hay contenido desplazable debajo, se aplica un
-gradiente vertical que evita que el texto del contenido colisione visualmente con
-los controles del header:
+**AppBar with veil (scroll gradient):**
+The AppBar is transparent. When there is scrollable content below it, a vertical
+gradient is applied to prevent the content text from visually colliding with the
+header controls:
 
-```
+```text
 surface @ opacity 0.95  →  surface @ 0.75  →  transparent
-(borde superior)            (mitad)             (borde inferior del velo)
-Altura del velo: ~64 dp
+(top edge)                  (middle)            (bottom edge of the veil)
+Veil height: ~64 dp
 ```
 
-> ⚠️ **No uses** un AppBar con fondo sólido en pantallas con contenido scrollable.
-> El velo sutil mantiene los controles legibles sin "cortar" el contenido.
+> ⚠️ **Do not use** an AppBar with a solid background on screens with scrollable
+> content. The subtle veil keeps the controls legible without "cutting off" the content.
 
 ---
 
 ### 4.2 AppBar / Header
 
-**Altura:** 56 dp (top bar estándar M3)
-**Estructura asimétrica:**
+**Height:** 56 dp (standard M3 top bar)
+**Asymmetric structure:**
 
+```text
+Left:    [≡ or ←]  [Model Picker Dropdown 36 dp]
+Center:  empty (no title on the main screen) or active conversation title
+Right:   [Temporary Chats Icon]  [Avatar/Profile 40 dp]
 ```
-Izquierda: [≡ o ←]  [Model Picker Dropdown 36 dp]
-Centro:    vacío (no título en pantalla principal) o título de conversación activa
-Derecha:   [Temporary Chats Icon]  [Avatar/Profile 40 dp]
-```
 
-#### Icon Surfaces en AppBar Transparente
+#### Icon Surfaces in a Transparent AppBar
 
-Cuando el AppBar es transparente, **todos los botones de acción deben tener superficie
-sólida**. No son iconos flotando sobre contenido — son *Icon Surfaces*:
+When the AppBar is transparent, **all action buttons must have a solid surface**.
+They are not icons floating over content — they are *Icon Surfaces*:
 
-- **Forma:** `BoxShape.circle` (no StadiumBorder)
-- **Tamaño del contenedor:** 40 dp diámetro / Área de toque: 48×48 dp (accesibilidad)
-- **Color de fondo:** `surfaceContainerHigh` — nunca `primary` ni `primaryContainer`
-  (el color neutro evita que compitan con el brand mark)
-- **Icono interior:** 20 dp, color `onSurface` o `onSurfaceVariant`
-- **Física táctil:** `spatialFast` (k=1400, ζ=0.90), escala 1.0 → 0.92 en press
+- **Shape:** `BoxShape.circle` (not StadiumBorder)
+- **Container size:** 40 dp diameter / Touch area: 48×48 dp (accessibility)
+- **Background color:** `surfaceContainerHigh` — never `primary` or `primaryContainer`
+  (the neutral color prevents them from competing with the brand mark)
+- **Inner icon:** 20 dp, color `onSurface` or `onSurfaceVariant`
+- **Tactile physics:** `spatialFast` (k=1400, ζ=0.90), scale 1.0 → 0.92 on press
 
-**Aplica a:** botón menú (hamburguesa), botón de chats temporales, botón de búsqueda,
-cualquier acción secundaria del header.
+**Applies to:** menu button (hamburger), temporary chats button, search button,
+any secondary header action.
 
 #### Model Picker Dropdown
 
-- Altura: 36 dp
-- Forma: `StadiumBorder`
+- Height: 36 dp
+- Shape: `StadiumBorder`
 - Color: `surfaceContainerHigh`
-- Contenido: ícono del modelo activo + nombre + chevron
-- Al desplegarse: usa `spatialDefault` para la apertura del menú
+- Content: active model icon + name + chevron
+- When expanding: use `spatialDefault` for opening the menu
 
 ---
 
-### 4.3 Campo de Entrada Flotante (Prompt Pill)
+### 4.3 Floating Input Field (Prompt Pill)
 
-```
+```text
 ┌────────────────────────────────────────────────────────┐
-│  ➕   [  Escribe un mensaje...                ]   🎙️  │
+│  ➕   [  Type a message...                     ]   🎙️  │
 └────────────────────────────────────────────────────────┘
-   Altura: 56 dp
-   Forma: StadiumBorder (radius = 28 dp = height/2)
+   Height: 56 dp
+   Shape: StadiumBorder (radius = 28 dp = height/2)
    Color: surfaceContainerHighest
-   Margin lateral: 16 dp en compact, 24 dp en medium+
-   Margin inferior: 16 dp + SafeArea bottom
-   Posición: flotante sobre el contenido (no anclado al teclado)
+   Lateral margin: 16 dp on compact, 24 dp on medium+
+   Bottom margin: 16 dp + SafeArea bottom
+   Position: floating over the content (not anchored to the keyboard)
 ```
 
-**Menú "+" (Unified Plus Menu):**
-Al pulsar "➕", se despliega un **bottom sheet** (no un menú contextual flotante) con:
-- Sección superior: carrusel horizontal de subida rápida (Photos, Camera, Recientes)
-- Sección inferior (scroll): acceso a almacenamiento (Files, Drive, Notebooks) y
-  herramientas AI (Deep Research, Canvas, Create Image, etc.)
-- Animación de apertura: `spatialDefault` (k=700, ζ=0.90)
+**"+" Menu (Unified Plus Menu):**
+When tapping "➕", a **bottom sheet** is displayed (not a floating context menu) with:
+- Top section: horizontal carousel for quick upload (Photos, Camera, Recent)
+- Bottom section (scroll): access to storage (Files, Drive, Notebooks) and
+  AI tools (Deep Research, Canvas, Create Image, etc.)
+- Opening animation: `spatialDefault` (k=700, ζ=0.90)
 
-**Estados del Pill Input:**
-```
-Default:    surfaceContainerHighest, sin borde
-Focused:    outline de 2 dp con color primary, sombra sutil elevation 2
-With text:  aparece botón de envío (→) reemplazando el ícono de voz
+**Pill Input states:**
+```text
+Default:    surfaceContainerHighest, no border
+Focused:    2 dp outline with primary color, subtle shadow elevation 2
+With text:  send button (→) appears, replacing the voice icon
 ```
 
 ---
 
 ### 4.4 Navigation Drawer / Sidebar
 
-#### ✅ Regla Fundamental: Push, no Overlay
+#### ✅ Fundamental Rule: Push, not Overlay
 
-El drawer **empuja** el contenido principal horizontalmente, no lo cubre con un scrim.
-El contenido principal desplazado actúa como ancla visual que comunica "sigues en la app".
+The drawer **pushes** the main content horizontally; it does not cover it with a scrim.
+The displaced main content acts as a visual anchor that communicates "you are still in the app."
 
-#### Ancho del Drawer por Breakpoint
+#### Drawer Width by Breakpoint
 
-| Breakpoint | Comportamiento | Ancho |
+| Breakpoint | Behavior | Width |
 |:-----------|:--------------|:------|
-| **Compact** (< 600 dp) | Modal, desliza desde el borde izquierdo | **100% de la pantalla** |
-| **Medium** (600–839 dp) | Modal, ancho fijo topado | 320 dp (máximo absoluto) |
-| **Expanded+** (≥ 840 dp) | **Permanente / Pinned** — sin animación de apertura | 320 dp |
+| **Compact** (< 600 dp) | Modal, slides from the left edge | **100% of the screen** |
+| **Medium** (600–839 dp) | Modal, capped fixed width | 320 dp (absolute maximum) |
+| **Expanded+** (≥ 840 dp) | **Permanent / Pinned** — no opening animation | 320 dp |
 
-> ✅ **Confirmado:** En **Compact (móvil)**, el drawer ocupa el **100% del ancho de
-> pantalla**. Así lo implementó Gemini en Neural Expressive. El usuario no ve contenido
-> principal mientras el drawer está abierto — está en "su espacio" propio, como una
-> pantalla completa limpia.
+> ✅ **Confirmed:** On **Compact (mobile)**, the drawer occupies **100% of the screen
+> width**. This is how Gemini implemented it in Neural Expressive. The user does not see
+> the main content while the drawer is open — they are in "their own space," like a
+> clean full screen.
 
-#### Parallax Suave (solo en Compact y Medium)
+#### Smooth Parallax (only on Compact and Medium)
 
-Durante la apertura/cierre, el contenido principal se desplaza con un leve desfase
-respecto al drawer para crear sensación de profundidad:
+During opening/closing, the main content moves with a slight offset relative to
+the drawer to create a sense of depth:
 
-```
+```text
 Δ_content = W_drawer × (1 - α) × p
 
-Donde:
-  p = progreso de animación [0.0 → 1.0]
-  α = 0.06 (factor de parallax)
-  W_drawer = ancho del drawer en dp
+Where:
+  p = animation progress [0.0 → 1.0]
+  α = 0.06 (parallax factor)
+  W_drawer = drawer width in dp
 
-Resultado: cuando el drawer está 100% abierto (p=1), el contenido
-se desplazó el 94% del ancho del drawer, dejando un "sliver" visible
-de ≈ 19 dp en un teléfono de 360 dp.
+Result: when the drawer is 100% open (p=1), the content
+has moved 94% of the drawer's width, leaving a visible "sliver"
+of ≈ 19 dp on a 360 dp phone.
 ```
 
-Este sliver comunica que el contenido sigue ahí, "empujado", no tapado.
+This sliver communicates that the content is still there, "pushed," not covered.
 
-#### Física de Animación del Drawer
+#### Drawer Animation Physics
 
+```text
+Opening:  spatialDefault (k=700, ζ=0.90)  → clean movement, ~320 ms
+Closing:  spatialFast  (k=1400, ζ=0.90)  → decisive and fast, ~240 ms
+Parallax: bouncySpatial (k=400, ζ=0.40)  → background content only (NOT the drawer)
 ```
-Apertura: spatialDefault (k=700, ζ=0.90)  → movimiento limpio, ~320 ms
-Cierre:   spatialFast  (k=1400, ζ=0.90)  → decisivo y rápido, ~240 ms
-Parallax: bouncySpatial (k=400, ζ=0.40)  → solo el contenido background (NO el drawer)
-```
 
-#### Layout Interno del Drawer (3 Zonas)
+#### Internal Drawer Layout (3 Zones)
 
-```
+```text
 ┌──────────────────────────────────┐
 │ [Logo / Brand]         [✕ close] │  ← Header ~88 dp
-│                                  │     El botón close sigue regla Icon Surface:
+│                                  │     The close button follows the Icon Surface rule:
 │                                  │     circular 40 dp, surfaceContainerHigh
 ├──────────────────────────────────┤
 │                                  │
-│  🔮  New Chat                    │  ← Destinations (zona expandible)
-│  🔍  Search Chats                │     Separación entre items: ≥ 20 dp
-│  📚  Library                     │     Item seleccionado: fondo secondaryContainer
-│  📓  Notebooks                   │       + peso tipográfico w600
-│  ⚙️  Settings                    │     Iconos: familia de trazos ultradelgados
-│                                  │     Padding horizontal: 20 dp
+│  🔮  New Chat                    │  ← Destinations (expandable zone)
+│  🔍  Search Chats                │     Spacing between items: ≥ 20 dp
+│  📚  Library                     │     Selected item: secondaryContainer background
+│  📓  Notebooks                   │       + w600 typographic weight
+│  ⚙️  Settings                    │     Icons: ultra-thin stroke family
+│                                  │     Horizontal padding: 20 dp
 │  ── Recent ──                    │
-│    Conversación 1                │
-│    Conversación 2                │
+│    Conversation 1                │
+│    Conversation 2                │
 │                                  │
 ├──────────────────────────────────┤
-│ [👤] Nombre de usuario           │  ← Footer ~72 dp + SafeArea
-│      Plan / Workspace  [chevron] │     Avatar: 40 dp con gradiente de marca
+│ [👤] User name                   │  ← Footer ~72 dp + SafeArea
+│      Plan / Workspace  [chevron] │     Avatar: 40 dp with brand gradient
 └──────────────────────────────────┘
 ```
 
-> **Botón de cierre:** Anclado al **borde derecho del drawer** (no al borde derecho
-> de la pantalla). En compact, esto significa que está al ~95-100% del ancho de pantalla.
-> En expanded, está a 320 dp del borde izquierdo.
+> **Close button:** Anchored to the **right edge of the drawer** (not the right edge
+> of the screen). On compact, this means it is at ~95-100% of the screen width.
+> On expanded, it is 320 dp from the left edge.
 
 ---
 
-### 4.5 Botones Expresivos y Grupos
+### 4.5 Expressive Buttons and Groups
 
-#### Connected Button Groups (reemplazo de Segmented Buttons)
+#### Connected Button Groups (replacing Segmented Buttons)
 
-Los botones segmentados están **oficialmente deprecados** en M3E para nuevas apps.
-Su reemplazo son los **Connected Button Groups**:
+Segmented buttons are **officially deprecated** in M3E for new apps.
+Their replacement is the **Connected Button Groups**:
 
-```
+```text
 ┌─────────────┐┌─────────────┐┌──────────────┐
 │   Button 1  ││   Button 2  ││   Button 3   │
 └─────────────┘└─────────────┘└──────────────┘
-   Gap entre botones: 3 dp
-   Altura: 40 dp
-   Radios: dinámicos (exteriores = 20 dp, interiores = 4 dp, igual que las card lists)
-   Máximo de opciones: 5 (para evitar desbordamiento en Compact)
+   Gap between buttons: 3 dp
+   Height: 40 dp
+   Radii: dynamic (outer = 20 dp, inner = 4 dp, same as the card lists)
+   Maximum options: 5 (to avoid overflow on Compact)
 ```
 
-**Efecto "Neighbor Squish":** Al presionar un botón, los adyacentes se comprimen
-ligeramente en el eje de colisión. Esto requiere animación coordinada con `spatialFast`.
+**"Neighbor Squish" effect:** When pressing a button, the adjacent ones compress
+slightly along the collision axis. This requires coordinated animation with `spatialFast`.
 
 #### Split Buttons
 
-```
+```text
 ┌───────────────────────────────────┬──────────────┐
-│         Acción Principal          │   ▾ (arrow)  │
+│         Primary Action            │   ▾ (arrow)  │
 └───────────────────────────────────┴──────────────┘
-  Altura: 40 dp
-  Radio exterior: 20 dp (StadiumBorder en las esquinas exteriores)
-  Separación interna: 2 dp (línea divisoria)
-  Al expandir: ícono rota 180°, radio interno del dropdown va de 20 dp → 7 dp
+  Height: 40 dp
+  Outer radius: 20 dp (StadiumBorder on the outer corners)
+  Internal separation: 2 dp (divider line)
+  On expand: the icon rotates 180°, the dropdown's inner radius goes from 20 dp → 7 dp
 ```
 
-#### FAB y FAB Menu
+#### FAB and FAB Menu
 
-- El FAB estándar (56 dp) se expande morfológicamente al pulsar, convirtiéndose
-  en una tarjeta con lista de opciones secundarias.
-- Reemplaza definitivamente el patrón Speed Dial.
-- Animación: `bouncySpatial` (k=400, ζ=0.40) — aquí sí es apropiado por ser un
-  elemento pequeño.
+- The standard FAB (56 dp) expands morphologically when tapped, becoming
+  a card with a list of secondary options.
+- It definitively replaces the Speed Dial pattern.
+- Animation: `bouncySpatial` (k=400, ζ=0.40) — here it is indeed appropriate, since it
+  is a small element.
 
-#### Jerarquía de Botones por Tamaño
+#### Button Hierarchy by Size
 
-| Tamaño | Alto | Uso |
+| Size | Height | Use |
 |:-------|:---:|:----|
-| Extra Small (XS) | 32 dp | Chips de filtro, acciones inline |
+| Extra Small (XS) | 32 dp | Filter chips, inline actions |
 | Small (S) | 40 dp | Connected groups, split buttons |
-| Medium (M) | 48 dp | Acciones secundarias de pantalla |
-| Large (L) | 56 dp | FAB, CTA principales |
-| Extra Large (XL) | 96 dp | CTA único en pantallas de baja densidad |
+| Medium (M) | 48 dp | Secondary screen actions |
+| Large (L) | 56 dp | FAB, primary CTAs |
+| Extra Large (XL) | 96 dp | Single CTA on low-density screens |
 
 ---
 
-### 4.6 Tarjetas y Listas
+### 4.6 Cards and Lists
 
 #### Dynamic Corner Card List
 
-Regla de radios para listas agrupadas (gap = 3 dp):
+Radius rule for grouped lists (gap = 3 dp):
 
 ```dart
-// Primer elemento del grupo
+// First item of the group
 BorderRadius.only(
   topLeft:     Radius.circular(24),
   topRight:    Radius.circular(24),
@@ -558,10 +555,10 @@ BorderRadius.only(
   bottomRight: Radius.circular(4),
 )
 
-// Elementos intermedios
+// Middle items
 BorderRadius.all(Radius.circular(4))
 
-// Último elemento del grupo
+// Last item of the group
 BorderRadius.only(
   topLeft:     Radius.circular(4),
   topRight:    Radius.circular(4),
@@ -569,106 +566,106 @@ BorderRadius.only(
   bottomRight: Radius.circular(24),
 )
 
-// Elemento único (sin vecinos)
+// Single item (no neighbors)
 BorderRadius.all(Radius.circular(24))
 ```
 
-#### Dismissible Cards con Neighbour-Pull
+#### Dismissible Cards with Neighbour-Pull
 
-Al hacer swipe-to-dismiss sobre un ítem:
-- Los items adyacentes (hasta 3 en cada dirección) se desplazan elásticamente hacia
-  el ítem arrastrado, anticipando visualmente el espacio que quedará.
-- Desplazamiento máximo de los vecinos: 8–12 dp
-- Animación del vecino: `spatialDefault` (k=700, ζ=0.90)
+When swipe-to-dismissing an item:
+- The adjacent items (up to 3 in each direction) shift elastically toward
+  the dragged item, visually anticipating the space that will be left.
+- Maximum neighbor displacement: 8–12 dp
+- Neighbor animation: `spatialDefault` (k=700, ζ=0.90)
 
 #### Expandable Cards
 
-- Expansión con `spatialSlow` (k=300, ζ=0.90) para maximizar la sensación de inercia
-  al desplegar contenido de soporte.
-- Auto-collapse de otras tarjetas del mismo grupo: `effectsDefault` para el fade del
-  contenido interno + `spatialDefault` para el colapso geométrico.
+- Expansion with `spatialSlow` (k=300, ζ=0.90) to maximize the sense of inertia
+  when unfolding supporting content.
+- Auto-collapse of other cards in the same group: `effectsDefault` for the fade of
+  the internal content + `spatialDefault` for the geometric collapse.
 
 ---
 
-### 4.7 Indicadores de Progreso
+### 4.7 Progress Indicators
 
-#### LinearProgressIndicator Wavy
+#### Wavy LinearProgressIndicator
 
-Variante del progreso lineal con onda sinusoidal activa durante el avance horizontal.
-Comunica actividad sin bloquear la UI.
+A variant of the linear progress indicator with a sinusoidal wave active during the
+horizontal advance. It communicates activity without blocking the UI.
 
-#### Loading Indicator Poligonal (Shape Morphing)
+#### Polygonal Loading Indicator (Shape Morphing)
 
-Reemplazo del `CircularProgressIndicator` para procesos de < 5 segundos.
+A replacement for the `CircularProgressIndicator` for processes of < 5 seconds.
 
-**Regla técnica crítica:** La secuencia de formas debe contener **mínimo 2 figuras**.
-Una secuencia de 1 forma no tiene transición y causa un crash de interpolación.
+**Critical technical rule:** The shape sequence must contain **at least 2 figures**.
+A sequence of 1 shape has no transition and causes an interpolation crash.
 
-Secuencia recomendada: `cuadrado → triángulo → octágono → estrella → cuadrado (loop)`
+Recommended sequence: `square → triangle → octagon → star → square (loop)`
 
 #### Contained Loading Indicator
 
-El polígono de morphing se aloja en un contenedor sólido `secondaryContainer`, ideal
-para aislar el estado de carga sobre una sección específica sin bloquear el resto de
-la UI.
+The morphing polygon is housed in a solid `secondaryContainer` container, ideal
+for isolating the loading state over a specific section without blocking the rest of
+the UI.
 
 ---
 
-### 4.8 Interfaz de Voz Inline
+### 4.8 Inline Voice Interface
 
-Durante conversación por voz activa, **no** se usa un panel que bloquea la pantalla.
-Se implementa un **pill inline** de 64 dp de altura anclado en la base de la pantalla:
+During an active voice conversation, a panel that blocks the screen is **not** used.
+A 64 dp tall **inline pill** is implemented, anchored at the bottom of the screen:
 
-```
+```text
 ┌──────────────────────────────────────────────────────┐
 │  [📷] [🖥️]     ≈≈≈≈≈[waveform]≈≈≈≈≈      [🔇] [✕]  │
 └──────────────────────────────────────────────────────┘
-  Alto: 64 dp
-  Forma: StadiumBorder
+  Height: 64 dp
+  Shape: StadiumBorder
   Color: surfaceContainerHigh
-  Izquierda: botones cámara + screen share
-  Centro: waveform animado (nivel de audio en tiempo real)
-  Derecha: botón mute + botón cerrar canal
+  Left: camera + screen share buttons
+  Center: animated waveform (real-time audio level)
+  Right: mute button + close-channel button
 ```
 
-Las respuestas habladas por Gemini aparecen como texto en el espacio principal de la
-pantalla, visibles y copiables sin cerrar el canal de voz.
+Responses spoken by Gemini appear as text in the main space of the screen,
+visible and copyable without closing the voice channel.
 
 ---
 
-## 5. Matriz de Decisión de Componentes
+## 5. Component Decision Matrix
 
-| Densidad Info | Volumen de Opciones | Acción Requerida | Componente Recomendado | Justificación |
+| Info Density | Option Volume | Required Action | Recommended Component | Justification |
 |:---|:---|:---|:---|:---|
-| **Baja** | 1 acción | Confirmación/ejecución directa | **XL/L Button** | Máxima área táctil, foco único |
-| **Baja** | 2–5 opciones | Selección excluyente o multi | **Connected Button Group** | Reemplaza segmented buttons; física vecinal |
-| **Baja–Media** | > 5 opciones | Filtrado continuo / etiquetas | **Chips + Scroll Horizontal** | Los groups no toleran > 5 sin overflow |
-| **Media** | Registros independientes | Navegación informativa, dismiss | **M3E Card List (radios dinámicos)** | Gap 3 dp + asimetría comunica cohesión |
-| **Alta** | Estructuras jerárquicas | Lectura bajo demanda | **Expandable Card List** | Auto-collapse reduce scroll excesivo |
-| **Alta** | Selección masiva con metadatos | Búsqueda + filtrado asociativo | **Dropdown + Búsqueda Difusa + Chip Tags** | Evita saturación; chips animados inline |
-| **Variable** | N/A | Respuesta de IA estructurada | **Editorial Layout** (títulos bold + cards + inline media) | Principio central de Neural Expressive |
+| **Low** | 1 action | Direct confirmation/execution | **XL/L Button** | Maximum touch area, single focus |
+| **Low** | 2–5 options | Exclusive or multi selection | **Connected Button Group** | Replaces segmented buttons; neighbor physics |
+| **Low–Medium** | > 5 options | Continuous filtering / labels | **Chips + Horizontal Scroll** | Groups do not tolerate > 5 without overflow |
+| **Medium** | Independent records | Informational navigation, dismiss | **M3E Card List (dynamic radii)** | Gap 3 dp + asymmetry communicates cohesion |
+| **High** | Hierarchical structures | On-demand reading | **Expandable Card List** | Auto-collapse reduces excessive scrolling |
+| **High** | Mass selection with metadata | Search + associative filtering | **Dropdown + Fuzzy Search + Chip Tags** | Avoids saturation; inline animated chips |
+| **Variable** | N/A | Structured AI response | **Editorial Layout** (bold titles + cards + inline media) | Central principle of Neural Expressive |
 
 ---
 
-## 6. Implementación en Flutter
+## 6. Implementation in Flutter
 
-### 6.1 Tokens de Movimiento M3E
+### 6.1 M3E Motion Tokens
 
-> **Corrección técnica importante:** `SpringDescription` en Flutter usa el coeficiente
-> de amortiguación **crítico** (`damping`), no el `dampingRatio`. La relación es:
+> **Important technical correction:** `SpringDescription` in Flutter uses the **critical**
+> damping coefficient (`damping`), not the `dampingRatio`. The relationship is:
 >
-> `damping_crítico = dampingRatio × 2 × sqrt(stiffness × mass)`
+> `critical_damping = dampingRatio × 2 × sqrt(stiffness × mass)`
 >
-> Para `mass = 1.0`: `damping_crítico = dampingRatio × 2 × sqrt(stiffness)`
+> For `mass = 1.0`: `critical_damping = dampingRatio × 2 × sqrt(stiffness)`
 
 ```dart
 import 'package:flutter/physics.dart';
 import 'dart:math' as math;
 
-/// Convierte los tokens de M3E (dampingRatio + stiffness) a SpringDescription
-/// compatible con Flutter, que usa damping crítico en lugar de dampingRatio.
+/// Converts the M3E tokens (dampingRatio + stiffness) to a SpringDescription
+/// compatible with Flutter, which uses critical damping instead of dampingRatio.
 class M3ESprings {
-  /// Calcula el coeficiente de amortiguación crítica para Flutter.
+  /// Computes the critical damping coefficient for Flutter.
   static double _criticalDamping({
     required double stiffness,
     required double dampingRatio,
@@ -677,34 +674,34 @@ class M3ESprings {
     return dampingRatio * 2.0 * math.sqrt(stiffness * mass);
   }
 
-  // ─── Tokens de Efectos (Non-Spatial) — sin rebote ───────────────────────
-  // Para: cambios de color, opacidad, fades
+  // ─── Effects Tokens (Non-Spatial) — no bounce ───────────────────────────
+  // For: color changes, opacity, fades
 
   static SpringDescription get effectsFast => SpringDescription(
     mass: 1.0,
     stiffness: 3800.0,
     damping: _criticalDamping(stiffness: 3800, dampingRatio: 1.0),
-    // ≈ 123.3 — amortiguación crítica, ~150 ms
+    // ≈ 123.3 — critical damping, ~150 ms
   );
 
   static SpringDescription get effectsDefault => SpringDescription(
     mass: 1.0,
     stiffness: 1600.0,
     damping: _criticalDamping(stiffness: 1600, dampingRatio: 1.0),
-    // ≈ 80.0 — amortiguación crítica, ~300 ms
+    // ≈ 80.0 — critical damping, ~300 ms
   );
 
   static SpringDescription get effectsSlow => SpringDescription(
     mass: 1.0,
     stiffness: 800.0,
     damping: _criticalDamping(stiffness: 800, dampingRatio: 1.0),
-    // ≈ 56.6 — amortiguación crítica, ~500 ms
+    // ≈ 56.6 — critical damping, ~500 ms
   );
 
-  // ─── Tokens Espaciales — con ligero rebote ───────────────────────────────
-  // Para: movimientos de posición, tamaño, rotación
+  // ─── Spatial Tokens — with slight bounce ─────────────────────────────────
+  // For: position, size, rotation movements
 
-  /// Rápido con overshoot leve (~10%). Icon surfaces, chips, feedback botones.
+  /// Fast with slight overshoot (~10%). Icon surfaces, chips, button feedback.
   static SpringDescription get spatialFast => SpringDescription(
     mass: 1.0,
     stiffness: 1400.0,
@@ -712,7 +709,7 @@ class M3ESprings {
     // ≈ 67.3 — ~240 ms
   );
 
-  /// Orgánico y responsivo. Bottom sheets, drawer apertura, paneles.
+  /// Organic and responsive. Bottom sheets, drawer opening, panels.
   static SpringDescription get spatialDefault => SpringDescription(
     mass: 1.0,
     stiffness: 700.0,
@@ -720,7 +717,7 @@ class M3ESprings {
     // ≈ 47.6 — ~320 ms
   );
 
-  /// Dramático con alta inercia. Hero animations, expansiones a pantalla completa.
+  /// Dramatic with high inertia. Hero animations, full-screen expansions.
   static SpringDescription get spatialSlow => SpringDescription(
     mass: 1.0,
     stiffness: 300.0,
@@ -728,16 +725,16 @@ class M3ESprings {
     // ≈ 31.2 — ~500 ms
   );
 
-  /// Gran rebote (~40% overshoot). SOLO para elementos pequeños (≤56 dp):
-  /// FAB menu, chips, pickers. NUNCA para drawers o superficies grandes.
+  /// Large bounce (~40% overshoot). ONLY for small elements (≤56 dp):
+  /// FAB menu, chips, pickers. NEVER for drawers or large surfaces.
   static SpringDescription get bouncySpatial => SpringDescription(
     mass: 1.0,
     stiffness: 400.0,
     damping: _criticalDamping(stiffness: 400, dampingRatio: 0.40),
-    // ≈ 16.0 — rebote expresivo visible
+    // ≈ 16.0 — visible expressive bounce
   );
 
-  /// Retorno rápido con oscilación leve. Drag de tarjetas, carruseles.
+  /// Fast return with slight oscillation. Card drag, carousels.
   static SpringDescription get snappySpatial => SpringDescription(
     mass: 1.0,
     stiffness: 1000.0,
@@ -746,7 +743,7 @@ class M3ESprings {
   );
 }
 
-/// Helper para aplicar un resorte a un AnimationController.
+/// Helper to apply a spring to an AnimationController.
 extension SpringControllerExtension on AnimationController {
   TickerFuture animateWithSpring({
     required double target,
@@ -755,8 +752,8 @@ extension SpringControllerExtension on AnimationController {
   }) {
     final simulation = SpringSimulation(
       spring,
-      value,         // posición actual
-      target,        // posición objetivo
+      value,         // current position
+      target,        // target position
       initialVelocity,
     );
     return animateWith(simulation);
@@ -771,7 +768,7 @@ extension SpringControllerExtension on AnimationController {
 ```dart
 import 'package:flutter/material.dart';
 
-/// Categorías de breakpoint basadas en M3 (5 niveles).
+/// Breakpoint categories based on M3 (5 levels).
 enum M3Breakpoint {
   compact,    // < 600 dp
   medium,     // 600–839 dp
@@ -789,8 +786,8 @@ extension M3BreakpointExtension on M3Breakpoint {
   bool get usesRail => this == M3Breakpoint.medium;
 
   double get drawerWidth {
-    if (isCompact) return double.infinity; // 100% de pantalla
-    return 320.0; // tope absoluto para medium y superiores
+    if (isCompact) return double.infinity; // 100% of the screen
+    return 320.0; // absolute cap for medium and above
   }
 
   double get contentMargin {
@@ -814,7 +811,7 @@ extension M3BreakpointExtension on M3Breakpoint {
   }
 }
 
-/// Widget que expone el breakpoint actual a sus descendientes.
+/// Widget that exposes the current breakpoint to its descendants.
 class M3BreakpointProvider extends InheritedWidget {
   final M3Breakpoint breakpoint;
 
@@ -835,7 +832,7 @@ class M3BreakpointProvider extends InheritedWidget {
       breakpoint != oldWidget.breakpoint;
 }
 
-/// Widget raíz que calcula el breakpoint a partir del ancho disponible.
+/// Root widget that computes the breakpoint from the available width.
 class M3AdaptiveLayout extends StatelessWidget {
   final Widget child;
 
@@ -866,23 +863,23 @@ class M3AdaptiveLayout extends StatelessWidget {
 
 ---
 
-### 6.3 Widget: Tarjeta Expresiva con Radios Dinámicos
+### 6.3 Widget: Expressive Card with Dynamic Radii
 
 ```dart
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-/// Posición del ítem dentro de un grupo de tarjetas.
+/// Position of the item within a group of cards.
 enum CardGroupPosition { first, middle, last, single }
 
-/// Tarjeta M3E con radios de esquina dinámicos según posición en el grupo.
-/// Incluye retroalimentación táctil elástica con física de resorte.
+/// M3E card with dynamic corner radii according to its position in the group.
+/// Includes elastic tactile feedback with spring physics.
 class M3EExpressiveCard extends StatefulWidget {
   final Widget child;
   final CardGroupPosition position;
   final VoidCallback? onTap;
-  final double outerRadius; // Radio de esquinas exteriores
-  final double innerRadius; // Radio de esquinas interiores (adyacentes a vecinos)
+  final double outerRadius; // Outer corner radius
+  final double innerRadius; // Inner corner radius (adjacent to neighbors)
   final Color? backgroundColor;
 
   const M3EExpressiveCard({
@@ -904,7 +901,7 @@ class _M3EExpressiveCardState extends State<M3EExpressiveCard>
   late AnimationController _scaleController;
   late Animation<double> _scaleAnimation;
 
-  // Escala mínima en el momento de presión
+  // Minimum scale at the moment of press
   static const double _pressedScale = 0.97;
 
   @override
@@ -912,7 +909,7 @@ class _M3EExpressiveCardState extends State<M3EExpressiveCard>
     super.initState();
     _scaleController = AnimationController(
       vsync: this,
-      // Duración máxima de seguridad; el resorte termina antes
+      // Maximum safety duration; the spring finishes earlier
       duration: const Duration(milliseconds: 600),
     );
     _scaleAnimation = Tween<double>(begin: 1.0, end: _pressedScale)
@@ -928,16 +925,16 @@ class _M3EExpressiveCardState extends State<M3EExpressiveCard>
   void _onTapDown(TapDownDetails _) {
     HapticFeedback.lightImpact();
     _scaleController.animateWithSpring(
-      target: 1.0, // hacia _pressedScale desde 1.0
+      target: 1.0, // toward _pressedScale from 1.0
       spring: M3ESprings.spatialFast,
     );
-    // Atajo: usamos forward para comprimir
+    // Shortcut: we use forward to compress
     _scaleController.forward();
   }
 
   void _onTapUp(TapUpDetails _) {
     _scaleController.animateWithSpring(
-      target: 0.0, // regresar a escala 1.0
+      target: 0.0, // return to scale 1.0
       spring: M3ESprings.spatialFast,
     );
     _scaleController.reverse();
@@ -947,7 +944,7 @@ class _M3EExpressiveCardState extends State<M3EExpressiveCard>
     _scaleController.reverse();
   }
 
-  /// Calcula el BorderRadius según posición en el grupo.
+  /// Computes the BorderRadius according to the position in the group.
   BorderRadius _buildRadius() {
     final o = Radius.circular(widget.outerRadius);
     final i = Radius.circular(widget.innerRadius);
@@ -1000,7 +997,7 @@ class _M3EExpressiveCardState extends State<M3EExpressiveCard>
   }
 }
 
-/// Wrapper para construir una lista de M3EExpressiveCards con gap de 3 dp.
+/// Wrapper to build a list of M3EExpressiveCards with a 3 dp gap.
 class M3ECardList extends StatelessWidget {
   final List<Widget> Function(int index, CardGroupPosition position) itemBuilder;
   final int itemCount;
@@ -1039,15 +1036,15 @@ class M3ECardList extends StatelessWidget {
 
 ---
 
-### 6.4 Widget: Navigation Drawer Responsivo
+### 6.4 Widget: Responsive Navigation Drawer
 
 ```dart
 import 'package:flutter/material.dart';
 
-/// Drawer responsivo que implementa las reglas Neural Expressive:
-/// - Compact: 100% ancho, push al contenido
-/// - Medium: 320 dp máx, push al contenido
-/// - Expanded+: permanente/pinned, sin animación
+/// Responsive drawer that implements the Neural Expressive rules:
+/// - Compact: 100% width, push to the content
+/// - Medium: 320 dp max, push to the content
+/// - Expanded+: permanent/pinned, no animation
 class M3EAdaptiveScaffold extends StatefulWidget {
   final Widget body;
   final Widget drawerContent;
@@ -1073,7 +1070,7 @@ class _M3EAdaptiveScaffoldState extends State<M3EAdaptiveScaffold>
   late AnimationController _drawerController;
   bool _drawerOpen = false;
 
-  // Factor de parallax: el contenido se mueve al 94% del ancho del drawer
+  // Parallax factor: the content moves at 94% of the drawer's width
   static const double _parallaxFactor = 0.94;
 
   @override
@@ -1115,7 +1112,7 @@ class _M3EAdaptiveScaffoldState extends State<M3EAdaptiveScaffold>
     final bp = M3BreakpointProvider.of(context);
     final screenWidth = MediaQuery.of(context).size.width;
 
-    // En expanded+, el drawer es permanente: no hay animación
+    // On expanded+, the drawer is permanent: there is no animation
     if (bp.usesPermanentDrawer) {
       return Row(
         children: [
@@ -1128,21 +1125,21 @@ class _M3EAdaptiveScaffoldState extends State<M3EAdaptiveScaffold>
       );
     }
 
-    // Compact y Medium: drawer modal con physics push
+    // Compact and Medium: modal drawer with physics push
     final drawerWidth = bp.isCompact
-        ? screenWidth               // 100% en compact
-        : bp.drawerWidth.clamp(0.0, screenWidth); // 320 dp topado en medium
+        ? screenWidth               // 100% on compact
+        : bp.drawerWidth.clamp(0.0, screenWidth); // 320 dp capped on medium
 
     return AnimatedBuilder(
       animation: _drawerController,
       builder: (context, _) {
         final progress = _drawerController.value;
-        // Contenido se mueve el 94% del ancho del drawer (parallax α=0.06)
+        // The content moves 94% of the drawer's width (parallax α=0.06)
         final contentOffset = drawerWidth * _parallaxFactor * progress;
 
         return Stack(
           children: [
-            // Body desplazado (parallax push)
+            // Body displaced (parallax push)
             Transform.translate(
               offset: Offset(contentOffset, 0),
               child: Scaffold(
@@ -1154,7 +1151,7 @@ class _M3EAdaptiveScaffoldState extends State<M3EAdaptiveScaffold>
               ),
             ),
 
-            // Drawer deslizándose desde la izquierda
+            // Drawer sliding from the left
             if (_drawerOpen || progress > 0)
               Transform.translate(
                 offset: Offset(drawerWidth * (progress - 1), 0),
@@ -1170,7 +1167,7 @@ class _M3EAdaptiveScaffoldState extends State<M3EAdaptiveScaffold>
   }
 }
 
-/// Contenido interior del drawer con las 3 zonas: header, destinations, footer.
+/// Inner content of the drawer with the 3 zones: header, destinations, footer.
 class M3EDrawerContent extends StatelessWidget {
   final VoidCallback onClose;
   final String brandName;
@@ -1223,7 +1220,7 @@ class M3EDrawerContent extends StatelessWidget {
               ),
             ),
 
-            // ── Destinations (expandible) ───────────────────────────────────
+            // ── Destinations (expandable) ───────────────────────────────────
             Expanded(
               child: ListView.separated(
                 padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
@@ -1339,7 +1336,7 @@ class _DrawerDestinationItem extends StatelessWidget {
   }
 }
 
-/// Icon Surface circular (para AppBar y header del drawer).
+/// Circular Icon Surface (for AppBar and drawer header).
 class _IconSurface extends StatelessWidget {
   final IconData icon;
   final VoidCallback? onTap;
@@ -1355,7 +1352,7 @@ class _IconSurface extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     return SizedBox(
-      // Área de toque mínima: 48×48 dp (accesibilidad)
+      // Minimum touch area: 48×48 dp (accessibility)
       width: 48,
       height: 48,
       child: Center(
@@ -1363,7 +1360,7 @@ class _IconSurface extends StatelessWidget {
           onTap: onTap,
           borderRadius: BorderRadius.circular(20),
           child: Container(
-            width: 40, // Contenedor visual: 40 dp
+            width: 40, // Visual container: 40 dp
             height: 40,
             decoration: BoxDecoration(
               color: backgroundColor ?? colorScheme.surfaceContainerHigh,
@@ -1384,24 +1381,24 @@ class _IconSurface extends StatelessWidget {
 
 ---
 
-### 6.5 Widget: Pill Input Flotante
+### 6.5 Widget: Floating Pill Input
 
 ```dart
 import 'package:flutter/material.dart';
 
-/// Campo de entrada tipo píldora flotante — estilo Neural Expressive.
-/// Se posiciona sobre el contenido, desvinculado del teclado.
+/// Floating pill-style input field — Neural Expressive style.
+/// It is positioned over the content, decoupled from the keyboard.
 class M3EPillInput extends StatefulWidget {
   final TextEditingController? controller;
   final String hintText;
-  final VoidCallback? onPlusPressed;   // Abre el bottom sheet de adjuntos/tools
+  final VoidCallback? onPlusPressed;   // Opens the attachments/tools bottom sheet
   final VoidCallback? onVoicePressed;
   final ValueChanged<String>? onSubmitted;
 
   const M3EPillInput({
     super.key,
     this.controller,
-    this.hintText = 'Escribe un mensaje...',
+    this.hintText = 'Type a message...',
     this.onPlusPressed,
     this.onVoicePressed,
     this.onSubmitted,
@@ -1446,13 +1443,13 @@ class _M3EPillInputState extends State<M3EPillInput> {
         decoration: BoxDecoration(
           color: colorScheme.surfaceContainerHighest,
           borderRadius: BorderRadius.circular(28), // StadiumBorder
-          // Sombra sutil solo cuando está enfocado — no como estado base
+          // Subtle shadow only when focused — not as a base state
         ),
         child: Row(
           children: [
             const SizedBox(width: 4),
 
-            // Botón "+" — abre bottom sheet de adjuntos y herramientas
+            // "+" button — opens the attachments and tools bottom sheet
             IconButton(
               icon: const Icon(Icons.add),
               iconSize: 20,
@@ -1460,7 +1457,7 @@ class _M3EPillInputState extends State<M3EPillInput> {
               onPressed: widget.onPlusPressed,
             ),
 
-            // Campo de texto expandible
+            // Expandable text field
             Expanded(
               child: TextField(
                 controller: _controller,
@@ -1480,7 +1477,7 @@ class _M3EPillInputState extends State<M3EPillInput> {
               ),
             ),
 
-            // Botón derecho: enviar (si hay texto) o micrófono (si no hay texto)
+            // Right button: send (if there is text) or microphone (if there is no text)
             AnimatedSwitcher(
               duration: const Duration(milliseconds: 200),
               transitionBuilder: (child, animation) => ScaleTransition(
@@ -1516,25 +1513,25 @@ class _M3EPillInputState extends State<M3EPillInput> {
 
 ---
 
-### 6.6 Widget: Indicador de Carga Poligonal (Shape Morphing)
+### 6.6 Widget: Polygonal Loading Indicator (Shape Morphing)
 
 ```dart
 import 'package:flutter/material.dart';
 import 'dart:math' as math;
 
-/// Indicador de carga poligonal — reemplazo de CircularProgressIndicator.
-/// Transiciona suavemente entre figuras geométricas usando interpolación
-/// de coordenadas de vértices.
+/// Polygonal loading indicator — a replacement for CircularProgressIndicator.
+/// Smoothly transitions between geometric figures using interpolation
+/// of vertex coordinates.
 ///
-/// REGLA: la lista [shapes] debe tener ≥ 2 elementos.
-/// Una sola forma no tiene transición y causa división por cero en el interpolador.
+/// RULE: the [shapes] list must have ≥ 2 elements.
+/// A single shape has no transition and causes a division by zero in the interpolator.
 class M3EPolygonLoader extends StatefulWidget {
   final double size;
   final Color? color;
   final Duration cycleDuration;
 
-  /// Número de lados de cada figura en la secuencia de morphing.
-  /// Mínimo 2 figuras requerido.
+  /// Number of sides of each figure in the morphing sequence.
+  /// A minimum of 2 figures is required.
   final List<int> shapes;
 
   const M3EPolygonLoader({
@@ -1542,9 +1539,9 @@ class M3EPolygonLoader extends StatefulWidget {
     this.size = 48.0,
     this.color,
     this.cycleDuration = const Duration(milliseconds: 1200),
-    this.shapes = const [4, 3, 8, 6], // cuadrado → triángulo → octágono → hexágono
+    this.shapes = const [4, 3, 8, 6], // square → triangle → octagon → hexagon
   }) : assert(shapes.length >= 2,
-            'shapes debe contener al menos 2 figuras para evitar crash de interpolación');
+            'shapes must contain at least 2 figures to avoid an interpolation crash');
 
   @override
   State<M3EPolygonLoader> createState() => _M3EPolygonLoaderState();
@@ -1639,7 +1636,7 @@ class _PolygonMorphPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final center = Offset(size.width / 2, size.height / 2);
-    final radius = size.width / 2 * 0.85; // margen visual interior
+    final radius = size.width / 2 * 0.85; // inner visual margin
 
     final current = _getVertices(currentSides, radius, center);
     final next = _getVertices(nextSides, radius, center);
@@ -1671,65 +1668,65 @@ class _PolygonMorphPainter extends CustomPainter {
 
 ---
 
-## 7. Gobernanza, Accesibilidad y Rendimiento
+## 7. Governance, Accessibility, and Performance
 
-### 7.1 Accesibilidad — No Negociable
+### 7.1 Accessibility — Non-Negotiable
 
-| Requisito | Valor | Aplicación |
+| Requirement | Value | Application |
 |:----------|:------|:-----------|
-| Área de toque mínima | 48×48 dp | Todos los elementos interactivos, incluyendo Icon Surfaces de 40 dp |
-| Contraste texto/fondo | 4.5:1 | Texto en `bodyLarge`, `bodyMedium`, `labelLarge` |
-| Contraste iconos/fondo | 3.0:1 | Iconos de navegación y acción |
-| `semanticLabel` | Requerido | Todos los botones solo-ícono |
-| `Semantics(checked:)` | Requerido | Toggle groups, checkboxes |
-| Reducción de movimiento | Respetar | Detectar `MediaQuery.of(ctx).disableAnimations` y usar `effectsDefault` |
+| Minimum touch area | 48×48 dp | All interactive elements, including 40 dp Icon Surfaces |
+| Text/background contrast | 4.5:1 | Text in `bodyLarge`, `bodyMedium`, `labelLarge` |
+| Icon/background contrast | 3.0:1 | Navigation and action icons |
+| `semanticLabel` | Required | All icon-only buttons |
+| `Semantics(checked:)` | Required | Toggle groups, checkboxes |
+| Reduced motion | Respect | Detect `MediaQuery.of(ctx).disableAnimations` and use `effectsDefault` |
 
 ```dart
-// Detectar preferencia de movimiento reducido
+// Detect reduced-motion preference
 final reducedMotion = MediaQuery.of(context).disableAnimations;
 final spring = reducedMotion
-    ? M3ESprings.effectsDefault  // sin rebote, resuelve rápido
-    : M3ESprings.spatialDefault; // comportamiento normal
+    ? M3ESprings.effectsDefault  // no bounce, resolves quickly
+    : M3ESprings.spatialDefault; // normal behavior
 ```
 
-### 7.2 Regla de Moderación Expresiva
+### 7.2 Expressive Moderation Rule
 
-**Máximo 1–2 momentos expresivos de alto impacto por pantalla.**
+**A maximum of 1–2 high-impact expressive moments per screen.**
 
-Los momentos expresivos son: animaciones Hero, FAB expandido, morphing poligonal, 
-`bouncySpatial`. El resto de la UI usa tokens Standard o Spatial sin bounce.
+The expressive moments are: Hero animations, expanded FAB, polygonal morphing,
+`bouncySpatial`. The rest of the UI uses Standard or Spatial tokens without bounce.
 
-El objetivo de Neural Expressive es **reducir ruido visual**, no aumentarlo.
-Un exceso de animaciones simultáneas contradice el principio fundamental del sistema.
+The goal of Neural Expressive is to **reduce visual noise**, not increase it.
+An excess of simultaneous animations contradicts the system's fundamental principle.
 
-### 7.3 Rendimiento
+### 7.3 Performance
 
-- Animaciones complejas (polygon morphing, Hero transitions): usar `RepaintBoundary`
-  para aislar el subtree de la capa de pintura del resto de la UI.
-- En dispositivos con < 4 GB RAM o GPU limitada, desactivar el morphing poligonal
-  y usar `CircularProgressIndicator` como fallback.
-- Verificar que todos los `AnimationController` se destruyen en `dispose()`.
-- En listas largas (> 100 items), los radios dinámicos se calculan sin overhead
-  en tiempo de pintado (son solo `BorderRadius`, sin shaders).
+- Complex animations (polygon morphing, Hero transitions): use `RepaintBoundary`
+  to isolate the subtree from the paint layer of the rest of the UI.
+- On devices with < 4 GB RAM or a limited GPU, disable polygonal morphing
+  and use `CircularProgressIndicator` as a fallback.
+- Verify that all `AnimationController`s are disposed in `dispose()`.
+- In long lists (> 100 items), the dynamic radii are computed without overhead
+  at paint time (they are just `BorderRadius`, no shaders).
 
-### 7.4 Checklist de Implementación
+### 7.4 Implementation Checklist
 
-Antes de marcar un widget como "completo" en tu sistema de diseño:
+Before marking a widget as "complete" in your design system:
 
-- [ ] ¿Los tokens de física de resorte usados son los correctos para el tamaño del elemento?
-- [ ] ¿El drawer usa `spatialDefault` en apertura y `spatialFast` en cierre?
-- [ ] ¿Las Icon Surfaces tienen 40 dp visual y 48 dp de área de toque?
-- [ ] ¿El drawer en Compact es 100% del ancho de pantalla?
-- [ ] ¿En Expanded+ el drawer es permanente (sin animación de apertura)?
-- [ ] ¿Las listas agrupadas tienen gap de 3 dp y radios dinámicos (24/4)?
-- [ ] ¿La lista de formas del polygon loader tiene ≥ 2 figuras?
-- [ ] ¿`bouncySpatial` se usa SOLO en elementos ≤ 56 dp?
-- [ ] ¿Hay soporte para `disableAnimations` de accesibilidad?
-- [ ] ¿Los textos de botones solo-ícono tienen `semanticLabel`?
-- [ ] ¿El contraste de color cumple WCAG AA (4.5:1 texto, 3:1 iconos)?
+- [ ] Are the spring physics tokens used correct for the element's size?
+- [ ] Does the drawer use `spatialDefault` on opening and `spatialFast` on closing?
+- [ ] Do the Icon Surfaces have 40 dp visual and 48 dp touch area?
+- [ ] Is the drawer in Compact 100% of the screen width?
+- [ ] In Expanded+, is the drawer permanent (no opening animation)?
+- [ ] Do the grouped lists have a 3 dp gap and dynamic radii (24/4)?
+- [ ] Does the polygon loader's shape list have ≥ 2 figures?
+- [ ] Is `bouncySpatial` used ONLY on elements ≤ 56 dp?
+- [ ] Is there support for accessibility `disableAnimations`?
+- [ ] Do the icon-only button texts have a `semanticLabel`?
+- [ ] Does the color contrast meet WCAG AA (4.5:1 text, 3:1 icons)?
 
 ---
 
-*Guía generada con base en fuentes verificadas: Google I/O 2025 (M3E announcement),
-Google I/O 2026 (Neural Expressive launch), especificaciones oficiales en m3.material.io,
-cobertura técnica de 9to5Google, Android Authority y UrDesign Magazine.*
+*Guide produced based on verified sources: Google I/O 2025 (M3E announcement),
+Google I/O 2026 (Neural Expressive launch), official specifications at m3.material.io,
+technical coverage from 9to5Google, Android Authority, and UrDesign Magazine.*

--- a/uxnanmobile/docs/testing.md
+++ b/uxnanmobile/docs/testing.md
@@ -1,8 +1,14 @@
 # Testing & validation — uxnanmobile
 
+![Analyze](https://img.shields.io/badge/flutter_analyze-very__good__analysis-0175C2?style=for-the-badge&logo=dart&logoColor=white)
+![Tests](https://img.shields.io/badge/flutter_test-unit_%2B_widget-02569B?style=for-the-badge&logo=flutter&logoColor=white)
+![DB](https://img.shields.io/badge/drift-in--memory_in_tests-003B57?style=for-the-badge&logo=sqlite&logoColor=white)
+
 How to run the checks, how the tests are organized, the patterns they use, and
 what still needs a real device or a live bridge. (For the **Node** side —
-`bridge`/`relay`/`shared` — see the monorepo [`../../TESTING.md`](../../TESTING.md).)
+`bridge`/`relay`/`shared` — see
+[`../../bridge/docs/testing.md`](../../bridge/docs/testing.md) and
+[`../../relay/docs/testing.md`](../../relay/docs/testing.md).)
 
 ## Commands
 
@@ -24,7 +30,7 @@ config (Gradle/manifest/plist) or renaming the applicationId.
 
 ## Layout
 
-```
+```text
 test/
 ├── unit/
 │   ├── core/            # extensions, small utils


### PR DESCRIPTION
Documentation overhaul across the monorepo. **No behavior or code changes** — the
only non-`.md` file touched is `bridge/src/daemon-config.ts`, and that edit is
**comment-only** (two stale doc-comments corrected to match the implementation).

## What's in here

**Root READMEs + rules**
- `README.md` / `README.es.md` rewritten as a focused, user-facing front door:
  why the ecosystem exists, a short tour of each project linking to its own
  README, a how-it-fits-together diagram, security, a slim status snapshot, a
  support/donations block, and a separated contributors section.
- `AGENTS.md`: define where status lives (README snapshot vs `FOR-DEV.md ## Status`
  vs `architecture/` tables); add the "docs track the code — re-verify them when
  the code moves" rule.

**Per-component READMEs**
- Each project README reframed around *what it is and does* (value, not a status
  inventory), with for-the-badge badges and collapsible Mermaid diagrams; the
  granular implementation status moved into each `FOR-DEV.md ## Status`.

**Per-component `docs/` (accuracy pass + light visual polish)**
Verified every command/path/flag/id/count against the source and fixed the
mismatches, e.g.:
- canonical agent ids (`gemini-cli` / `pi-agent`, not `gemini` / `pi`);
- `interactiveApprovals` covers Claude Code **and** Gemini CLI;
- all five adapters are wired (next agent is Aider, not Gemini);
- `~/.uxnan/config.json` → `~/.uxnan/daemon-config.json`;
- two broken links fixed (a non-existent relay push doc, and a non-existent root
  `TESTING.md`);
- dropped a misleading `(Phase 6)` tag and neutralized "private repo" push
  guidance (the project is open source);
- added the Tailscale-direct off-LAN mode; tagged bare code fences for lint.

**Design guide**
- `uxnanmobile/docs/neural-expressive-design.md` translated ES → EN faithfully
  (every heading/table/example preserved; all Dart code and ASCII diagrams kept
  verbatim — only prose/comments translated).

**Source comment fix**
- `bridge/src/daemon-config.ts`: `browseRoots` empty-fallback is `process.cwd()`
  (not home); `interactiveApprovals` is Claude + Gemini (not Claude only).

## Verification
Documentation-only. Locally verified: no broken relative links, balanced code
fences with language tags, no trailing whitespace; `prettier --check` is clean on
the full `format:check` scope (the one `.ts` edit included).