### PR TITLE
fix(rust): stop console windows flashing on Windows release builds

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — no more console windows flashing open on Windows
+- **The packaged Windows app no longer flashes a cascade of console windows on
+  launch (and during use).** A release build runs under the Windows `windows`
+  subsystem (no console of its own), so every child process the app spawned —
+  `git` (including the 3s status watcher and the initial repo load), `wsl.exe`
+  for WSL repos, and the agent CLIs probed for model discovery / AI commit
+  messages — got a brand-new console **window** allocated by Windows. They
+  appeared as terminal windows blinking open and shut, one after another. The bug
+  was invisible in `cargo tauri dev` because a debug build keeps a console the
+  children inherit.
+- **Fix:** a new `src-tauri/src/winproc.rs` helper (`winproc::command`) creates
+  every spawned `tokio::process::Command` with the `CREATE_NO_WINDOW` creation
+  flag on Windows (no-op elsewhere). `git.rs` (`git_command`, covering `git` +
+  `wsl.exe`) and `aicommit.rs` (agent generation + Codex/Claude/Gemini model
+  discovery) now route through it. PTY-hosted shells were never affected — they
+  run under ConPTY, which is already windowless.
+
 ## [0.0.1-alpha.20260627] - 2026-06-27
 
 ### Added — in-app auto-updater (Settings → Updates)

--- a/uxnandesktop/src-tauri/src/aicommit.rs
+++ b/uxnandesktop/src-tauri/src/aicommit.rs
@@ -15,7 +15,6 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::Command;
 
 use crate::agentcli::{self, AgentModel};
 use crate::error::AppError;
@@ -116,7 +115,7 @@ async fn run_generate(
     args: &[String],
     cwd: &str,
 ) -> Result<String, AppError> {
-    let mut cmd = Command::new(&resolved.program);
+    let mut cmd = crate::winproc::command(&resolved.program);
     cmd.args(&resolved.prepend)
         .args(args)
         .current_dir(cwd)
@@ -160,7 +159,7 @@ async fn run_list(
     extra: &[&str],
     include_stderr: bool,
 ) -> Option<String> {
-    let mut cmd = Command::new(&resolved.program);
+    let mut cmd = crate::winproc::command(&resolved.program);
     cmd.args(&resolved.prepend)
         .args(extra)
         .stdin(Stdio::null())
@@ -188,7 +187,7 @@ async fn codex_models(resolved: &agentcli::Resolved) -> Vec<AgentModel> {
 }
 
 async fn codex_models_inner(resolved: &agentcli::Resolved) -> Option<Vec<AgentModel>> {
-    let mut child = Command::new(&resolved.program)
+    let mut child = crate::winproc::command(&resolved.program)
         .args(&resolved.prepend)
         .arg("app-server")
         .stdin(Stdio::piped())

--- a/uxnandesktop/src-tauri/src/git.rs
+++ b/uxnandesktop/src-tauri/src/git.rs
@@ -109,7 +109,7 @@ fn git_command(repo_path: &str, args: &[&str]) -> Command {
     // lints — identically on every platform; it's simply never taken off Windows.
     if cfg!(windows) {
         if let Some(w) = crate::wsl::parse(repo_path) {
-            let mut cmd = Command::new("wsl.exe");
+            let mut cmd = crate::winproc::command("wsl.exe");
             cmd.arg("-d")
                 .arg(&w.distro)
                 .arg("git")
@@ -128,7 +128,7 @@ fn git_command(repo_path: &str, args: &[&str]) -> Command {
             return cmd;
         }
     }
-    let mut cmd = Command::new("git");
+    let mut cmd = crate::winproc::command("git");
     cmd.arg("-C").arg(repo_path).args(args);
     cmd
 }

--- a/uxnandesktop/src-tauri/src/lib.rs
+++ b/uxnandesktop/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ mod pty;
 mod state;
 mod updater;
 mod which;
+mod winproc;
 mod wsl;
 
 use std::sync::atomic::Ordering;

--- a/uxnandesktop/src-tauri/src/winproc.rs
+++ b/uxnandesktop/src-tauri/src/winproc.rs
@@ -27,7 +27,10 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 /// window on Windows. Behaves exactly like `Command::new(program)` everywhere
 /// else.
 pub fn command<S: AsRef<OsStr>>(program: S) -> Command {
+    #[cfg(windows)]
     let mut cmd = Command::new(program);
+    #[cfg(not(windows))]
+    let cmd = Command::new(program);
     #[cfg(windows)]
     cmd.creation_flags(CREATE_NO_WINDOW);
     cmd

--- a/uxnandesktop/src-tauri/src/winproc.rs
+++ b/uxnandesktop/src-tauri/src/winproc.rs
@@ -1,0 +1,48 @@
+//! Spawn helper that suppresses the console window Windows would otherwise
+//! allocate for every child process.
+//!
+//! A packaged build runs under the Windows `windows` subsystem (see
+//! `main.rs`'s `windows_subsystem = "windows"`), so it has no console of its
+//! own. When such a GUI process spawns a console-subsystem child (`git`,
+//! `wsl.exe`, an agent CLI), Windows allocates a brand-new console **window** for
+//! the child unless `CREATE_NO_WINDOW` is set. With the app launching `git` on a
+//! timer (the status watcher) and probing agent CLIs for model discovery, those
+//! windows flash open and shut in a cascade — visible only in the installed app,
+//! never in `cargo tauri dev` (a debug build keeps a console the children
+//! inherit). Setting `CREATE_NO_WINDOW` makes every child run windowless.
+//!
+//! Use [`command`] instead of `tokio::process::Command::new` for any child the
+//! app spawns. PTY-hosted shells are unaffected: they run under ConPTY, which is
+//! already windowless. The flag is a no-op off Windows.
+
+use std::ffi::OsStr;
+
+use tokio::process::Command;
+
+/// `CREATE_NO_WINDOW` (winbase.h) — run the child without a console window.
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Build a [`tokio::process::Command`] for `program` that never pops a console
+/// window on Windows. Behaves exactly like `Command::new(program)` everywhere
+/// else.
+pub fn command<S: AsRef<OsStr>>(program: S) -> Command {
+    let mut cmd = Command::new(program);
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_command_for_the_given_program() {
+        // The flag is opaque (not readable back through the public API), so the
+        // observable contract is just "same program as `Command::new`". On
+        // Windows the `creation_flags` call must also compile and not panic.
+        let cmd = command("git");
+        assert_eq!(cmd.as_std().get_program(), OsStr::new("git"));
+    }
+}


### PR DESCRIPTION
## Problem

The packaged **Windows** app flashed a cascade of console windows on launch and during use — terminal windows blinking open and shut, one after another (described by the user as virus-like behavior).

**Root cause:** a release build runs under the Windows `windows` subsystem (`main.rs` → `windows_subsystem = "windows"`), so it has no console of its own. Every console-subsystem child the app spawned got a brand-new console **window** allocated by Windows because no `CREATE_NO_WINDOW` flag was set:

- `git` — including the **3s git status watcher** and the initial repo load (the main cascade source)
- `wsl.exe` — for WSL-hosted repos
- the agent CLIs — probed for model discovery and AI commit-message generation

The bug was invisible in `cargo tauri dev` because a debug build keeps a console the children inherit.

## Fix

- New `src-tauri/src/winproc.rs` (`winproc::command`) creates every spawned `tokio::process::Command` with `CREATE_NO_WINDOW` on Windows (no-op elsewhere).
- `git.rs` (`git_command`, covering `git` + `wsl.exe`) and `aicommit.rs` (agent generation + Codex/Claude/Gemini model discovery) route through it.
- PTY-hosted shells were never affected — they run under ConPTY, which is already windowless.
- `power.rs` spawns are `#[cfg]`-gated to macOS/Linux, so untouched.

## Verification

- `cargo clippy --all-targets` — no warnings/errors
- `cargo fmt --check` — clean
- `cargo test winproc` — 1 passed
- **Validated on a real installed release build** by the maintainer: no more flashing console windows.

Docs: `uxnandesktop/CHANGELOG.md` `[Unreleased]` → Fixed.