### PR TITLE
feat(desktop): integrated developer browser (iframe tab + agent/terminal links)

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,38 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — integrated developer browser
+- **A lightweight in-app developer browser** to preview/debug the systems agents
+  build and open the links agents produce — a new `browser` center tab (splittable
+  beside terminals), **not** a general-purpose browser. Open one from the center
+  "+" menu (*New browser tab*) or let a link route into it. Chrome: back / forward
+  / reload / address bar / open-in-system-browser.
+- **Rendered with a DOM `<iframe>`** (frontend `BrowserPane`): a real center tab
+  that composes with the layout, can never freeze the app or paint over menus, and
+  is very light (just another browsing context in the webview the ADE already
+  runs). Ideal for `localhost` dev servers and most links; sites that refuse to be
+  embedded (`X-Frame-Options` / `frame-ancestors`) render blank — the toolbar's
+  *open in system browser* covers those. The `browser` tab is transient (never
+  serialized).
+- **One link-routing decision point** (`open_url` → `browser::route_url`): every
+  link the ADE opens funnels through the user's policy — the in-app browser, the OS
+  browser, or a per-link prompt — with the OS browser always available as a fallback
+  (`open_external`).
+- **`BrowserSettings` / `BrowserLinkPolicy`** in the persisted `AppSettings`
+  (`enabled` · `linkPolicy` internal/external/ask · `allowAgents` · `terminalLinks`
+  · `homepage`; all `#[serde(default)]` so older state loads unchanged) with a new
+  **Settings → Browser** pane (EN/ES).
+- **Agents open links in-app automatically.** When the browser is enabled and
+  *allow agents* is on, each agent terminal gets `UXNAN_BROWSER_URL` +
+  `UXNAN_BROWSER_TOKEN` and a `$BROWSER` shim (`static/hooks/uxnan-browser.{sh,cmd}`,
+  written alongside the hook scripts). A URL the agent opens is POSTed to the hook
+  server's new **`/browser`** route, which applies the same link policy. Agents can
+  also open one explicitly: `curl -X POST "$UXNAN_BROWSER_URL" -H "X-Uxnan-Token:
+  $UXNAN_BROWSER_TOKEN" -d '{"url":"…"}'`.
+- **Clickable terminal links** (`@xterm/addon-web-links`): **Ctrl/Cmd-click** a URL
+  printed in the terminal to open it through the link policy (a plain click is just
+  text, like VS Code). Toggle in Settings → Browser.
+
 ## [0.0.1-alpha.20260627] - 2026-06-27
 
 ### Added — in-app auto-updater (Settings → Updates)

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -15,7 +15,7 @@ which tracks assets only a human can provide.)
 standalone app** (three-panel shell, PTY terminals + splits, git worktrees, git
 status/diff/stage/commit/history, agent monitoring with the axum hook server +
 OSC/process layers, settings/themes/i18n, multi-agent orchestration,
-**in-app auto-updater**). 100 Rust backend tests + 25 frontend Vitest unit tests
+**in-app auto-updater**). 104 Rust backend tests + 25 frontend Vitest unit tests
 (pure logic); **no Svelte component or E2E tests yet**. macOS is **unvalidated**
 (developed on Windows; CI is `{ubuntu, windows}`). **Phase 6 (embedded bridge /
 mobile pairing) is NOT started.**
@@ -54,6 +54,40 @@ mobile pairing) is NOT started.**
   waits for the safe window or explicit consent), banner UI, EN/ES i18n. Endpoint
   per channel + signing/CI in [`docs/updates.md`](docs/updates.md); signing key is
   a `FOR-HUMAN.md` item.
+
+## Integrated developer browser ☐
+
+**Goal:** a lightweight in-app browser tab to preview/debug the systems agents
+build and open the links agents produce — **not** a general-purpose browser. A
+`browser` center tab kind (foreseen in `architecture/02a` §4.2b). Agent link
+interception **on by default**; one central link-policy decision point with an
+always-working OS fallback.
+
+**Engine decision:** an iframe, **not** a native child webview. The native
+multiwebview path (Tauri `unstable`) froze the app on Windows (`add_child` blocked
+the main thread), so it was dropped; the iframe is stable, truly embedded, and
+light. Trade-off: framing-protected sites (`X-Frame-Options`) render blank → the
+toolbar's "open in system browser" covers them.
+
+**Done (code-complete, validated by clippy/fmt/tests + svelte-check + vite build):**
+`BrowserSettings`/`BrowserLinkPolicy` model + Settings → Browser pane; the
+iframe-based `BrowserPane` (back/forward/reload/address/open-external) + the
+`browser` center tab + "+ New browser tab"; `open_url`/`open_external` routing
+(shared `browser::route_url`) + the `browser:open-url` listener; **agent
+auto-interception** (`UXNAN_BROWSER_*` env + `$BROWSER` shim
+`static/hooks/uxnan-browser.{sh,cmd}` + the hook-server `/browser` route, gated on
+`enabled && allow_agents`); **Ctrl/Cmd-clickable terminal links**
+(`@xterm/addon-web-links`).
+
+Spec synced: `architecture/02a` §4.2b now documents the integrated browser
+(content-type table + design); user guide in `docs/browser.md`.
+
+### Still pending
+- [ ] **On-device validation of the agent `$BROWSER` shim.** The iframe browser,
+      its chrome, link routing and Ctrl/Cmd-click are verified on device; the
+      `$BROWSER` shim auto-interception (and the `/browser` route end-to-end) still
+      needs a real agent run to confirm. The explicit `curl` path is the reliable
+      fallback meanwhile.
 
 ## Phase 6 — Bridge integration (embedded bridge / mobile pairing) ☐
 
@@ -137,7 +171,7 @@ are **done** (see `CHANGELOG.md` + `architecture/02d` §3). Remaining follow-ups
 
 - ✅ **Verify** — `.github/workflows/ci-desktop.yml` runs svelte-check + `npm test`
   (Vitest) + vite build + cargo fmt/clippy/test on `{ubuntu, windows}` (macOS
-  deferred with Apple). 100 Rust + 25 Vitest tests.
+  deferred with Apple). 104 Rust + 25 Vitest tests.
 - ✅ **`release-desktop.yml`** — exists: `tauri-action` bundles on a `desktop-v*` tag
   → draft GitHub Release, **and signs the updater artifacts** when the signing
   secrets are set. **Windows ships without OS code-signing for now; macOS deferred.**

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -63,6 +63,11 @@ available today are:
   message to all of them, to one agent type (fan-out), or to a coordinator's
   workers, applying backpressure so no agent receives a new message before it is
   free.
+- **Integrated developer browser.** A lightweight in-app browser tab (a DOM
+  iframe) to preview and debug what your agents build — `localhost` dev servers and
+  most sites — and to open the links they create. Links route by a policy you
+  choose (in-app · system browser · ask); when allowed, agents open URLs in it
+  automatically. See [the integrated browser](./docs/browser.md).
 - **Personalization and internationalization.** Full custom theming with design
   tokens and light/dark modes, terminal profiles, per-agent launch settings and
   environment variables, a configurable launch shell, and a completely translated
@@ -139,6 +144,7 @@ Detailed docs live in [`docs/`](./docs/):
 [agent launch & configuration](./docs/agent-launch.md) ·
 [multi-agent orchestration](./docs/orchestration.md) ·
 [agent hooks (precise states)](./docs/agent-hooks.md) ·
+[integrated browser](./docs/browser.md) ·
 [updates & release channels](./docs/updates.md).
 
 The full product/engineering specification is in

--- a/uxnandesktop/architecture/02a-system-architecture.md
+++ b/uxnandesktop/architecture/02a-system-architecture.md
@@ -147,7 +147,7 @@ Cada tab vive dentro de un TabGroup y representa una unidad de contenido en el a
 
 | Campo | Descripcion |
 |-------|-------------|
-| Tipo de contenido | `terminal` (emulador PTY), `editor` (CodeMirror 6), `diff` (visor de comparacion), `browser` (webview embebido) |
+| Tipo de contenido | `terminal` (emulador PTY), `editor` (CodeMirror 6), `diff` (visor de comparacion), `browser` (webview embebido — implementado, ver §4.2b) |
 | TabGroup padre | A que TabGroup pertenece este tab |
 
 ### 2.6 TabGroup
@@ -285,6 +285,37 @@ Esto es una distincion importante que diferencia al ADE de un terminal convencio
 - Dentro de un mismo tab de terminal, divide el area en multiples panes PTY.
 - Cada pane es un proceso independiente con su propio shell/agente.
 - Similar a como funcionan los splits en Vim o tmux.
+
+### 4.2b Navegador integrado (tab `browser`) — implementado
+
+El tipo de contenido `browser` (webview embebido) **está implementado** como un
+navegador *de desarrollo* ligero: para previsualizar/depurar lo que construyen los
+agentes y abrir los enlaces que generan — no un navegador de uso general.
+
+- **Motor:** un `<iframe>` del DOM dentro del webview de la app (`BrowserPane`), no
+  un webview nativo. Es un tab central real que compone con el layout, **no puede
+  congelar la app ni pintar sobre menús**, y es muy ligero (otro *browsing context*
+  en el webview que la app ya ejecuta). *Decisión de diseño:* se descartó el
+  *child webview* nativo (multiwebview `unstable` de Tauri) porque en Windows
+  bloqueaba el hilo principal (congelaba la app) — el iframe es estable. El tab
+  `browser` es **transitorio** (nunca se serializa). Límite conocido: sitios que
+  rechazan ser embebidos (`X-Frame-Options` / `frame-ancestors`) quedan en blanco →
+  el botón "abrir en el navegador del sistema" los cubre; `localhost` casi nunca lo
+  bloquea.
+- **Política de enlaces (`BrowserSettings`):** un único punto de decisión
+  (`browser::route_url`, expuesto como el comando `open_url`) enruta cada enlace
+  según `linkPolicy` (`internal` → tab interno vía el evento `browser:open-url`,
+  `external` → navegador del SO vía `tauri-plugin-opener`/`open_external`, `ask` →
+  el usuario elige). Un navegador deshabilitado siempre va a externo. Campos:
+  `enabled`, `linkPolicy`, `allowAgents`, `terminalLinks`, `homepage` (todos con
+  `#[serde(default)]`).
+- **Agentes:** con `enabled && allowAgents`, cada terminal de agente recibe
+  `UXNAN_BROWSER_URL` + `UXNAN_BROWSER_TOKEN` y un shim `$BROWSER`
+  (`static/hooks/uxnan-browser.{sh,cmd}`). Una URL que el agente abre se hace `POST`
+  a la ruta **`/browser`** del servidor de hooks local (`hooks.rs`), que la enruta
+  por la misma política. Mismo patrón que `UXNAN_HOOK_*`.
+- **Terminal:** las URLs impresas en la terminal son clicables con **Ctrl/Cmd+clic**
+  (`@xterm/addon-web-links`) y pasan por `open_url` (toggle `terminalLinks`).
 
 ### 4.3 Ejemplo de Layout Complejo
 

--- a/uxnandesktop/docs/browser.md
+++ b/uxnandesktop/docs/browser.md
@@ -1,0 +1,90 @@
+# Integrated developer browser
+
+A lightweight in-app browser **tab** for previewing and debugging what your agents
+build — `localhost` dev servers and most websites — and for opening the links
+agents create. It is deliberately **not** a general-purpose browser (no
+bookmarks/profiles/extensions); it's a developer preview surface.
+
+It's rendered as a plain **`<iframe>`** inside the app, so it's a real center tab
+that composes with the layout (split it beside a terminal), can never freeze the
+app or paint over menus, and is very light — just another browsing context in the
+webview the ADE already runs. Some public sites refuse to be embedded (they send an
+`X-Frame-Options` / `frame-ancestors` header) and will appear blank; for those use
+**open in system browser** (see below). `localhost` dev servers almost never block
+embedding.
+
+## Opening a browser tab
+
+- **Manually:** the center "+" (new-tab) menu → **New browser tab**. It opens at
+  your configured *home page*, or a blank page.
+- **From a link:** anything the ADE opens as a URL (a **Ctrl/Cmd-clicked** terminal link, or a
+  link an agent opens) lands here when your link policy is *internal* (the default).
+
+The browser is a normal center tab: you can split it beside a terminal, drag it
+between regions, and have several open at once.
+
+### Chrome
+
+Back · Forward · Reload · address bar (type a URL and press Enter) · **open in
+system browser**. For `localhost` the address bar assumes `http://`; otherwise it
+defaults to `https://`. To inspect a page, use the app's own DevTools (they reach
+into the iframe).
+
+## Settings → Browser
+
+| Setting | What it does | Default |
+| --- | --- | --- |
+| **Integrated browser** | Master switch. Off → every link opens in your system browser and agents can't use the in-app one. | On |
+| **Open links** | Where links open: *in the integrated browser* (`internal`), *in my system browser* (`external`), or *ask each time* (`ask`). | Internal |
+| **Let agents open links** | Inject a `$BROWSER` shim so agents' links land in-app automatically (see below). | On |
+| **Clickable terminal links** | Make URLs printed in the terminal **Ctrl/Cmd-clickable** (applies to terminals opened afterwards). | On |
+| **Home page** | Opened when a new browser tab has no target. Blank if empty. | — |
+
+The setting is one **decision point**: links from the UI, the terminal, and agents
+all flow through the same policy, and the system browser is always available as a
+fallback (the address bar's "open in system browser" button, or `external` policy).
+
+## How an agent uses it automatically
+
+When the browser is **enabled** and **Let agents open links** is on, every agent
+terminal is launched with:
+
+- `UXNAN_BROWSER_URL` — the local endpoint that opens a URL in the ADE.
+- `UXNAN_BROWSER_TOKEN` — a per-launch secret (sent as the `X-Uxnan-Token` header).
+- `BROWSER` — a path to a bundled shim (`uxnan-browser.sh` / `uxnan-browser.cmd`).
+
+Two ways an agent ends up in the in-app browser:
+
+1. **Automatically**, for any tool that honors the Unix `$BROWSER` convention
+   (many CLIs use it for OAuth logins and "open this URL" prompts): the shim
+   forwards the URL to the ADE.
+2. **Explicitly**, for any agent that can run a shell command — ask it to run:
+
+   ```sh
+   curl -X POST "$UXNAN_BROWSER_URL" \
+     -H "Content-Type: application/json" \
+     -H "X-Uxnan-Token: $UXNAN_BROWSER_TOKEN" \
+     -d '{"url":"http://localhost:5173"}'
+   ```
+
+Either way the URL is routed through your link policy, so it opens in the in-app
+browser (or your system browser / a prompt, depending on the setting).
+
+> Tip: tell your agent something like *"when you start the dev server, open its URL
+> in the browser"* — if it runs `$BROWSER <url>` or the `curl` above, the preview
+> shows up next to your terminal.
+
+## Performance
+
+The in-app browser only consumes resources while a browser tab is open (it's an
+iframe in the webview the app already runs, far lighter than a separate browser).
+Keep heavy pages closed when you don't need them.
+
+## Limitations
+
+- It's a developer preview surface, not a hardened/general-purpose browser.
+- Sites that send `X-Frame-Options` / `frame-ancestors` refuse to be embedded and
+  render blank — use **open in system browser** for those. `localhost` dev servers
+  almost never block embedding.
+- The `$BROWSER` auto-interception only covers tools that honor that convention; for
+  others, use the explicit `curl` call above.

--- a/uxnandesktop/package-lock.json
+++ b/uxnandesktop/package-lock.json
@@ -36,6 +36,7 @@
         "@tauri-apps/plugin-opener": "^2",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-ligatures": "^0.10.0",
+        "@xterm/addon-web-links": "^0.11.0",
         "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
         "bits-ui": "^2.18.1",
@@ -2212,6 +2213,15 @@
       },
       "engines": {
         "node": ">8.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz",
+      "integrity": "sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
       }
     },
     "node_modules/@xterm/addon-webgl": {

--- a/uxnandesktop/package.json
+++ b/uxnandesktop/package.json
@@ -44,6 +44,7 @@
     "@tauri-apps/plugin-opener": "^2",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-ligatures": "^0.10.0",
+    "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "bits-ui": "^2.18.1",

--- a/uxnandesktop/src-tauri/src/agent_hooks.rs
+++ b/uxnandesktop/src-tauri/src/agent_hooks.rs
@@ -45,12 +45,19 @@ pub const WRAPPER_BASH: &str = include_str!("../../static/hooks/uxnan-hook-wrapp
 pub const WRAPPER_POWERSHELL: &str = include_str!("../../static/hooks/uxnan-hook-wrapper.ps1");
 /// The generic wrapper for any CLI agent (cmd / batch — the no-PowerShell fallback).
 pub const WRAPPER_CMD: &str = include_str!("../../static/hooks/uxnan-hook-wrapper.cmd");
+/// The integrated-browser shim (Unix / Git Bash / WSL) — `$BROWSER` points here so
+/// a URL an agent opens lands in the in-app browser (see `commands.rs` pty env).
+pub const BROWSER_SHIM_BASH: &str = include_str!("../../static/hooks/uxnan-browser.sh");
+/// The integrated-browser shim (Windows / cmd) — `%BROWSER%` points here.
+pub const BROWSER_SHIM_CMD: &str = include_str!("../../static/hooks/uxnan-browser.cmd");
 
 /// File names of the bundled scripts (used when writing them to disk).
 const CLAUDE_HOOK_FILENAME: &str = "uxnan-claude-hook.cjs";
 const WRAPPER_BASH_FILENAME: &str = "uxnan-hook-wrapper.sh";
 const WRAPPER_POWERSHELL_FILENAME: &str = "uxnan-hook-wrapper.ps1";
 const WRAPPER_CMD_FILENAME: &str = "uxnan-hook-wrapper.cmd";
+const BROWSER_SHIM_BASH_FILENAME: &str = "uxnan-browser.sh";
+const BROWSER_SHIM_CMD_FILENAME: &str = "uxnan-browser.cmd";
 
 /// A platform-aware absolute path of every script the ADE writes under
 /// `<app-data>/hooks/`, plus the resolved Claude `settings.json` path and
@@ -68,6 +75,10 @@ pub struct HookInstall {
     pub wrapper_powershell: String,
     /// Absolute path of the cmd / batch wrapper.
     pub wrapper_cmd: String,
+    /// Absolute path of the integrated-browser shim (Bash).
+    pub browser_shim_bash: String,
+    /// Absolute path of the integrated-browser shim (cmd / batch).
+    pub browser_shim_cmd: String,
     /// The resolved Claude `settings.json` path (`%USERPROFILE%\.claude\settings.json`
     /// on Windows, `~/.claude/settings.json` elsewhere).
     pub claude_settings_path: String,
@@ -120,6 +131,14 @@ pub fn install_scripts_to(dir: &Path) -> Result<HookInstall, AppError> {
     let bash = write(WRAPPER_BASH_FILENAME, WRAPPER_BASH)?;
     let ps = write(WRAPPER_POWERSHELL_FILENAME, WRAPPER_POWERSHELL)?;
     let cmd = write(WRAPPER_CMD_FILENAME, WRAPPER_CMD)?;
+    let browser_bash = write(BROWSER_SHIM_BASH_FILENAME, BROWSER_SHIM_BASH)?;
+    let browser_cmd = write(BROWSER_SHIM_CMD_FILENAME, BROWSER_SHIM_CMD)?;
+    // The Bash shim is invoked directly as `$BROWSER <url>`, so it needs +x on Unix.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&browser_bash, std::fs::Permissions::from_mode(0o755));
+    }
     let settings = claude_settings_path().ok_or_else(|| {
         AppError::Invalid("cannot resolve home directory for Claude settings path".into())
     })?;
@@ -129,6 +148,8 @@ pub fn install_scripts_to(dir: &Path) -> Result<HookInstall, AppError> {
         wrapper_bash: bash.to_string_lossy().into_owned(),
         wrapper_powershell: ps.to_string_lossy().into_owned(),
         wrapper_cmd: cmd.to_string_lossy().into_owned(),
+        browser_shim_bash: browser_bash.to_string_lossy().into_owned(),
+        browser_shim_cmd: browser_cmd.to_string_lossy().into_owned(),
         claude_settings_path: settings.to_string_lossy().into_owned(),
     })
 }
@@ -332,6 +353,14 @@ mod tests {
                 .join(WRAPPER_CMD_FILENAME)
                 .to_string_lossy()
                 .into_owned(),
+            browser_shim_bash: dir
+                .join(BROWSER_SHIM_BASH_FILENAME)
+                .to_string_lossy()
+                .into_owned(),
+            browser_shim_cmd: dir
+                .join(BROWSER_SHIM_CMD_FILENAME)
+                .to_string_lossy()
+                .into_owned(),
             claude_settings_path: settings.to_string_lossy().into_owned(),
         }
     }
@@ -401,13 +430,15 @@ mod tests {
     }
 
     #[test]
-    fn install_scripts_writes_all_four_files_idempotently() {
+    fn install_scripts_writes_all_files_idempotently() {
         let tmp = tempdir();
         let info = install_scripts_to(&tmp).expect("install succeeds");
         assert!(Path::new(&info.claude_hook_script).is_file());
         assert!(Path::new(&info.wrapper_bash).is_file());
         assert!(Path::new(&info.wrapper_powershell).is_file());
         assert!(Path::new(&info.wrapper_cmd).is_file());
+        assert!(Path::new(&info.browser_shim_bash).is_file());
+        assert!(Path::new(&info.browser_shim_cmd).is_file());
         // Re-running is a no-op (mtime + content-stable).
         let first_mtime = std::fs::metadata(&info.claude_hook_script)
             .unwrap()

--- a/uxnandesktop/src-tauri/src/browser.rs
+++ b/uxnandesktop/src-tauri/src/browser.rs
@@ -1,0 +1,118 @@
+//! Integrated developer browser — link routing.
+//!
+//! The browser itself is rendered in the frontend as a plain `<iframe>` center tab
+//! (`BrowserPane.svelte`), so there is no native webview to manage here. This module
+//! owns the one decision every link funnels through: open `url` in the in-app
+//! browser tab, hand it to the OS default browser, or prompt — per the user's
+//! [`crate::model::BrowserSettings`]. Shared by the `open_url` command and the agent
+//! `/browser` hook route (`hooks.rs`).
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::error::CommandError;
+use crate::model::BrowserLinkPolicy;
+use crate::state::AppState;
+
+/// Where a link should open, resolved from [`BrowserLinkPolicy`] and the master
+/// switch. Pure decision (see [`resolve_link_target`]) so it can be unit-tested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinkTarget {
+    /// Open in the integrated browser tab.
+    Internal,
+    /// Hand off to the OS default browser.
+    External,
+    /// Let the user choose per link (the frontend prompts).
+    Ask,
+}
+
+/// Resolve where a link opens. The master switch wins: a disabled browser always
+/// routes to the OS browser, regardless of the policy.
+pub fn resolve_link_target(enabled: bool, policy: BrowserLinkPolicy) -> LinkTarget {
+    if !enabled {
+        return LinkTarget::External;
+    }
+    match policy {
+        BrowserLinkPolicy::Internal => LinkTarget::Internal,
+        BrowserLinkPolicy::External => LinkTarget::External,
+        BrowserLinkPolicy::Ask => LinkTarget::Ask,
+    }
+}
+
+/// Event telling the frontend to open `url` in the integrated browser. The `ask`
+/// flag asks it to prompt internal-vs-external (the `Ask` policy).
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OpenUrlEvent {
+    url: String,
+    ask: bool,
+}
+
+fn emit_open_url(app: &AppHandle, url: &str, ask: bool) -> Result<(), CommandError> {
+    app.emit(
+        "browser:open-url",
+        OpenUrlEvent {
+            url: url.to_string(),
+            ask,
+        },
+    )
+    .map_err(|e| CommandError::new("EMIT_FAILED", e.to_string()))
+}
+
+/// Open `url` per the user's [`crate::model::BrowserSettings`]: the in-app browser
+/// tab, the OS default browser, or a per-link prompt. The single decision point
+/// shared by the `open_url` command and the agent `/browser` hook route; a disabled
+/// browser always goes external.
+pub async fn route_url(app: &AppHandle, url: String) -> Result<(), CommandError> {
+    let (enabled, policy) = {
+        let state = app.state::<AppState>();
+        let data = state.data.read().await;
+        (
+            data.settings.browser.enabled,
+            data.settings.browser.link_policy,
+        )
+    };
+    match resolve_link_target(enabled, policy) {
+        LinkTarget::External => {
+            use tauri_plugin_opener::OpenerExt;
+            app.opener()
+                .open_url(url, None::<&str>)
+                .map_err(|e| CommandError::new("OPEN_URL_FAILED", e.to_string()))
+        }
+        LinkTarget::Internal => emit_open_url(app, &url, false),
+        LinkTarget::Ask => emit_open_url(app, &url, true),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_always_routes_external() {
+        assert_eq!(
+            resolve_link_target(false, BrowserLinkPolicy::Internal),
+            LinkTarget::External
+        );
+        assert_eq!(
+            resolve_link_target(false, BrowserLinkPolicy::Ask),
+            LinkTarget::External
+        );
+    }
+
+    #[test]
+    fn enabled_follows_policy() {
+        assert_eq!(
+            resolve_link_target(true, BrowserLinkPolicy::Internal),
+            LinkTarget::Internal
+        );
+        assert_eq!(
+            resolve_link_target(true, BrowserLinkPolicy::External),
+            LinkTarget::External
+        );
+        assert_eq!(
+            resolve_link_target(true, BrowserLinkPolicy::Ask),
+            LinkTarget::Ask
+        );
+    }
+}

--- a/uxnandesktop/src-tauri/src/commands.rs
+++ b/uxnandesktop/src-tauri/src/commands.rs
@@ -99,9 +99,40 @@ pub async fn pty_create(
     let mut env: Vec<(String, String)> = env.unwrap_or_default();
     env.retain(|(k, _)| !k.trim().is_empty());
     env.push(("UXNAN_AGENT_ID".to_string(), id.clone()));
-    if let Some(hook) = state.hook.read().await.clone() {
-        env.push(("UXNAN_HOOK_URL".to_string(), hook.url));
-        env.push(("UXNAN_HOOK_TOKEN".to_string(), hook.token));
+    let hook = state.hook.read().await.clone();
+    if let Some(h) = &hook {
+        env.push(("UXNAN_HOOK_URL".to_string(), h.url.clone()));
+        env.push(("UXNAN_HOOK_TOKEN".to_string(), h.token.clone()));
+    }
+
+    // Integrated browser: when enabled and agents are allowed, let an agent open a
+    // URL in the in-app browser by POSTing it to the hook server's `/browser` route
+    // (`UXNAN_BROWSER_URL` + `_TOKEN`), and point `$BROWSER` at the bundled shim so
+    // tools that honor it (logins/previews) land in-app too. Honors the user's
+    // link policy on arrival (see `browser::route_url`).
+    let (browser_enabled, allow_agents) = {
+        let data = state.data.read().await;
+        (
+            data.settings.browser.enabled,
+            data.settings.browser.allow_agents,
+        )
+    };
+    if browser_enabled && allow_agents {
+        if let Some(h) = &hook {
+            env.push((
+                "UXNAN_BROWSER_URL".to_string(),
+                h.url.replacen("/hook", "/browser", 1),
+            ));
+            env.push(("UXNAN_BROWSER_TOKEN".to_string(), h.token.clone()));
+        }
+        if let Some(install) = state.hook_install.read().await.clone() {
+            let shim = if cfg!(windows) {
+                install.browser_shim_cmd
+            } else {
+                install.browser_shim_bash
+            };
+            env.push(("BROWSER".to_string(), shim));
+        }
     }
 
     state
@@ -414,6 +445,27 @@ pub fn reveal_path(app: AppHandle, path: String) -> Result<(), CommandError> {
     app.opener()
         .reveal_item_in_dir(std::path::PathBuf::from(path))
         .map_err(|e| CommandError::new("REVEAL_FAILED", e.to_string()))
+}
+
+/// The single decision point every link in the ADE funnels through: open `url` in
+/// the integrated browser tab, hand it to the OS default browser, or (for the
+/// `Ask` policy) let the frontend prompt — per the user's `BrowserSettings`.
+/// Powers the `openUrl` frontend wrapper and terminal link clicks; the agent
+/// `BROWSER` shim reaches the same logic via the hook server's `/browser` route.
+#[tauri::command]
+pub async fn open_url(app: AppHandle, url: String) -> Result<(), CommandError> {
+    crate::browser::route_url(&app, url).await
+}
+
+/// Open `url` in the OS default browser unconditionally (ignores the link policy).
+/// Powers the integrated browser's "open in system browser" action and the `Ask`
+/// prompt's external choice.
+#[tauri::command]
+pub fn open_external(app: AppHandle, url: String) -> Result<(), CommandError> {
+    use tauri_plugin_opener::OpenerExt;
+    app.opener()
+        .open_url(url, None::<&str>)
+        .map_err(|e| CommandError::new("OPEN_EXTERNAL_FAILED", e.to_string()))
 }
 
 /// Working-tree-vs-`HEAD` diff for one file, powering the editor's change gutter

--- a/uxnandesktop/src-tauri/src/hooks.rs
+++ b/uxnandesktop/src-tauri/src/hooks.rs
@@ -105,6 +105,7 @@ pub async fn start(app: AppHandle, token: String) -> std::io::Result<HookServerI
     };
     let router = Router::new()
         .route("/hook", post(handle_hook))
+        .route("/browser", post(handle_browser))
         .route("/health", get(|| async { "ok" }))
         .with_state(ctx);
     tauri::async_runtime::spawn(async move {
@@ -173,6 +174,37 @@ async fn handle_hook(
         },
     );
     StatusCode::NO_CONTENT
+}
+
+/// The JSON body the agent `BROWSER` shim POSTs to open a URL in-app: `{"url": …}`.
+#[derive(Debug, Clone, Deserialize)]
+struct BrowserRequest {
+    url: String,
+}
+
+/// Handle one `POST /browser`: authorize, then route the URL through the user's
+/// browser policy (in-app tab / OS browser / prompt). Lets an agent open a link in
+/// the integrated browser via `UXNAN_BROWSER_URL` + `UXNAN_BROWSER_TOKEN`.
+async fn handle_browser(
+    AxumState(ctx): AxumState<HookCtx>,
+    headers: HeaderMap,
+    Json(payload): Json<BrowserRequest>,
+) -> StatusCode {
+    let authorized = headers
+        .get(TOKEN_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v == ctx.token)
+        .unwrap_or(false);
+    if !authorized {
+        return StatusCode::UNAUTHORIZED;
+    }
+    if payload.url.trim().is_empty() {
+        return StatusCode::BAD_REQUEST;
+    }
+    match crate::browser::route_url(&ctx.app, payload.url).await {
+        Ok(()) => StatusCode::NO_CONTENT,
+        Err(_) => StatusCode::BAD_REQUEST,
+    }
 }
 
 #[cfg(test)]

--- a/uxnandesktop/src-tauri/src/lib.rs
+++ b/uxnandesktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod agent_hooks;
 mod agentcli;
 mod aicommit;
 mod browse;
+mod browser;
 mod commands;
 mod error;
 mod fs;
@@ -222,6 +223,8 @@ pub fn run() {
             commands::fs_write_file,
             commands::fs_set_watch,
             commands::reveal_path,
+            commands::open_url,
+            commands::open_external,
             commands::git_diff_head,
             commands::set_terminal_layout,
             commands::agents_detect,

--- a/uxnandesktop/src-tauri/src/model.rs
+++ b/uxnandesktop/src-tauri/src/model.rs
@@ -286,6 +286,11 @@ pub struct AppSettings {
     /// (see `updater.rs`). All fields default, so older state loads unchanged.
     #[serde(default)]
     pub updater: UpdaterSettings,
+    /// Integrated developer browser (Settings → Browser): whether links route to
+    /// the in-app webview tab vs the OS browser, and whether agents may drive it
+    /// (see `BrowserSettings`). All fields default, so older state loads unchanged.
+    #[serde(default)]
+    pub browser: BrowserSettings,
 }
 
 /// Release channel the updater follows. Mapped to GitHub's only release
@@ -357,6 +362,60 @@ impl Default for UpdaterSettings {
             channel: UpdateChannel::Stable,
             auto_download: true,
             install_policy: InstallPolicy::Ask,
+        }
+    }
+}
+
+/// Where a link opens when the integrated browser is enabled. Governs both links
+/// the user clicks inside the ADE and URLs agents try to open (via the injected
+/// `BROWSER` shim — see `hooks.rs`). `Internal` uses the in-app browser tab;
+/// `External` always hands off to the OS default browser; `Ask` defers the choice
+/// to the user per link (frontend-resolved).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum BrowserLinkPolicy {
+    #[default]
+    Internal,
+    External,
+    Ask,
+}
+
+/// Integrated **developer** browser (Settings → Browser). A lightweight in-app
+/// webview tab for previewing/debugging the systems agents build and opening the
+/// links agents produce — deliberately not a general-purpose browser. The webview
+/// is created lazily (only when a browser tab opens) and torn down when closed, so
+/// it costs nothing until used. All fields default, so older state loads unchanged.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserSettings {
+    /// Master switch. When off, every link goes to the OS default browser and no
+    /// `BROWSER` shim is injected into agents. Default on.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Where links open by default (see [`BrowserLinkPolicy`]). Default `internal`.
+    #[serde(default)]
+    pub link_policy: BrowserLinkPolicy,
+    /// Let agents open URLs in the integrated browser by injecting a `BROWSER`
+    /// shim into their environment (see `hooks.rs`). Default on.
+    #[serde(default = "default_true")]
+    pub allow_agents: bool,
+    /// Make URLs printed in the terminal clickable (routed through `link_policy`).
+    /// Default on.
+    #[serde(default = "default_true")]
+    pub terminal_links: bool,
+    /// Page opened when a fresh browser tab has no target URL. Empty = blank tab.
+    #[serde(default)]
+    pub homepage: String,
+}
+
+impl Default for BrowserSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            link_policy: BrowserLinkPolicy::Internal,
+            allow_agents: true,
+            terminal_links: true,
+            homepage: String::new(),
         }
     }
 }
@@ -461,6 +520,7 @@ impl Default for AppSettings {
             terminal_theme_dark_id: default_terminal_theme_id(),
             ai_commit: AiCommitSettings::default(),
             updater: UpdaterSettings::default(),
+            browser: BrowserSettings::default(),
         }
     }
 }
@@ -674,6 +734,29 @@ mod tests {
     #[test]
     fn theme_serializes_lowercase() {
         assert_eq!(serde_json::to_string(&Theme::System).unwrap(), "\"system\"");
+    }
+
+    #[test]
+    fn browser_settings_default_on_and_serialize_camel_case() {
+        let settings = AppSettings::default();
+        assert!(settings.browser.enabled);
+        assert!(settings.browser.allow_agents);
+        assert_eq!(settings.browser.link_policy, BrowserLinkPolicy::Internal);
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("linkPolicy"));
+        assert!(json.contains("\"internal\""));
+        assert!(!json.contains("link_policy"));
+    }
+
+    #[test]
+    fn settings_deserialize_without_browser_defaults_on() {
+        // State persisted before the integrated browser existed must still load,
+        // and pick up the default-on browser settings.
+        let json = r#"{"theme":"system","leftSidebarWidth":280,"rightSidebarWidth":350,
+            "leftSidebarOpen":true,"rightSidebarOpen":true}"#;
+        let settings: AppSettings = serde_json::from_str(json).unwrap();
+        assert!(settings.browser.enabled);
+        assert_eq!(settings.browser.link_policy, BrowserLinkPolicy::Internal);
     }
 
     #[test]

--- a/uxnandesktop/src/lib/api.ts
+++ b/uxnandesktop/src/lib/api.ts
@@ -202,6 +202,21 @@ export function revealPath(path: string): Promise<void> {
   return invoke("reveal_path", { path });
 }
 
+// --- Integrated browser ----------------------------------------------------
+// The browser itself is a DOM `<iframe>` in the frontend; the backend only owns
+// link routing. `openUrl` is the single decision point: it routes to the in-app
+// browser tab, the OS browser, or a prompt per the user's BrowserSettings.
+
+/** Route a URL per the user's browser settings (internal tab / OS browser / ask). */
+export function openUrl(url: string): Promise<void> {
+  return invoke("open_url", { url });
+}
+
+/** Open a URL in the OS default browser unconditionally (ignores the policy). */
+export function openExternal(url: string): Promise<void> {
+  return invoke("open_external", { url });
+}
+
 /** Set (or clear with `null`) the worktree root the filesystem watcher follows.
  *  The backend then emits `fs:changed` as files under it change on disk. */
 export function fsSetWatch(path: string | null): Promise<void> {

--- a/uxnandesktop/src/lib/components/BrowserPane.svelte
+++ b/uxnandesktop/src/lib/components/BrowserPane.svelte
@@ -1,0 +1,155 @@
+<script lang="ts">
+  // Integrated developer-browser pane.
+  //
+  // Renders the target URL in a plain DOM `<iframe>` — a real center tab that
+  // composes naturally with the layout (no native overlay, so it can never freeze
+  // the app or paint over menus) and is very light (just another browsing context
+  // in the webview the ADE already runs). Ideal for previewing/debugging local dev
+  // servers and opening the links agents create.
+  //
+  // Trade-off: some public sites refuse to be embedded (`X-Frame-Options` /
+  // `frame-ancestors`) and will render blank — the toolbar's "open in system
+  // browser" handles those. `localhost` dev servers almost never block framing.
+
+  import { untrack } from "svelte";
+  import { openExternal } from "$lib/api";
+  import type { BrowserTab } from "$lib/state/terminals.svelte";
+  import { i18n } from "$lib/i18n";
+  import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
+  import ArrowRightIcon from "@lucide/svelte/icons/arrow-right";
+  import RotateCwIcon from "@lucide/svelte/icons/rotate-cw";
+  import ExternalLinkIcon from "@lucide/svelte/icons/external-link";
+
+  let { tab }: { tab: BrowserTab } = $props();
+
+  let address = $state(untrack(() => tab.url));
+  let src = $state("");
+  /** Bumping this remounts the iframe → a reload (works cross-origin too). */
+  let reloadEpoch = $state(0);
+
+  // Our own history of navigated URLs (the iframe's internal cross-origin history
+  // isn't readable), powering Back/Forward over the addresses we set. Reactive so
+  // the Back/Forward buttons enable/disable as you navigate.
+  let stack = $state<string[]>([]);
+  let pos = $state(-1);
+
+  /** Turn an address-bar entry into a navigable URL: keep explicit schemes and
+   *  `about:`; use http for localhost/loopback (dev servers), else https. */
+  function normalizeUrl(input: string): string {
+    const s = input.trim();
+    if (!s) return "about:blank";
+    if (/^about:/i.test(s)) return s;
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(s)) return s;
+    if (/^(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])(:|\/|$)/.test(s)) return `http://${s}`;
+    return `https://${s}`;
+  }
+
+  function load(raw: string, pushHistory = true): void {
+    const u = normalizeUrl(raw);
+    address = u;
+    src = u;
+    if (pushHistory) {
+      stack = [...stack.slice(0, pos + 1), u];
+      pos = stack.length - 1;
+    }
+  }
+
+  // Load the initial URL, and re-load when the tab's target changes from outside
+  // (an agent reusing this tab via `showUrl`).
+  $effect(() => {
+    const u = tab.url;
+    untrack(() => {
+      if (u && u !== src) load(u);
+    });
+  });
+
+  function go(): void {
+    load(address);
+  }
+
+  function onKey(e: KeyboardEvent): void {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      go();
+    }
+  }
+
+  function back(): void {
+    if (pos > 0) {
+      pos -= 1;
+      load(stack[pos], false);
+    }
+  }
+  function forward(): void {
+    if (pos < stack.length - 1) {
+      pos += 1;
+      load(stack[pos], false);
+    }
+  }
+  function reload(): void {
+    reloadEpoch += 1;
+  }
+</script>
+
+<div class="flex h-full w-full flex-col bg-background">
+  <!-- Toolbar / address bar -->
+  <div class="flex shrink-0 items-center gap-1 border-b border-border px-1.5 py-1">
+    <button
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-40"
+      title={i18n.t("browser.back")}
+      aria-label={i18n.t("browser.back")}
+      disabled={pos <= 0}
+      onclick={back}
+    >
+      <ArrowLeftIcon class="size-4" />
+    </button>
+    <button
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-40"
+      title={i18n.t("browser.forward")}
+      aria-label={i18n.t("browser.forward")}
+      disabled={pos >= stack.length - 1}
+      onclick={forward}
+    >
+      <ArrowRightIcon class="size-4" />
+    </button>
+    <button
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+      title={i18n.t("browser.reload")}
+      aria-label={i18n.t("browser.reload")}
+      onclick={reload}
+    >
+      <RotateCwIcon class="size-4" />
+    </button>
+    <input
+      class="min-w-0 flex-1 rounded border border-input bg-card px-2 py-1 text-xs outline-none focus:border-ring"
+      type="text"
+      spellcheck="false"
+      autocapitalize="off"
+      autocomplete="off"
+      placeholder={i18n.t("browser.addressPlaceholder")}
+      bind:value={address}
+      onkeydown={onKey}
+    />
+    <button
+      class="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+      title={i18n.t("browser.openExternal")}
+      aria-label={i18n.t("browser.openExternal")}
+      onclick={() => void openExternal(address).catch(() => {})}
+    >
+      <ExternalLinkIcon class="size-4" />
+    </button>
+  </div>
+
+  <!-- Page -->
+  <div class="relative min-h-0 flex-1">
+    {#key reloadEpoch}
+      <iframe
+        title={i18n.t("settings.browser")}
+        {src}
+        class="absolute inset-0 h-full w-full border-0 bg-white"
+        referrerpolicy="no-referrer-when-downgrade"
+        allow="clipboard-read; clipboard-write; fullscreen"
+      ></iframe>
+    {/key}
+  </div>
+</div>

--- a/uxnandesktop/src/lib/components/Settings.svelte
+++ b/uxnandesktop/src/lib/components/Settings.svelte
@@ -8,6 +8,7 @@
   import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
   import { Button } from "$lib/components/ui/button";
   import { Textarea } from "$lib/components/ui/textarea";
+  import { Input } from "$lib/components/ui/input";
   import { app } from "$lib/state/app.svelte";
   import { i18n, LOCALES } from "$lib/i18n";
   import type { MessageKey } from "$lib/i18n/locales/en";
@@ -26,6 +27,8 @@
     UpdaterSettings,
     UpdateChannel,
     InstallPolicy,
+    BrowserSettings,
+    BrowserLinkPolicy,
   } from "$lib/types";
   import TerminalProfileEditor from "./TerminalProfileEditor.svelte";
   import AgentProfileEditor from "./AgentProfileEditor.svelte";
@@ -54,6 +57,7 @@
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
   import XIcon from "@lucide/svelte/icons/x";
   import SparklesIcon from "@lucide/svelte/icons/sparkles";
+  import GlobeIcon from "@lucide/svelte/icons/globe";
 
   // Persist (debounced for typing; immediate for discrete actions).
   let saveTimer: ReturnType<typeof setTimeout> | undefined;
@@ -394,6 +398,32 @@
       : i18n.t("updates.neverChecked"),
   );
 
+  // --- Integrated browser ---------------------------------------------------
+  // Merge over a full default so reads/writes are always complete (state saved
+  // before this feature, or the web preview, may lack the object).
+  const BROWSER_DEFAULT: BrowserSettings = {
+    enabled: true,
+    linkPolicy: "internal",
+    allowAgents: true,
+    terminalLinks: true,
+    homepage: "",
+  };
+  const br = $derived<BrowserSettings>({
+    ...BROWSER_DEFAULT,
+    ...app.settings.browser,
+  });
+  function setBr(patch: Partial<BrowserSettings>) {
+    app.settings.browser = { ...BROWSER_DEFAULT, ...app.settings.browser, ...patch };
+  }
+  const LINK_POLICIES: { value: BrowserLinkPolicy; labelKey: MessageKey; descKey: MessageKey }[] = [
+    { value: "internal", labelKey: "browser.policyInternal", descKey: "browser.policyInternalDesc" },
+    { value: "external", labelKey: "browser.policyExternal", descKey: "browser.policyExternalDesc" },
+    { value: "ask", labelKey: "browser.policyAsk", descKey: "browser.policyAskDesc" },
+  ];
+  const linkPolicyLabel = $derived(
+    i18n.t(LINK_POLICIES.find((p) => p.value === br.linkPolicy)?.labelKey ?? "browser.policyInternal"),
+  );
+
   const navItems = [
     { id: "appearance", key: "settings.appearance", icon: PaletteIcon },
     { id: "language", key: "settings.language", icon: LanguagesIcon },
@@ -402,6 +432,7 @@
     { id: "aicommit", key: "settings.aiCommit", icon: SparklesIcon },
     { id: "hooks", key: "settings.hooks", icon: WebhookIcon },
     { id: "terminal", key: "settings.terminal", icon: TerminalIcon },
+    { id: "browser", key: "settings.browser", icon: GlobeIcon },
     { id: "updates", key: "settings.updates", icon: DownloadIcon },
   ] as const;
 </script>
@@ -1032,6 +1063,122 @@
                 </Select.Content>
               </Select.Root>
               <p class={text.meta}>{i18n.t("updates.installPolicyDesc")}</p>
+            </div>
+          </div>
+        {:else if app.settingsSection === "browser"}
+          <div class="flex flex-col gap-4">
+            <div class="flex flex-col gap-1">
+              <span class={text.heading}>{i18n.t("settings.browser")}</span>
+              <p class={text.meta}>{i18n.t("settings.browserDesc")}</p>
+            </div>
+
+            <!-- Master switch. -->
+            <div class="flex flex-col gap-1.5">
+              <span class={cn("font-medium", text.body)}>{i18n.t("browser.enabled")}</span>
+              <Select.Root
+                type="single"
+                value={br.enabled ? "on" : "off"}
+                onValueChange={(v) => {
+                  setBr({ enabled: v === "on" });
+                  persistNow();
+                }}
+              >
+                <Select.Trigger class="w-56">
+                  {br.enabled ? i18n.t("common.on") : i18n.t("common.off")}
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="on" label={i18n.t("common.on")}>{i18n.t("common.on")}</Select.Item>
+                  <Select.Item value="off" label={i18n.t("common.off")}>{i18n.t("common.off")}</Select.Item>
+                </Select.Content>
+              </Select.Root>
+              <p class={text.meta}>{i18n.t("browser.enabledDesc")}</p>
+            </div>
+
+            <!-- Link policy: where links open. -->
+            <div class="flex flex-col gap-1.5">
+              <span class={cn("font-medium", text.body)}>{i18n.t("browser.linkPolicy")}</span>
+              <Select.Root
+                type="single"
+                value={br.linkPolicy}
+                disabled={!br.enabled}
+                onValueChange={(v) => {
+                  setBr({ linkPolicy: (v as BrowserLinkPolicy) ?? "internal" });
+                  persistNow();
+                }}
+              >
+                <Select.Trigger class="w-56">{linkPolicyLabel}</Select.Trigger>
+                <Select.Content>
+                  {#each LINK_POLICIES as p (p.value)}
+                    <Select.Item value={p.value} label={i18n.t(p.labelKey)}>
+                      <div class="flex flex-col">
+                        <span>{i18n.t(p.labelKey)}</span>
+                        <span class={text.meta}>{i18n.t(p.descKey)}</span>
+                      </div>
+                    </Select.Item>
+                  {/each}
+                </Select.Content>
+              </Select.Root>
+              <p class={text.meta}>{i18n.t("browser.linkPolicyDesc")}</p>
+            </div>
+
+            <!-- Let agents open URLs in the integrated browser. -->
+            <div class="flex flex-col gap-1.5">
+              <span class={cn("font-medium", text.body)}>{i18n.t("browser.allowAgents")}</span>
+              <Select.Root
+                type="single"
+                value={br.allowAgents ? "on" : "off"}
+                disabled={!br.enabled}
+                onValueChange={(v) => {
+                  setBr({ allowAgents: v === "on" });
+                  persistNow();
+                }}
+              >
+                <Select.Trigger class="w-56">
+                  {br.allowAgents ? i18n.t("common.on") : i18n.t("common.off")}
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="on" label={i18n.t("common.on")}>{i18n.t("common.on")}</Select.Item>
+                  <Select.Item value="off" label={i18n.t("common.off")}>{i18n.t("common.off")}</Select.Item>
+                </Select.Content>
+              </Select.Root>
+              <p class={text.meta}>{i18n.t("browser.allowAgentsDesc")}</p>
+            </div>
+
+            <!-- Make terminal URLs clickable. -->
+            <div class="flex flex-col gap-1.5">
+              <span class={cn("font-medium", text.body)}>{i18n.t("browser.terminalLinks")}</span>
+              <Select.Root
+                type="single"
+                value={br.terminalLinks ? "on" : "off"}
+                disabled={!br.enabled}
+                onValueChange={(v) => {
+                  setBr({ terminalLinks: v === "on" });
+                  persistNow();
+                }}
+              >
+                <Select.Trigger class="w-56">
+                  {br.terminalLinks ? i18n.t("common.on") : i18n.t("common.off")}
+                </Select.Trigger>
+                <Select.Content>
+                  <Select.Item value="on" label={i18n.t("common.on")}>{i18n.t("common.on")}</Select.Item>
+                  <Select.Item value="off" label={i18n.t("common.off")}>{i18n.t("common.off")}</Select.Item>
+                </Select.Content>
+              </Select.Root>
+              <p class={text.meta}>{i18n.t("browser.terminalLinksDesc")}</p>
+            </div>
+
+            <!-- Homepage. -->
+            <div class="flex flex-col gap-1.5">
+              <span class={cn("font-medium", text.body)}>{i18n.t("browser.homepage")}</span>
+              <Input
+                class="w-full max-w-md"
+                value={br.homepage}
+                placeholder={i18n.t("browser.homepagePlaceholder")}
+                disabled={!br.enabled}
+                oninput={(e) => setBr({ homepage: e.currentTarget.value })}
+                onchange={() => persistNow()}
+              />
+              <p class={text.meta}>{i18n.t("browser.homepageDesc")}</p>
             </div>
           </div>
         {:else}

--- a/uxnandesktop/src/lib/components/Terminal.svelte
+++ b/uxnandesktop/src/lib/components/Terminal.svelte
@@ -21,7 +21,9 @@
   import { FitAddon } from "@xterm/addon-fit";
   import { WebglAddon } from "@xterm/addon-webgl";
   import { LigaturesAddon } from "@xterm/addon-ligatures";
+  import { WebLinksAddon } from "@xterm/addon-web-links";
   import "@xterm/xterm/css/xterm.css";
+  import { openUrl } from "$lib/api";
   import { clipboardRead, clipboardWrite } from "$lib/clipboard";
   import { terminals } from "$lib/state/terminals.svelte";
   import { agentMonitor } from "$lib/state/agentMonitor.svelte";
@@ -130,6 +132,25 @@
         term.loadAddon(new WebglAddon());
       } catch {
         // WebGL unavailable — xterm falls back to the DOM renderer.
+      }
+    }
+
+    // Make printed URLs clickable, routed through the integrated-browser link
+    // policy (in-app tab / OS browser / prompt). Gated on the setting; like
+    // ligatures, the choice applies to terminals created after it changes.
+    if (app.settings.browser?.terminalLinks ?? true) {
+      try {
+        term.loadAddon(
+          new WebLinksAddon((event, uri) => {
+            // Like VS Code: only Ctrl/Cmd-click follows a link; a plain click is
+            // just text selection (so links don't open by accident).
+            if (!event.ctrlKey && !event.metaKey) return;
+            event.preventDefault();
+            void openUrl(uri).catch(() => {});
+          }),
+        );
+      } catch {
+        // web-links addon unavailable — URLs just stay non-clickable.
       }
     }
 

--- a/uxnandesktop/src/lib/components/TerminalArea.svelte
+++ b/uxnandesktop/src/lib/components/TerminalArea.svelte
@@ -18,6 +18,7 @@
   import FileEditor from "./FileEditor.svelte";
   import DiffPane from "./DiffPane.svelte";
   import CommitPane from "./CommitPane.svelte";
+  import BrowserPane from "./BrowserPane.svelte";
   import { resolveAgentDisplay } from "$lib/state/agentDisplay";
   import AgentStatusDot from "./AgentStatusDot.svelte";
   import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
@@ -33,6 +34,7 @@
   import FileIcon from "@lucide/svelte/icons/file";
   import FileDiffIcon from "@lucide/svelte/icons/file-diff";
   import GitCommitIcon from "@lucide/svelte/icons/git-commit-horizontal";
+  import GlobeIcon from "@lucide/svelte/icons/globe";
   import NewWorktreeDialog from "./NewWorktreeDialog.svelte";
 
   /** Default profile's shell/args, for region-level + and splits. A blank
@@ -46,6 +48,12 @@
   // The terminal area background follows the resolved terminal theme (matches
   // xterm's background).
   const paneBg = $derived(app.resolveTerminal().theme.background);
+
+  /** Open a new integrated-browser tab at the configured homepage (or blank). */
+  function openBrowserTab(): void {
+    const home = app.settings.browser?.homepage?.trim();
+    terminals.openBrowser(home && home.length > 0 ? home : "about:blank");
+  }
 
   // --- Workspaces (one terminal set per worktree + a Global space) ---------
   // Active workspace breadcrumb (repo / branch). Rendered in the status bar
@@ -344,6 +352,13 @@
               {p.name.trim() || i18n.t("terminal.unnamedProfile")}
             </DropdownMenu.Item>
           {/each}
+          {#if app.settings.browser?.enabled ?? true}
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item class={text.menu} onclick={openBrowserTab}>
+              <GlobeIcon class={icon.button} />
+              {i18n.t("terminal.newBrowser")}
+            </DropdownMenu.Item>
+          {/if}
         </DropdownMenu.Content>
       </DropdownMenu.Root>
     </div>
@@ -449,6 +464,15 @@
                           >
                             {t.title}
                           </button>
+                        {:else if t.kind === "browser"}
+                          <GlobeIcon class={cn(icon.decorative, "shrink-0")} />
+                          <button
+                            class="max-w-[120px] truncate"
+                            onclick={() => terminals.setActiveTab(g.group.id, t.id)}
+                            title={t.url}
+                          >
+                            {t.title}
+                          </button>
                         {:else}
                           <GitCommitIcon class={cn(icon.decorative, "shrink-0")} />
                           <button
@@ -551,6 +575,8 @@
                           {#if st}
                             <DiffPane state={st} />
                           {/if}
+                        {:else if t.kind === "browser"}
+                          <BrowserPane tab={t} />
                         {:else}
                           {@const st = terminals.commitState(t.id)}
                           {#if st}

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -100,6 +100,7 @@ export const en = {
   "terminal.terminal": "Terminal",
   "terminal.chooseProfile": "Choose a terminal profile",
   "terminal.newTerminal": "New terminal",
+  "terminal.newBrowser": "New browser tab",
   "terminal.unnamedProfile": "Unnamed profile",
   "terminal.context":
     "Active terminal context — choose a project or worktree in the left panel",
@@ -141,6 +142,9 @@ export const en = {
   "settings.updates": "Updates",
   "settings.updatesDesc":
     "Choose how Uxnan Desktop checks for, downloads and installs new versions.",
+  "settings.browser": "Browser",
+  "settings.browserDesc":
+    "A lightweight in-app browser to preview and debug what your agents build, and to open the links they create.",
   "settings.aiCommit": "AI commit message",
   "settings.aiCommitDesc":
     "Optionally draft commit messages from your staged changes with a local CLI agent. Off by default; nothing runs until you enable it and pick an agent.",
@@ -597,6 +601,35 @@ export const en = {
   "updates.policyAsk": "Ask me",
   "updates.policyWhenIdle": "Automatically when agents are idle",
   "updates.policyManual": "Only when I trigger it",
+
+  // Integrated developer browser (Settings → Browser + the browser tab chrome)
+  "browser.enabled": "Integrated browser",
+  "browser.enabledDesc":
+    "When off, every link opens in your system browser and agents can't use the in-app one.",
+  "browser.linkPolicy": "Open links",
+  "browser.linkPolicyDesc": "Where links open by default — in the app or your system browser.",
+  "browser.policyInternal": "In the integrated browser",
+  "browser.policyInternalDesc": "Open links in an in-app browser tab.",
+  "browser.policyExternal": "In my system browser",
+  "browser.policyExternalDesc": "Always hand links to your default browser (Chrome, Firefox…).",
+  "browser.policyAsk": "Ask each time",
+  "browser.policyAskDesc": "Choose in-app or system browser per link.",
+  "browser.allowAgents": "Let agents open links",
+  "browser.allowAgentsDesc":
+    "Agents that open a URL (logins, previews) land in the integrated browser automatically.",
+  "browser.terminalLinks": "Clickable terminal links",
+  "browser.terminalLinksDesc":
+    "Make URLs printed in the terminal clickable (applies to new terminals).",
+  "browser.homepage": "Home page",
+  "browser.homepageDesc": "Opened when a new browser tab has no target (leave blank for none).",
+  "browser.homepagePlaceholder": "https://example.com",
+  "browser.back": "Back",
+  "browser.forward": "Forward",
+  "browser.reload": "Reload",
+  "browser.openExternal": "Open in system browser",
+  "browser.addressPlaceholder": "Enter a URL",
+  "browser.unavailable": "The integrated browser isn't available here.",
+  "browser.askPrompt": "Open {url} in the integrated browser? (Cancel opens your system browser.)",
 } as const;
 
 /** Union of every message key (drives `t()` and the locale type). */

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -97,6 +97,7 @@ export const es: Record<MessageKey, string> = {
   "terminal.terminal": "Terminal",
   "terminal.chooseProfile": "Elegir un perfil de terminal",
   "terminal.newTerminal": "Nueva terminal",
+  "terminal.newBrowser": "Nueva pestaña de navegador",
   "terminal.unnamedProfile": "Perfil sin nombre",
   "terminal.context":
     "Contexto de terminal activo — elige un proyecto o worktree en el panel izquierdo",
@@ -138,6 +139,9 @@ export const es: Record<MessageKey, string> = {
   "settings.updates": "Actualizaciones",
   "settings.updatesDesc":
     "Elige cómo Uxnan Desktop busca, descarga e instala nuevas versiones.",
+  "settings.browser": "Navegador",
+  "settings.browserDesc":
+    "Un navegador ligero dentro de la app para previsualizar y depurar lo que construyen tus agentes, y abrir los enlaces que crean.",
   "settings.aiCommit": "Mensaje de commit con IA",
   "settings.aiCommitDesc":
     "Redacta opcionalmente mensajes de commit a partir de tus cambios preparados con un agente CLI local. Desactivado por defecto; no se ejecuta nada hasta que lo actives y elijas un agente.",
@@ -598,4 +602,33 @@ export const es: Record<MessageKey, string> = {
   "updates.policyAsk": "Preguntarme",
   "updates.policyWhenIdle": "Automáticamente cuando los agentes estén inactivos",
   "updates.policyManual": "Solo cuando yo lo active",
+
+  // Navegador de desarrollo integrado (Ajustes → Navegador + barra del navegador)
+  "browser.enabled": "Navegador integrado",
+  "browser.enabledDesc":
+    "Si está apagado, todos los enlaces se abren en tu navegador del sistema y los agentes no pueden usar el integrado.",
+  "browser.linkPolicy": "Abrir enlaces",
+  "browser.linkPolicyDesc": "Dónde se abren los enlaces por defecto: en la app o en tu navegador del sistema.",
+  "browser.policyInternal": "En el navegador integrado",
+  "browser.policyInternalDesc": "Abre los enlaces en una pestaña del navegador interno.",
+  "browser.policyExternal": "En mi navegador del sistema",
+  "browser.policyExternalDesc": "Manda siempre los enlaces a tu navegador por defecto (Chrome, Firefox…).",
+  "browser.policyAsk": "Preguntar cada vez",
+  "browser.policyAskDesc": "Elige interno o del sistema en cada enlace.",
+  "browser.allowAgents": "Permitir que los agentes abran enlaces",
+  "browser.allowAgentsDesc":
+    "Los agentes que abran una URL (inicios de sesión, previsualizaciones) caen en el navegador integrado automáticamente.",
+  "browser.terminalLinks": "Enlaces clicables en la terminal",
+  "browser.terminalLinksDesc":
+    "Hace clicables las URLs que se imprimen en la terminal (aplica a nuevas terminales).",
+  "browser.homepage": "Página de inicio",
+  "browser.homepageDesc": "Se abre cuando una pestaña nueva no tiene destino (déjala vacía para ninguna).",
+  "browser.homepagePlaceholder": "https://ejemplo.com",
+  "browser.back": "Atrás",
+  "browser.forward": "Adelante",
+  "browser.reload": "Recargar",
+  "browser.openExternal": "Abrir en el navegador del sistema",
+  "browser.addressPlaceholder": "Escribe una URL",
+  "browser.unavailable": "El navegador integrado no está disponible aquí.",
+  "browser.askPrompt": "¿Abrir {url} en el navegador integrado? (Cancelar abre tu navegador del sistema.)",
 };

--- a/uxnandesktop/src/lib/state/app.svelte.ts
+++ b/uxnandesktop/src/lib/state/app.svelte.ts
@@ -4,14 +4,17 @@
 // of the backend's persisted document. Backend remains authoritative for repos,
 // worktrees and settings on disk; here we hold the live copy the UI binds to.
 
+import { listen } from "@tauri-apps/api/event";
 import {
   getAppState,
   getClaudeHooksStatus,
   getHookInstall,
+  openExternal,
   ping,
   setAgentCommands,
   updateSettings,
 } from "$lib/api";
+import { i18n } from "$lib/i18n";
 import { AGENT_CATALOG, agentLogoKey } from "$lib/agentCatalog";
 import {
   DEFAULT_SETTINGS,
@@ -58,7 +61,8 @@ export type SettingsSection =
   | "aicommit"
   | "hooks"
   | "terminal"
-  | "updates";
+  | "updates"
+  | "browser";
 
 class AppStore {
   /** Registered repositories (and their worktrees). */
@@ -223,6 +227,27 @@ class AppStore {
       // Still hydrate (with the default layout) so terminals render even when
       // the backend is unreachable (e.g. the web preview).
       terminals.restore(null);
+    }
+    // Route URLs the backend decides to open internally to the browser tab
+    // (independent of backend health above; a no-op without the Tauri event bus).
+    void this.listenOpenUrl();
+  }
+
+  /** Route backend `browser:open-url` events to the integrated browser tab. Fired
+   *  by `open_url` (terminal link clicks, the agent `BROWSER` shim). For the `ask`
+   *  policy the user picks in-app vs the OS browser. */
+  private async listenOpenUrl(): Promise<void> {
+    try {
+      await listen<{ url: string; ask: boolean }>("browser:open-url", (e) => {
+        const { url, ask } = e.payload;
+        if (ask && !confirm(i18n.t("browser.askPrompt", { url }))) {
+          void openExternal(url).catch(() => {});
+          return;
+        }
+        terminals.showUrl(url);
+      });
+    } catch {
+      // No Tauri event bus (web preview) — nothing to route.
     }
   }
 

--- a/uxnandesktop/src/lib/state/terminals.svelte.ts
+++ b/uxnandesktop/src/lib/state/terminals.svelte.ts
@@ -93,7 +93,26 @@ export interface CommitTab extends BaseTab {
   subject: string;
 }
 
-export type GroupTab = TerminalTab | FileTab | DiffTab | CommitTab;
+/** An integrated developer-browser tab. Hosts a native child webview (managed by
+ *  the Rust `browser_*` commands) positioned over this tab's region; `url` is the
+ *  target / current address. Transient — never serialized (the webview spawns
+ *  lazily on open and is destroyed on close, so nothing reopens on restart). */
+export interface BrowserTab extends BaseTab {
+  kind: "browser";
+  /** Target URL (updated as the user/agent navigates). */
+  url: string;
+}
+
+export type GroupTab = TerminalTab | FileTab | DiffTab | CommitTab | BrowserTab;
+
+/** A readable tab title from a URL (its hostname), falling back to "Browser". */
+function browserTitle(url: string): string {
+  try {
+    return new URL(url).hostname || "Browser";
+  } catch {
+    return "Browser";
+  }
+}
 
 /** A region: a tab strip over one-or-more terminals. */
 export interface TabGroup {
@@ -277,13 +296,15 @@ export function computeAreaLayout(root: AreaNode): {
 
 // --- Persistence (structure only; fresh shells spawn on restore) ----------
 
-/** Drop **diff** and **commit** tabs from a cloned tree (both transient — never
- *  persisted) and collapse any region/split left empty, so serialization only
- *  ever sees terminal + file tabs in non-empty groups. Returns null when nothing
- *  remains. */
+/** Drop **diff**, **commit** and **browser** tabs from a cloned tree (all
+ *  transient — never persisted) and collapse any region/split left empty, so
+ *  serialization only ever sees terminal + file tabs in non-empty groups. Returns
+ *  null when nothing remains. */
 function pruneDiffs(node: AreaNode): AreaNode | null {
   if (node.kind === "group") {
-    const tabs = node.tabs.filter((t) => t.kind !== "diff" && t.kind !== "commit");
+    const tabs = node.tabs.filter(
+      (t) => t.kind !== "diff" && t.kind !== "commit" && t.kind !== "browser",
+    );
     if (tabs.length === 0) return null;
     const activeTabId = tabs.some((t) => t.id === node.activeTabId)
       ? node.activeTabId
@@ -684,6 +705,34 @@ class TerminalStore {
     this.commitStates.set(id, new CommitViewerState(worktree, hash, subject));
     this.insertTab(tab, opts?.groupId);
     return id;
+  }
+
+  /** Open a new integrated-browser tab at `url` (focus + insert). The native
+   *  webview is created lazily by `BrowserPane` once the tab mounts. */
+  openBrowser(url: string, opts?: { workspace?: string; groupId?: string }): string {
+    if (opts?.workspace !== undefined) this.setWorkspace(opts.workspace);
+    const id = crypto.randomUUID();
+    const tab: BrowserTab = { kind: "browser", id, title: browserTitle(url), url };
+    this.insertTab(tab, opts?.groupId);
+    return id;
+  }
+
+  /** Route a URL to the integrated browser: if the active tab is already a browser,
+   *  navigate it in place (no tab explosion from chatty agents); otherwise open a
+   *  new browser tab. Returns the tab id. */
+  showUrl(url: string): string {
+    const root = this.root;
+    if (root) {
+      const group = findGroup(root, this.activeGroupId) ?? firstGroup(root);
+      const active = group?.tabs.find((t) => t.id === group.activeTabId);
+      if (active?.kind === "browser") {
+        active.url = url;
+        active.title = browserTitle(url);
+        this.setActiveTab(group.id, active.id);
+        return active.id;
+      }
+    }
+    return this.openBrowser(url);
   }
 
   /** The live editor state for a file tab (undefined for other kinds). */

--- a/uxnandesktop/src/lib/types.ts
+++ b/uxnandesktop/src/lib/types.ts
@@ -102,6 +102,27 @@ export interface AppSettings {
   aiCommit?: AiCommitSettings;
   /** In-app auto-updater (Settings → Updates). */
   updater?: UpdaterSettings;
+  /** Integrated developer browser (Settings → Browser). */
+  browser?: BrowserSettings;
+}
+
+/** Where a link opens when the integrated browser is enabled (mirror of Rust
+ *  `BrowserLinkPolicy`). `internal` uses the in-app tab; `external` hands off to
+ *  the OS browser; `ask` prompts per link. */
+export type BrowserLinkPolicy = "internal" | "external" | "ask";
+
+/** Integrated developer-browser preferences (mirror of Rust `BrowserSettings`). */
+export interface BrowserSettings {
+  /** Master switch. Off → every link goes to the OS browser, no agent shim. */
+  enabled: boolean;
+  /** Where links open by default. Default `internal`. */
+  linkPolicy: BrowserLinkPolicy;
+  /** Let agents open URLs in the integrated browser (inject a `BROWSER` shim). */
+  allowAgents: boolean;
+  /** Make URLs printed in the terminal clickable (routed through `linkPolicy`). */
+  terminalLinks: boolean;
+  /** Page opened when a fresh browser tab has no target URL. Empty = blank. */
+  homepage: string;
 }
 
 /** Release channel the updater follows (mirror of Rust `UpdateChannel`). Mapped
@@ -485,5 +506,12 @@ export const DEFAULT_SETTINGS: AppSettings = {
     channel: "stable",
     autoDownload: true,
     installPolicy: "ask",
+  },
+  browser: {
+    enabled: true,
+    linkPolicy: "internal",
+    allowAgents: true,
+    terminalLinks: true,
+    homepage: "",
   },
 };

--- a/uxnandesktop/static/hooks/uxnan-browser.cmd
+++ b/uxnandesktop/static/hooks/uxnan-browser.cmd
@@ -1,0 +1,13 @@
+@echo off
+rem uxnan integrated-browser shim (Windows).
+rem
+rem Tools that honor %BROWSER% invoke this as `uxnan-browser <url>`. We forward the
+rem URL to the ADE's local browser endpoint so it opens in the in-app developer
+rem browser, honoring the user's link policy. Best-effort + silent (curl ships with
+rem Windows 10+); on any failure we exit cleanly so the calling tool isn't disrupted.
+setlocal
+set "URL=%~1"
+if "%URL%"=="" exit /b 0
+if "%UXNAN_BROWSER_URL%"=="" exit /b 0
+curl -s -m 3 -X POST "%UXNAN_BROWSER_URL%" -H "Content-Type: application/json" -H "X-Uxnan-Token: %UXNAN_BROWSER_TOKEN%" --data-raw "{\"url\":\"%URL%\"}" >nul 2>&1
+exit /b 0

--- a/uxnandesktop/static/hooks/uxnan-browser.sh
+++ b/uxnandesktop/static/hooks/uxnan-browser.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# uxnan integrated-browser shim (Unix / Git Bash / WSL).
+#
+# Tools that honor the `$BROWSER` convention invoke this as `uxnan-browser <url>`.
+# We forward the URL to the ADE's local browser endpoint so it opens in the in-app
+# developer browser, honoring the user's link policy. Best-effort and silent: if
+# the ADE isn't reachable (or curl is missing), just exit cleanly so the calling
+# tool isn't disrupted.
+url="$1"
+[ -n "$url" ] || exit 0
+if [ -n "$UXNAN_BROWSER_URL" ] && command -v curl >/dev/null 2>&1; then
+  curl -s -m 3 -X POST "$UXNAN_BROWSER_URL" \
+    -H 'Content-Type: application/json' \
+    -H "X-Uxnan-Token: $UXNAN_BROWSER_TOKEN" \
+    --data-raw "{\"url\":\"$url\"}" >/dev/null 2>&1 || true
+fi
+exit 0


### PR DESCRIPTION
## What

A lightweight **in-app developer browser** for uxnandesktop: a new `browser` center tab to preview/debug what agents build and open the links they create. Not a general-purpose browser.

## How it works

- **Rendered with a DOM `<iframe>`** (`BrowserPane.svelte`) — a real center tab that composes with the layout, **can't freeze the app** or paint over menus, and is light (just another browsing context in the webview the app already runs). Chrome: back/forward (own URL stack) · reload · address bar · open-in-system-browser. Open one from the center **"+" → New browser tab** or let a link route into it. The tab is transient (never serialized).
  - *Trade-off:* sites that refuse embedding (`X-Frame-Options` / `frame-ancestors`, e.g. Google) render blank → the toolbar's **open in system browser** covers them; `localhost` dev servers work fine.
- **One link-routing decision point** (`open_url` → `browser::route_url`): every link honors the user's policy — in-app tab (`browser:open-url`) / OS browser (`open_external`) / per-link prompt. A disabled browser always goes external.
- **`BrowserSettings`** persisted (enable · linkPolicy · allowAgents · terminalLinks · homepage; all `#[serde(default)]`) with a **Settings → Browser** pane + EN/ES i18n.
- **Agents open links in-app automatically** (gated on `enabled && allowAgents`): each agent terminal gets `UXNAN_BROWSER_URL` + `_TOKEN` and a `$BROWSER` shim (`static/hooks/uxnan-browser.{sh,cmd}`); the shim POSTs to the hook server's new `/browser` route, which applies the policy. Agents can also POST it explicitly.
- **Ctrl/Cmd-click** a URL in the terminal to open it (plain click = text, like VS Code) via `@xterm/addon-web-links`.

### Design note
The first cut used a native child webview (Tauri `unstable` multiwebview); on Windows it froze the app (`add_child` blocked the main thread), so it was dropped for the iframe. The `unstable`/`devtools` Tauri features were reverted too.

## Validation

Full local CI gate (matches `ci-desktop.yml`): `cargo fmt --check` ✓ · `cargo clippy --all-targets -D warnings` ✓ · `cargo test` (**104 passed**) ✓ · `npm run check` (svelte-check 0/0) ✓ · `vite build` ✓. Verified on device by the maintainer (browse, navigate, Ctrl/Cmd-click, external fallback). **Still pending:** on-device test of the agent `$BROWSER` shim end-to-end (the explicit `curl` path is the reliable fallback meanwhile).

## Docs
CHANGELOG `[Unreleased]`, `README.md`, `docs/browser.md`, `architecture/02a §4.2b`, `FOR-DEV.md`.

Please do **not** merge yet — awaiting review + CI.