### PR TITLE
feat(desktop): two-step add-project with sub-folder selection + picker keyboard fixes

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,34 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — add several projects at once (parent vs. sub-folders) + reliable picker keyboard nav
+- **New two-step "Add project" flow.** The directory picker's primary
+  **"Add this folder"** now opens a second dialog (`AddProjectDialog.svelte`)
+  where you choose to add **this folder as one project** or **tick sub-folders to
+  add each as its own project** — repos are pre-checked, a select-all toggles the
+  lot, and only the ticked folders (repos **and** non-repos alike) are added.
+  When the browsed folder has no sub-folders, the primary action still adds it
+  directly (no empty dialog). Backed by a new `projects.addProjectPaths()` that
+  adds in order, skips failures, and toasts a summary (`toast.projectsAdded` /
+  `toast.projectsAddedSome`).
+- **The picker keeps its per-folder Add and gains an informational note.** Each
+  listed folder still has its own hover **Add** for one-off registration; when git
+  repos are detected among the children, a quiet banner notes it (no action of its
+  own — the choice lives in the new dialog).
+- **Keyboard navigation in the picker is fixed.** Arrow-key navigation is now
+  handled at the dialog level (not only the path field), so **↑/↓ keep working
+  regardless of which control has focus** — and the highlighted row now scrolls
+  into view, so selection no longer runs off-screen and appears to stall. Added
+  **`Ctrl/⌘+Enter`** to trigger the primary "Add this folder" action from the
+  keyboard.
+- **New `Checkbox` UI primitive** (`components/ui/checkbox`, bits-ui + lucide),
+  matching the existing shadcn-svelte components.
+- **Files:** `AddProjectDialog.svelte` (new), `components/ui/checkbox/*` (new),
+  `DirectoryPicker.svelte` (note banner, second-dialog trigger, dialog-level key
+  handling, scroll-into-view, `autocomplete="off"`), `state/projects.svelte.ts`
+  (`addProjectPaths`), EN/ES i18n (`picker.bulkHint`, `picker.hintAdd`,
+  `addProject.*`, `toast.projectsAdded*`).
+
 ## [0.0.5-alpha.20260703] - 2026-07-03
 
 ### Fixed — blank white screen on startup (0.0.4 regression)

--- a/uxnandesktop/src/lib/components/AddProjectDialog.svelte
+++ b/uxnandesktop/src/lib/components/AddProjectDialog.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  // Second step of "Add project": once the user picks a folder in the directory
+  // picker, this dialog lets them either add that folder itself as a single
+  // project, or tick sub-folders to add each as its own project. Repos are
+  // pre-checked for convenience; both actions live in the footer.
+  import * as Dialog from "$lib/components/ui/dialog";
+  import { Button } from "$lib/components/ui/button";
+  import { Checkbox } from "$lib/components/ui/checkbox";
+  import Kbd from "./Kbd.svelte";
+  import { projects } from "$lib/state/projects.svelte";
+  import { cn } from "$lib/utils";
+  import { icon, text } from "$lib/design";
+  import { i18n } from "$lib/i18n";
+  import type { DirEntry } from "$lib/types";
+  import FolderIcon from "@lucide/svelte/icons/folder";
+  import FolderGitIcon from "@lucide/svelte/icons/folder-git-2";
+
+  let {
+    open = $bindable(false),
+    folderPath,
+    folderName,
+    entries = [],
+    onadded,
+  }: {
+    open?: boolean;
+    folderPath: string;
+    folderName: string;
+    entries?: DirEntry[];
+    /** Called after at least one project was added, so the caller can close the
+     *  underlying picker too. */
+    onadded?: () => void;
+  } = $props();
+
+  /** Paths ticked to be added as separate projects. */
+  let selected = $state<Set<string>>(new Set());
+  let busy = $state(false);
+  let error = $state<string | null>(null);
+
+  // Seed the selection each time the dialog opens: pre-check the git repos (the
+  // folders most likely meant as separate projects), leave plain folders to the
+  // user. Clear transient state on close.
+  $effect(() => {
+    if (open) {
+      selected = new Set(entries.filter((e) => e.isRepo).map((e) => e.path));
+      error = null;
+      busy = false;
+    }
+  });
+
+  const selectedCount = $derived(selected.size);
+  const allSelected = $derived(entries.length > 0 && selected.size === entries.length);
+  const someSelected = $derived(selected.size > 0 && selected.size < entries.length);
+
+  function toggle(path: string) {
+    const next = new Set(selected);
+    if (next.has(path)) next.delete(path);
+    else next.add(path);
+    selected = next;
+  }
+
+  function toggleAll() {
+    selected = allSelected ? new Set() : new Set(entries.map((e) => e.path));
+  }
+
+  async function addParent() {
+    busy = true;
+    error = null;
+    const ok = await projects.addProjectPath(folderPath);
+    busy = false;
+    if (ok) {
+      open = false;
+      onadded?.();
+    } else {
+      error = projects.error;
+    }
+  }
+
+  async function addSelected() {
+    if (selectedCount === 0) return;
+    busy = true;
+    error = null;
+    // Preserve the listing order for a predictable result.
+    const paths = entries.filter((e) => selected.has(e.path)).map((e) => e.path);
+    const { added } = await projects.addProjectPaths(paths);
+    busy = false;
+    if (added > 0) {
+      open = false;
+      onadded?.();
+    } else {
+      error = projects.error;
+    }
+  }
+</script>
+
+<Dialog.Root bind:open>
+  <Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-[560px]">
+    <!-- Header: what we're adding and where. -->
+    <div class="flex flex-col gap-1 border-b border-border/60 px-4 pb-3 pt-4 pr-10">
+      <Dialog.Title class="text-[15px] font-semibold leading-none">{i18n.t("addProject.title")}</Dialog.Title>
+      <Dialog.Description class={cn(text.meta, "truncate")} title={folderPath}>
+        {i18n.t("addProject.desc", { folder: folderName })}
+      </Dialog.Description>
+    </div>
+
+    {#if entries.length > 0}
+      <!-- Select-all header for the sub-folder list. -->
+      <div class="flex items-center gap-2.5 border-b border-border/60 px-4 py-2.5">
+        <button
+          type="button"
+          role="checkbox"
+          aria-checked={allSelected}
+          aria-label={i18n.t("addProject.selectAll")}
+          class="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+          onclick={toggleAll}
+        >
+          <Checkbox
+            checked={allSelected}
+            indeterminate={someSelected}
+            tabindex={-1}
+            class="pointer-events-none"
+          />
+          <span class={cn(text.meta, "truncate")}>
+            {i18n.t("addProject.subfolders", { count: String(entries.length) })}
+          </span>
+        </button>
+        <span class={cn(text.meta, "shrink-0")}>
+          {i18n.t("addProject.selectedCount", { count: String(selectedCount) })}
+        </span>
+      </div>
+
+      <!-- Tickable sub-folders. Clicking a row toggles its checkbox; repos carry
+           the same git glyph + tag as the picker so the two read coherently. -->
+      <div class="uxnan-scroll max-h-64 overflow-y-auto p-2">
+        {#each entries as entry (entry.path)}
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked={selected.has(entry.path)}
+            class="group flex h-9 w-full items-center gap-2.5 rounded-md px-2 text-left hover:bg-accent/50"
+            onclick={() => toggle(entry.path)}
+          >
+            <!-- Display-only: the whole row is the click target, so the checkbox
+                 itself must not capture clicks (that would double-toggle). -->
+            <Checkbox checked={selected.has(entry.path)} tabindex={-1} class="pointer-events-none" />
+            {#if entry.isRepo}
+              <FolderGitIcon class={cn(icon.button, "shrink-0 text-primary")} />
+            {:else}
+              <FolderIcon class={cn(icon.button, "shrink-0 text-muted-foreground/80")} />
+            {/if}
+            <span class={cn(text.body, "min-w-0 flex-1 truncate")}>{entry.name}</span>
+            {#if entry.isRepo}
+              <span
+                class="shrink-0 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary"
+              >
+                {i18n.t("picker.repoBadge")}
+              </span>
+            {/if}
+          </button>
+        {/each}
+      </div>
+    {:else}
+      <div class="flex flex-col items-center gap-2.5 px-4 py-10 text-center">
+        <FolderIcon class="size-6 text-muted-foreground/40" />
+        <p class={text.meta}>{i18n.t("addProject.noSubfolders")}</p>
+      </div>
+    {/if}
+
+    {#if error}
+      <div class="border-t border-border/60 bg-destructive/10 px-4 py-2 text-xs text-destructive">
+        {error}
+      </div>
+    {/if}
+
+    <!-- Footer: add just this folder, or add the ticked sub-folders (Esc / the
+         top-right ✕ dismiss). The action group stays put (shrink-0); the hint
+         text shrinks first. -->
+    <div class="flex min-w-0 items-center justify-between gap-3 border-t border-border/60 bg-muted/30 px-4 py-2.5">
+      <div class="hidden min-w-0 flex-1 items-center gap-4 overflow-hidden text-[11px] text-muted-foreground sm:flex">
+        <span class="flex shrink-0 items-center gap-1.5">
+          <Kbd>Esc</Kbd>{i18n.t("palette.hintExit")}
+        </span>
+      </div>
+      <div class="flex shrink-0 items-center gap-2">
+        <Button variant="outline" size="sm" disabled={busy} onclick={addParent}>
+          {i18n.t("addProject.addParent")}
+        </Button>
+        <Button size="sm" disabled={busy || selectedCount === 0} onclick={addSelected}>
+          {busy
+            ? i18n.t("common.adding")
+            : i18n.t("addProject.addSelected", { count: String(selectedCount) })}
+        </Button>
+      </div>
+    </div>
+  </Dialog.Content>
+</Dialog.Root>

--- a/uxnandesktop/src/lib/components/DirectoryPicker.svelte
+++ b/uxnandesktop/src/lib/components/DirectoryPicker.svelte
@@ -7,11 +7,14 @@
   import { cn } from "$lib/utils";
   import { icon, text } from "$lib/design";
   import { i18n } from "$lib/i18n";
-  import DialogHints from "./DialogHints.svelte";
+  import { isMac } from "$lib/keybindings";
+  import Kbd from "./Kbd.svelte";
+  import AddProjectDialog from "./AddProjectDialog.svelte";
   import type { DirListing } from "$lib/types";
   import FolderIcon from "@lucide/svelte/icons/folder";
   import FolderGitIcon from "@lucide/svelte/icons/folder-git-2";
   import CornerLeftUpIcon from "@lucide/svelte/icons/corner-left-up";
+  import LayersIcon from "@lucide/svelte/icons/layers";
 
   let { open = $bindable(false) }: { open?: boolean } = $props();
 
@@ -22,6 +25,20 @@
   let busy = $state(false);
   /** Highlighted sub-folder index, for keyboard navigation. */
   let activeIdx = $state(0);
+  /** The scroll region, so the active row can be kept in view. */
+  let listEl = $state<HTMLDivElement | null>(null);
+  /** Whether the add-project selection dialog (parent vs. sub-folders) is open. */
+  let selectOpen = $state(false);
+
+  /** Child folders that are git repos — when any exist, we surface a note that
+   *  this folder likely holds several projects (they can be added separately). */
+  const repoChildCount = $derived(
+    listing?.entries.filter((e) => e.isRepo).length ?? 0,
+  );
+  const hasRepoChildren = $derived(repoChildCount > 0);
+
+  const baseName = (p: string) =>
+    p.replace(/[\\/]+$/, "").split(/[\\/]/).pop() ?? p;
 
   const msg = (e: unknown) =>
     e && typeof e === "object" && "message" in e
@@ -48,10 +65,29 @@
     if (activeIdx >= n) activeIdx = Math.max(0, n - 1);
   });
 
-  /** Arrow/Enter navigation from the path field: ↑/↓ move the highlight, Enter
-   *  opens the highlighted folder (or goes to a typed path when it was edited). */
-  function onNavKey(e: KeyboardEvent) {
+  // Keep the highlighted row scrolled into view as the selection moves by
+  // keyboard, so navigation never runs "off screen" and appears to stall.
+  $effect(() => {
+    void activeIdx;
+    listEl
+      ?.querySelector('[data-active="true"]')
+      ?.scrollIntoView({ block: "nearest" });
+  });
+
+  /** Keyboard handling for the whole dialog (attached to the content, so arrows
+   *  keep working no matter which control holds focus — not just the path field):
+   *  ↑/↓ move the highlight, Enter opens the highlighted folder (or a typed path),
+   *  Mod+Enter runs the primary "add this folder" action. */
+  function onDialogKey(e: KeyboardEvent) {
+    if (busy || loading) return;
     const entries = listing?.entries ?? [];
+    const mod = e.metaKey || e.ctrlKey;
+
+    if (mod && e.key === "Enter") {
+      e.preventDefault();
+      addFolder();
+      return;
+    }
     if (e.key === "ArrowDown") {
       e.preventDefault();
       activeIdx = Math.min(entries.length - 1, activeIdx + 1);
@@ -59,6 +95,10 @@
       e.preventDefault();
       activeIdx = Math.max(0, activeIdx - 1);
     } else if (e.key === "Enter") {
+      // Enter submits from the path field (typed path or highlighted folder);
+      // from a button it stays a plain click, so don't hijack it there.
+      const el = e.target as HTMLElement | null;
+      if (el?.tagName === "BUTTON") return;
       e.preventDefault();
       const typed = pathInput.trim();
       if (typed && typed !== listing?.path) void go(typed);
@@ -77,6 +117,7 @@
     }
   });
 
+  /** Add a single folder as a project (the per-row "Add" action). */
   async function add(path: string) {
     busy = true;
     const ok = await projects.addProjectPath(path);
@@ -84,13 +125,22 @@
     if (ok) open = false;
     else error = projects.error;
   }
+
+  /** Primary action ("Add this folder"): with sub-folders present, open the
+   *  selection dialog so the user can add this folder OR pick sub-folders to add
+   *  separately; with none, just add the folder directly. */
+  function addFolder() {
+    if (!listing) return;
+    if (listing.entries.length === 0) void add(listing.path);
+    else selectOpen = true;
+  }
 </script>
 
 <Dialog.Root bind:open>
   <!-- Same shell as the quick-switch palette: overflow-hidden + p-0 so the
        rounded card clips every section (the scroll list and its scrollbar
        included) and nothing bleeds past the frame; each section owns its px-4. -->
-  <Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-[560px]">
+  <Dialog.Content class="gap-0 overflow-hidden p-0 sm:max-w-[560px]" onkeydown={onDialogKey}>
     <!-- Header -->
     <div class="flex flex-col gap-1 border-b border-border/60 px-4 pb-3 pt-4 pr-10">
       <Dialog.Title class="text-[15px] font-semibold leading-none">{i18n.t("picker.title")}</Dialog.Title>
@@ -119,14 +169,26 @@
           placeholder={i18n.t("picker.pathPlaceholder")}
           bind:value={pathInput}
           spellcheck={false}
-          onkeydown={onNavKey}
+          autocomplete="off"
         />
       </div>
     </div>
 
+    <!-- Note (informational only): when child git repos are detected here, hint
+         that "Add this folder" lets you add them separately. No action of its
+         own — the choice happens in the add-project dialog. -->
+    {#if hasRepoChildren}
+      <div class="flex items-center gap-3 border-b border-border/60 bg-primary/5 px-4 py-2.5">
+        <LayersIcon class={cn(icon.button, "shrink-0 text-primary")} />
+        <p class="min-w-0 flex-1 text-xs text-muted-foreground">
+          {i18n.t("picker.bulkHint", { repos: String(repoChildCount) })}
+        </p>
+      </div>
+    {/if}
+
     <!-- Sub-folders scroll region. Each row is a folder glyph + name; repos are
          flagged with a git-folder icon and a quiet primary tag, plus a hover Add. -->
-    <div class="uxnan-scroll h-64 overflow-y-auto p-2">
+    <div bind:this={listEl} class="uxnan-scroll h-64 overflow-y-auto p-2">
       {#if loading}
         <div class={cn("py-10 text-center", text.meta)}>{i18n.t("common.loading")}</div>
       {:else if listing && listing.entries.length === 0}
@@ -137,6 +199,7 @@
       {:else if listing}
         {#each listing.entries as entry, i (entry.path)}
           <div
+            data-active={i === activeIdx}
             class={cn(
               "group flex h-9 items-center gap-2.5 rounded-md px-2",
               i === activeIdx ? "bg-accent" : "hover:bg-accent/50",
@@ -183,17 +246,44 @@
       </div>
     {/if}
 
-    <!-- Footer: hints + cancel / add, on a quiet band with a top hairline. -->
+    <!-- Footer: hints + cancel / add, on a quiet band with a top hairline. The
+         hint group shrinks and clips first (min-w-0 + overflow-hidden) so it can
+         never force the dialog wider than its max width; the actions stay put. -->
     <div
-      class="flex items-center justify-between gap-2 border-t border-border/60 bg-muted/30 px-4 py-2.5"
+      class="flex min-w-0 items-center justify-between gap-3 border-t border-border/60 bg-muted/30 px-4 py-2.5"
     >
-      <DialogHints class="hidden sm:flex" />
-      <div class="flex items-center gap-2">
-        <Button variant="ghost" size="sm" onclick={() => (open = false)}>{i18n.t("common.cancel")}</Button>
-        <Button size="sm" disabled={!listing || busy} onclick={() => listing && add(listing.path)}>
+      <div
+        class="hidden min-w-0 flex-1 items-center gap-4 overflow-hidden text-[11px] text-muted-foreground sm:flex"
+      >
+        <span class="flex shrink-0 items-center gap-1.5">
+          <span class="flex items-center gap-1"><Kbd>↑</Kbd><Kbd>↓</Kbd></span>
+          {i18n.t("palette.hintNavigate")}
+        </span>
+        <span class="flex shrink-0 items-center gap-1.5">
+          <span class="flex items-center gap-1"><Kbd>{isMac ? "⌘" : "Ctrl"}</Kbd><Kbd>↵</Kbd></span>
+          {i18n.t("picker.hintAdd")}
+        </span>
+        <span class="flex shrink-0 items-center gap-1.5">
+          <Kbd>Esc</Kbd>{i18n.t("palette.hintExit")}
+        </span>
+      </div>
+      <div class="flex shrink-0 items-center gap-2">
+        <Button size="sm" disabled={!listing || busy} onclick={addFolder}>
           {busy ? i18n.t("common.adding") : i18n.t("picker.addFolder")}
         </Button>
       </div>
     </div>
   </Dialog.Content>
 </Dialog.Root>
+
+<!-- Step 2: choose to add this folder as one project, or tick sub-folders to add
+     each separately. On success it closes the picker too. -->
+{#if listing}
+  <AddProjectDialog
+    bind:open={selectOpen}
+    folderPath={listing.path}
+    folderName={baseName(listing.path)}
+    entries={listing.entries}
+    onadded={() => (open = false)}
+  />
+{/if}

--- a/uxnandesktop/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/uxnandesktop/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { Checkbox as CheckboxPrimitive } from "bits-ui";
+	import CheckIcon from "@lucide/svelte/icons/check";
+	import MinusIcon from "@lucide/svelte/icons/minus";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
+</script>
+
+<CheckboxPrimitive.Root
+	bind:ref
+	data-slot="checkbox"
+	class={cn(
+		"peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:checked
+	bind:indeterminate
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<span
+			data-slot="checkbox-indicator"
+			class="flex size-full items-center justify-center text-current transition-none"
+		>
+			{#if indeterminate}
+				<MinusIcon class="size-3.5" />
+			{:else if checked}
+				<CheckIcon class="size-3.5" />
+			{/if}
+		</span>
+	{/snippet}
+</CheckboxPrimitive.Root>

--- a/uxnandesktop/src/lib/components/ui/checkbox/index.ts
+++ b/uxnandesktop/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,7 @@
+import Root from "./checkbox.svelte";
+
+export {
+	Root,
+	//
+	Root as Checkbox,
+};

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -15,6 +15,8 @@ export const en = {
   "toast.worktreeRemovedSquash": "Worktree removed · squash-merged branch cleaned up",
   "toast.aiCommitGenerated": "Commit message drafted",
   "toast.projectRemoved": "Project removed",
+  "toast.projectsAdded": "Added {added} projects",
+  "toast.projectsAddedSome": "Added {added} projects · {failed} skipped",
   "toast.agent": "Agent",
   "toast.agentDone": "{name} finished",
   "toast.agentBlocked": "{name} is blocked",
@@ -159,6 +161,19 @@ export const en = {
   "picker.open": "Open {name}",
   "picker.addFolder": "Add this folder",
   "picker.repoBadge": "repo",
+  "picker.bulkHint":
+    "{repos} git repos detected here — “Add this folder” lets you add them as separate projects.",
+  "picker.hintAdd": "Add folder",
+
+  // Add-project selection dialog (parent vs. sub-folders)
+  "addProject.title": "Add project",
+  "addProject.desc": "How do you want to add “{folder}”?",
+  "addProject.selectAll": "Select all sub-folders",
+  "addProject.subfolders": "Sub-folders ({count})",
+  "addProject.selectedCount": "{count} selected",
+  "addProject.noSubfolders": "This folder has no sub-folders.",
+  "addProject.addParent": "Add this folder",
+  "addProject.addSelected": "Add {count} separately",
 
   // Settings
   "settings.title": "Settings",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -12,6 +12,8 @@ export const es: Record<MessageKey, string> = {
   "toast.worktreeRemovedSquash": "Worktree eliminado · rama squash-merged depurada",
   "toast.aiCommitGenerated": "Mensaje de commit redactado",
   "toast.projectRemoved": "Proyecto eliminado",
+  "toast.projectsAdded": "Se agregaron {added} proyectos",
+  "toast.projectsAddedSome": "Se agregaron {added} proyectos · {failed} omitidos",
   "toast.agent": "Agente",
   "toast.agentDone": "{name} terminó",
   "toast.agentBlocked": "{name} está bloqueado",
@@ -156,6 +158,19 @@ export const es: Record<MessageKey, string> = {
   "picker.open": "Abrir {name}",
   "picker.addFolder": "Agregar esta carpeta",
   "picker.repoBadge": "repo",
+  "picker.bulkHint":
+    "Se detectaron {repos} repos git aquí — con «Agregar esta carpeta» puedes agregarlos como proyectos separados.",
+  "picker.hintAdd": "Agregar carpeta",
+
+  // Diálogo de selección al agregar proyecto (carpeta padre vs. subcarpetas)
+  "addProject.title": "Agregar proyecto",
+  "addProject.desc": "¿Cómo quieres agregar «{folder}»?",
+  "addProject.selectAll": "Seleccionar todas las subcarpetas",
+  "addProject.subfolders": "Subcarpetas ({count})",
+  "addProject.selectedCount": "{count} seleccionadas",
+  "addProject.noSubfolders": "Esta carpeta no tiene subcarpetas.",
+  "addProject.addParent": "Agregar esta carpeta",
+  "addProject.addSelected": "Agregar {count} por separado",
 
   // Settings
   "settings.title": "Configuración",

--- a/uxnandesktop/src/lib/state/projects.svelte.ts
+++ b/uxnandesktop/src/lib/state/projects.svelte.ts
@@ -221,8 +221,9 @@ class ProjectsStore {
     return branchList(repoId);
   }
 
-  /** Register a git repository by path (from the in-app directory picker).
-   *  Returns false (with `error` set) when the path isn't a git repo. */
+  /** Register a project folder by path (from the in-app directory picker). Any
+   *  folder works — git or not; a non-git one simply has no worktrees. Returns
+   *  false (with `error` set) when the path can't be registered. */
   async addProjectPath(path: string): Promise<boolean> {
     this.error = null;
     try {
@@ -234,6 +235,40 @@ class ProjectsStore {
       this.error = msg(e);
       return false;
     }
+  }
+
+  /** Register several project folders at once (the picker's "add all separately"
+   *  action, one project per child folder). Adds them in order, skips ones that
+   *  fail, and returns how many were added / failed; `error` is set only when
+   *  every path failed. */
+  async addProjectPaths(
+    paths: string[],
+  ): Promise<{ added: number; failed: number }> {
+    this.error = null;
+    let added = 0;
+    let failed = 0;
+    let lastError: string | null = null;
+    for (const path of paths) {
+      try {
+        const repo = await repoAdd(path);
+        if (!app.repos.find((r) => r.id === repo.id)) app.repos.push(repo);
+        await this.loadWorktrees(repo.id);
+        added += 1;
+      } catch (e) {
+        failed += 1;
+        lastError = msg(e);
+      }
+    }
+    if (added === 0 && lastError) this.error = lastError;
+    if (added > 0) {
+      toast.success(
+        i18n.t(
+          failed > 0 ? "toast.projectsAddedSome" : "toast.projectsAdded",
+          { added: String(added), failed: String(failed) },
+        ),
+      );
+    }
+    return { added, failed };
   }
 
   async removeProject(id: string): Promise<void> {


### PR DESCRIPTION
## Summary

Reworks the desktop ADE's **"Add project"** flow so a folder holding several
repos can be onboarded in one pass, and fixes the picker's keyboard navigation.

### Two-step add-project
- The directory picker's primary **"Add this folder"** now opens a second dialog
  (`AddProjectDialog.svelte`) where you either:
  - **add this folder as one project**, or
  - **tick sub-folders** to add each as its own project — repos are pre-checked,
    a select-all toggles the lot, and both repos and non-repos can be selected.
- Folders with **no sub-folders** skip the dialog and add directly.
- Backed by a new `projects.addProjectPaths()` that adds in order, skips failures,
  and toasts a summary (`toast.projectsAdded` / `toast.projectsAddedSome`).
- The picker keeps each folder's per-row **Add** and shows a quiet informational
  note when child git repos are detected (no action of its own).

### Picker keyboard fixes
- Arrow navigation moved to the **dialog level** so ↑/↓ keep working regardless of
  which control holds focus (previously stopped after the first keypress).
- The highlighted row now **scrolls into view**.
- **Ctrl/⌘+Enter** runs the primary "Add this folder" action; `autocomplete="off"`
  on the path field so the WebView doesn't hijack the arrows.

### UI cleanup
- Removed the redundant **Cancel** button from both dialogs (the top-right ✕ and
  **Esc** dismiss them) and restored the **Esc** hint.
- New **`Checkbox`** UI primitive (`components/ui/checkbox`, bits-ui + lucide,
  shadcn-svelte style).

## Files
- `AddProjectDialog.svelte` (new), `components/ui/checkbox/*` (new)
- `DirectoryPicker.svelte`, `state/projects.svelte.ts`
- EN/ES i18n (`picker.*`, `addProject.*`, `toast.projectsAdded*`)
- `CHANGELOG.md`

## Verification
- `npm run check` → **0 errors / 0 warnings**
- `npm run build` → green
- Reviewed on-device iteratively (banner, checkboxes, footer balance, kbd hints).

> Note: UI-only change; no Rust/contract changes. `repo_add` already accepts
> non-git folders, so no backend work was required.
