### PR TITLE
feat(desktop): gate "new worktree" to git repos + drop redundant launcher cancel

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -20,6 +20,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   `requestNewWorktree`), `TerminalArea.svelte` (git-gated empty-state button +
   tab-strip menu + hint), EN/ES i18n (`terminal.worktreeNeedsGitRepo`).
 
+### Removed — redundant Cancel button in the project launcher dialog
+- **Removed the redundant Cancel button from the project launcher dialog**
+  (`LauncherDialog`) — the top-right ✕ and Esc already dismiss it, matching the
+  add-project dialogs.
+- **Files:** `LauncherDialog.svelte`.
+
 ## [0.0.5-alpha.20260703] - 2026-07-03
 
 ### Fixed — blank white screen on startup (0.0.4 regression)

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Changed — "New worktree" is gated to git repos, not just the Global space
+- **"New worktree" affordances are now disabled for non-git project folders.**
+  Worktrees need a git repo, so for a registered folder that isn't one:
+  - the center empty-state **"New worktree"** button renders disabled (with a
+    tooltip explaining the folder isn't a git repo);
+  - the center tab-strip **"+"** launcher menu omits its **New worktree** option
+    (terminals / agents / browser stay available);
+  - the `newWorktree` keyboard shortcut and its empty-state hint are inert.
+  Backed by a new `projects.activeGitRepo` getter (the active repo only when
+  `isGit !== false`); `requestNewWorktree()` now checks it. The project card's
+  launcher dialog already hid the option for non-git folders.
+- **Files:** `state/projects.svelte.ts` (`activeGitRepo`, gated
+  `requestNewWorktree`), `TerminalArea.svelte` (git-gated empty-state button +
+  tab-strip menu + hint), EN/ES i18n (`terminal.worktreeNeedsGitRepo`).
+
 ## [0.0.5-alpha.20260703] - 2026-07-03
 
 ### Fixed — blank white screen on startup (0.0.4 regression)

--- a/uxnandesktop/src/lib/components/LauncherDialog.svelte
+++ b/uxnandesktop/src/lib/components/LauncherDialog.svelte
@@ -300,12 +300,9 @@
         <SettingsIcon class={icon.decorative} />
         {i18n.t("agent.configure")}
       </button>
-      <div class="flex items-center gap-2">
-        <Button variant="ghost" onclick={() => (open = false)}>{i18n.t("common.cancel")}</Button>
-        <Button onclick={submit} disabled={!canSubmit || busy || (isNew && loadingBranches)}>
-          {busy ? i18n.t("common.creating") : primaryLabel}
-        </Button>
-      </div>
+      <Button onclick={submit} disabled={!canSubmit || busy || (isNew && loadingBranches)}>
+        {busy ? i18n.t("common.creating") : primaryLabel}
+      </Button>
     </Dialog.Footer>
   </Dialog.Content>
 </Dialog.Root>

--- a/uxnandesktop/src/lib/components/TerminalArea.svelte
+++ b/uxnandesktop/src/lib/components/TerminalArea.svelte
@@ -52,14 +52,18 @@
   // from the shared store so the empty-state "New worktree" button, the global
   // shortcut and the page-mounted dialog all agree on the same repo + open state.
   const activeRepo = $derived(projects.activeRepo);
+  // Whether the active workspace is a real git repo — worktrees need git, so the
+  // "new worktree" affordances are disabled for a non-git project folder (and the
+  // Global space), just like they already are outside any repo.
+  const activeRepoIsGit = $derived(!!activeRepo && activeRepo.isGit !== false);
 
   // Keyboard hints listed under the empty-state buttons (informative only). "New
-  // worktree" appears only inside a repo; filtered to bound actions so a blank /
-  // disabled chord never renders an empty row.
+  // worktree" appears only inside a git repo; filtered to bound actions so a
+  // blank / disabled chord never renders an empty row.
   const emptyHints = $derived(
     [
       { label: i18n.t("shortcuts.newTerminal"), chord: resolveBinding("newTerminal") },
-      activeRepo
+      activeRepoIsGit
         ? { label: i18n.t("shortcuts.newWorktree"), chord: resolveBinding("newWorktree") }
         : null,
       { label: i18n.t("shortcuts.addProject"), chord: resolveBinding("addProject") },
@@ -470,7 +474,9 @@
                       <LauncherMenu
                         repo={activeRepo}
                         target={{ path: wsKey, branch: null }}
-                        onNewWorktree={() => (projects.newWorktreeOpen = true)}
+                        onNewWorktree={activeRepoIsGit
+                          ? () => (projects.newWorktreeOpen = true)
+                          : undefined}
                         align="start"
                         triggerClass="ml-0.5 size-6"
                         title={i18n.t("launcher.openHere")}
@@ -612,7 +618,7 @@
               <PlusIcon class={icon.button} />
               {i18n.t("terminal.newTerminal")}
             </button>
-            {#if activeRepo}
+            {#if activeRepoIsGit}
               <button
                 class={cn(
                   "inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 font-medium text-foreground hover:bg-accent hover:text-accent-foreground",
@@ -630,7 +636,9 @@
                   text.body,
                 )}
                 disabled
-                title={i18n.t("terminal.worktreeNeedsRepo")}
+                title={activeRepo
+                  ? i18n.t("terminal.worktreeNeedsGitRepo")
+                  : i18n.t("terminal.worktreeNeedsRepo")}
               >
                 <GitBranchIcon class={icon.button} />
                 {i18n.t("newWorktree.title")}

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -141,6 +141,8 @@ export const en = {
     "a name with no relation to, or derivation from, any existing product.",
   "terminal.worktreeNeedsRepo":
     "Pick a project or worktree in the left panel to enable this.",
+  "terminal.worktreeNeedsGitRepo":
+    "This project isn’t a git repository, so it has no worktrees.",
   "terminal.newInRegion": "New terminal in this region",
   "terminal.copy": "Copy",
   "terminal.paste": "Paste",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -138,6 +138,8 @@ export const es: Record<MessageKey, string> = {
     "un nombre sin relación ni derivación de ningún producto existente.",
   "terminal.worktreeNeedsRepo":
     "Selecciona un proyecto o worktree en el panel izquierdo para habilitar esto.",
+  "terminal.worktreeNeedsGitRepo":
+    "Este proyecto no es un repositorio git, por lo que no tiene worktrees.",
   "terminal.newInRegion": "Nueva terminal en esta región",
   "terminal.copy": "Copiar",
   "terminal.paste": "Pegar",

--- a/uxnandesktop/src/lib/state/projects.svelte.ts
+++ b/uxnandesktop/src/lib/state/projects.svelte.ts
@@ -79,11 +79,19 @@ class ProjectsStore {
     return null;
   }
 
-  /** Open the "new worktree" dialog for the active repo. A no-op outside a repo
-   *  (Global space / nothing selected), so a shortcut does nothing rather than
-   *  prompting with no repo to branch from. */
+  /** The active repo only when it is a real git repository — worktrees need git,
+   *  so non-git project folders (and the Global space) resolve to null. Drives
+   *  every "new worktree" affordance's enabled state. */
+  get activeGitRepo(): RepoData | null {
+    const r = this.activeRepo;
+    return r && r.isGit !== false ? r : null;
+  }
+
+  /** Open the "new worktree" dialog for the active repo. A no-op outside a git
+   *  repo (Global space / a non-git folder / nothing selected), so a shortcut
+   *  does nothing rather than prompting with no repo to branch from. */
   requestNewWorktree(): void {
-    if (this.activeRepo) this.newWorktreeOpen = true;
+    if (this.activeGitRepo) this.newWorktreeOpen = true;
   }
 
   /** Projects visible for the search query: those whose name/path matches OR


### PR DESCRIPTION
## Summary

Registered project folders can be **non-git**, but a **worktree needs a git
repo**. This PR makes the "New worktree" affordances honor that (they were only
disabled for the Global space), and drops a redundant Cancel button.

Two separate commits:

### 1. Gate "New worktree" to git repos (`feat`)
For a registered folder that isn't a git repo:
- the center **empty-state "New worktree"** button renders **disabled** with a
  tooltip explaining the folder isn't a git repository;
- the center **tab-strip "+"** launcher menu **omits** its *New worktree* option
  (terminals / agents / browser stay available);
- the `newWorktree` **keyboard shortcut** and its empty-state hint go inert.

Backed by a new `projects.activeGitRepo` getter (the active repo only when
`isGit !== false`); `requestNewWorktree()` now checks it. The project card's
launcher dialog already hid the option for non-git folders.

### 2. Drop redundant Cancel from the launcher dialog (`refactor`)
`LauncherDialog`'s Cancel duplicated the top-right ✕ and Esc; removed it to match
the add-project dialogs.

## Files
- `state/projects.svelte.ts`, `TerminalArea.svelte`, EN/ES i18n
  (`terminal.worktreeNeedsGitRepo`) — commit 1
- `LauncherDialog.svelte` — commit 2
- `CHANGELOG.md`

## Verification
- `npm run check` → **0 errors / 0 warnings**
- `npm run build` → green
- Reviewed on-device (non-git project: disabled button + tooltip, tab-strip menu
  without the worktree option, dialog without Cancel).

> UI-only; no Rust/contract changes. `RepoData.isGit` already exists and
> `repo_add` accepts non-git folders.
