### PR TITLE
feat(desktop): expose the integrated browser to agents via an MCP server

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -22,8 +22,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   reuse the existing link-policy path (`browser::route_url` → the frontend panel);
   `status` reports the live open/URL/policy via a new `AppState.browser_url` tracker.
 - **Config injection** (`src-tauri/src/mcpinject.rs`) — writes each CLI's native MCP
-  config so it finds the server on startup, for **Claude Code, Codex, Gemini CLI,
-  OpenCode and Pi**. The **token is never written to a file**: every config references
+  config so it finds the server on startup, for **Claude Code, Codex, Gemini CLI and
+  OpenCode**. The **token is never written to a file**: every config references
   the `UXNAN_MCP_TOKEN` env var (injected into the agent's PTY), so the secret stays
   in the process env *and* the injected config is inert outside a uxnan-launched
   terminal (an agent run elsewhere can't authenticate — it won't hijack the browser).
@@ -36,10 +36,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   **`off`** (wire it by hand from the Settings copy-paste snippet). Per-agent opt-out
   via `mcpDisabledAgents`; master switch `mcpEnabled` (default on). New `mcp_info`
   command surfaces the endpoint + token + supported-agent catalog to Settings.
-- **Extensible** — a new agent (e.g. `agy`/Antigravity, Cursor, Grok, amp) is one row
-  in `mcpinject::AGENTS` plus a match arm in `config_path`/`write_entry`; recipe in
-  `docs/browser.md`. Pi's HTTP+auth config shape is unverified upstream, so its
-  injection is best-effort (tracked in `FOR-DEV.md`).
+- **Extensible** — a new agent (e.g. `agy`/Antigravity, Cursor, Grok, amp, Pi) is one
+  row in `mcpinject::AGENTS` plus a match arm in `config_path`/`write_entry`; recipe
+  in `docs/browser.md`.
 
 ## [0.0.5-alpha.20260703] - 2026-07-03
 

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,42 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — agents discover & drive the integrated browser via an MCP server
+- **The integrated developer browser is now exposed to agents as Model Context
+  Protocol tools, so they discover it automatically — no docs, no prompt.** Before,
+  an agent could only open a URL in the in-app browser if it *knew* to POST to the
+  `/browser` hook route (it had to read `docs/browser.md` first). Now the ADE runs a
+  small **browser-control MCP server** and registers it in each launched agent's own
+  MCP config, so `browser_*` tools show up in the agent's tool list like any native
+  capability.
+- **MCP server** (`src-tauri/src/mcp.rs`) — a minimal, spec-correct Streamable-HTTP
+  MCP endpoint mounted at **`/mcp`** on the existing local hook server (same
+  ephemeral `127.0.0.1` port), authorized with the same per-launch token
+  (`Authorization: Bearer <token>`, or the legacy `x-uxnan-token`). Control-only tool
+  surface: **`browser_open`**, **`browser_navigate`**, **`browser_reload`**,
+  **`browser_back`**, **`browser_forward`**, **`browser_status`**. `open`/`navigate`
+  reuse the existing link-policy path (`browser::route_url` → the frontend panel);
+  `status` reports the live open/URL/policy via a new `AppState.browser_url` tracker.
+- **Config injection** (`src-tauri/src/mcpinject.rs`) — writes each CLI's native MCP
+  config so it finds the server on startup, for **Claude Code, Codex, Gemini CLI,
+  OpenCode and Pi**. The **token is never written to a file**: every config references
+  the `UXNAN_MCP_TOKEN` env var (injected into the agent's PTY), so the secret stays
+  in the process env *and* the injected config is inert outside a uxnan-launched
+  terminal (an agent run elsewhere can't authenticate — it won't hijack the browser).
+  Merges into existing config files without clobbering (JSON via `serde_json`, Codex
+  TOML via the new `toml_edit` dep); files it creates are hidden from Git (added to
+  the repo's `info/exclude`, worktree-aware via `git2`) and removed on exit.
+- **Injection modes** (`BrowserSettings.mcpInjection`) — **`workspace`** (default:
+  a project-scoped config in the terminal's cwd, covering hand-typed and app-launched
+  agents there, cleaned on exit), **`global`** (each CLI's global user config), or
+  **`off`** (wire it by hand from the Settings copy-paste snippet). Per-agent opt-out
+  via `mcpDisabledAgents`; master switch `mcpEnabled` (default on). New `mcp_info`
+  command surfaces the endpoint + token + supported-agent catalog to Settings.
+- **Extensible** — a new agent (e.g. `agy`/Antigravity, Cursor, Grok, amp) is one row
+  in `mcpinject::AGENTS` plus a match arm in `config_path`/`write_entry`; recipe in
+  `docs/browser.md`. Pi's HTTP+auth config shape is unverified upstream, so its
+  injection is best-effort (tracked in `FOR-DEV.md`).
+
 ## [0.0.5-alpha.20260703] - 2026-07-03
 
 ### Fixed — blank white screen on startup (0.0.4 regression)

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -15,8 +15,9 @@ which tracks assets only a human can provide.)
 standalone app** (three-panel shell, PTY terminals + splits, git worktrees, git
 status/diff/stage/commit/history, agent monitoring with the axum hook server +
 OSC/process layers, settings/themes/i18n, multi-agent orchestration,
-**in-app auto-updater**). 106 Rust backend tests + 25 frontend Vitest unit tests
-(pure logic); **no Svelte component or E2E tests yet**. macOS is **unvalidated**
+**in-app auto-updater**, **browser-control MCP for agents**). 117 Rust backend tests
++ 25 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests
+yet**. macOS is **unvalidated**
 (developed on Windows; CI is `{ubuntu, windows}`). **Phase 6 (embedded bridge /
 mobile pairing) is NOT started.**
 
@@ -81,13 +82,43 @@ right-side panel + status-bar toggle; `open_url`/`open_external` routing (shared
 hook-server `/browser` route, gated on `enabled && allow_agents`); **Ctrl/Cmd-
 clickable terminal links** (`@xterm/addon-web-links`).
 
-Spec synced: `architecture/02a` §4.2b documents the integrated browser; user guide
-in `docs/browser.md`.
+**Done — browser-control MCP (backend, spec `02d` §1.6):** the browser is now
+**discoverable** to agents as MCP tools, not just via the `/browser` curl. `mcp.rs`
+serves a minimal Streamable-HTTP MCP endpoint at `/mcp` (control tools
+`browser_open/navigate/reload/back/forward/status`, same hook-server token);
+`mcpinject.rs` writes each launched CLI's native MCP config (Claude/Codex/Gemini/
+OpenCode/Pi) referencing the `UXNAN_MCP_TOKEN` env (token never in a file), merging
+without clobbering and cleaning up on exit; `BrowserSettings.mcp*` (enabled /
+injection mode `off|workspace|global` / disabled-agents) + `mcp_info` command. See
+`docs/browser.md` → *Agent browser MCP*.
+
+Spec synced: `architecture/02a` §4.2b documents the integrated browser, `02d` §1.6
+the browser MCP; user guide in `docs/browser.md`.
 
 ### Still pending
 - [ ] **On-device validation.** The docked `WebviewWindow` (its gluing to the panel
       on move/resize/DPI) and the agent `$BROWSER` shim end-to-end need a real run to
       confirm. The explicit `curl` path is the reliable fallback for the shim.
+- [ ] **Browser MCP — Settings UI.** The backend + `mcp_info` command are done; the
+      Settings → Browser panel controls (MCP master switch, injection-mode selector,
+      per-agent toggles, copy-paste snippet) are not built yet. Wire them in
+      `Settings.svelte` against `mcp_info` + `BrowserSettings.mcp*`.
+- [ ] **Browser MCP — Pi injection is best-effort.** Pi has no project-scoped MCP
+      config (only global `~/.pi/agent/mcp.json`) and its HTTP-server + auth-header
+      shape isn't documented upstream; `mcpinject::json_entry` writes a best-guess
+      `{url, headers:{Authorization}}`. Verify against a real Pi install and fix the
+      shape if needed (`FOR-DEV:` marker at the `"pi"` arm in `mcpinject.rs`).
+- [ ] **Browser MCP — add more agents.** The injector is a registry: to support a new
+      CLI (e.g. `agy`/Antigravity, Cursor's `cursor-agent`, Grok, amp), add a row to
+      `mcpinject::AGENTS` + a match arm in `config_path` (its config file path) and
+      `write_entry`/`json_entry` (its MCP-server shape). Recipe + the per-agent table
+      in `docs/browser.md` → *Adding another agent*.
+- [ ] **Browser MCP — interaction tools (control-only for now).** The tool surface is
+      navigation-only. Page inspection/interaction (`browser_snapshot`,
+      `browser_evaluate`, `browser_click`, `browser_type`) needs a JS return-channel
+      from the docked `WebviewWindow` (`.eval()` is fire-and-forget) — an injected
+      init-script that posts results back, mindful of page CSP. Deferred as a second
+      pass (`FOR-DEV:` marker in `mcp.rs`).
 
 ## Phase 6 — Bridge integration (embedded bridge / mobile pairing) ☐
 

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -99,10 +99,6 @@ the browser MCP; user guide in `docs/browser.md`.
 - [ ] **On-device validation.** The docked `WebviewWindow` (its gluing to the panel
       on move/resize/DPI) and the agent `$BROWSER` shim end-to-end need a real run to
       confirm. The explicit `curl` path is the reliable fallback for the shim.
-- [ ] **Browser MCP — Settings UI on-device review.** The Settings → Browser panel
-      controls are built (master switch, setup-mode selector, per-agent toggles,
-      copy-paste snippet, EN/ES; `svelte-check` + Vitest green) but not yet
-      visually reviewed in the Tauri app. Confirm layout/copy on-device and adjust.
 - [ ] **Browser MCP — add more agents.** The injector is a registry: to support a new
       CLI (e.g. `agy`/Antigravity, Cursor's `cursor-agent`, Grok, amp, Pi), add a row to
       `mcpinject::AGENTS` + a match arm in `config_path` (its config file path) and

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -87,7 +87,7 @@ clickable terminal links** (`@xterm/addon-web-links`).
 serves a minimal Streamable-HTTP MCP endpoint at `/mcp` (control tools
 `browser_open/navigate/reload/back/forward/status`, same hook-server token);
 `mcpinject.rs` writes each launched CLI's native MCP config (Claude/Codex/Gemini/
-OpenCode/Pi) referencing the `UXNAN_MCP_TOKEN` env (token never in a file), merging
+OpenCode) referencing the `UXNAN_MCP_TOKEN` env (token never in a file), merging
 without clobbering and cleaning up on exit; `BrowserSettings.mcp*` (enabled /
 injection mode `off|workspace|global` / disabled-agents) + `mcp_info` command. See
 `docs/browser.md` → *Agent browser MCP*.
@@ -103,13 +103,8 @@ the browser MCP; user guide in `docs/browser.md`.
       controls are built (master switch, setup-mode selector, per-agent toggles,
       copy-paste snippet, EN/ES; `svelte-check` + Vitest green) but not yet
       visually reviewed in the Tauri app. Confirm layout/copy on-device and adjust.
-- [ ] **Browser MCP — Pi injection is best-effort.** Pi has no project-scoped MCP
-      config (only global `~/.pi/agent/mcp.json`) and its HTTP-server + auth-header
-      shape isn't documented upstream; `mcpinject::json_entry` writes a best-guess
-      `{url, headers:{Authorization}}`. Verify against a real Pi install and fix the
-      shape if needed (`FOR-DEV:` marker at the `"pi"` arm in `mcpinject.rs`).
 - [ ] **Browser MCP — add more agents.** The injector is a registry: to support a new
-      CLI (e.g. `agy`/Antigravity, Cursor's `cursor-agent`, Grok, amp), add a row to
+      CLI (e.g. `agy`/Antigravity, Cursor's `cursor-agent`, Grok, amp, Pi), add a row to
       `mcpinject::AGENTS` + a match arm in `config_path` (its config file path) and
       `write_entry`/`json_entry` (its MCP-server shape). Recipe + the per-agent table
       in `docs/browser.md` → *Adding another agent*.

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -99,10 +99,10 @@ the browser MCP; user guide in `docs/browser.md`.
 - [ ] **On-device validation.** The docked `WebviewWindow` (its gluing to the panel
       on move/resize/DPI) and the agent `$BROWSER` shim end-to-end need a real run to
       confirm. The explicit `curl` path is the reliable fallback for the shim.
-- [ ] **Browser MCP — Settings UI.** The backend + `mcp_info` command are done; the
-      Settings → Browser panel controls (MCP master switch, injection-mode selector,
-      per-agent toggles, copy-paste snippet) are not built yet. Wire them in
-      `Settings.svelte` against `mcp_info` + `BrowserSettings.mcp*`.
+- [ ] **Browser MCP — Settings UI on-device review.** The Settings → Browser panel
+      controls are built (master switch, setup-mode selector, per-agent toggles,
+      copy-paste snippet, EN/ES; `svelte-check` + Vitest green) but not yet
+      visually reviewed in the Tauri app. Confirm layout/copy on-device and adjust.
 - [ ] **Browser MCP — Pi injection is best-effort.** Pi has no project-scoped MCP
       config (only global `~/.pi/agent/mcp.json`) and its HTTP-server + auth-header
       shape isn't documented upstream; `mcpinject::json_entry` writes a best-guess

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -96,9 +96,6 @@ Spec synced: `architecture/02a` §4.2b documents the integrated browser, `02d` �
 the browser MCP; user guide in `docs/browser.md`.
 
 ### Still pending
-- [ ] **On-device validation.** The docked `WebviewWindow` (its gluing to the panel
-      on move/resize/DPI) and the agent `$BROWSER` shim end-to-end need a real run to
-      confirm. The explicit `curl` path is the reliable fallback for the shim.
 - [ ] **Browser MCP — add more agents.** The injector is a registry: to support a new
       CLI (e.g. `agy`/Antigravity, Cursor's `cursor-agent`, Grok, amp, Pi), add a row to
       `mcpinject::AGENTS` + a match arm in `config_path` (its config file path) and

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -68,7 +68,9 @@ available today are:
   DevTools) to preview and debug what your agents build — `localhost` dev servers
   and any site — and to open the links they create. Links route by a policy you
   choose (in-app · system browser · ask); when allowed, agents open URLs in it
-  automatically. See [the integrated browser](./docs/browser.md).
+  automatically — and, via an injected **browser-control MCP server**, discover
+  `browser_*` tools to preview and test what they build with no setup. See
+  [the integrated browser](./docs/browser.md).
 - **Personalization and internationalization.** Full custom theming with design
   tokens and light/dark modes, terminal profiles, per-agent launch settings and
   environment variables, a configurable launch shell, and a completely translated

--- a/uxnandesktop/architecture/02d-agent-monitoring.md
+++ b/uxnandesktop/architecture/02d-agent-monitoring.md
@@ -122,6 +122,24 @@ Para evitar que estados obsoletos contaminen la interfaz:
 
 ---
 
+### 1.6 Capa MCP: Navegador Controlable por Agentes
+
+El mismo servidor HTTP local (Capa 1) expone tambien un endpoint **`/mcp`**: un servidor **Model Context Protocol** (transporte Streamable HTTP) que hace **descubrible** el navegador integrado (`architecture/02a` §4.2b) para los agentes CLI. En lugar de que el agente tenga que *conocer* la convencion `$BROWSER`/`curl` al hook `/browser`, las herramientas del navegador aparecen en su lista de tools como cualquier capacidad nativa, y las usa sin leer documentacion.
+
+**Superficie de herramientas (solo control):** `browser_open`, `browser_navigate`, `browser_reload`, `browser_back`, `browser_forward`, `browser_status`. Reusan los mismos caminos del navegador (`browser::route_url` + comandos de ventana) y respetan la misma politica de enlaces que un enlace clicado. La inspeccion/interaccion de pagina (snapshot/evaluate/click/type) queda como fase posterior (requiere un canal de retorno JS desde la `WebviewWindow`).
+
+**Autenticacion y aislamiento:** el endpoint acepta el **mismo token por lanzamiento** que el hook server (`Authorization: Bearer <token>`, o el header legado `x-uxnan-token`). Los agentes reciben la configuracion MCP de su propio CLI apuntando a `/mcp`, pero el **token nunca se escribe en un archivo**: cada config lo referencia por la variable de entorno `UXNAN_MCP_TOKEN`, que el ADE inyecta en el PTY del agente. Consecuencia de diseno: la config inyectada **solo funciona dentro de una terminal lanzada por uxnan** — un agente ejecutado en otro entorno lee el mismo archivo pero no tiene la variable, no autentica y el servidor simplemente no carga para el (no puede secuestrar el navegador in-app).
+
+**Inyeccion por agente (`mcpinject.rs`):** el ADE escribe la config MCP nativa de cada CLI soportado (Claude Code, Codex, Gemini, OpenCode, Pi) en su ubicacion estandar, segun el modo elegido en Settings → Browser:
+
+- **`workspace`** (default): archivo con alcance de proyecto en el directorio de trabajo de la terminal (`.mcp.json`, `.codex/config.toml`, `.gemini/settings.json`, `opencode.json`); cubre agentes lanzados por el ADE y tecleados a mano ahi. Los archivos que el ADE crea se ocultan de Git (`info/exclude`, con soporte de worktrees via `git2`) y se eliminan al salir.
+- **`global`**: config global del usuario de cada CLI (aplica en todos los proyectos; mayor huella).
+- **`off`**: no inyecta nada (el endpoint `/mcp` sigue disponible para cableado manual desde el snippet copiable de Settings).
+
+El merge preserva el resto de la configuracion del usuario (JSON via `serde_json`, TOML de Codex via `toml_edit`). El registro es extensible: agregar un agente nuevo (p. ej. `agy`/Antigravity, Cursor, Grok, amp) es una fila en `AGENTS` + un brazo en `config_path`/`write_entry` (receta en `docs/browser.md`). Pi solo tiene config global y su forma HTTP+auth no esta verificada upstream, por lo que su inyeccion es best-effort.
+
+---
+
 ## 2. Notificaciones
 
 El sistema de notificaciones mantiene al usuario informado del progreso de los agentes, incluso cuando no esta mirando activamente la ventana del ADE.

--- a/uxnandesktop/architecture/02d-agent-monitoring.md
+++ b/uxnandesktop/architecture/02d-agent-monitoring.md
@@ -130,13 +130,13 @@ El mismo servidor HTTP local (Capa 1) expone tambien un endpoint **`/mcp`**: un 
 
 **Autenticacion y aislamiento:** el endpoint acepta el **mismo token por lanzamiento** que el hook server (`Authorization: Bearer <token>`, o el header legado `x-uxnan-token`). Los agentes reciben la configuracion MCP de su propio CLI apuntando a `/mcp`, pero el **token nunca se escribe en un archivo**: cada config lo referencia por la variable de entorno `UXNAN_MCP_TOKEN`, que el ADE inyecta en el PTY del agente. Consecuencia de diseno: la config inyectada **solo funciona dentro de una terminal lanzada por uxnan** — un agente ejecutado en otro entorno lee el mismo archivo pero no tiene la variable, no autentica y el servidor simplemente no carga para el (no puede secuestrar el navegador in-app).
 
-**Inyeccion por agente (`mcpinject.rs`):** el ADE escribe la config MCP nativa de cada CLI soportado (Claude Code, Codex, Gemini, OpenCode, Pi) en su ubicacion estandar, segun el modo elegido en Settings → Browser:
+**Inyeccion por agente (`mcpinject.rs`):** el ADE escribe la config MCP nativa de cada CLI soportado (Claude Code, Codex, Gemini, OpenCode) en su ubicacion estandar, segun el modo elegido en Settings → Browser:
 
 - **`workspace`** (default): archivo con alcance de proyecto en el directorio de trabajo de la terminal (`.mcp.json`, `.codex/config.toml`, `.gemini/settings.json`, `opencode.json`); cubre agentes lanzados por el ADE y tecleados a mano ahi. Los archivos que el ADE crea se ocultan de Git (`info/exclude`, con soporte de worktrees via `git2`) y se eliminan al salir.
 - **`global`**: config global del usuario de cada CLI (aplica en todos los proyectos; mayor huella).
 - **`off`**: no inyecta nada (el endpoint `/mcp` sigue disponible para cableado manual desde el snippet copiable de Settings).
 
-El merge preserva el resto de la configuracion del usuario (JSON via `serde_json`, TOML de Codex via `toml_edit`). El registro es extensible: agregar un agente nuevo (p. ej. `agy`/Antigravity, Cursor, Grok, amp) es una fila en `AGENTS` + un brazo en `config_path`/`write_entry` (receta en `docs/browser.md`). Pi solo tiene config global y su forma HTTP+auth no esta verificada upstream, por lo que su inyeccion es best-effort.
+El merge preserva el resto de la configuracion del usuario (JSON via `serde_json`, TOML de Codex via `toml_edit`). El registro es extensible: agregar un agente nuevo (p. ej. `agy`/Antigravity, Cursor, Grok, amp, Pi) es una fila en `AGENTS` + un brazo en `config_path`/`write_entry` (receta en `docs/browser.md`).
 
 ---
 

--- a/uxnandesktop/docs/browser.md
+++ b/uxnandesktop/docs/browser.md
@@ -132,7 +132,6 @@ always referenced via `UXNAN_MCP_TOKEN` (never inlined):
 | Codex | `.codex/config.toml` | `~/.codex/config.toml` | `[mcp_servers.uxnan-browser]` `url` + `bearer_token_env_var` |
 | Gemini CLI | `.gemini/settings.json` | `~/.gemini/settings.json` | `mcpServers.uxnan-browser` `{httpUrl, headers}` |
 | OpenCode | `opencode.json` | `~/.config/opencode/opencode.json` | `mcp.uxnan-browser` `{type:"remote", url, headers, enabled}` |
-| Pi | — *(global only)* | `~/.pi/agent/mcp.json` | `mcpServers.uxnan-browser` `{url, headers}` — **best-effort** (unverified upstream) |
 
 Merges are non-destructive (your other keys/servers are preserved), and a file the
 ADE creates is added to the repo's local `info/exclude` so it doesn't show up in
@@ -141,7 +140,7 @@ ADE creates is added to the repo's local `info/exclude` so it doesn't show up in
 ### Adding another agent
 
 The injector is a small registry, so wiring a new CLI (e.g. `agy`/Antigravity,
-Cursor's `cursor-agent`, Grok, amp, …) is three edits in `src-tauri/src/mcpinject.rs`:
+Cursor's `cursor-agent`, Grok, amp, Pi, …) is three edits in `src-tauri/src/mcpinject.rs`:
 
 1. Add a row to **`AGENTS`** — its stable id, label, and whether it has a
    project-scoped config or only a global one (`Scope`).

--- a/uxnandesktop/docs/browser.md
+++ b/uxnandesktop/docs/browser.md
@@ -74,6 +74,86 @@ browser (or your system browser / a prompt, depending on the setting).
 > in the browser"* — if it runs `$BROWSER <url>` or the `curl` above, the preview
 > shows up next to your terminal.
 
+## Agent browser MCP (discoverable tools)
+
+The `$BROWSER`/curl path above only works if the agent *knows* the convention. The
+**browser MCP** removes that: the ADE exposes the browser as **Model Context
+Protocol** tools and registers them in each agent it launches, so the tools appear
+in the agent's tool list automatically — it drives the browser with **no setup and
+no documentation**.
+
+### Tools
+
+| Tool | What it does |
+| --- | --- |
+| `browser_open` | Open the in-app browser and load a URL (routed through your link policy). |
+| `browser_navigate` | Navigate the browser to a URL (opening the panel first if needed). |
+| `browser_reload` | Reload the current page (e.g. after the agent changes code). |
+| `browser_back` / `browser_forward` | Move through history. |
+| `browser_status` | Report whether a page is open, the current URL, and how opens are routed. |
+
+They map onto the same in-app browser and the same link policy as a clicked link.
+(Page inspection/interaction — snapshot/click/type — is a planned follow-up; see
+`FOR-DEV.md`.)
+
+### How it connects
+
+The ADE runs a tiny MCP server at **`/mcp`** on the same local hook server the agent
+monitor already uses (`127.0.0.1`, ephemeral port, `Authorization: Bearer <token>`).
+When enabled, the ADE writes the agent CLI's **own** MCP config so it finds that
+server on launch. The bearer **token is never written to a file** — the config
+references the `UXNAN_MCP_TOKEN` environment variable, which the ADE injects into the
+terminal it spawns.
+
+That env-scoping is deliberate: **the injected config only works inside a terminal
+uxnan launched.** The same agent run in another IDE/terminal reads the same config
+file but has no `UXNAN_MCP_TOKEN`, so it can't authenticate — the server simply
+doesn't load for it (it won't hijack your in-app browser). The worst case outside
+uxnan is a harmless, non-connecting entry, and files uxnan *creates* are removed when
+it exits.
+
+### Settings → Browser → Agent browser MCP
+
+| Setting | What it does | Default |
+| --- | --- | --- |
+| **Agent browser MCP** | Master switch for exposing the `browser_*` tools to agents. Off → no MCP config is injected (the `/mcp` endpoint still exists for manual wiring). | On |
+| **Injection mode** | `Workspace` writes a project-scoped config into the terminal's working directory (covers hand-typed and app-launched agents there, removed on exit). `Global` registers it in each CLI's global user config (every project; more footprint). `Off` injects nothing. | Workspace |
+| **Per-agent** | Toggle injection per agent. | All on |
+| **Copy config** | Copy a ready-to-paste MCP-server config (endpoint + token) to wire an agent by hand — e.g. one the ADE doesn't auto-configure yet. | — |
+
+### Where each agent's config is written
+
+The ADE writes each CLI's native config in its standard location. The token is
+always referenced via `UXNAN_MCP_TOKEN` (never inlined):
+
+| Agent | Workspace file (`<cwd>/…`) | Global file | Shape |
+| --- | --- | --- | --- |
+| Claude Code | `.mcp.json` | `~/.claude.json` | `mcpServers.uxnan-browser` `{type:"http", url, headers}` |
+| Codex | `.codex/config.toml` | `~/.codex/config.toml` | `[mcp_servers.uxnan-browser]` `url` + `bearer_token_env_var` |
+| Gemini CLI | `.gemini/settings.json` | `~/.gemini/settings.json` | `mcpServers.uxnan-browser` `{httpUrl, headers}` |
+| OpenCode | `opencode.json` | `~/.config/opencode/opencode.json` | `mcp.uxnan-browser` `{type:"remote", url, headers, enabled}` |
+| Pi | — *(global only)* | `~/.pi/agent/mcp.json` | `mcpServers.uxnan-browser` `{url, headers}` — **best-effort** (unverified upstream) |
+
+Merges are non-destructive (your other keys/servers are preserved), and a file the
+ADE creates is added to the repo's local `info/exclude` so it doesn't show up in
+`git status`.
+
+### Adding another agent
+
+The injector is a small registry, so wiring a new CLI (e.g. `agy`/Antigravity,
+Cursor's `cursor-agent`, Grok, amp, …) is three edits in `src-tauri/src/mcpinject.rs`:
+
+1. Add a row to **`AGENTS`** — its stable id, label, and whether it has a
+   project-scoped config or only a global one (`Scope`).
+2. Add a match arm to **`config_path`** — where its MCP config file lives, relative
+   to the working directory (workspace mode) and to `$HOME` (global mode).
+3. Add its server shape to **`json_entry`** (JSON configs) or handle it in
+   **`write_entry`** (a non-JSON format, like Codex's TOML). Reference the token via
+   the CLI's own env-expansion syntax so it's never written to the file.
+
+Then add the agent's id to the frontend's per-agent toggle list. Nothing else
+changes — injection, merging, git-hiding and cleanup are format-driven.
+
 ## Performance
 
 The browser only consumes resources while the panel is open: the webview window is

--- a/uxnandesktop/src-tauri/Cargo.lock
+++ b/uxnandesktop/src-tauri/Cargo.lock
@@ -1545,7 +1545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3157,11 +3157,10 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
 ]
 
@@ -4781,7 +4780,7 @@ checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "toml_edit 0.20.2",
 ]
 
@@ -4817,9 +4816,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -4849,7 +4848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -4862,8 +4861,20 @@ dependencies = [
  "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4886,6 +4897,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5169,6 +5186,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml_edit 0.22.27",
  "uuid",
  "windows-sys 0.59.0",
 ]
@@ -6110,6 +6128,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/uxnandesktop/src-tauri/Cargo.toml
+++ b/uxnandesktop/src-tauri/Cargo.toml
@@ -53,6 +53,10 @@ sysinfo = "0.33"
 # git CLI (git.rs); git2 is the fast path with a CLI fallback. Vendored libgit2.
 git2 = { version = "0.20", default-features = false }
 axum = { version = "0.8", default-features = false, features = ["json", "tokio", "http1"] }
+# Format-preserving TOML editor, used to merge our MCP server entry into an
+# agent's `config.toml` (Codex) without clobbering the user's other settings or
+# comments. Pure Rust; `serde` handles the JSON-config agents (Claude/Gemini/…).
+toml_edit = "0.22"
 # Filesystem watcher for the right-panel file tree + the open-file editor: a
 # debounced, cross-platform watch of the active worktree root that emits
 # `fs:changed` so the UI reflects files created/deleted/edited on disk without a

--- a/uxnandesktop/src-tauri/src/browser.rs
+++ b/uxnandesktop/src-tauri/src/browser.rs
@@ -112,6 +112,60 @@ fn parse_url(raw: &str) -> Result<tauri::Url, CommandError> {
     tauri::Url::parse(raw).map_err(|e| CommandError::new("BROWSER_BAD_URL", e.to_string()))
 }
 
+/// Record the browser's live URL in shared state so the browser MCP server's
+/// `browser_status` tool can report the current page to an agent (see
+/// [`AppState::browser_url`]). Best-effort: a poisoned lock is ignored.
+fn track_url(app: &AppHandle, url: &str) {
+    let slot = app.state::<AppState>().browser_url.clone();
+    let mut guard = match slot.lock() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    *guard = Some(url.to_string());
+}
+
+/// Snapshot of the integrated browser, returned by the browser MCP server's
+/// `browser_status` tool so an agent can see whether a page is open, which URL
+/// it's on, and how its opens will be routed (in-app vs OS browser).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserStatus {
+    /// Whether the docked browser window currently exists (a panel is open).
+    pub open: bool,
+    /// Last URL the browser navigated to, if any (`None` = never opened).
+    pub url: Option<String>,
+    /// Master switch — when off, an agent's opens go to the OS default browser.
+    pub enabled: bool,
+    /// Link routing policy in effect (`internal`/`external`/`ask`).
+    pub policy: BrowserLinkPolicy,
+}
+
+/// Read the live integrated-browser status (window open? current URL? settings?)
+/// for the browser MCP server's `browser_status` tool.
+pub async fn status(app: &AppHandle) -> BrowserStatus {
+    let open = app.get_webview_window(BROWSER_WINDOW).is_some();
+    let state = app.state::<AppState>();
+    let url = state
+        .browser_url
+        .clone()
+        .lock()
+        .ok()
+        .and_then(|s| s.clone());
+    let (enabled, policy) = {
+        let data = state.data.read().await;
+        (
+            data.settings.browser.enabled,
+            data.settings.browser.link_policy,
+        )
+    };
+    BrowserStatus {
+        open,
+        url,
+        enabled,
+        policy,
+    }
+}
+
 /// Fetch the docked browser window, or a clean "not open" error.
 fn window(app: &AppHandle) -> Result<tauri::WebviewWindow, CommandError> {
     app.get_webview_window(BROWSER_WINDOW)
@@ -156,6 +210,7 @@ pub async fn browser_window_open(
     height: f64,
 ) -> Result<(), CommandError> {
     let target = parse_url(&url)?;
+    track_url(&app, &url);
 
     if app.get_webview_window(BROWSER_WINDOW).is_some() {
         place(&app, x, y, width, height)?;
@@ -182,7 +237,9 @@ pub async fn browser_window_open(
         .shadow(false)
         .visible(false)
         .on_navigation(move |u| {
-            let _ = nav_app.emit("browser:navigated", NavigatedEvent { url: u.to_string() });
+            let url = u.to_string();
+            track_url(&nav_app, &url);
+            let _ = nav_app.emit("browser:navigated", NavigatedEvent { url });
             true
         });
     // Own the browser window to the main window: it stays above it and
@@ -216,6 +273,7 @@ pub fn browser_window_set_bounds(
 #[tauri::command]
 pub fn browser_window_navigate(app: AppHandle, url: String) -> Result<(), CommandError> {
     let target = parse_url(&url)?;
+    track_url(&app, &url);
     window(&app)?
         .navigate(target)
         .map_err(|e| CommandError::new("BROWSER_NAV_FAILED", e.to_string()))

--- a/uxnandesktop/src-tauri/src/commands.rs
+++ b/uxnandesktop/src-tauri/src/commands.rs
@@ -110,11 +110,12 @@ pub async fn pty_create(
     // (`UXNAN_BROWSER_URL` + `_TOKEN`), and point `$BROWSER` at the bundled shim so
     // tools that honor it (logins/previews) land in-app too. Honors the user's
     // link policy on arrival (see `browser::route_url`).
-    let (browser_enabled, allow_agents) = {
+    let (browser_enabled, allow_agents, mcp_enabled) = {
         let data = state.data.read().await;
         (
             data.settings.browser.enabled,
             data.settings.browser.allow_agents,
+            data.settings.browser.mcp_enabled,
         )
     };
     if browser_enabled && allow_agents {
@@ -135,6 +136,21 @@ pub async fn pty_create(
         }
     }
 
+    // Browser-control MCP (spec `02d` §1.6): expose the `/mcp` endpoint + token so
+    // the agent's injected MCP config (see `mcpinject.rs`) can reach it. The config
+    // reads the token from `UXNAN_MCP_TOKEN` (never written to a file). Then write
+    // that config for the terminal's cwd, per the user's injection mode.
+    if mcp_enabled {
+        if let Some(h) = &hook {
+            env.push((
+                "UXNAN_MCP_URL".to_string(),
+                crate::mcpinject::mcp_endpoint(&h.url),
+            ));
+            env.push((crate::mcpinject::TOKEN_ENV.to_string(), h.token.clone()));
+        }
+        crate::mcpinject::prepare(&app, cwd.as_deref().unwrap_or_default()).await;
+    }
+
     state
         .pty
         .create(
@@ -151,6 +167,39 @@ pub async fn pty_create(
             on_exit,
         )
         .map_err(CommandError::from)
+}
+
+/// Runtime info for the Settings → Browser MCP panel: the live `/mcp` endpoint +
+/// token (for the copy-paste config snippet) and the catalog of agents the ADE can
+/// auto-configure. `endpoint`/`token` are `None` until the hook server is listening.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpInfo {
+    pub endpoint: Option<String>,
+    pub token: Option<String>,
+    pub token_env: String,
+    pub server_name: String,
+    pub agents: Vec<crate::mcpinject::AgentInfo>,
+}
+
+/// Return the browser MCP server coordinates + supported-agent catalog for the
+/// Settings panel. The token is the app's own local loopback secret, surfaced only
+/// so the user can copy a ready-to-paste config for an agent the ADE doesn't
+/// auto-configure yet.
+#[tauri::command]
+pub async fn mcp_info(state: State<'_, AppState>) -> Result<McpInfo, CommandError> {
+    let hook = state.hook.read().await.clone();
+    let (endpoint, token) = match hook {
+        Some(h) => (Some(crate::mcpinject::mcp_endpoint(&h.url)), Some(h.token)),
+        None => (None, None),
+    };
+    Ok(McpInfo {
+        endpoint,
+        token,
+        token_env: crate::mcpinject::TOKEN_ENV.to_string(),
+        server_name: crate::mcpinject::SERVER_NAME.to_string(),
+        agents: crate::mcpinject::agent_infos(),
+    })
 }
 
 /// Send user input to a PTY's stdin.

--- a/uxnandesktop/src-tauri/src/hooks.rs
+++ b/uxnandesktop/src-tauri/src/hooks.rs
@@ -20,8 +20,10 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::{
+    body::Bytes,
     extract::State as AxumState,
     http::{HeaderMap, StatusCode},
+    response::Response,
     routing::{get, post},
     Json, Router,
 };
@@ -106,6 +108,9 @@ pub async fn start(app: AppHandle, token: String) -> std::io::Result<HookServerI
     let router = Router::new()
         .route("/hook", post(handle_hook))
         .route("/browser", post(handle_browser))
+        // Browser-control MCP server (spec `02d` §1.6): makes the integrated
+        // browser discoverable to agents as MCP tools. Same server + token.
+        .route("/mcp", post(handle_mcp).get(mcp_get))
         .route("/health", get(|| async { "ok" }))
         .with_state(ctx);
     tauri::async_runtime::spawn(async move {
@@ -205,6 +210,18 @@ async fn handle_browser(
         Ok(()) => StatusCode::NO_CONTENT,
         Err(_) => StatusCode::BAD_REQUEST,
     }
+}
+
+/// Handle a `POST /mcp`: the browser-control MCP endpoint. Thin wrapper that hands
+/// the app handle + token to [`crate::mcp::handle`] (which authorizes and runs the
+/// JSON-RPC handshake). Kept here so it shares the hook server's `HookCtx`/token.
+async fn handle_mcp(AxumState(ctx): AxumState<HookCtx>, headers: HeaderMap, body: Bytes) -> Response {
+    crate::mcp::handle(ctx.app.clone(), ctx.token.clone(), headers, body).await
+}
+
+/// Handle a `GET /mcp`: we don't offer the optional server→client SSE stream.
+async fn mcp_get() -> Response {
+    crate::mcp::handle_get().await
 }
 
 #[cfg(test)]

--- a/uxnandesktop/src-tauri/src/hooks.rs
+++ b/uxnandesktop/src-tauri/src/hooks.rs
@@ -215,7 +215,11 @@ async fn handle_browser(
 /// Handle a `POST /mcp`: the browser-control MCP endpoint. Thin wrapper that hands
 /// the app handle + token to [`crate::mcp::handle`] (which authorizes and runs the
 /// JSON-RPC handshake). Kept here so it shares the hook server's `HookCtx`/token.
-async fn handle_mcp(AxumState(ctx): AxumState<HookCtx>, headers: HeaderMap, body: Bytes) -> Response {
+async fn handle_mcp(
+    AxumState(ctx): AxumState<HookCtx>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
     crate::mcp::handle(ctx.app.clone(), ctx.token.clone(), headers, body).await
 }
 

--- a/uxnandesktop/src-tauri/src/lib.rs
+++ b/uxnandesktop/src-tauri/src/lib.rs
@@ -18,6 +18,8 @@ mod fswatch;
 mod git;
 mod gitfast;
 mod hooks;
+mod mcp;
+mod mcpinject;
 mod model;
 mod persistence;
 mod power;
@@ -206,6 +208,7 @@ pub fn run() {
             commands::get_app_state,
             commands::update_settings,
             commands::ping,
+            commands::mcp_info,
             commands::pty_create,
             commands::pty_write,
             commands::pty_resize,
@@ -287,6 +290,10 @@ pub fn run() {
                     // systemd-inhibit on macOS/Linux) so none is left running.
                     state.power.set(false);
                 }
+                // Remove any MCP config files we injected into workspaces / global
+                // config so nothing stale is left behind (best-effort; see
+                // `mcpinject.rs`).
+                crate::mcpinject::cleanup(app_handle);
             }
         });
 }

--- a/uxnandesktop/src-tauri/src/mcp.rs
+++ b/uxnandesktop/src-tauri/src/mcp.rs
@@ -1,0 +1,356 @@
+//! Browser-control MCP server — makes the integrated developer browser
+//! **discoverable** to CLI agents (spec `02d` §1.6).
+//!
+//! The problem this solves: an agent could already open a URL in the in-app
+//! browser by POSTing to the `/browser` hook route (see `hooks.rs`), but only if
+//! it *knew* that convention — it had to read the docs first. This module instead
+//! exposes the browser as a set of **Model Context Protocol** tools
+//! (`browser_open`, `browser_navigate`, `browser_reload`, `browser_back`,
+//! `browser_forward`, `browser_status`). When the ADE injects this server into an
+//! agent's MCP config (see `mcpinject.rs`), the agent discovers the tools with
+//! their descriptions automatically — they show up in its tool list like any
+//! native capability — so it drives the browser without any documentation.
+//!
+//! ## Transport
+//! A minimal, spec-correct **Streamable HTTP** MCP endpoint mounted at `/mcp` on
+//! the same local `axum` server as the hook routes, reusing its per-launch token
+//! (accepted as `Authorization: Bearer <token>` — the header every supported CLI
+//! can send — or the legacy `x-uxnan-token`). The tool surface is tiny and
+//! synchronous, so we implement the JSON-RPC handshake directly (`initialize` →
+//! `tools/list` → `tools/call`) and respond with `application/json`; no SSE /
+//! streaming is needed. This avoids pulling in a heavyweight MCP SDK whose macro
+//! API churns between releases.
+//!
+//! ## Control-only surface
+//! The tools map to the existing browser paths in [`crate::browser`]: `open` /
+//! `navigate` go through [`crate::browser::route_url`] (honoring the user's link
+//! policy and driving the frontend panel, exactly like a clicked link), while
+//! `reload` / `back` / `forward` act on the already-open window.
+//!
+//! FOR-DEV: page inspection + interaction tools (`browser_snapshot`,
+//! `browser_evaluate`, `browser_click`, `browser_type`) are intentionally out of
+//! scope for this pass. They need a JS return-channel from the docked
+//! `WebviewWindow` (Tauri's `.eval()` is fire-and-forget) — an injected
+//! init-script that posts results back, mindful of page CSP. See `FOR-DEV.md`.
+
+use axum::{
+    body::Bytes,
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use serde_json::{json, Value};
+
+use tauri::AppHandle;
+
+/// The MCP protocol revision we default to when a client doesn't pin one. We echo
+/// the client's requested version when it sends one (forward-compatible).
+const DEFAULT_PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Header carrying the shared secret (mirrors `hooks.rs`), accepted in addition to
+/// the standard `Authorization: Bearer <token>`.
+const TOKEN_HEADER: &str = "x-uxnan-token";
+
+/// True if the request presents the shared secret, via `Authorization: Bearer
+/// <token>` (what every supported CLI sends for a remote MCP server) or the
+/// legacy `x-uxnan-token` header.
+fn authorized(headers: &HeaderMap, token: &str) -> bool {
+    let bearer = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer ").or_else(|| v.strip_prefix("bearer ")))
+        .map(|v| v.trim() == token)
+        .unwrap_or(false);
+    let legacy = headers
+        .get(TOKEN_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v == token)
+        .unwrap_or(false);
+    bearer || legacy
+}
+
+/// The static tool catalog advertised on `tools/list`. Descriptions are written
+/// for the *agent*: they say when to reach for the tool, so it discovers the
+/// browser without docs.
+fn tool_catalog() -> Value {
+    json!([
+        {
+            "name": "browser_open",
+            "description": "Open the uxnan integrated in-app browser and load a URL. Use this to preview or test a web app, page, or dev server you are building or running (for example http://localhost:5173). The page shows up in a panel next to the terminal so the user sees it too. Routed through the user's browser settings (it may open the system browser instead if they chose that).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "url": { "type": "string", "description": "Absolute URL to open, e.g. http://localhost:3000 or https://example.com." }
+                },
+                "required": ["url"],
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "browser_navigate",
+            "description": "Navigate the integrated browser to a new URL (opening the panel first if it is not already open). Same routing as browser_open.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "url": { "type": "string", "description": "Absolute URL to navigate to." }
+                },
+                "required": ["url"],
+                "additionalProperties": false
+            }
+        },
+        {
+            "name": "browser_reload",
+            "description": "Reload the current page in the integrated browser. Use after you change code and want to see the updated result. Errors if no browser page is open.",
+            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
+        },
+        {
+            "name": "browser_back",
+            "description": "Go back one entry in the integrated browser's history. Errors if no browser page is open.",
+            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
+        },
+        {
+            "name": "browser_forward",
+            "description": "Go forward one entry in the integrated browser's history. Errors if no browser page is open.",
+            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
+        },
+        {
+            "name": "browser_status",
+            "description": "Report the integrated browser's state: whether a page is open, the current URL, whether the in-app browser is enabled, and how opens are routed (internal in-app / external system browser / ask). Call this first to decide whether to open or just navigate.",
+            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
+        }
+    ])
+}
+
+/// Build a JSON-RPC success envelope for `id`.
+fn ok_response(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+/// Build a JSON-RPC error envelope for `id`.
+fn err_response(id: Value, code: i64, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+/// Wrap a plain-text tool result in the MCP `content` shape.
+fn text_result(text: String, is_error: bool) -> Value {
+    json!({
+        "content": [ { "type": "text", "text": text } ],
+        "isError": is_error
+    })
+}
+
+/// Run one `tools/call`: dispatch the named browser tool and return an MCP
+/// tool-result value (with `isError` set on failure — MCP surfaces tool failures
+/// in-band, not as JSON-RPC errors, so the agent can read the reason).
+async fn call_tool(app: &AppHandle, name: &str, args: &Value) -> Value {
+    let url_arg = || args.get("url").and_then(|v| v.as_str()).map(str::to_string);
+    match name {
+        "browser_open" | "browser_navigate" => {
+            let Some(url) = url_arg() else {
+                return text_result("missing required \"url\" argument".into(), true);
+            };
+            match crate::browser::route_url(app, url.clone()).await {
+                Ok(()) => text_result(format!("Requested to open {url} in the browser."), false),
+                Err(e) => text_result(format!("Failed to open {url}: {}", e.message), true),
+            }
+        }
+        "browser_reload" => match crate::browser::browser_window_reload(app.clone()) {
+            Ok(()) => text_result("Reloaded the current page.".into(), false),
+            Err(e) => text_result(e.message, true),
+        },
+        "browser_back" => match crate::browser::browser_window_back(app.clone()) {
+            Ok(()) => text_result("Navigated back.".into(), false),
+            Err(e) => text_result(e.message, true),
+        },
+        "browser_forward" => match crate::browser::browser_window_forward(app.clone()) {
+            Ok(()) => text_result("Navigated forward.".into(), false),
+            Err(e) => text_result(e.message, true),
+        },
+        "browser_status" => {
+            let status = crate::browser::status(app).await;
+            let text = serde_json::to_string(&status)
+                .unwrap_or_else(|_| "{\"open\":false}".into());
+            text_result(text, false)
+        }
+        other => text_result(format!("unknown tool: {other}"), true),
+    }
+}
+
+/// Handle one JSON-RPC message. Returns `Some(response)` for a request (something
+/// with an `id`) and `None` for a notification (no `id` → no reply, per spec).
+async fn handle_message(app: &AppHandle, msg: &Value) -> Option<Value> {
+    let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+    // Notifications (e.g. `notifications/initialized`) carry no id and get no reply.
+    let id = msg.get("id").cloned()?;
+
+    let result = match method {
+        "initialize" => {
+            let protocol = msg
+                .get("params")
+                .and_then(|p| p.get("protocolVersion"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(DEFAULT_PROTOCOL_VERSION)
+                .to_string();
+            ok_response(
+                id,
+                json!({
+                    "protocolVersion": protocol,
+                    "capabilities": { "tools": { "listChanged": false } },
+                    "serverInfo": {
+                        "name": "uxnan-browser",
+                        "version": env!("CARGO_PKG_VERSION"),
+                        "title": "uxnan integrated browser"
+                    },
+                    "instructions": "Drive uxnan's integrated in-app browser to preview and test web apps and dev servers you build. Call browser_status first, then browser_open/browser_navigate; browser_reload after code changes."
+                }),
+            )
+        }
+        "ping" => ok_response(id, json!({})),
+        "tools/list" => ok_response(id, json!({ "tools": tool_catalog() })),
+        "tools/call" => {
+            let params = msg.get("params");
+            let name = params
+                .and_then(|p| p.get("name"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if name.is_empty() {
+                err_response(id, -32602, "missing tool name")
+            } else {
+                let empty = json!({});
+                let args = params.and_then(|p| p.get("arguments")).unwrap_or(&empty);
+                ok_response(id, call_tool(app, name, args).await)
+            }
+        }
+        "" => err_response(id, -32600, "invalid request: no method"),
+        other => err_response(id, -32601, &format!("method not found: {other}")),
+    };
+    Some(result)
+}
+
+/// Handle a `POST /mcp`: authorize, parse the JSON-RPC body (single message or a
+/// batch array), dispatch each, and reply. A body with only notifications gets a
+/// `202 Accepted` with no content; anything with a request replies `200` with the
+/// JSON-RPC response(s). Called from the thin route wrapper in `hooks.rs`.
+pub async fn handle(app: AppHandle, token: String, headers: HeaderMap, body: Bytes) -> Response {
+    if !authorized(&headers, &token) {
+        return (StatusCode::UNAUTHORIZED, "unauthorized").into_response();
+    }
+    let Ok(parsed) = serde_json::from_slice::<Value>(&body) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            axum::Json(err_response(Value::Null, -32700, "parse error")),
+        )
+            .into_response();
+    };
+
+    // Batch (array) or single message.
+    if let Some(batch) = parsed.as_array() {
+        let mut out = Vec::new();
+        for msg in batch {
+            if let Some(resp) = handle_message(&app, msg).await {
+                out.push(resp);
+            }
+        }
+        if out.is_empty() {
+            return StatusCode::ACCEPTED.into_response();
+        }
+        return json_response(Value::Array(out));
+    }
+
+    match handle_message(&app, &parsed).await {
+        Some(resp) => json_response(resp),
+        None => StatusCode::ACCEPTED.into_response(),
+    }
+}
+
+/// A `200 OK` JSON-RPC response with the MCP-friendly content type.
+fn json_response(value: Value) -> Response {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        serde_json::to_string(&value).unwrap_or_else(|_| "{}".into()),
+    )
+        .into_response()
+}
+
+/// A `GET /mcp` with no server-initiated stream to offer: MCP allows the server to
+/// decline the optional SSE channel with `405`. We only serve request/response.
+pub async fn handle_get() -> Response {
+    (StatusCode::METHOD_NOT_ALLOWED, "sse stream not supported").into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with(name: &str, value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(
+            axum::http::HeaderName::from_bytes(name.as_bytes()).unwrap(),
+            HeaderValue::from_str(value).unwrap(),
+        );
+        h
+    }
+
+    #[test]
+    fn authorizes_bearer_and_legacy_header() {
+        assert!(authorized(
+            &headers_with("authorization", "Bearer secret"),
+            "secret"
+        ));
+        assert!(authorized(&headers_with("x-uxnan-token", "secret"), "secret"));
+        assert!(!authorized(
+            &headers_with("authorization", "Bearer wrong"),
+            "secret"
+        ));
+        assert!(!authorized(&HeaderMap::new(), "secret"));
+    }
+
+    #[test]
+    fn tool_catalog_lists_the_control_tools() {
+        let cat = tool_catalog();
+        let names: Vec<&str> = cat
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+            .collect();
+        assert_eq!(
+            names,
+            vec![
+                "browser_open",
+                "browser_navigate",
+                "browser_reload",
+                "browser_back",
+                "browser_forward",
+                "browser_status",
+            ]
+        );
+        // Every tool carries a non-empty description + object input schema so the
+        // agent can discover it without docs.
+        for t in cat.as_array().unwrap() {
+            assert!(!t["description"].as_str().unwrap_or("").is_empty());
+            assert_eq!(t["inputSchema"]["type"], "object");
+        }
+    }
+
+    #[test]
+    fn envelopes_are_well_formed_json_rpc() {
+        let ok = ok_response(json!(1), json!({"a": true}));
+        assert_eq!(ok["jsonrpc"], "2.0");
+        assert_eq!(ok["id"], 1);
+        assert_eq!(ok["result"]["a"], true);
+
+        let err = err_response(json!("x"), -32601, "nope");
+        assert_eq!(err["error"]["code"], -32601);
+        assert_eq!(err["error"]["message"], "nope");
+    }
+
+    #[test]
+    fn text_result_shapes_content_and_error_flag() {
+        let r = text_result("hi".into(), true);
+        assert_eq!(r["content"][0]["type"], "text");
+        assert_eq!(r["content"][0]["text"], "hi");
+        assert_eq!(r["isError"], true);
+    }
+}

--- a/uxnandesktop/src-tauri/src/mcp.rs
+++ b/uxnandesktop/src-tauri/src/mcp.rs
@@ -57,7 +57,10 @@ fn authorized(headers: &HeaderMap, token: &str) -> bool {
     let bearer = headers
         .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer ").or_else(|| v.strip_prefix("bearer ")))
+        .and_then(|v| {
+            v.strip_prefix("Bearer ")
+                .or_else(|| v.strip_prefix("bearer "))
+        })
         .map(|v| v.trim() == token)
         .unwrap_or(false);
     let legacy = headers
@@ -167,8 +170,7 @@ async fn call_tool(app: &AppHandle, name: &str, args: &Value) -> Value {
         },
         "browser_status" => {
             let status = crate::browser::status(app).await;
-            let text = serde_json::to_string(&status)
-                .unwrap_or_else(|_| "{\"open\":false}".into());
+            let text = serde_json::to_string(&status).unwrap_or_else(|_| "{\"open\":false}".into());
             text_result(text, false)
         }
         other => text_result(format!("unknown tool: {other}"), true),
@@ -298,7 +300,10 @@ mod tests {
             &headers_with("authorization", "Bearer secret"),
             "secret"
         ));
-        assert!(authorized(&headers_with("x-uxnan-token", "secret"), "secret"));
+        assert!(authorized(
+            &headers_with("x-uxnan-token", "secret"),
+            "secret"
+        ));
         assert!(!authorized(
             &headers_with("authorization", "Bearer wrong"),
             "secret"

--- a/uxnandesktop/src-tauri/src/mcpinject.rs
+++ b/uxnandesktop/src-tauri/src/mcpinject.rs
@@ -1,0 +1,531 @@
+//! MCP config injection — makes the browser MCP server (`mcp.rs`) **discoverable**
+//! to the CLI agents the ADE launches, so they get the `browser_*` tools with zero
+//! setup and zero documentation.
+//!
+//! ## The idea
+//! `mcp.rs` serves the tools; this module writes each agent CLI's own native MCP
+//! config so the agent finds that server on startup. The endpoint is the local
+//! hook server's `/mcp` route; the **token is never written to a file** — every
+//! config references the `UXNAN_MCP_TOKEN` environment variable (injected into the
+//! agent's terminal in `commands.rs`), so the secret stays in the process env.
+//!
+//! ## Modes (see [`crate::model::McpInjection`])
+//! - **Workspace** (default): write a project-scoped config into the terminal's
+//!   working directory (auto-discovered by the CLI there), so both app-launched and
+//!   hand-typed agents in that folder get the tools. Files we *create* are hidden
+//!   from Git (added to the repo's `info/exclude`) and removed on exit.
+//! - **Global**: write into each CLI's global user config, so the tools are
+//!   available in every project (covers agents without a project-scoped config).
+//! - **Off**: inject nothing (the user can wire it by hand — the Settings panel
+//!   shows a copy-paste snippet).
+//!
+//! ## Per-agent config (this is the extension point)
+//! Each supported agent is one [`McpAgent`] row in [`AGENTS`]. To support a **new**
+//! agent (e.g. `agy`/Antigravity, Cursor, Grok, amp), add a row and a match arm in
+//! [`config_path`] + [`write_entry`] describing where its MCP config lives and its
+//! shape — nothing else changes. Current rows:
+//!
+//! | Agent | Project file (workspace) | Global file | Shape |
+//! |-------|--------------------------|-------------|-------|
+//! | Claude Code | `.mcp.json` | `~/.claude.json` | `mcpServers.<n> {type:http,url,headers}` |
+//! | Codex | `.codex/config.toml` | `~/.codex/config.toml` | `[mcp_servers.<n>] url + bearer_token_env_var` |
+//! | Gemini CLI | `.gemini/settings.json` | `~/.gemini/settings.json` | `mcpServers.<n> {httpUrl,headers}` |
+//! | OpenCode | `opencode.json` | `~/.config/opencode/opencode.json` | `mcp.<n> {type:remote,url,headers,enabled}` |
+//! | Pi | — (global only) | `~/.pi/agent/mcp.json` | `mcpServers.<n> {url,headers}` |
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Manager};
+
+use crate::model::McpInjection;
+use crate::state::AppState;
+
+/// The MCP server name every agent config registers us under (its tools appear
+/// prefixed with this, e.g. `mcp__uxnan-browser__browser_open`).
+pub const SERVER_NAME: &str = "uxnan-browser";
+/// Environment variable the injected configs read the bearer token from, so the
+/// token itself is never written to a config file.
+pub const TOKEN_ENV: &str = "UXNAN_MCP_TOKEN";
+
+/// Where an agent keeps its config, for the Settings panel + docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    /// Has a project-scoped config auto-discovered in the working directory.
+    Project,
+    /// Only a single global user config (no per-project file).
+    GlobalOnly,
+}
+
+/// One agent the ADE can auto-configure to reach the browser MCP server.
+#[derive(Debug, Clone, Copy)]
+pub struct McpAgent {
+    /// Stable id used in `mcpDisabledAgents` + the Settings toggles.
+    pub id: &'static str,
+    /// Human-readable name for the UI.
+    pub label: &'static str,
+    /// Whether it supports a project-scoped config or only a global one.
+    pub scope: Scope,
+}
+
+/// Serializable view of a supported agent for the Settings → Browser panel (the
+/// per-agent injection toggles + the "which agents" list in the copy-paste help).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentInfo {
+    pub id: String,
+    pub label: String,
+    /// True for agents with no project-scoped config (only injected in Global mode
+    /// / via their global file — e.g. Pi). The UI notes this.
+    pub global_only: bool,
+}
+
+/// The supported-agent catalog for the frontend (Settings panel + docs).
+pub fn agent_infos() -> Vec<AgentInfo> {
+    AGENTS
+        .iter()
+        .map(|a| AgentInfo {
+            id: a.id.to_string(),
+            label: a.label.to_string(),
+            global_only: a.scope == Scope::GlobalOnly,
+        })
+        .collect()
+}
+
+/// The agents we currently know how to configure. Add a row here (plus a match arm
+/// in [`config_path`] and [`write_entry`]) to support a new agent.
+pub const AGENTS: &[McpAgent] = &[
+    McpAgent { id: "claude", label: "Claude Code", scope: Scope::Project },
+    McpAgent { id: "codex", label: "Codex", scope: Scope::Project },
+    McpAgent { id: "gemini", label: "Gemini CLI", scope: Scope::Project },
+    McpAgent { id: "opencode", label: "OpenCode", scope: Scope::Project },
+    McpAgent { id: "pi", label: "Pi", scope: Scope::GlobalOnly },
+];
+
+/// A config file we wrote, recorded so it can be undone on exit.
+#[derive(Debug, Clone)]
+pub struct Written {
+    /// Absolute path of the config file.
+    pub path: PathBuf,
+    /// Agent id (selects the cleanup format).
+    pub agent: String,
+    /// True if we created the file (so cleanup may delete it when left empty).
+    pub created: bool,
+}
+
+/// Turn the hook server's `…/hook` URL into its `…/mcp` sibling (the MCP endpoint).
+pub fn mcp_endpoint(hook_url: &str) -> String {
+    hook_url.replacen("/hook", "/mcp", 1)
+}
+
+/// The config file path for `agent` under `mode`, given the terminal `cwd` and the
+/// user's `home`. `None` when the agent has no config for that mode (Pi has no
+/// project file, so it always uses its global path).
+fn config_path(agent: &str, mode: McpInjection, cwd: &Path, home: &Path) -> Option<PathBuf> {
+    let project = matches!(mode, McpInjection::Workspace);
+    match agent {
+        "claude" => Some(if project {
+            cwd.join(".mcp.json")
+        } else {
+            home.join(".claude.json")
+        }),
+        "codex" => Some(if project {
+            cwd.join(".codex").join("config.toml")
+        } else {
+            home.join(".codex").join("config.toml")
+        }),
+        "gemini" => Some(if project {
+            cwd.join(".gemini").join("settings.json")
+        } else {
+            home.join(".gemini").join("settings.json")
+        }),
+        "opencode" => Some(if project {
+            cwd.join("opencode.json")
+        } else {
+            home.join(".config").join("opencode").join("opencode.json")
+        }),
+        // Pi has no project-scoped config — always its global agent dir.
+        "pi" => Some(home.join(".pi").join("agent").join("mcp.json")),
+        _ => None,
+    }
+}
+
+/// The JSON entry (server definition) for a JSON-config agent. `None` for Codex
+/// (TOML, handled separately).
+fn json_entry(agent: &str, endpoint: &str) -> Option<(Vec<&'static str>, Value)> {
+    // Token is referenced by env, never inlined — each CLI's own expansion syntax.
+    let bearer_dollar = format!("Bearer ${{{TOKEN_ENV}}}"); // ${UXNAN_MCP_TOKEN}
+    let bearer_brace = format!("Bearer {{env:{TOKEN_ENV}}}"); // {env:UXNAN_MCP_TOKEN}
+    match agent {
+        "claude" => Some((
+            vec!["mcpServers", SERVER_NAME],
+            json!({ "type": "http", "url": endpoint, "headers": { "Authorization": bearer_dollar } }),
+        )),
+        "gemini" => Some((
+            vec!["mcpServers", SERVER_NAME],
+            json!({ "httpUrl": endpoint, "headers": { "Authorization": bearer_dollar } }),
+        )),
+        "opencode" => Some((
+            vec!["mcp", SERVER_NAME],
+            json!({ "type": "remote", "url": endpoint, "enabled": true, "headers": { "Authorization": bearer_brace } }),
+        )),
+        // FOR-DEV: Pi's HTTP-server + auth-header config shape is unverified upstream
+        // (no project config, only global `~/.pi/agent/mcp.json`). This is a
+        // best-guess `{url, headers:{Authorization}}` — verify against a real Pi
+        // install and fix the shape if needed. See `FOR-DEV.md` → browser MCP.
+        "pi" => Some((
+            vec!["mcpServers", SERVER_NAME],
+            json!({ "url": endpoint, "headers": { "Authorization": bearer_dollar } }),
+        )),
+        _ => None,
+    }
+}
+
+// --- File format helpers (pure, unit-tested) -------------------------------
+
+/// Set a nested key in a JSON document (creating intermediate objects), returning
+/// the updated document. Overwrites only the leaf at `pointer` — the user's other
+/// keys are preserved.
+fn json_set(mut doc: Value, pointer: &[&str], entry: Value) -> Value {
+    if !doc.is_object() {
+        doc = json!({});
+    }
+    fn set(node: &mut Value, pointer: &[&str], entry: Value) {
+        match pointer {
+            [] => {}
+            [last] => {
+                node[*last] = entry;
+            }
+            [head, rest @ ..] => {
+                if !node[*head].is_object() {
+                    node[*head] = json!({});
+                }
+                set(&mut node[*head], rest, entry);
+            }
+        }
+    }
+    set(&mut doc, pointer, entry);
+    doc
+}
+
+/// Remove a nested key from a JSON document, pruning now-empty parent objects.
+/// Returns the updated document (which may be an empty object).
+fn json_remove(mut doc: Value, pointer: &[&str]) -> Value {
+    fn remove(node: &mut Value, pointer: &[&str]) {
+        match pointer {
+            [] => {}
+            [last] => {
+                if let Some(obj) = node.as_object_mut() {
+                    obj.remove(*last);
+                }
+            }
+            [head, rest @ ..] => {
+                if node.get(*head).is_some() {
+                    remove(&mut node[*head], rest);
+                    // Prune an emptied parent object.
+                    if node[*head].as_object().map(|o| o.is_empty()).unwrap_or(false) {
+                        if let Some(obj) = node.as_object_mut() {
+                            obj.remove(*head);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    remove(&mut doc, pointer);
+    doc
+}
+
+/// Merge (or remove) our Codex server in a `config.toml`, preserving the user's
+/// other settings and formatting. `endpoint = Some` inserts; `None` removes.
+fn toml_codex(existing: &str, endpoint: Option<&str>) -> String {
+    let mut doc = existing.parse::<toml_edit::DocumentMut>().unwrap_or_default();
+    match endpoint {
+        Some(url) => {
+            // Ensure `mcp_servers` is a real (header) table, then add our server as
+            // a `[mcp_servers.<name>]` sub-table. Existing servers/keys are kept.
+            if !doc.get("mcp_servers").map(|i| i.is_table()).unwrap_or(false) {
+                doc["mcp_servers"] = toml_edit::Item::Table(toml_edit::Table::new());
+            }
+            let mut entry = toml_edit::Table::new();
+            entry["url"] = toml_edit::value(url);
+            entry["bearer_token_env_var"] = toml_edit::value(TOKEN_ENV);
+            if let Some(servers) = doc["mcp_servers"].as_table_mut() {
+                servers.insert(SERVER_NAME, toml_edit::Item::Table(entry));
+            }
+        }
+        None => {
+            // Remove our entry whether `mcp_servers` is a header table or an inline
+            // table, pruning it if it becomes empty.
+            let emptied = if let Some(t) = doc.get_mut("mcp_servers").and_then(|i| i.as_table_mut()) {
+                t.remove(SERVER_NAME);
+                t.is_empty()
+            } else if let Some(t) = doc.get_mut("mcp_servers").and_then(|i| i.as_inline_table_mut()) {
+                t.remove(SERVER_NAME);
+                t.is_empty()
+            } else {
+                false
+            };
+            if emptied {
+                doc.as_table_mut().remove("mcp_servers");
+            }
+        }
+    }
+    doc.to_string()
+}
+
+// --- Injection + cleanup ---------------------------------------------------
+
+/// Write `agent`'s config so it points at the browser MCP server, recording the
+/// write for later cleanup. Merges into an existing file (never clobbers other
+/// keys) and hides a file we create from Git. Best-effort: I/O errors are ignored
+/// (a failed injection just means that agent won't see the tools).
+fn write_entry(agent: &str, path: &Path, endpoint: &str) -> Option<Written> {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let existed = path.exists();
+
+    if agent == "codex" {
+        let existing = std::fs::read_to_string(path).unwrap_or_default();
+        let merged = toml_codex(&existing, Some(endpoint));
+        std::fs::write(path, merged).ok()?;
+    } else {
+        let (pointer, entry) = json_entry(agent, endpoint)?;
+        let current: Value = std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_else(|| json!({}));
+        let merged = json_set(current, &pointer, entry);
+        std::fs::write(path, format!("{}\n", serde_json::to_string_pretty(&merged).ok()?)).ok()?;
+    }
+
+    if !existed {
+        hide_from_git(path);
+    }
+    Some(Written { path: path.to_path_buf(), agent: agent.to_string(), created: !existed })
+}
+
+/// Undo one injected config: remove our server entry, deleting the file only if we
+/// created it and it's now empty. Best-effort.
+fn undo_entry(w: &Written) {
+    let Ok(text) = std::fs::read_to_string(&w.path) else {
+        return;
+    };
+    if w.agent == "codex" {
+        let stripped = toml_codex(&text, None);
+        if w.created && stripped.trim().is_empty() {
+            let _ = std::fs::remove_file(&w.path);
+        } else {
+            let _ = std::fs::write(&w.path, stripped);
+        }
+        return;
+    }
+    let Some((pointer, _)) = json_entry(&w.agent, "") else {
+        return;
+    };
+    let doc: Value = serde_json::from_str(&text).unwrap_or_else(|_| json!({}));
+    let stripped = json_remove(doc, &pointer);
+    let empty = stripped.as_object().map(|o| o.is_empty()).unwrap_or(false);
+    if w.created && empty {
+        let _ = std::fs::remove_file(&w.path);
+    } else if let Ok(s) = serde_json::to_string_pretty(&stripped) {
+        let _ = std::fs::write(&w.path, format!("{s}\n"));
+    }
+}
+
+/// Add a created config file to its repo's `info/exclude` so it doesn't show up in
+/// `git status` (works for both normal repos and linked worktrees via the common
+/// git dir). Best-effort; no-op outside a repo.
+fn hide_from_git(path: &Path) {
+    let Some(dir) = path.parent() else { return };
+    let Ok(repo) = git2::Repository::discover(dir) else {
+        return;
+    };
+    let exclude = repo.commondir().join("info").join("exclude");
+    // Store the path relative to the repo workdir when possible, else the file name.
+    let entry = repo
+        .workdir()
+        .and_then(|wd| path.strip_prefix(wd).ok())
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_else(|| path.file_name().unwrap_or_default().to_string_lossy().into());
+    let existing = std::fs::read_to_string(&exclude).unwrap_or_default();
+    if existing.lines().any(|l| l.trim() == entry) {
+        return;
+    }
+    if let Some(parent) = exclude.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let sep = if existing.is_empty() || existing.ends_with('\n') { "" } else { "\n" };
+    let _ = std::fs::write(&exclude, format!("{existing}{sep}{entry}\n"));
+}
+
+/// Ensure every enabled agent's config points at the browser MCP server for this
+/// `cwd` under the current settings. Deduplicated per (mode, cwd) so it runs once
+/// per workspace per session. Called from `pty_create` before an agent starts.
+pub async fn prepare(app: &AppHandle, cwd: &str) {
+    let (enabled, mode, disabled) = {
+        let state = app.state::<AppState>();
+        let data = state.data.read().await;
+        let b = &data.settings.browser;
+        (b.mcp_enabled, b.mcp_injection, b.mcp_disabled_agents.clone())
+    };
+    if !enabled || mode == McpInjection::Off {
+        return;
+    }
+    let endpoint = {
+        let state = app.state::<AppState>();
+        let hook = state.hook.read().await.clone();
+        match hook {
+            Some(h) => mcp_endpoint(&h.url),
+            None => return,
+        }
+    };
+
+    let cwd_path = PathBuf::from(cwd);
+    // Workspace mode targets the project dir; only inject into an existing dir.
+    if mode == McpInjection::Workspace && !cwd_path.is_dir() {
+        return;
+    }
+    let home = match app.path().home_dir() {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+
+    // Dedup key: workspace configs vary by cwd; global configs are written once.
+    let dedup_key = match mode {
+        McpInjection::Global => "global".to_string(),
+        _ => format!("ws:{cwd}"),
+    };
+    {
+        let state = app.state::<AppState>();
+        let mut prepared = state.mcp_prepared.lock().unwrap();
+        if !prepared.insert(dedup_key) {
+            return; // already done this session
+        }
+    }
+
+    let disabled: HashSet<&str> = disabled.iter().map(String::as_str).collect();
+    let mut writes = Vec::new();
+    for agent in AGENTS {
+        if disabled.contains(agent.id) {
+            continue;
+        }
+        if let Some(path) = config_path(agent.id, mode, &cwd_path, &home) {
+            if let Some(w) = write_entry(agent.id, &path, &endpoint) {
+                writes.push(w);
+            }
+        }
+    }
+    if !writes.is_empty() {
+        let state = app.state::<AppState>();
+        state.mcp_written.lock().unwrap().extend(writes);
+    }
+}
+
+/// Remove every injected config (called on app exit). Best-effort so shutdown is
+/// never blocked; leftover entries are harmless (a stale local endpoint just fails
+/// to connect) and are overwritten with the live one next launch.
+pub fn cleanup(app: &AppHandle) {
+    let state = app.state::<AppState>();
+    let written = {
+        let mut guard = state.mcp_written.lock().unwrap();
+        std::mem::take(&mut *guard)
+    };
+    for w in &written {
+        undo_entry(w);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_rewrites_hook_to_mcp() {
+        assert_eq!(
+            mcp_endpoint("http://127.0.0.1:5123/hook"),
+            "http://127.0.0.1:5123/mcp"
+        );
+    }
+
+    #[test]
+    fn json_set_creates_nested_and_preserves_siblings() {
+        let doc = json!({ "existing": { "keep": true } });
+        let out = json_set(doc, &["mcpServers", "uxnan-browser"], json!({ "url": "x" }));
+        assert_eq!(out["existing"]["keep"], true);
+        assert_eq!(out["mcpServers"]["uxnan-browser"]["url"], "x");
+    }
+
+    #[test]
+    fn json_remove_prunes_empty_parents_but_keeps_others() {
+        let doc = json!({ "mcpServers": { "uxnan-browser": { "url": "x" } }, "other": 1 });
+        let out = json_remove(doc, &["mcpServers", "uxnan-browser"]);
+        assert!(out.get("mcpServers").is_none()); // pruned (was only child)
+        assert_eq!(out["other"], 1);
+
+        let doc2 = json!({ "mcpServers": { "uxnan-browser": {}, "keep": {} } });
+        let out2 = json_remove(doc2, &["mcpServers", "uxnan-browser"]);
+        assert!(out2["mcpServers"].get("uxnan-browser").is_none());
+        assert!(out2["mcpServers"].get("keep").is_some()); // sibling stays
+    }
+
+    #[test]
+    fn json_entry_never_inlines_the_token() {
+        for agent in ["claude", "gemini", "opencode", "pi"] {
+            let (_, entry) = json_entry(agent, "http://x/mcp").unwrap();
+            let s = entry.to_string();
+            assert!(s.contains("Authorization"));
+            // The literal token env var name is referenced, never a raw secret.
+            assert!(s.contains("UXNAN_MCP_TOKEN"));
+        }
+    }
+
+    #[test]
+    fn toml_codex_inserts_and_removes_without_clobbering() {
+        let existing = "model = \"o3\"\n\n[some.other]\nk = 1\n";
+        let with = toml_codex(existing, Some("http://127.0.0.1:9/mcp"));
+        // Verify the structure by re-parsing (robust to header formatting).
+        let doc = with.parse::<toml_edit::DocumentMut>().unwrap();
+        assert_eq!(
+            doc["mcp_servers"][SERVER_NAME]["url"].as_str(),
+            Some("http://127.0.0.1:9/mcp")
+        );
+        assert_eq!(
+            doc["mcp_servers"][SERVER_NAME]["bearer_token_env_var"].as_str(),
+            Some("UXNAN_MCP_TOKEN")
+        );
+        assert!(with.contains("model = \"o3\"")); // user's settings preserved
+        assert!(with.contains("[some.other]"));
+
+        let without = toml_codex(&with, None);
+        assert!(!without.contains("uxnan-browser"));
+        assert!(without.contains("model = \"o3\"")); // still preserved
+    }
+
+    #[test]
+    fn config_path_maps_each_agent() {
+        let cwd = Path::new("/work/repo");
+        let home = Path::new("/home/u");
+        // Workspace (project) paths.
+        assert_eq!(
+            config_path("claude", McpInjection::Workspace, cwd, home).unwrap(),
+            cwd.join(".mcp.json")
+        );
+        assert_eq!(
+            config_path("codex", McpInjection::Workspace, cwd, home).unwrap(),
+            cwd.join(".codex").join("config.toml")
+        );
+        // Pi is global even in workspace mode.
+        assert_eq!(
+            config_path("pi", McpInjection::Workspace, cwd, home).unwrap(),
+            home.join(".pi").join("agent").join("mcp.json")
+        );
+        // Global paths.
+        assert_eq!(
+            config_path("gemini", McpInjection::Global, cwd, home).unwrap(),
+            home.join(".gemini").join("settings.json")
+        );
+    }
+}

--- a/uxnandesktop/src-tauri/src/mcpinject.rs
+++ b/uxnandesktop/src-tauri/src/mcpinject.rs
@@ -80,10 +80,22 @@ pub fn agent_infos() -> Vec<AgentInfo> {
 /// The agents we currently know how to configure. Add a row here (plus a match arm
 /// in [`config_path`] and [`write_entry`]) to support a new agent.
 pub const AGENTS: &[McpAgent] = &[
-    McpAgent { id: "claude", label: "Claude Code" },
-    McpAgent { id: "codex", label: "Codex" },
-    McpAgent { id: "gemini", label: "Gemini CLI" },
-    McpAgent { id: "opencode", label: "OpenCode" },
+    McpAgent {
+        id: "claude",
+        label: "Claude Code",
+    },
+    McpAgent {
+        id: "codex",
+        label: "Codex",
+    },
+    McpAgent {
+        id: "gemini",
+        label: "Gemini CLI",
+    },
+    McpAgent {
+        id: "opencode",
+        label: "OpenCode",
+    },
 ];
 
 /// A config file we wrote, recorded so it can be undone on exit.
@@ -196,7 +208,11 @@ fn json_remove(mut doc: Value, pointer: &[&str]) -> Value {
                 if node.get(*head).is_some() {
                     remove(&mut node[*head], rest);
                     // Prune an emptied parent object.
-                    if node[*head].as_object().map(|o| o.is_empty()).unwrap_or(false) {
+                    if node[*head]
+                        .as_object()
+                        .map(|o| o.is_empty())
+                        .unwrap_or(false)
+                    {
                         if let Some(obj) = node.as_object_mut() {
                             obj.remove(*head);
                         }
@@ -212,12 +228,18 @@ fn json_remove(mut doc: Value, pointer: &[&str]) -> Value {
 /// Merge (or remove) our Codex server in a `config.toml`, preserving the user's
 /// other settings and formatting. `endpoint = Some` inserts; `None` removes.
 fn toml_codex(existing: &str, endpoint: Option<&str>) -> String {
-    let mut doc = existing.parse::<toml_edit::DocumentMut>().unwrap_or_default();
+    let mut doc = existing
+        .parse::<toml_edit::DocumentMut>()
+        .unwrap_or_default();
     match endpoint {
         Some(url) => {
             // Ensure `mcp_servers` is a real (header) table, then add our server as
             // a `[mcp_servers.<name>]` sub-table. Existing servers/keys are kept.
-            if !doc.get("mcp_servers").map(|i| i.is_table()).unwrap_or(false) {
+            if !doc
+                .get("mcp_servers")
+                .map(|i| i.is_table())
+                .unwrap_or(false)
+            {
                 doc["mcp_servers"] = toml_edit::Item::Table(toml_edit::Table::new());
             }
             let mut entry = toml_edit::Table::new();
@@ -230,10 +252,14 @@ fn toml_codex(existing: &str, endpoint: Option<&str>) -> String {
         None => {
             // Remove our entry whether `mcp_servers` is a header table or an inline
             // table, pruning it if it becomes empty.
-            let emptied = if let Some(t) = doc.get_mut("mcp_servers").and_then(|i| i.as_table_mut()) {
+            let emptied = if let Some(t) = doc.get_mut("mcp_servers").and_then(|i| i.as_table_mut())
+            {
                 t.remove(SERVER_NAME);
                 t.is_empty()
-            } else if let Some(t) = doc.get_mut("mcp_servers").and_then(|i| i.as_inline_table_mut()) {
+            } else if let Some(t) = doc
+                .get_mut("mcp_servers")
+                .and_then(|i| i.as_inline_table_mut())
+            {
                 t.remove(SERVER_NAME);
                 t.is_empty()
             } else {
@@ -270,13 +296,21 @@ fn write_entry(agent: &str, path: &Path, endpoint: &str) -> Option<Written> {
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or_else(|| json!({}));
         let merged = json_set(current, &pointer, entry);
-        std::fs::write(path, format!("{}\n", serde_json::to_string_pretty(&merged).ok()?)).ok()?;
+        std::fs::write(
+            path,
+            format!("{}\n", serde_json::to_string_pretty(&merged).ok()?),
+        )
+        .ok()?;
     }
 
     if !existed {
         hide_from_git(path);
     }
-    Some(Written { path: path.to_path_buf(), agent: agent.to_string(), created: !existed })
+    Some(Written {
+        path: path.to_path_buf(),
+        agent: agent.to_string(),
+        created: !existed,
+    })
 }
 
 /// Undo one injected config: remove our server entry, deleting the file only if we
@@ -321,7 +355,12 @@ fn hide_from_git(path: &Path) {
         .workdir()
         .and_then(|wd| path.strip_prefix(wd).ok())
         .map(|p| p.to_string_lossy().replace('\\', "/"))
-        .unwrap_or_else(|| path.file_name().unwrap_or_default().to_string_lossy().into());
+        .unwrap_or_else(|| {
+            path.file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into()
+        });
     let existing = std::fs::read_to_string(&exclude).unwrap_or_default();
     if existing.lines().any(|l| l.trim() == entry) {
         return;
@@ -329,7 +368,11 @@ fn hide_from_git(path: &Path) {
     if let Some(parent) = exclude.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let sep = if existing.is_empty() || existing.ends_with('\n') { "" } else { "\n" };
+    let sep = if existing.is_empty() || existing.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
     let _ = std::fs::write(&exclude, format!("{existing}{sep}{entry}\n"));
 }
 
@@ -341,7 +384,11 @@ pub async fn prepare(app: &AppHandle, cwd: &str) {
         let state = app.state::<AppState>();
         let data = state.data.read().await;
         let b = &data.settings.browser;
-        (b.mcp_enabled, b.mcp_injection, b.mcp_disabled_agents.clone())
+        (
+            b.mcp_enabled,
+            b.mcp_injection,
+            b.mcp_disabled_agents.clone(),
+        )
     };
     if !enabled || mode == McpInjection::Off {
         return;

--- a/uxnandesktop/src-tauri/src/mcpinject.rs
+++ b/uxnandesktop/src-tauri/src/mcpinject.rs
@@ -31,7 +31,6 @@
 //! | Codex | `.codex/config.toml` | `~/.codex/config.toml` | `[mcp_servers.<n>] url + bearer_token_env_var` |
 //! | Gemini CLI | `.gemini/settings.json` | `~/.gemini/settings.json` | `mcpServers.<n> {httpUrl,headers}` |
 //! | OpenCode | `opencode.json` | `~/.config/opencode/opencode.json` | `mcp.<n> {type:remote,url,headers,enabled}` |
-//! | Pi | — (global only) | `~/.pi/agent/mcp.json` | `mcpServers.<n> {url,headers}` |
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -49,15 +48,6 @@ pub const SERVER_NAME: &str = "uxnan-browser";
 /// token itself is never written to a config file.
 pub const TOKEN_ENV: &str = "UXNAN_MCP_TOKEN";
 
-/// Where an agent keeps its config, for the Settings panel + docs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Scope {
-    /// Has a project-scoped config auto-discovered in the working directory.
-    Project,
-    /// Only a single global user config (no per-project file).
-    GlobalOnly,
-}
-
 /// One agent the ADE can auto-configure to reach the browser MCP server.
 #[derive(Debug, Clone, Copy)]
 pub struct McpAgent {
@@ -65,8 +55,6 @@ pub struct McpAgent {
     pub id: &'static str,
     /// Human-readable name for the UI.
     pub label: &'static str,
-    /// Whether it supports a project-scoped config or only a global one.
-    pub scope: Scope,
 }
 
 /// Serializable view of a supported agent for the Settings → Browser panel (the
@@ -76,9 +64,6 @@ pub struct McpAgent {
 pub struct AgentInfo {
     pub id: String,
     pub label: String,
-    /// True for agents with no project-scoped config (only injected in Global mode
-    /// / via their global file — e.g. Pi). The UI notes this.
-    pub global_only: bool,
 }
 
 /// The supported-agent catalog for the frontend (Settings panel + docs).
@@ -88,7 +73,6 @@ pub fn agent_infos() -> Vec<AgentInfo> {
         .map(|a| AgentInfo {
             id: a.id.to_string(),
             label: a.label.to_string(),
-            global_only: a.scope == Scope::GlobalOnly,
         })
         .collect()
 }
@@ -96,11 +80,10 @@ pub fn agent_infos() -> Vec<AgentInfo> {
 /// The agents we currently know how to configure. Add a row here (plus a match arm
 /// in [`config_path`] and [`write_entry`]) to support a new agent.
 pub const AGENTS: &[McpAgent] = &[
-    McpAgent { id: "claude", label: "Claude Code", scope: Scope::Project },
-    McpAgent { id: "codex", label: "Codex", scope: Scope::Project },
-    McpAgent { id: "gemini", label: "Gemini CLI", scope: Scope::Project },
-    McpAgent { id: "opencode", label: "OpenCode", scope: Scope::Project },
-    McpAgent { id: "pi", label: "Pi", scope: Scope::GlobalOnly },
+    McpAgent { id: "claude", label: "Claude Code" },
+    McpAgent { id: "codex", label: "Codex" },
+    McpAgent { id: "gemini", label: "Gemini CLI" },
+    McpAgent { id: "opencode", label: "OpenCode" },
 ];
 
 /// A config file we wrote, recorded so it can be undone on exit.
@@ -120,8 +103,7 @@ pub fn mcp_endpoint(hook_url: &str) -> String {
 }
 
 /// The config file path for `agent` under `mode`, given the terminal `cwd` and the
-/// user's `home`. `None` when the agent has no config for that mode (Pi has no
-/// project file, so it always uses its global path).
+/// user's `home`. `None` for an unknown agent.
 fn config_path(agent: &str, mode: McpInjection, cwd: &Path, home: &Path) -> Option<PathBuf> {
     let project = matches!(mode, McpInjection::Workspace);
     match agent {
@@ -145,8 +127,6 @@ fn config_path(agent: &str, mode: McpInjection, cwd: &Path, home: &Path) -> Opti
         } else {
             home.join(".config").join("opencode").join("opencode.json")
         }),
-        // Pi has no project-scoped config — always its global agent dir.
-        "pi" => Some(home.join(".pi").join("agent").join("mcp.json")),
         _ => None,
     }
 }
@@ -169,14 +149,6 @@ fn json_entry(agent: &str, endpoint: &str) -> Option<(Vec<&'static str>, Value)>
         "opencode" => Some((
             vec!["mcp", SERVER_NAME],
             json!({ "type": "remote", "url": endpoint, "enabled": true, "headers": { "Authorization": bearer_brace } }),
-        )),
-        // FOR-DEV: Pi's HTTP-server + auth-header config shape is unverified upstream
-        // (no project config, only global `~/.pi/agent/mcp.json`). This is a
-        // best-guess `{url, headers:{Authorization}}` — verify against a real Pi
-        // install and fix the shape if needed. See `FOR-DEV.md` → browser MCP.
-        "pi" => Some((
-            vec!["mcpServers", SERVER_NAME],
-            json!({ "url": endpoint, "headers": { "Authorization": bearer_dollar } }),
         )),
         _ => None,
     }
@@ -473,7 +445,7 @@ mod tests {
 
     #[test]
     fn json_entry_never_inlines_the_token() {
-        for agent in ["claude", "gemini", "opencode", "pi"] {
+        for agent in ["claude", "gemini", "opencode"] {
             let (_, entry) = json_entry(agent, "http://x/mcp").unwrap();
             let s = entry.to_string();
             assert!(s.contains("Authorization"));
@@ -516,11 +488,6 @@ mod tests {
         assert_eq!(
             config_path("codex", McpInjection::Workspace, cwd, home).unwrap(),
             cwd.join(".codex").join("config.toml")
-        );
-        // Pi is global even in workspace mode.
-        assert_eq!(
-            config_path("pi", McpInjection::Workspace, cwd, home).unwrap(),
-            home.join(".pi").join("agent").join("mcp.json")
         );
         // Global paths.
         assert_eq!(

--- a/uxnandesktop/src-tauri/src/model.rs
+++ b/uxnandesktop/src-tauri/src/model.rs
@@ -388,6 +388,23 @@ pub enum BrowserLinkPolicy {
     Ask,
 }
 
+/// How the browser-control MCP server (spec `02d` §1.6) is made discoverable to the
+/// CLI agents the ADE launches (see `mcpinject.rs`). `Workspace` is the default: it
+/// writes a project-scoped MCP config into the terminal's working directory so both
+/// app-launched and hand-typed agents there get the `browser_*` tools, and removes
+/// what it created on exit. `Global` registers the server in each CLI's global user
+/// config (works in every project; covers CLIs without a project config). `Off`
+/// injects nothing — the user can wire it manually from the copy-paste snippet in
+/// Settings → Browser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum McpInjection {
+    Off,
+    #[default]
+    Workspace,
+    Global,
+}
+
 /// Integrated **developer** browser (Settings → Browser). A lightweight in-app
 /// webview tab for previewing/debugging the systems agents build and opening the
 /// links agents produce — deliberately not a general-purpose browser. The webview
@@ -414,6 +431,20 @@ pub struct BrowserSettings {
     /// Page opened when a fresh browser tab has no target URL. Empty = blank tab.
     #[serde(default)]
     pub homepage: String,
+    /// Expose the browser-control MCP server (spec `02d` §1.6) to agents, so they
+    /// discover the `browser_*` tools automatically. When off, no MCP config is
+    /// injected (the `/mcp` endpoint still exists for manual wiring). Default on.
+    #[serde(default = "default_true")]
+    pub mcp_enabled: bool,
+    /// How the MCP server is injected into agents (see [`McpInjection`]). Default
+    /// `workspace`.
+    #[serde(default)]
+    pub mcp_injection: McpInjection,
+    /// Agent ids (`claude`, `codex`, `gemini`, `opencode`, `pi`) to skip when
+    /// injecting the MCP config. Empty = every supported agent gets it. Default
+    /// empty.
+    #[serde(default)]
+    pub mcp_disabled_agents: Vec<String>,
 }
 
 impl Default for BrowserSettings {
@@ -424,6 +455,9 @@ impl Default for BrowserSettings {
             allow_agents: true,
             terminal_links: true,
             homepage: String::new(),
+            mcp_enabled: true,
+            mcp_injection: McpInjection::default(),
+            mcp_disabled_agents: Vec::new(),
         }
     }
 }

--- a/uxnandesktop/src-tauri/src/state.rs
+++ b/uxnandesktop/src-tauri/src/state.rs
@@ -68,6 +68,18 @@ pub struct AppState {
     /// download and the (agent-stopping) install stay separate steps. `None`
     /// until a download finishes; cleared once installed. See `updater.rs`.
     pub staged_update: Arc<RwLock<Option<crate::updater::StagedUpdate>>>,
+    /// Last URL the integrated browser navigated to, tracked so the browser MCP
+    /// server's `browser_status` tool can report the live page to an agent
+    /// (updated on open/navigate + the window's own navigations — see
+    /// `browser.rs`). A plain `std::sync::Mutex` so the sync `on_navigation`
+    /// closure can update it without an async context. `None` = never opened.
+    pub browser_url: Arc<std::sync::Mutex<Option<String>>>,
+    /// Dedup keys for MCP config injection (`mcpinject.rs`), so a workspace's (or
+    /// the global) config is written at most once per session (`ws:<cwd>` /
+    /// `global`).
+    pub mcp_prepared: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    /// MCP config files we wrote, recorded so they're undone on exit (best-effort).
+    pub mcp_written: Arc<std::sync::Mutex<Vec<crate::mcpinject::Written>>>,
 }
 
 impl AppState {
@@ -84,6 +96,9 @@ impl AppState {
             hook_install: Arc::new(RwLock::new(None)),
             power: SleepBlocker::new(),
             staged_update: Arc::new(RwLock::new(None)),
+            browser_url: Arc::new(std::sync::Mutex::new(None)),
+            mcp_prepared: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
+            mcp_written: Arc::new(std::sync::Mutex::new(Vec::new())),
         }
     }
 }

--- a/uxnandesktop/src/lib/api.ts
+++ b/uxnandesktop/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   FsEntry,
   HookInstall,
   HookScripts,
+  McpInfo,
   HookServerInfo,
   ImageDiff,
   RemoveOutcome,
@@ -285,6 +286,12 @@ export function browserWindowClose(): Promise<void> {
 /** Open the browser window's DevTools. */
 export function browserWindowDevtools(): Promise<void> {
   return invoke("browser_window_devtools");
+}
+
+/** Browser-control MCP coordinates + supported-agent catalog for Settings →
+ *  Browser (the live `/mcp` endpoint + token for the copy-paste snippet). */
+export function mcpInfo(): Promise<McpInfo> {
+  return invoke("mcp_info");
 }
 
 /** Set (or clear with `null`) the worktree root the filesystem watcher follows.

--- a/uxnandesktop/src/lib/components/Settings.svelte
+++ b/uxnandesktop/src/lib/components/Settings.svelte
@@ -30,7 +30,11 @@
     InstallPolicy,
     BrowserSettings,
     BrowserLinkPolicy,
+    McpInjection,
+    McpInfo,
   } from "$lib/types";
+  import { mcpInfo } from "$lib/api";
+  import { clipboardWrite } from "$lib/clipboard";
   import TerminalProfileEditor from "./TerminalProfileEditor.svelte";
   import AgentProfileEditor from "./AgentProfileEditor.svelte";
   import AiModelPicker from "./AiModelPicker.svelte";
@@ -65,6 +69,8 @@
   import SparklesIcon from "@lucide/svelte/icons/sparkles";
   import GlobeIcon from "@lucide/svelte/icons/globe";
   import CircleHelpIcon from "@lucide/svelte/icons/circle-help";
+  import CopyIcon from "@lucide/svelte/icons/copy";
+  import CheckIcon from "@lucide/svelte/icons/check";
 
   // Persist (debounced for typing; immediate for discrete actions).
   let saveTimer: ReturnType<typeof setTimeout> | undefined;
@@ -447,6 +453,73 @@
   const linkPolicyGroups = $derived<ComboGroup[]>([
     { items: LINK_POLICIES.map((p) => ({ value: p.value, label: i18n.t(p.labelKey) })) },
   ]);
+
+  // --- Agent browser MCP (Settings → Browser) -------------------------------
+  // Runtime coordinates + supported-agent catalog, loaded once when the Browser
+  // section is first opened (needs the local hook server to be listening).
+  let mcpData = $state<McpInfo | null>(null);
+  let mcpLoaded = $state(false);
+  async function loadMcp() {
+    try {
+      mcpData = await mcpInfo();
+    } catch {
+      mcpData = null;
+    }
+    mcpLoaded = true;
+  }
+  $effect(() => {
+    if (app.settingsSection === "browser" && !mcpLoaded) void loadMcp();
+  });
+  const MCP_MODES: { value: McpInjection; labelKey: MessageKey; descKey: MessageKey }[] = [
+    { value: "workspace", labelKey: "browser.mcpModeWorkspace", descKey: "browser.mcpModeWorkspaceDesc" },
+    { value: "global", labelKey: "browser.mcpModeGlobal", descKey: "browser.mcpModeGlobalDesc" },
+    { value: "off", labelKey: "browser.mcpModeOff", descKey: "browser.mcpModeOffDesc" },
+  ];
+  const mcpModeGroups = $derived<ComboGroup[]>([
+    { items: MCP_MODES.map((m) => ({ value: m.value, label: i18n.t(m.labelKey) })) },
+  ]);
+  // Helper text under the injection row tracks the selected mode.
+  const mcpModeDesc = $derived(
+    i18n.t(MCP_MODES.find((m) => m.value === br.mcpInjection)?.descKey ?? "browser.mcpInjectionDesc"),
+  );
+  function mcpAgentOn(id: string): boolean {
+    return !(br.mcpDisabledAgents ?? []).includes(id);
+  }
+  function toggleMcpAgent(id: string, on: boolean) {
+    const next = new Set(br.mcpDisabledAgents ?? []);
+    if (on) next.delete(id);
+    else next.add(id);
+    setBr({ mcpDisabledAgents: [...next] });
+    persistNow();
+  }
+  // Ready-to-paste MCP server config (standard `mcpServers` http shape) for wiring
+  // an agent by hand. Empty until the endpoint is known.
+  const mcpSnippet = $derived(
+    mcpData?.endpoint
+      ? JSON.stringify(
+          {
+            mcpServers: {
+              [mcpData.serverName]: {
+                type: "http",
+                url: mcpData.endpoint,
+                headers: { Authorization: `Bearer ${mcpData.token ?? ""}` },
+              },
+            },
+          },
+          null,
+          2,
+        )
+      : "",
+  );
+  let mcpCopied = $state(false);
+  let mcpCopyTimer: ReturnType<typeof setTimeout> | undefined;
+  async function copyMcpSnippet() {
+    if (!mcpSnippet) return;
+    await clipboardWrite(mcpSnippet);
+    mcpCopied = true;
+    clearTimeout(mcpCopyTimer);
+    mcpCopyTimer = setTimeout(() => (mcpCopied = false), 1500);
+  }
   const profileGroups = $derived<ComboGroup[]>([
     {
       items: app.terminalProfiles.map((p) => ({
@@ -1060,6 +1133,84 @@
                     oninput={(e) => setBr({ homepage: e.currentTarget.value })}
                     onchange={() => persistNow()}
                   />
+                {/snippet}
+              </SettingsRow>
+
+              <!-- Agent browser MCP — expose the browser as discoverable tools. -->
+              <div class="pt-5 pb-1">
+                <div class="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
+                  {i18n.t("browser.mcpHeading")}
+                </div>
+              </div>
+
+              <SettingsRow label={i18n.t("browser.mcpEnabled")} description={i18n.t("browser.mcpEnabledDesc")}>
+                {#snippet control()}
+                  <Switch
+                    checked={br.mcpEnabled}
+                    disabled={!br.enabled}
+                    onCheckedChange={(c) => { setBr({ mcpEnabled: c }); persistNow(); }}
+                  />
+                {/snippet}
+              </SettingsRow>
+
+              <SettingsRow label={i18n.t("browser.mcpInjection")} description={mcpModeDesc}>
+                {#snippet control()}
+                  <Combobox
+                    value={br.mcpInjection}
+                    groups={mcpModeGroups}
+                    disabled={!br.enabled || !br.mcpEnabled}
+                    triggerClass="w-56"
+                    searchPlaceholder={i18n.t("common.search")}
+                    onChange={(v) => { setBr({ mcpInjection: v as McpInjection }); persistNow(); }}
+                  />
+                {/snippet}
+              </SettingsRow>
+
+              {#if mcpData && mcpData.agents.length > 0}
+                <SettingsRow label={i18n.t("browser.mcpAgents")} description={i18n.t("browser.mcpAgentsDesc")}>
+                  {#snippet children()}
+                    <div class="flex flex-wrap gap-x-6 gap-y-2.5">
+                      {#each mcpData?.agents ?? [] as agent (agent.id)}
+                        <label class="flex items-center gap-2 text-[13px]">
+                          <Switch
+                            checked={mcpAgentOn(agent.id)}
+                            disabled={!br.enabled || !br.mcpEnabled || br.mcpInjection === "off"}
+                            onCheckedChange={(c) => toggleMcpAgent(agent.id, c)}
+                          />
+                          <span class="text-foreground/80">{agent.label}</span>
+                          {#if agent.globalOnly}
+                            <span class="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                              {i18n.t("browser.mcpGlobalOnly")}
+                            </span>
+                          {/if}
+                        </label>
+                      {/each}
+                    </div>
+                  {/snippet}
+                </SettingsRow>
+              {/if}
+
+              <SettingsRow label={i18n.t("browser.mcpSnippet")} description={i18n.t("browser.mcpSnippetDesc")}>
+                {#snippet children()}
+                  {#if mcpSnippet}
+                    <div class="relative mt-1 w-full">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        class="absolute right-1.5 top-1.5 h-6 gap-1 px-1.5 text-[11px]"
+                        onclick={copyMcpSnippet}
+                      >
+                        {#if mcpCopied}
+                          <CheckIcon class="size-3" />{i18n.t("browser.mcpCopied")}
+                        {:else}
+                          <CopyIcon class="size-3" />{i18n.t("browser.mcpCopy")}
+                        {/if}
+                      </Button>
+                      <pre class="scrollbar-sleek overflow-x-auto rounded-lg border border-border/50 bg-muted/40 p-3 pr-16 font-mono text-[11px] leading-relaxed text-foreground/80">{mcpSnippet}</pre>
+                    </div>
+                  {:else}
+                    <span class="text-[12px] text-muted-foreground">{i18n.t("browser.mcpWaiting")}</span>
+                  {/if}
                 {/snippet}
               </SettingsRow>
             </div>

--- a/uxnandesktop/src/lib/components/Settings.svelte
+++ b/uxnandesktop/src/lib/components/Settings.svelte
@@ -51,7 +51,7 @@
     resolveBinding,
   } from "$lib/keybindings";
   import { cn } from "$lib/utils";
-  import { divider, icon, iconButton, text } from "$lib/design";
+  import { divider, icon, iconButton, panel, text } from "$lib/design";
   import PaletteIcon from "@lucide/svelte/icons/palette";
   import TerminalIcon from "@lucide/svelte/icons/terminal";
   import BotIcon from "@lucide/svelte/icons/bot";
@@ -1074,145 +1074,143 @@
             </div>
           </SettingsSection>
         {:else if app.settingsSection === "browser"}
-          <SettingsSection
-            title={i18n.t("settings.browser")}
-            description={i18n.t("settings.browserDesc")}
-          >
-            <div class="divide-y divide-border/60">
-              <!-- On/off settings are Switches (not on/off comboboxes). -->
-              <SettingsRow label={i18n.t("browser.enabled")} description={i18n.t("browser.enabledDesc")}>
-                {#snippet control()}
-                  <Switch
-                    checked={br.enabled}
-                    onCheckedChange={(c) => { setBr({ enabled: c }); persistNow(); }}
-                  />
-                {/snippet}
-              </SettingsRow>
+          <SettingsSection bare title={i18n.t("settings.browser")} description={i18n.t("settings.browserDesc")}>
+            <div class="space-y-6">
+              <!-- Integrated browser settings. -->
+              <div class={panel.settingsBody}>
+                <div class="divide-y divide-border/60">
+                <!-- On/off settings are Switches (not on/off comboboxes). -->
+                <SettingsRow label={i18n.t("browser.enabled")} description={i18n.t("browser.enabledDesc")}>
+                  {#snippet control()}
+                    <Switch
+                      checked={br.enabled}
+                      onCheckedChange={(c) => { setBr({ enabled: c }); persistNow(); }}
+                    />
+                  {/snippet}
+                </SettingsRow>
 
-              <!-- Link policy has three options, so it stays a Select. -->
-              <SettingsRow label={i18n.t("browser.linkPolicy")} description={i18n.t("browser.linkPolicyDesc")}>
-                {#snippet control()}
-                  <Combobox
-                    value={br.linkPolicy}
-                    groups={linkPolicyGroups}
-                    disabled={!br.enabled}
-                    triggerClass="w-56"
-                    searchPlaceholder={i18n.t("common.search")}
-                    onChange={(v) => { setBr({ linkPolicy: v as BrowserLinkPolicy }); persistNow(); }}
-                  />
-                {/snippet}
-              </SettingsRow>
+                <!-- Link policy has three options, so it stays a Select. -->
+                <SettingsRow label={i18n.t("browser.linkPolicy")} description={i18n.t("browser.linkPolicyDesc")}>
+                  {#snippet control()}
+                    <Combobox
+                      value={br.linkPolicy}
+                      groups={linkPolicyGroups}
+                      disabled={!br.enabled}
+                      triggerClass="w-56"
+                      searchPlaceholder={i18n.t("common.search")}
+                      onChange={(v) => { setBr({ linkPolicy: v as BrowserLinkPolicy }); persistNow(); }}
+                    />
+                  {/snippet}
+                </SettingsRow>
 
-              <SettingsRow label={i18n.t("browser.allowAgents")} description={i18n.t("browser.allowAgentsDesc")}>
-                {#snippet control()}
-                  <Switch
-                    checked={br.allowAgents}
-                    disabled={!br.enabled}
-                    onCheckedChange={(c) => { setBr({ allowAgents: c }); persistNow(); }}
-                  />
-                {/snippet}
-              </SettingsRow>
+                <SettingsRow label={i18n.t("browser.allowAgents")} description={i18n.t("browser.allowAgentsDesc")}>
+                  {#snippet control()}
+                    <Switch
+                      checked={br.allowAgents}
+                      disabled={!br.enabled}
+                      onCheckedChange={(c) => { setBr({ allowAgents: c }); persistNow(); }}
+                    />
+                  {/snippet}
+                </SettingsRow>
 
-              <SettingsRow label={i18n.t("browser.terminalLinks")} description={i18n.t("browser.terminalLinksDesc")}>
-                {#snippet control()}
-                  <Switch
-                    checked={br.terminalLinks}
-                    disabled={!br.enabled}
-                    onCheckedChange={(c) => { setBr({ terminalLinks: c }); persistNow(); }}
-                  />
-                {/snippet}
-              </SettingsRow>
+                <SettingsRow label={i18n.t("browser.terminalLinks")} description={i18n.t("browser.terminalLinksDesc")}>
+                  {#snippet control()}
+                    <Switch
+                      checked={br.terminalLinks}
+                      disabled={!br.enabled}
+                      onCheckedChange={(c) => { setBr({ terminalLinks: c }); persistNow(); }}
+                    />
+                  {/snippet}
+                </SettingsRow>
 
-              <SettingsRow label={i18n.t("browser.homepage")} description={i18n.t("browser.homepageDesc")}>
-                {#snippet control()}
-                  <Input
-                    class="w-72 max-w-full"
-                    value={br.homepage}
-                    placeholder={i18n.t("browser.homepagePlaceholder")}
-                    disabled={!br.enabled}
-                    oninput={(e) => setBr({ homepage: e.currentTarget.value })}
-                    onchange={() => persistNow()}
-                  />
-                {/snippet}
-              </SettingsRow>
-
-              <!-- Agent browser MCP — expose the browser as discoverable tools. -->
-              <div class="pt-5 pb-1">
-                <div class="text-[11px] font-medium uppercase tracking-[0.04em] text-muted-foreground">
-                  {i18n.t("browser.mcpHeading")}
+                <SettingsRow label={i18n.t("browser.homepage")} description={i18n.t("browser.homepageDesc")}>
+                  {#snippet control()}
+                    <Input
+                      class="w-72 max-w-full"
+                      value={br.homepage}
+                      placeholder={i18n.t("browser.homepagePlaceholder")}
+                      disabled={!br.enabled}
+                      oninput={(e) => setBr({ homepage: e.currentTarget.value })}
+                      onchange={() => persistNow()}
+                    />
+                  {/snippet}
+                </SettingsRow>
                 </div>
               </div>
 
-              <SettingsRow label={i18n.t("browser.mcpEnabled")} description={i18n.t("browser.mcpEnabledDesc")}>
-                {#snippet control()}
-                  <Switch
-                    checked={br.mcpEnabled}
-                    disabled={!br.enabled}
-                    onCheckedChange={(c) => { setBr({ mcpEnabled: c }); persistNow(); }}
-                  />
-                {/snippet}
-              </SettingsRow>
+              <!-- Agent browser MCP — its own titled group (title outside the card). -->
+              <div class="space-y-2">
+                <span class={cn("px-1", text.section)}>{i18n.t("browser.mcpHeading")}</span>
+                <div class={panel.settingsBody}>
+                  <div class="divide-y divide-border/60">
+                  <SettingsRow label={i18n.t("browser.mcpEnabled")} description={i18n.t("browser.mcpEnabledDesc")}>
+                    {#snippet control()}
+                      <Switch
+                        checked={br.mcpEnabled}
+                        disabled={!br.enabled}
+                        onCheckedChange={(c) => { setBr({ mcpEnabled: c }); persistNow(); }}
+                      />
+                    {/snippet}
+                  </SettingsRow>
 
-              <SettingsRow label={i18n.t("browser.mcpInjection")} description={mcpModeDesc}>
-                {#snippet control()}
-                  <Combobox
-                    value={br.mcpInjection}
-                    groups={mcpModeGroups}
-                    disabled={!br.enabled || !br.mcpEnabled}
-                    triggerClass="w-56"
-                    searchPlaceholder={i18n.t("common.search")}
-                    onChange={(v) => { setBr({ mcpInjection: v as McpInjection }); persistNow(); }}
-                  />
-                {/snippet}
-              </SettingsRow>
+                  <SettingsRow label={i18n.t("browser.mcpInjection")} description={mcpModeDesc}>
+                    {#snippet control()}
+                      <Combobox
+                        value={br.mcpInjection}
+                        groups={mcpModeGroups}
+                        disabled={!br.enabled || !br.mcpEnabled}
+                        triggerClass="w-56"
+                        searchPlaceholder={i18n.t("common.search")}
+                        onChange={(v) => { setBr({ mcpInjection: v as McpInjection }); persistNow(); }}
+                      />
+                    {/snippet}
+                  </SettingsRow>
 
-              {#if mcpData && mcpData.agents.length > 0}
-                <SettingsRow label={i18n.t("browser.mcpAgents")} description={i18n.t("browser.mcpAgentsDesc")}>
-                  {#snippet children()}
-                    <div class="flex flex-wrap gap-x-6 gap-y-2.5">
-                      {#each mcpData?.agents ?? [] as agent (agent.id)}
-                        <label class="flex items-center gap-2 text-[13px]">
-                          <Switch
-                            checked={mcpAgentOn(agent.id)}
-                            disabled={!br.enabled || !br.mcpEnabled || br.mcpInjection === "off"}
-                            onCheckedChange={(c) => toggleMcpAgent(agent.id, c)}
-                          />
-                          <span class="text-foreground/80">{agent.label}</span>
-                          {#if agent.globalOnly}
-                            <span class="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-                              {i18n.t("browser.mcpGlobalOnly")}
-                            </span>
-                          {/if}
-                        </label>
-                      {/each}
-                    </div>
-                  {/snippet}
-                </SettingsRow>
-              {/if}
-
-              <SettingsRow label={i18n.t("browser.mcpSnippet")} description={i18n.t("browser.mcpSnippetDesc")}>
-                {#snippet children()}
-                  {#if mcpSnippet}
-                    <div class="relative mt-1 w-full">
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        class="absolute right-1.5 top-1.5 h-6 gap-1 px-1.5 text-[11px]"
-                        onclick={copyMcpSnippet}
-                      >
-                        {#if mcpCopied}
-                          <CheckIcon class="size-3" />{i18n.t("browser.mcpCopied")}
-                        {:else}
-                          <CopyIcon class="size-3" />{i18n.t("browser.mcpCopy")}
-                        {/if}
-                      </Button>
-                      <pre class="scrollbar-sleek overflow-x-auto rounded-lg border border-border/50 bg-muted/40 p-3 pr-16 font-mono text-[11px] leading-relaxed text-foreground/80">{mcpSnippet}</pre>
-                    </div>
-                  {:else}
-                    <span class="text-[12px] text-muted-foreground">{i18n.t("browser.mcpWaiting")}</span>
+                  {#if mcpData && mcpData.agents.length > 0}
+                    <SettingsRow label={i18n.t("browser.mcpAgents")} description={i18n.t("browser.mcpAgentsDesc")}>
+                      {#snippet children()}
+                        <div class="flex flex-wrap gap-x-6 gap-y-2.5">
+                          {#each mcpData?.agents ?? [] as agent (agent.id)}
+                            <label class="flex items-center gap-2 text-[13px]">
+                              <Switch
+                                checked={mcpAgentOn(agent.id)}
+                                disabled={!br.enabled || !br.mcpEnabled || br.mcpInjection === "off"}
+                                onCheckedChange={(c) => toggleMcpAgent(agent.id, c)}
+                              />
+                              <span class="text-foreground/80">{agent.label}</span>
+                            </label>
+                          {/each}
+                        </div>
+                      {/snippet}
+                    </SettingsRow>
                   {/if}
-                {/snippet}
-              </SettingsRow>
+
+                  <SettingsRow label={i18n.t("browser.mcpSnippet")} description={i18n.t("browser.mcpSnippetDesc")}>
+                    {#snippet children()}
+                      {#if mcpSnippet}
+                        <div class="relative mt-1 w-full">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            class="absolute right-1.5 top-1.5 h-6 gap-1 px-1.5 text-[11px]"
+                            onclick={copyMcpSnippet}
+                          >
+                            {#if mcpCopied}
+                              <CheckIcon class="size-3" />{i18n.t("browser.mcpCopied")}
+                            {:else}
+                              <CopyIcon class="size-3" />{i18n.t("browser.mcpCopy")}
+                            {/if}
+                          </Button>
+                          <pre class="scrollbar-sleek overflow-x-auto rounded-lg border border-border/50 bg-muted/40 p-3 pr-16 font-mono text-[11px] leading-relaxed text-foreground/80">{mcpSnippet}</pre>
+                        </div>
+                      {:else}
+                        <span class="text-[12px] text-muted-foreground">{i18n.t("browser.mcpWaiting")}</span>
+                      {/if}
+                    {/snippet}
+                  </SettingsRow>
+                </div>
+                </div>
+              </div>
             </div>
           </SettingsSection>
         {:else}

--- a/uxnandesktop/src/lib/components/Settings.svelte
+++ b/uxnandesktop/src/lib/components/Settings.svelte
@@ -371,6 +371,9 @@
     allowAgents: true,
     terminalLinks: true,
     homepage: "",
+    mcpEnabled: true,
+    mcpInjection: "workspace",
+    mcpDisabledAgents: [],
   };
   const br = $derived<BrowserSettings>({
     ...BROWSER_DEFAULT,

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -723,7 +723,6 @@ export const en = {
   "browser.mcpModeOffDesc": "Don't inject anything — wire an agent by hand from the snippet below.",
   "browser.mcpAgents": "Agents",
   "browser.mcpAgentsDesc": "Which agents get the browser tools set up automatically.",
-  "browser.mcpGlobalOnly": "global only",
   "browser.mcpSnippet": "Manual config",
   "browser.mcpSnippetDesc":
     "Copy a ready-to-paste MCP server config to wire an agent yourself (e.g. one not listed above).",

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -706,6 +706,30 @@ export const en = {
   "browser.addressPlaceholder": "Enter a URL",
   "browser.unavailable": "The integrated browser isn't available here.",
   "browser.askPrompt": "Open {url} in the integrated browser? (Cancel opens your system browser.)",
+  "browser.mcpHeading": "Agent browser MCP",
+  "browser.mcpEnabled": "Let agents drive the browser",
+  "browser.mcpEnabledDesc":
+    "Expose the browser as MCP tools so launched agents discover and drive it automatically — no setup, no docs.",
+  "browser.mcpInjection": "Setup mode",
+  "browser.mcpInjectionDesc":
+    "How agents receive the tools. The token stays in the terminal's environment — never written to a file.",
+  "browser.mcpModeWorkspace": "Per project (recommended)",
+  "browser.mcpModeWorkspaceDesc":
+    "Write a project-scoped config in the terminal's folder; covers hand-typed and app-launched agents, and is removed on exit.",
+  "browser.mcpModeGlobal": "Global",
+  "browser.mcpModeGlobalDesc":
+    "Register the server in each agent's global config, so it's available in every project (larger footprint).",
+  "browser.mcpModeOff": "Manual only",
+  "browser.mcpModeOffDesc": "Don't inject anything — wire an agent by hand from the snippet below.",
+  "browser.mcpAgents": "Agents",
+  "browser.mcpAgentsDesc": "Which agents get the browser tools set up automatically.",
+  "browser.mcpGlobalOnly": "global only",
+  "browser.mcpSnippet": "Manual config",
+  "browser.mcpSnippetDesc":
+    "Copy a ready-to-paste MCP server config to wire an agent yourself (e.g. one not listed above).",
+  "browser.mcpCopy": "Copy",
+  "browser.mcpCopied": "Copied",
+  "browser.mcpWaiting": "Available once the app's local server is running.",
 } as const;
 
 /** Union of every message key (drives `t()` and the locale type). */

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -724,7 +724,6 @@ export const es: Record<MessageKey, string> = {
   "browser.mcpModeOffDesc": "No inyectar nada — cablea un agente a mano con el snippet de abajo.",
   "browser.mcpAgents": "Agentes",
   "browser.mcpAgentsDesc": "Qué agentes reciben las herramientas del navegador automáticamente.",
-  "browser.mcpGlobalOnly": "solo global",
   "browser.mcpSnippet": "Config manual",
   "browser.mcpSnippetDesc":
     "Copia una config de servidor MCP lista para pegar y cablear un agente tú mismo (p. ej. uno no listado arriba).",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -707,4 +707,28 @@ export const es: Record<MessageKey, string> = {
   "browser.addressPlaceholder": "Escribe una URL",
   "browser.unavailable": "El navegador integrado no está disponible aquí.",
   "browser.askPrompt": "¿Abrir {url} en el navegador integrado? (Cancelar abre tu navegador del sistema.)",
+  "browser.mcpHeading": "MCP de navegador para agentes",
+  "browser.mcpEnabled": "Deja que los agentes usen el navegador",
+  "browser.mcpEnabledDesc":
+    "Expón el navegador como herramientas MCP para que los agentes que lances lo descubran y lo usen solos — sin configurar, sin documentación.",
+  "browser.mcpInjection": "Modo de configuración",
+  "browser.mcpInjectionDesc":
+    "Cómo reciben las herramientas los agentes. El token queda en el entorno de la terminal — nunca se escribe en un archivo.",
+  "browser.mcpModeWorkspace": "Por proyecto (recomendado)",
+  "browser.mcpModeWorkspaceDesc":
+    "Escribe una config con alcance de proyecto en la carpeta de la terminal; cubre agentes tecleados a mano y lanzados por la app, y se elimina al salir.",
+  "browser.mcpModeGlobal": "Global",
+  "browser.mcpModeGlobalDesc":
+    "Registra el servidor en la config global de cada agente, así está disponible en todos los proyectos (mayor huella).",
+  "browser.mcpModeOff": "Solo manual",
+  "browser.mcpModeOffDesc": "No inyectar nada — cablea un agente a mano con el snippet de abajo.",
+  "browser.mcpAgents": "Agentes",
+  "browser.mcpAgentsDesc": "Qué agentes reciben las herramientas del navegador automáticamente.",
+  "browser.mcpGlobalOnly": "solo global",
+  "browser.mcpSnippet": "Config manual",
+  "browser.mcpSnippetDesc":
+    "Copia una config de servidor MCP lista para pegar y cablear un agente tú mismo (p. ej. uno no listado arriba).",
+  "browser.mcpCopy": "Copiar",
+  "browser.mcpCopied": "Copiado",
+  "browser.mcpWaiting": "Disponible cuando el servidor local de la app esté corriendo.",
 };

--- a/uxnandesktop/src/lib/types.ts
+++ b/uxnandesktop/src/lib/types.ts
@@ -146,8 +146,6 @@ export interface BrowserSettings {
 export interface McpAgentInfo {
   id: string;
   label: string;
-  /** True for agents with no project-scoped config (Global mode only, e.g. Pi). */
-  globalOnly: boolean;
 }
 
 /** Runtime MCP coordinates for the Settings panel (mirror of Rust `McpInfo`). */

--- a/uxnandesktop/src/lib/types.ts
+++ b/uxnandesktop/src/lib/types.ts
@@ -113,6 +113,12 @@ export interface AppSettings {
  *  the OS browser; `ask` prompts per link. */
 export type BrowserLinkPolicy = "internal" | "external" | "ask";
 
+/** How the browser-control MCP server is injected into agents (mirror of Rust
+ *  `McpInjection`). `workspace` writes a project-scoped config in the terminal's
+ *  cwd (default); `global` registers it in each CLI's global user config; `off`
+ *  injects nothing (wire it by hand from the copy-paste snippet). */
+export type McpInjection = "off" | "workspace" | "global";
+
 /** Integrated developer-browser preferences (mirror of Rust `BrowserSettings`). */
 export interface BrowserSettings {
   /** Master switch. Off → every link goes to the OS browser, no agent shim. */
@@ -125,6 +131,37 @@ export interface BrowserSettings {
   terminalLinks: boolean;
   /** Page opened when a fresh browser tab has no target URL. Empty = blank. */
   homepage: string;
+  /** Expose the browser-control MCP server to agents so they discover the
+   *  `browser_*` tools automatically. Default on. */
+  mcpEnabled: boolean;
+  /** How the MCP server is injected into agents. Default `workspace`. */
+  mcpInjection: McpInjection;
+  /** Agent ids (`claude`/`codex`/`gemini`/`opencode`/`pi`) to skip when injecting
+   *  the MCP config. Empty = all supported agents. */
+  mcpDisabledAgents: string[];
+}
+
+/** One agent the ADE can auto-configure for the browser MCP server (mirror of Rust
+ *  `mcpinject::AgentInfo`). */
+export interface McpAgentInfo {
+  id: string;
+  label: string;
+  /** True for agents with no project-scoped config (Global mode only, e.g. Pi). */
+  globalOnly: boolean;
+}
+
+/** Runtime MCP coordinates for the Settings panel (mirror of Rust `McpInfo`). */
+export interface McpInfo {
+  /** Live `/mcp` endpoint, or null until the hook server is listening. */
+  endpoint: string | null;
+  /** Local loopback token for the copy-paste snippet, or null. */
+  token: string | null;
+  /** Env var the injected configs read the token from (`UXNAN_MCP_TOKEN`). */
+  tokenEnv: string;
+  /** MCP server name agents register us under (`uxnan-browser`). */
+  serverName: string;
+  /** Supported-agent catalog. */
+  agents: McpAgentInfo[];
 }
 
 /** Release channel the updater follows (mirror of Rust `UpdateChannel`). Mapped

--- a/uxnandesktop/src/lib/types.ts
+++ b/uxnandesktop/src/lib/types.ts
@@ -552,6 +552,9 @@ export const DEFAULT_SETTINGS: AppSettings = {
     allowAgents: true,
     terminalLinks: true,
     homepage: "",
+    mcpEnabled: true,
+    mcpInjection: "workspace",
+    mcpDisabledAgents: [],
   },
   browserPanelWidth: 520,
 };


### PR DESCRIPTION
## What

Makes uxnandesktop's integrated developer browser **discoverable to CLI agents** as
Model Context Protocol tools. Previously an agent could only open a URL in the in-app
browser if it *knew* to POST the `/browser` hook route (it had to read the docs first,
which agents can't rely on). Now the ADE runs a small **browser-control MCP server** and
registers it in each launched agent's own MCP config, so `browser_*` tools show up in the
agent's tool list like any native capability — **no setup, no docs**.

Validated on-device: Claude Code, Codex, Gemini and OpenCode all opened the in-app browser
without reading any documentation.

## How

- **MCP server** (`src-tauri/src/mcp.rs`) — a minimal, spec-correct Streamable-HTTP MCP
  endpoint mounted at `/mcp` on the existing local hook server (same ephemeral port + token;
  `Authorization: Bearer <token>` or legacy `x-uxnan-token`). Control-only tools:
  `browser_open`, `browser_navigate`, `browser_reload`, `browser_back`, `browser_forward`,
  `browser_status`. They reuse the existing link-policy path (`browser::route_url` → the
  frontend panel) and a new `AppState.browser_url` tracker for `browser_status`.
- **Config injection** (`src-tauri/src/mcpinject.rs`) — writes each CLI's native MCP config
  so it finds the server on startup, for **Claude Code, Codex, Gemini CLI and OpenCode**. The
  **token is never written to a file**: every config references the `UXNAN_MCP_TOKEN` env var
  (injected into the agent's PTY), so the secret stays in the process env *and* the injected
  config is inert outside a uxnan-launched terminal (an agent run elsewhere can't authenticate
  — it won't hijack the browser). Non-clobbering merge (JSON via `serde_json`, Codex TOML via
  `toml_edit`); files the ADE creates are hidden from Git (`info/exclude`, worktree-aware via
  `git2`) and removed on exit. Extensible registry (`AGENTS` + `config_path`/`write_entry`).
- **Settings → Browser → Agent browser MCP** — master switch, setup-mode selector
  (per-project / global / manual-only), per-agent toggles, and a copy-paste MCP-server config
  snippet. Full EN/ES i18n; two titled groups using the standard `panel.settingsBody` token.

## Injection modes (`BrowserSettings.mcpInjection`)

- **workspace** (default) — project-scoped config in the terminal's cwd; covers hand-typed and
  app-launched agents there; removed on exit.
- **global** — each CLI's global user config (every project; larger footprint).
- **off** — inject nothing (wire it by hand from the Settings snippet).

## Verification

- Rust: **117 tests** pass, `cargo clippy` clean, `cargo fmt` applied.
- Frontend: `svelte-check` 0 errors, **Vitest 33** pass.
- On-device: agents open the in-app browser with zero docs; Settings UI reviewed.

## Docs (synced in the same change set)

- `architecture/02d-agent-monitoring.md` — new §1.6 (browser MCP layer).
- `docs/browser.md` — new "Agent browser MCP" section (tools, connection model, per-agent
  config table, "adding another agent" recipe).
- `CHANGELOG.md` [Unreleased]; `README.md` snapshot; `FOR-DEV.md` (status + remaining items:
  add more agents incl. Pi, interaction tools).

## Notes / follow-ups (in FOR-DEV.md)

- **Pi** was dropped — it always launched an external browser in testing and its HTTP+auth
  config shape isn't documented upstream. It's a candidate to add back via the same registry
  recipe.
- Page **interaction tools** (snapshot/click/type) are out of scope for this pass (need a JS
  return-channel from the Tauri `WebviewWindow`).