### PR TITLE
feat(desktop): redesigned update toast with elevated card and release notes link

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Changed
+- **Update toast redesigned as elevated card** (`UpdateToast.svelte`): solid
+  `bg-[var(--ux-elevated)]` background with `border-border/70` border, replacing
+  the previous transparent/default card style. Added a **release notes link**
+  pointing to the version's GitHub Releases page. Per-thread activity indicator
+  preserved.
+- **i18n**: added `updates.releaseNotes` and `updates.releaseNotesTitle` keys (en
+  and es) for the new release notes link.
+- **FOR-HUMAN.md**: removed the "Updater minisign keypair" entry — the keypair is
+  already generated, configured in `tauri.conf.json`, and set as GitHub secrets.
+
 ## [0.0.6-alpha.20260704] - 2026-07-04
 
 ### Added — agents discover & drive the integrated browser via an MCP server

--- a/uxnandesktop/src/lib/components/UpdateToast.svelte
+++ b/uxnandesktop/src/lib/components/UpdateToast.svelte
@@ -3,10 +3,8 @@
   // for the old fixed top-of-page UpdateBanner. Same phases, copy and actions as
   // the banner (available → download; downloading → progress; downloaded →
   // install now / install when idle; installing → spinner; Dismiss), but styled
-  // to sit inside a sonner toast card instead of a full-width primary strip.
-  // Driven entirely by the `updater` store (see state/updater.svelte.ts), so its
-  // content updates itself as `status`/`progress` change — the toast is shown
-  // once with a stable id (see updateToast.ts) and never re-created.
+  // as a proper elevated card following the uxnan clean desktop UI design system:
+  // solid background, border, release notes link, and consistent surface layering.
 
   import { updater } from "$lib/state/updater.svelte";
   import { i18n } from "$lib/i18n";
@@ -17,29 +15,32 @@
   import SparklesIcon from "@lucide/svelte/icons/sparkles";
   import LoaderIcon from "@lucide/svelte/icons/loader-circle";
   import TriangleAlertIcon from "@lucide/svelte/icons/triangle-alert";
+  import ExternalLinkIcon from "@lucide/svelte/icons/external-link";
   import XIcon from "@lucide/svelte/icons/x";
 
-  // svelte-sonner passes `closeToast` to a custom component; we don't use it —
-  // dismissal goes through the store (updater.dismiss) so the toast re-hides via
-  // bannerVisible. Declaring it keeps the prop a known attribute; it's
-  // intentionally left unread.
   let { closeToast: _closeToast }: { closeToast?: () => void } = $props();
 
   const version = $derived(updater.update?.version ?? "");
   const pct = $derived(updater.progressFraction);
+  const hasNotes = $derived(
+    updater.update?.notes !== null && updater.update?.notes !== undefined && updater.update?.notes.length > 0
+  );
+  const releaseUrl = $derived(
+    `https://github.com/luisgamas/uxnan/releases/tag/desktop-v${version}`
+  );
 </script>
 
-<div class="flex w-full items-center gap-3" role="status">
+<div class="flex w-full items-start gap-3 rounded-lg border border-border/70 bg-[var(--ux-elevated)] p-3 shadow-md" role="status">
   <!-- Leading icon reflects the phase. -->
   {#if updater.status === "downloading" || updater.status === "installing"}
-    <LoaderIcon class={cn(icon.button, "shrink-0 animate-spin text-primary")} />
+    <LoaderIcon class={cn(icon.button, "mt-0.5 shrink-0 animate-spin text-primary")} />
   {:else}
-    <SparklesIcon class={cn(icon.button, "shrink-0 text-primary")} />
+    <SparklesIcon class={cn(icon.button, "mt-0.5 shrink-0 text-primary")} />
   {/if}
 
-  <!-- Message + (when downloading) a thin progress bar. -->
-  <div class="flex min-w-0 flex-1 flex-col gap-0.5">
-    <span class={cn("truncate text-foreground", text.body)}>
+  <!-- Message + progress bar + release notes link -->
+  <div class="flex min-w-0 flex-1 flex-col gap-1">
+    <span class={cn("text-foreground", text.body)}>
       {#if updater.status === "available"}
         {i18n.t("updates.bannerAvailable", { version })}
       {:else if updater.status === "downloading"}
@@ -55,6 +56,8 @@
         {i18n.t("updates.bannerInstalling")}
       {/if}
     </span>
+
+    <!-- Progress bar (download phase only) -->
     {#if updater.status === "downloading" && pct !== null}
       <div class="h-1 w-full max-w-48 overflow-hidden rounded-full bg-primary/20">
         <div
@@ -63,11 +66,30 @@
         ></div>
       </div>
     {/if}
+
+    <!-- Agents-busy warning (install phase) -->
     {#if updater.status === "downloaded" && updater.agentsBusy}
       <span class="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400">
         <TriangleAlertIcon class={icon.decorative} />
         <span class={text.indicator}>{i18n.t("updates.agentsBusyWarning")}</span>
       </span>
+    {/if}
+
+    <!-- Release notes link -->
+    {#if hasNotes || (updater.status !== "idle" && updater.status !== "checking")}
+      <a
+        href={releaseUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class={cn(
+          "inline-flex items-center gap-1 text-muted-foreground no-underline transition-colors hover:text-foreground",
+          text.indicator,
+        )}
+        title={i18n.t("updates.releaseNotesTitle", { version })}
+      >
+        <ExternalLinkIcon class={icon.decorative} />
+        {i18n.t("updates.releaseNotes")}
+      </a>
     {/if}
   </div>
 

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -642,6 +642,8 @@ export const en = {
   "updates.installNow": "Install now",
   "updates.installWhenIdle": "Install when idle",
   "updates.dismiss": "Dismiss",
+  "updates.releaseNotes": "Release notes",
+  "updates.releaseNotesTitle": "See what's new in {version}",
   "updates.agentsBusyWarning": "An agent is running — installing will stop it",
   "updates.willInstallWhenIdle": "Will install once all agents are idle",
   "updates.upToDate": "You're on the latest version",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -641,6 +641,8 @@ export const es: Record<MessageKey, string> = {
   "updates.installNow": "Instalar ahora",
   "updates.installWhenIdle": "Instalar al quedar libre",
   "updates.dismiss": "Descartar",
+  "updates.releaseNotes": "Notas de versión",
+  "updates.releaseNotesTitle": "Ver novedades de {version}",
   "updates.agentsBusyWarning":
     "Hay un agente en ejecución — instalar lo detendrá",
   "updates.willInstallWhenIdle":


### PR DESCRIPTION
## Summary

Redesigned `UpdateToast.svelte` as a proper elevated card following the uxnan clean desktop UI design system:
- Solid `bg-[var(--ux-elevated)]` background with `border-border/70` border
- Release notes link pointing to GitHub Releases for the version
- Proper surface layering matching other UI cards

## Changes

- **`UpdateToast.svelte`** — elevated card with rounded-lg + border + shadow-md; release notes link with ExternalLinkIcon; mt-0.5 on leading icons for alignment
- **`locales/en.ts`, `locales/es.ts`** — added `updates.releaseNotes` and `updates.releaseNotesTitle` i18n keys
- **`FOR-HUMAN.md`** — removed stale "Updater minisign keypair" entry (keypair already exists and is configured)
- **`CHANGELOG.md`** — added `[Unreleased]` entry documenting the change

## Verification

- `npm run check`: 0 errors, 0 warnings
- `cargo build`: compiles cleanly
