### PR TITLE
ci(desktop): separate stable and nightly release channels

### DIFF
--- a/.github/workflows/release-desktop-manifest.yml
+++ b/.github/workflows/release-desktop-manifest.yml
@@ -4,17 +4,13 @@ name: Release — Desktop updater manifest
 # a STABLE url per channel:
 #   https://github.com/<owner>/<repo>/releases/download/desktop-updater-<channel>/latest.json
 # (see uxnandesktop/src-tauri/src/updater.rs `endpoint_for`). This workflow keeps
-# that file current: when you PUBLISH a `desktop-v*` GitHub Release (the draft
-# `release-desktop.yml` created), it reads the merged `latest.json` tauri-action
-# attached to that release and copies it onto the rolling channel release,
-# creating that release on first use.
-#
-# Channel mirrors GitHub's only release distinction — the `prerelease` flag —
-# NOT the tag's contents:
-#   a normal Release            -> stable
-#   a Release marked prerelease -> nightly
-# So a tag like `desktop-v0.0.5-alpha.20260628` still ships to STABLE as long as
-# the Release isn't flagged pre-release.
+# that file current: when you PUBLISH an explicitly-channelled Desktop Release
+# (the draft `release-desktop.yml` created), it reads the merged `latest.json`
+# attached to that release and copies it onto the matching rolling channel
+# release, creating that release on first use. The tag determines the channel;
+# this workflow rejects a Release whose GitHub pre-release flag disagrees:
+#   desktop-stable-v0.0.PATCH                       -> stable, prerelease=false
+#   desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N   -> nightly, prerelease=true
 #
 # Trigger is `release: published` (not the tag push) so the version release's
 # assets are already public — the URLs inside latest.json resolve. Until the
@@ -30,26 +26,36 @@ permissions:
 
 jobs:
   publish-manifest:
-    # Only desktop releases; ignore the rolling channel releases themselves and
-    # every other component's tags.
-    if: startsWith(github.event.release.tag_name, 'desktop-v')
+    # Only explicitly-channelled desktop releases; ignore the rolling channel
+    # releases themselves, legacy tags, and every other component's tags.
+    if: startsWith(github.event.release.tag_name, 'desktop-stable-v') || startsWith(github.event.release.tag_name, 'desktop-nightly-v')
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TAG: ${{ github.event.release.tag_name }}
       IS_PRERELEASE: ${{ github.event.release.prerelease }}
     steps:
-      - name: Resolve channel from the release's prerelease flag
+      - name: Checkout the tagged release contract
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Resolve and validate channel from tag
         id: meta
         shell: bash
         run: |
-          if [ "$IS_PRERELEASE" = "true" ]; then
-            channel="nightly"
-          else
-            channel="stable"
+          node uxnandesktop/scripts/desktop-release-tag.mjs "$TAG" >> "$GITHUB_OUTPUT"
+          . "$GITHUB_OUTPUT"
+          if [ "$IS_PRERELEASE" != "$prerelease" ]; then
+            echo "::error::Release $TAG declares channel '$channel', which requires prerelease=$prerelease; GitHub Release has prerelease=$IS_PRERELEASE."
+            exit 1
           fi
-          echo "channel=$channel" >> "$GITHUB_OUTPUT"
-          echo "Release $TAG (prerelease=$IS_PRERELEASE) -> channel '$channel'"
+          echo "Release $TAG validated as channel '$channel' (prerelease=$IS_PRERELEASE)."
 
       - name: Download latest.json from the published release
         id: fetch

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,10 +1,14 @@
 name: Release — Desktop (Tauri installers)
 
-# Builds desktop installers on a `desktop-v<version>` tag and attaches them to a
+# Builds desktop installers from an explicit channel tag and attaches them to a
 # DRAFT GitHub Release, together with the updater artifacts (`.sig` signatures +
-# a merged `latest.json`) when the signing secrets are present. Publishing that
-# draft fires `release-desktop-manifest.yml`, which copies `latest.json` onto the
-# rolling per-channel release the in-app updater polls (see uxnandesktop/docs/updates.md).
+# a merged `latest.json`) when the signing secrets are present. The tag is the
+# source of truth for the channel, so a stable build cannot accidentally become a
+# nightly (or vice versa) by changing a GitHub checkbox after the build:
+#   desktop-stable-v0.0.PATCH
+#   desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N
+# Publishing that draft fires `release-desktop-manifest.yml`, which copies
+# `latest.json` onto the matching rolling updater release.
 #
 # Windows ships without OS code-signing for now (SmartScreen warning) — that is a
 # SEPARATE, paid certificate, unrelated to the free updater signature below.
@@ -21,7 +25,8 @@ name: Release — Desktop (Tauri installers)
 on:
   push:
     tags:
-      - "desktop-v*"
+      - 'desktop-stable-v*'
+      - 'desktop-nightly-v*'
 
 permissions:
   contents: write # create/upload the GitHub Release
@@ -43,11 +48,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Resolve version from tag
-        id: meta
-        shell: bash
-        run: echo "version=${GITHUB_REF_NAME#desktop-v}" >> "$GITHUB_OUTPUT"
-
       - name: Install Linux deps (Tauri/WebKitGTK)
         if: runner.os == 'Linux'
         run: |
@@ -60,9 +60,14 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: '22'
           cache: npm
           cache-dependency-path: uxnandesktop/package-lock.json
+
+      - name: Resolve and validate release channel from tag
+        id: meta
+        shell: bash
+        run: node uxnandesktop/scripts/desktop-release-tag.mjs "$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -76,7 +81,7 @@ jobs:
         shell: bash
         working-directory: uxnandesktop
         run: |
-          V="${{ steps.meta.outputs.version }}"   # full, e.g. 0.0.1-alpha.20260621
+          V="${{ steps.meta.outputs.version }}"   # stable: 0.0.10; nightly: 0.0.11-nightly.20260712.1
           # The Windows MSI target rejects a non-numeric pre-release identifier
           # (and any number > 65535), so the BUNDLE version is the numeric base
           # only. The full version still names the GitHub Release + tag.
@@ -106,6 +111,6 @@ jobs:
         with:
           projectPath: uxnandesktop
           tagName: ${{ github.ref_name }}
-          releaseName: "Uxnan Desktop ${{ steps.meta.outputs.version }}"
+          releaseName: 'Uxnan Desktop ${{ steps.meta.outputs.version }}'
           releaseDraft: true
-          prerelease: true
+          prerelease: ${{ steps.meta.outputs.prerelease }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,13 @@ first re-runs the verification and only builds/publishes if it's green.
 | Tag | Result |
 | --- | ------ |
 | `shared-v*` / `bridge-v*` / `relay-v*` | publish to **npm** (publish `shared` first) |
-| `desktop-v*` | build installers → **GitHub Release** (draft) |
+| `desktop-stable-v0.0.PATCH` | stable installers → **GitHub Release** (draft) |
+| `desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N` | nightly installers → **GitHub pre-release** (draft) |
 | `mobile-v*[+build]` | signed AAB → **Google Play** (open testing / beta) |
 
-Versions follow `0.0.PATCH-alpha.YYYYMMDD` (see [`VERSIONS.md`](VERSIONS.md)).
+Versions follow `0.0.PATCH-alpha.YYYYMMDD` for the npm/mobile alpha line. Desktop
+uses explicit stable/nightly tag forms so its updater channels cannot be mixed;
+see [`VERSIONS.md`](VERSIONS.md).
 
 ### Non-negotiable rule — mobile release notes
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,8 +10,23 @@ which versions "go together".
 - Base SemVer starts at `0.0.1` (pre-1.0 = unstable; breaking changes allowed).
 - Alpha builds use `0.0.PATCH-alpha.YYYYMMDD`. The `YYYYMMDD` date orders
   correctly under SemVer/npm.
+- **Desktop channels are intentionally different.** The tag is the channel's
+  source of truth, not a manual GitHub Release checkbox:
+  - **Stable:** `desktop-stable-v0.0.PATCH` (for example,
+    `desktop-stable-v0.0.10`). It produces a normal GitHub Release and feeds the
+    stable updater manifest.
+  - **Nightly:** `desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N` (for example,
+    `desktop-nightly-v0.0.11-nightly.20260712.1`). `N` starts at `1` and only
+    distinguishes multiple nightlies cut on the same date. It produces a GitHub
+    pre-release and feeds the nightly updater manifest.
+  - The numeric `0.0.PATCH` base must be **new for every Desktop build in either
+    channel**. Windows MSI and Tauri's updater compare only that numeric base, so
+    reusing it would make a newer nightly invisible. Choose a base greater than
+    every already-shipped Desktop build; switching from a higher nightly build to
+    an older stable build is a downgrade and is intentionally not automatic.
 - Per-component git tags drive releases:
-  `shared-v*`, `bridge-v*`, `relay-v*`, `desktop-v*`, `mobile-v*`
+  `shared-v*`, `bridge-v*`, `relay-v*`, `desktop-stable-v*`,
+  `desktop-nightly-v*`, `mobile-v*`
   (mobile may append `+<buildNumber>`, e.g. `mobile-v0.0.1-alpha.20260621+5`).
 - **Source tracks the tag — bump EVERY version file AND its lockfile in the same
   commit.** A stale lockfile is silent drift: the npm/desktop release workflows
@@ -47,7 +62,8 @@ which versions "go together".
 
 ## Release checklist
 
-Cutting a release for component `<comp>` (tag `<comp>-v<version>`):
+Cutting a release for component `<comp>` (tag `<comp>-v<version>`; Desktop uses
+the channel-specific forms above):
 
 1. **Pre-flight** — the commit you will tag is green on CI (`ci-*.yml`) and its
    `CHANGELOG.md [Unreleased]` accurately describes what ships.

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to the Uxnan Desktop ADE are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Changed — Desktop stable and nightly releases now have separate, enforced tags
+
+- **Stable:** `desktop-stable-v0.0.PATCH` produces a normal GitHub Release and
+  updates only the stable updater manifest.
+- **Nightly:** `desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N` produces a GitHub
+  pre-release and updates only the nightly updater manifest.
+- A shared tag parser validates both forms in CI; the release workflow derives
+  the draft's pre-release flag from it, and the manifest workflow rejects a
+  manually altered flag. This removes the former ambiguous `desktop-v…-alpha…`
+  convention and prevents stable/nightly cross-publication.
+
 ## [0.0.9-alpha.20260711] - 2026-07-11
 
 ### Added — group the sidebar by agent attention

--- a/uxnandesktop/docs/updates.md
+++ b/uxnandesktop/docs/updates.md
@@ -45,8 +45,9 @@ quitting the app), so nothing is killed mid-write.
     `https://github.com/luisgamas/uxnan/releases/download/desktop-updater-<channel>/latest.json`
     (`<channel>` is `stable` or `nightly`; the plugin has no `{{channel}}` URL
     variable, so we set the endpoint at runtime from the user's channel).
-  - `app_version` returns the **full** release name for display (e.g.
-    `0.0.5-alpha.20260628`); the bundled/compared version is the numeric base.
+  - `app_version` returns the **full** release name for display (for example,
+    `0.0.10` or `0.0.11-nightly.20260712.1`); the bundled/compared version is
+    the numeric base.
   - `updater_check` → returns `UpdateInfo` or `null`.
   - `updater_download` → downloads + **stages the installer bytes in memory**
     (`AppState.staged_update`), emitting `updater:download-progress` and
@@ -64,10 +65,11 @@ quitting the app), so nothing is killed mid-write.
   `src-tauri/tauri.conf.json`. This is a **free minisign key**, unrelated to OS
   code-signing (the paid Authenticode/Apple cert that removes "unknown publisher"
   warnings — see `FOR-HUMAN.md`).
-- **Channel = GitHub's `prerelease` flag** — not the tag. A normal Release feeds
-  `stable`; a Release marked **pre-release** feeds `nightly`. The tag can say
-  anything (e.g. `desktop-v0.0.5-alpha.20260628`) and still ship to stable as
-  long as the Release isn't flagged pre-release.
+- **Channel = the release tag, enforced by CI.** A
+  `desktop-stable-v0.0.PATCH` tag creates a normal Release and feeds `stable`.
+  A `desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N` tag creates a GitHub
+  pre-release and feeds `nightly`. The manifest workflow validates the matching
+  GitHub pre-release flag and fails rather than silently crossing channels.
 - **Version comparison** — the updater compares the **numeric base** version
   (`0.0.5`), which CI bundles (the Windows MSI rejects a non-numeric pre-release
   id). So bump that base each release (e.g. `0.0.5` → `0.0.6`) for the updater to
@@ -103,13 +105,17 @@ app starts; replace it with your own (free):
 
 ## Cutting a release on a channel
 
-Tag a green commit. The channel is chosen later, when you publish, by the
-Release's **pre-release** checkbox — not by the tag. Bump the numeric base each
-time (the part before any `-`) so the updater detects the new version.
+Tag a green commit with the channel encoded in the tag. Bump the numeric base
+for **every** Desktop build, regardless of channel, so the updater detects it.
 
 ```bash
-git tag desktop-v0.0.6-alpha.20260701   # tag can say anything
-git push origin desktop-v0.0.6-alpha.20260701
+# Stable: a normal GitHub Release and the stable updater manifest.
+git tag desktop-stable-v0.0.10
+git push origin desktop-stable-v0.0.10
+
+# Nightly: a GitHub pre-release and the nightly updater manifest.
+git tag desktop-nightly-v0.0.11-nightly.20260712.1
+git push origin desktop-nightly-v0.0.11-nightly.20260712.1
 ```
 
 Then:
@@ -117,16 +123,16 @@ Then:
 1. `release-desktop.yml` runs (verify → build → sign), creating a **draft**
    GitHub Release named after the version, with the installers, their `.sig`
    files, and a merged `latest.json`.
-2. Review the draft, decide the channel, then **Publish**:
-   - leave **"Set as a pre-release" unchecked** → ships to **stable**;
-   - **check it** → ships to **nightly**.
-3. Publishing fires `release-desktop-manifest.yml`, which reads that flag and
-   copies `latest.json` onto the rolling `desktop-updater-stable` /
-   `desktop-updater-nightly` release (created on first use — don't delete it).
-   Apps on that channel pick up the update on their next check.
+2. Review the draft body and assets, but **do not change its pre-release
+   checkbox**: the workflow already set it from the tag. Publish it as-is.
+3. Publishing fires `release-desktop-manifest.yml`, which validates the tag ↔
+   pre-release invariant, then copies `latest.json` onto the matching rolling
+   `desktop-updater-stable` / `desktop-updater-nightly` release (created on first
+   use — don't delete it). Apps on that channel pick up the update on their next
+   check.
 
-> What puts an app on nightly is the GitHub **pre-release flag**, not the tag.
-> A `…-alpha.…` tag published as a normal release still ships to **stable**.
+> A tag with the wrong shape is rejected before installers are built. A manually
+> altered GitHub pre-release flag is rejected before the updater manifest changes.
 
 ## Without the signing key
 

--- a/uxnandesktop/scripts/desktop-release-tag.mjs
+++ b/uxnandesktop/scripts/desktop-release-tag.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * The one source of truth for Uxnan Desktop release-tag channels.
+ *
+ * Stable:  desktop-stable-v0.0.PATCH
+ * Nightly: desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N
+ *
+ * The numeric base must advance for every build because Windows MSI and the
+ * Tauri updater compare that base, not the descriptive nightly suffix.
+ */
+
+import { pathToFileURL } from "node:url";
+
+const NUM = "(?:0|[1-9]\\d*)";
+const BASE = `(${NUM}\\.${NUM}\\.${NUM})`;
+const STABLE = new RegExp(`^desktop-stable-v${BASE}$`);
+const NIGHTLY = new RegExp(`^desktop-nightly-v${BASE}-nightly\\.(\\d{8})\\.([1-9]\\d*)$`);
+
+/** @param {string} value */
+function isCalendarDate(value) {
+  const year = Number(value.slice(0, 4));
+  const month = Number(value.slice(4, 6));
+  const day = Number(value.slice(6, 8));
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+}
+
+/**
+ * Parse and validate a Desktop release tag.
+ * @param {string} tag
+ */
+export function parseDesktopReleaseTag(tag) {
+  const stable = tag.match(STABLE);
+  if (stable) {
+    return {
+      channel: "stable",
+      prerelease: false,
+      version: stable[1],
+    };
+  }
+
+  const nightly = tag.match(NIGHTLY);
+  if (nightly && isCalendarDate(nightly[2])) {
+    return {
+      channel: "nightly",
+      prerelease: true,
+      version: `${nightly[1]}-nightly.${nightly[2]}.${nightly[3]}`,
+    };
+  }
+
+  throw new Error(
+    `Invalid Desktop release tag '${tag}'. Expected ` +
+      "desktop-stable-v0.0.PATCH or desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N.",
+  );
+}
+
+function main() {
+  const tag = process.argv[2];
+  if (!tag) {
+    throw new Error("Usage: node scripts/desktop-release-tag.mjs <tag>");
+  }
+  const release = parseDesktopReleaseTag(tag);
+  // GitHub Actions consumes these lines through $GITHUB_OUTPUT.
+  console.log(`version=${release.version}`);
+  console.log(`channel=${release.channel}`);
+  console.log(`prerelease=${release.prerelease}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/uxnandesktop/src-tauri/src/updater.rs
+++ b/uxnandesktop/src-tauri/src/updater.rs
@@ -115,7 +115,8 @@ fn info_of(update: &tauri_plugin_updater::Update) -> UpdateInfo {
     }
 }
 
-/// The full human-facing app version for display (e.g. `0.0.5-alpha.20260628`).
+/// The full human-facing app version for display (e.g. `0.0.10` or
+/// `0.0.11-nightly.20260712.1`).
 ///
 /// The bundled version in `tauri.conf.json` is the **numeric base** only
 /// (`0.0.5`) because the Windows MSI target rejects a non-numeric pre-release

--- a/uxnandesktop/src/lib/components/Settings.svelte
+++ b/uxnandesktop/src/lib/components/Settings.svelte
@@ -477,7 +477,7 @@
     { value: "manual", labelKey: "updates.policyManual" },
   ];
   // The running app's full version name (shown in the Updates pane). This is the
-  // complete release name (e.g. 0.0.5-alpha.20260628), not the numeric MSI base.
+  // complete release name (e.g. 0.0.10 or 0.0.11-nightly.20260712.1), not the numeric MSI base.
   let currentVersion = $state("");
   $effect(() => {
     if (app.settingsOpen && app.settingsSection === "updates" && !currentVersion) {

--- a/uxnandesktop/src/lib/desktop-release-tag.test.ts
+++ b/uxnandesktop/src/lib/desktop-release-tag.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { parseDesktopReleaseTag } from "../../scripts/desktop-release-tag.mjs";
+
+describe("parseDesktopReleaseTag", () => {
+  it("classifies a numeric stable tag", () => {
+    expect(parseDesktopReleaseTag("desktop-stable-v0.0.10")).toEqual({
+      channel: "stable",
+      prerelease: false,
+      version: "0.0.10",
+    });
+  });
+
+  it("classifies a dated nightly tag", () => {
+    expect(parseDesktopReleaseTag("desktop-nightly-v0.0.11-nightly.20260712.2")).toEqual({
+      channel: "nightly",
+      prerelease: true,
+      version: "0.0.11-nightly.20260712.2",
+    });
+  });
+
+  it.each([
+    "desktop-v0.0.10-alpha.20260712",
+    "desktop-stable-v0.0.10-nightly.20260712.1",
+    "desktop-nightly-v0.0.11-nightly.20260230.1",
+    "desktop-nightly-v0.0.11-nightly.20260712.0",
+    "desktop-nightly-v0.0.11",
+  ])("rejects ambiguous or malformed tag %s", (tag) => {
+    expect(() => parseDesktopReleaseTag(tag)).toThrow("Invalid Desktop release tag");
+  });
+});


### PR DESCRIPTION
## Summary

Makes Desktop release channels explicit and enforced instead of choosing the channel manually at GitHub Release publish time.

## Release contract

- Stable: `desktop-stable-v0.0.PATCH`
- Nightly: `desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N`
- Every Desktop build uses a new numeric base because MSI and the updater compare that base.

## Safeguards

- A shared, tested parser validates tags before installers build.
- The release workflow derives the GitHub pre-release setting from the tag.
- The manifest workflow rejects a published release whose pre-release setting disagrees with its tag, preventing cross-channel updater publication.
- Contributor and updater documentation now carries the exact release procedure and downgrade caveat.

## Verification

- `npm test` — 12 files, 117 tests passed.
- `npm run check` — passed.
- `npm run build` — passed.
- Prettier check for both release workflows — passed.