### PR TITLE
fix(agent): attribute only the shell's foreground job, not background agent helpers

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,34 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — agent detection: non-agent processes mislabeled as agents (Layer 3)
+
+- **A non-agent command that spawns an agent CLI as a background helper no longer
+  hijacks the tab.** Layer 3 process detection (`src-tauri/src/procscan.rs`) used to
+  walk the terminal's **entire descendant tree** and attribute the tab to *any*
+  known-agent process found anywhere below the shell. So running a program that
+  itself launches an agent CLI in the background (e.g. `node .\bridge\dist\src\cli.js
+  start`, whose bridge spawns a long-lived `zero acp` child) made the worktree card
+  and tab adopt that agent's name/logo/status a few seconds later — even though the
+  foreground job was never an agent. Detection now identifies only the shell's
+  **foreground job**: it descends **through shells only** (seeing through a
+  `.cmd`/`.ps1`/shell shim that runs the real agent as its child), and treats any
+  non-shell process as a dead end — its background helpers are never attributed to
+  the terminal.
+- **Look-alike misidentification — launching one agent showing another's name/logo —
+  fixed.** Matching used to tokenize the process's **whole command line** and
+  substring-match every segment against the agent catalog, so a prompt or flag that
+  mentioned another agent (`claude "compare with codex"`) or a path segment that
+  collided with an agent name could win the wrong identity. A process is now
+  identified only by its **executable name** and — for a language interpreter — the
+  **path of the script it runs** (`node …\@openai\codex\cli.js` → Codex); prompt
+  text, flags and the working directory are ignored.
+- Both fixes are covered by new unit tests in `procscan.rs` (foreground-job
+  discipline, shell-shim transparency, script-path identity, prompt-text immunity);
+  the backend suite is now **183 tests**. A launched tab still carries its true launch
+  identity, and a hook report still seals identity by the agent's self-declared type —
+  neither path is affected. Spec: `architecture/02d-agent-monitoring.md` §1.4.
+
 ### Fixed — terminal rendering: blank panes on launch & doubled text
 
 - **Intermittent blank terminal on launch (cursor blinks, no prompt) — the primary

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -16,7 +16,7 @@ standalone app** (three-panel shell, PTY terminals + splits, git worktrees, git
 status/diff/stage/commit/history, agent monitoring with the axum hook server +
 OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
-engine**, **user quick commands**). 174 Rust backend tests + 166 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS is **unvalidated**
+engine**, **user quick commands**). 183 Rust backend tests + 166 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS is **unvalidated**
 (developed on Windows; CI is `{ubuntu, windows}`). **Phase 6 (embedded bridge /
 mobile pairing) is NOT started.**
 
@@ -338,7 +338,7 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
 
 - ✅ **Verify** — `.github/workflows/ci-desktop.yml` runs svelte-check + `npm test`
   (Vitest) + vite build + cargo fmt/clippy/test on `{ubuntu, windows}` (macOS
-  deferred with Apple). 165 Rust + 146 Vitest tests.
+  deferred with Apple). 183 Rust + 166 Vitest tests.
 - ✅ **`release-desktop.yml`** — exists: `tauri-action` bundles on a `desktop-v*` tag
   → draft GitHub Release, **and signs the updater artifacts** when the signing
   secrets are set. **Windows ships without OS code-signing for now; macOS deferred.**

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -206,7 +206,7 @@ uxnandesktop/
 │       ├── gitfast.rs     # git2 fast path (status / diff / numstat / log / show)
 │       ├── hooks.rs       # axum HTTP hook server (Layer 1 agent monitoring)
 │       ├── agent_hooks.rs # per-agent hook configs (Claude auto-install + wrappers)
-│       ├── procscan.rs    # process-tree detection (Layer 3)
+│       ├── procscan.rs    # foreground-job agent detection (Layer 3)
 │       ├── power.rs       # keep-awake (Win; macOS/Linux untested)
 │       ├── browse.rs      # in-app directory picker
 │       ├── fs.rs          # file read/write for the center editor

--- a/uxnandesktop/architecture/02d-agent-monitoring.md
+++ b/uxnandesktop/architecture/02d-agent-monitoring.md
@@ -196,12 +196,36 @@ Como **fallback** para agentes que no soportan hooks HTTP nativos, el ADE analiz
 
 ### 1.4 Capa 3: Deteccion de Proceso en Ejecucion
 
-El ADE detecta **que proceso esta corriendo en primer plano** en cada PTY:
+El ADE detecta **que agente corre como el trabajo en primer plano** de cada PTY —
+el que el usuario realmente lanzo en esa terminal, **no** cualquier proceso-agente
+que aparezca en cualquier lugar del arbol. Esa distincion es la que mantiene honesta
+a la terminal: un programa que **no es un agente** (p. ej. un servidor local o el
+daemon `bridge`) puede a su vez lanzar un CLI de agente como **ayudante de fondo**
+(el bridge mantiene un `zero acp` de larga vida), y atribuir ese ayudante a la
+pestana la etiquetaria con un nombre/logo/estado que nunca lanzo.
 
-- Si el proceso coincide con un agente conocido (por nombre del ejecutable, por ejemplo `claude`, `codex`, `aider`, `opencode`), se activa el **tracking automatico**.
-- El matching (`procscan.rs`) puntua por **especificidad** (exacto ▸ variante `cmd-`/`cmd_` ▸ substring; el comando mas largo gana) y recorre el arbol de procesos **en anchura**, quedandose con la coincidencia del proceso **mas cercano al shell**. Asi un agente "envoltorio" (p. ej. `openclaude`, que contiene `claude`) no se confunde con el que envuelve, de forma determinista. Ademas, un tab **lanzado** por el ADE ya conoce su identidad y la deteccion **no la sobrescribe** (solo nombra agentes iniciados a mano).
-- Esta capa no determina el estado especifico del agente, pero confirma que un agente esta activo en un PTY determinado y habilita el monitoreo por las capas superiores.
-- Es la capa mas basica: solo detecta presencia, no estado detallado.
+Dos reglas gobiernan `procscan.rs` (`detect_agent`):
+
+- **Descender solo a traves de shells.** Desde el shell se mira su trabajo en primer
+  plano. Se ve **a traves** de shells anidados (un shim `.cmd`/`.ps1`/shell que corre
+  el agente real como su hijo), pero un proceso **no-shell es un callejon sin salida**:
+  sus hijos son ayudantes que el lanzo, nunca el agente en primer plano de la terminal.
+  Gana el nivel coincidente **mas cercano al shell** (el trabajo lanzado); dentro de un
+  nivel gana la coincidencia mas especifica.
+- **Identificar por tokens de identidad, no por toda la linea de comandos.** Un proceso
+  se identifica por su **nombre de ejecutable** y — para un interprete de lenguaje
+  (`node …\codex\cli.js`) — por la **ruta del script que ejecuta**. El texto del prompt,
+  los flags y el directorio de trabajo se ignoran a proposito, para que
+  `claude "compara con codex"` siga siendo Claude y no Codex. El scoring por
+  **especificidad** se conserva (exacto ▸ variante `cmd-`/`cmd_` ▸ substring de 4+;
+  el comando mas largo gana), asi un agente "envoltorio" (`openclaude`, que contiene
+  `claude`) no se confunde con el que envuelve, de forma determinista.
+
+Ademas, un tab **lanzado** por el ADE ya conoce su identidad y la deteccion **no la
+sobrescribe** (solo nombra agentes iniciados a mano). Esta capa no determina el estado
+especifico del agente, pero confirma que un agente esta activo en un PTY determinado y
+habilita el monitoreo por las capas superiores: es la capa mas basica, solo detecta
+presencia, no estado detallado.
 
 **Identidad por hook (no solo por proceso).** Ademas de `procscan`, **el propio
 reporte de hook (Capa 1) establece la identidad del tab**: como el reporter declara

--- a/uxnandesktop/src-tauri/src/procscan.rs
+++ b/uxnandesktop/src-tauri/src/procscan.rs
@@ -1,15 +1,28 @@
 //! Foreground-process detection for agent monitoring (spec §1.4 / 02d, Layer 3).
 //!
-//! Given a shell's process id, we walk its descendant processes and look for one
-//! that matches a known agent command. Matching is by token: the process's exe
-//! name and every path/space-separated segment of its command line are
-//! extension-stripped and compared to the agent command. That covers both real
-//! executables (`claude.exe`) and node-shim CLIs (`node …\codex\cli.js`), where
-//! the executable is `node` but the command line carries the agent's name.
+//! Given a shell's process id, we identify the agent running as its **foreground
+//! job** — the process the user actually launched in that terminal — not merely
+//! any known-agent process anywhere below it. That distinction is what keeps a
+//! terminal honest: a *non-agent* program the user runs (say a local server or a
+//! bridge daemon) can itself spawn a known agent CLI as a **background helper**,
+//! and attributing that helper to the tab would mislabel the terminal with a
+//! logo/name it never launched.
+//!
+//! Two rules enforce this:
+//!
+//! 1. **Descend through shells only.** From the shell we look at its foreground
+//!    job. We see *through* nested shells (a `.cmd`/`.ps1`/shell shim that runs
+//!    the real agent as its child), but a non-shell process is a dead end: its
+//!    children are helpers it spawned, never this terminal's foreground agent.
+//! 2. **Match on identity tokens, not the whole command line.** A process is
+//!    identified by its executable name and — for a language interpreter
+//!    (`node …\codex\cli.js`) — the path of the **script it runs**. Prompt text,
+//!    flags and the working directory are deliberately ignored, so
+//!    `claude "compare with codex"` stays Claude, not Codex.
 
 use std::collections::{HashMap, HashSet};
 
-use sysinfo::{Pid, Process, System};
+use sysinfo::System;
 
 /// Strip a known executable/script extension from a path segment.
 fn strip_ext(s: &str) -> &str {
@@ -20,6 +33,40 @@ fn strip_ext(s: &str) -> &str {
         }
     }
     s
+}
+
+/// Shell executables we transparently descend through: agents are frequently
+/// launched via a `.cmd`/`.ps1`/shell shim, so the real agent process is a child
+/// of a nested shell. Compared on the extension-stripped, lowercased basename.
+fn is_shell(name: &str) -> bool {
+    matches!(
+        name,
+        "cmd" | "powershell" | "pwsh" | "bash" | "sh" | "dash" | "zsh" | "fish" | "ksh" | "nu"
+    )
+}
+
+/// Language interpreters whose agent identity comes from the **script** they run,
+/// not from the interpreter name itself (`node`, `python`, …). Handles versioned
+/// Python (`python3`, `python3.12`).
+fn is_interpreter(name: &str) -> bool {
+    if matches!(name, "node" | "bun" | "deno" | "ruby" | "perl" | "pythonw") {
+        return true;
+    }
+    match name.strip_prefix("python") {
+        Some("") => true,
+        Some(rest) => rest.chars().all(|c| c.is_ascii_digit() || c == '.'),
+        None => false,
+    }
+}
+
+/// Whether a token looks like a script path rather than a flag/word — an
+/// interpreter entrypoint carries a path separator or a script extension.
+fn looks_like_script(token: &str) -> bool {
+    token.contains('/')
+        || token.contains('\\')
+        || [".js", ".mjs", ".cjs", ".py", ".pyw"]
+            .iter()
+            .any(|ext| token.to_ascii_lowercase().ends_with(ext))
 }
 
 /// How strongly a path/exe token identifies the agent command `cmd`, or `None`.
@@ -67,50 +114,130 @@ fn best_command(tokens: &HashSet<String>, commands: &[String]) -> Option<(String
         .max_by_key(|(_, score)| *score)
 }
 
-/// The agent command (from `commands`) this process most specifically looks like
-/// + its match score, from its exe name or any command-line token.
-fn matches_agent(proc: &Process, commands: &[String]) -> Option<(String, u32)> {
+/// The entrypoint script an interpreter runs (`node <script>`, `python -m <mod>`),
+/// or `None` when there is no script (a REPL, or inline source via `-e`/`-p`). It
+/// skips interpreter flags and their values so a `--loader x` argument — or any
+/// prompt text further along — never masquerades as the entrypoint.
+fn interpreter_entrypoint(argv: &[String], is_python: bool) -> Option<&str> {
+    let with_value = [
+        "-r",
+        "--require",
+        "--import",
+        "--loader",
+        "--experimental-loader",
+    ];
+    let inline_source = ["-e", "--eval", "-p", "--print", "--check"];
+    let mut i = 1; // argv[0] is the interpreter itself
+    while i < argv.len() {
+        let tok = argv[i].as_str();
+        if tok == "--" {
+            i += 1;
+            continue;
+        }
+        if is_python && tok == "-m" {
+            return argv.get(i + 1).map(String::as_str);
+        }
+        if tok.starts_with('-') {
+            let name = tok.split('=').next().unwrap_or(tok);
+            if inline_source.contains(&name) {
+                return None; // running inline source → no script entrypoint
+            }
+            if name == tok && with_value.contains(&name) {
+                i += 2; // this flag consumes the next token as its value
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        if looks_like_script(tok) {
+            return Some(tok);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// The identity tokens for a process: its executable basename, its `argv[0]`
+/// basename (robust when the OS truncates the process name), and — for an
+/// interpreter — the path segments of the **script** it runs. Everything else on
+/// the command line (prompt text, flags, cwd) is intentionally excluded: those are
+/// the source of look-alike misidentification.
+fn agent_tokens(name: &str, argv: &[String]) -> HashSet<String> {
     let mut tokens: HashSet<String> = HashSet::new();
-    tokens.insert(strip_ext(&proc.name().to_string_lossy()).to_ascii_lowercase());
-    for part in proc.cmd() {
-        for seg in part.to_string_lossy().split(['/', '\\', ' ']) {
-            if !seg.is_empty() {
-                tokens.insert(strip_ext(seg).to_ascii_lowercase());
+    tokens.insert(name.to_string());
+    if let Some(arg0) = argv.first() {
+        if let Some(base) = arg0.rsplit(['/', '\\']).next() {
+            tokens.insert(strip_ext(base).to_ascii_lowercase());
+        }
+    }
+    if is_interpreter(name) {
+        if let Some(entry) = interpreter_entrypoint(argv, name.starts_with("python")) {
+            for seg in entry.split(['/', '\\']) {
+                if !seg.is_empty() {
+                    tokens.insert(strip_ext(seg).to_ascii_lowercase());
+                }
             }
         }
     }
-    best_command(&tokens, commands)
+    tokens
 }
 
-/// The agent command running as a descendant of `root_pid`, or `None` when the
-/// shell is idle / running a non-agent command. Walks **breadth-first** and returns
-/// the match on the process **nearest the shell** — that's the agent the user
-/// launched (e.g. `zero`, `openclaude`), not a helper it spawns (`agy`, `claude`) —
-/// picking the most specific match within that level. Deterministic regardless of
-/// the OS process-map order.
-pub fn detect_agent(sys: &System, root_pid: u32, commands: &[String]) -> Option<String> {
+/// Minimal process facts detection needs — extracted from `sysinfo` in
+/// [`detect_agent`], hand-built in tests. `name` is the extension-stripped,
+/// lowercased executable basename.
+struct ProcInfo {
+    name: String,
+    argv: Vec<String>,
+    parent: Option<u32>,
+}
+
+/// The agent command (from `commands`) this process most specifically looks like,
+/// plus its match score, or `None` when it is not a known agent.
+fn recognize(info: &ProcInfo, commands: &[String]) -> Option<(String, u32)> {
+    best_command(&agent_tokens(&info.name, &info.argv), commands)
+}
+
+/// Walk the shell's foreground job over the process table `procs` and return the
+/// agent command it runs. Breadth-first from the root shell, descending **only
+/// through shells** (nested shells / `.cmd` shims), so a non-shell foreground
+/// program's background helpers are never attributed to this terminal. The
+/// shallowest matching level wins (the job nearest the shell); within a level the
+/// most specific match wins.
+fn detect_in_tree(
+    procs: &HashMap<u32, ProcInfo>,
+    root_pid: u32,
+    commands: &[String],
+) -> Option<String> {
     if commands.is_empty() {
         return None;
     }
-    let mut children: HashMap<Pid, Vec<Pid>> = HashMap::new();
-    for (pid, proc) in sys.processes() {
-        if let Some(parent) = proc.parent() {
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    for (pid, info) in procs {
+        if let Some(parent) = info.parent {
             children.entry(parent).or_default().push(*pid);
         }
     }
-    let mut level = vec![Pid::from_u32(root_pid)];
-    let mut seen: HashSet<Pid> = HashSet::new();
+    let mut level = vec![root_pid];
+    let mut seen: HashSet<u32> = HashSet::new();
     while !level.is_empty() {
         let mut best: Option<(String, u32)> = None;
-        let mut next: Vec<Pid> = Vec::new();
-        for pid in &level {
-            if !seen.insert(*pid) {
+        let mut next: Vec<u32> = Vec::new();
+        for &pid in &level {
+            if !seen.insert(pid) {
                 continue;
             }
-            if let Some(kids) = children.get(pid) {
+            // Only the root shell and nested shells expose a foreground job; a
+            // non-shell process's children are helpers it spawned, so we neither
+            // match them nor descend into them.
+            let is_shell_or_root =
+                pid == root_pid || procs.get(&pid).map(|i| is_shell(&i.name)).unwrap_or(false);
+            if !is_shell_or_root {
+                continue;
+            }
+            if let Some(kids) = children.get(&pid) {
                 for &kid in kids {
-                    if let Some(proc) = sys.process(kid) {
-                        if let Some((cmd, score)) = matches_agent(proc, commands) {
+                    if let Some(info) = procs.get(&kid) {
+                        if let Some((cmd, score)) = recognize(info, commands) {
                             if best.as_ref().map(|(_, s)| score > *s).unwrap_or(true) {
                                 best = Some((cmd, score));
                             }
@@ -128,10 +255,67 @@ pub fn detect_agent(sys: &System, root_pid: u32, commands: &[String]) -> Option<
     None
 }
 
+/// The agent command running as the foreground job of `root_pid`, or `None` when
+/// the shell is idle / running a non-agent command. See [`detect_in_tree`].
+pub fn detect_agent(sys: &System, root_pid: u32, commands: &[String]) -> Option<String> {
+    if commands.is_empty() {
+        return None;
+    }
+    let mut procs: HashMap<u32, ProcInfo> = HashMap::new();
+    for (pid, proc) in sys.processes() {
+        procs.insert(
+            pid.as_u32(),
+            ProcInfo {
+                name: strip_ext(&proc.name().to_string_lossy()).to_ascii_lowercase(),
+                argv: proc
+                    .cmd()
+                    .iter()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .collect(),
+                parent: proc.parent().map(|p| p.as_u32()),
+            },
+        );
+    }
+    detect_in_tree(&procs, root_pid, commands)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{best_command, token_matches};
-    use std::collections::HashSet;
+    use super::{agent_tokens, best_command, detect_in_tree, token_matches, ProcInfo};
+    use std::collections::HashMap;
+
+    /// The catalog commands as `syncAgentCommands` sends them (base brand first).
+    fn catalog() -> Vec<String> {
+        [
+            "claude",
+            "codex",
+            "gemini",
+            "opencode",
+            "pi",
+            "agy",
+            "goose",
+            "grok",
+            "zero",
+            "openclaude",
+            "aider",
+            "cursor-agent",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+    }
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn proc(name: &str, argv_parts: &[&str], parent: Option<u32>) -> ProcInfo {
+        ProcInfo {
+            name: name.to_string(),
+            argv: argv(argv_parts),
+            parent,
+        }
+    }
 
     #[test]
     fn matches_exact_and_suffix_variants() {
@@ -149,7 +333,7 @@ mod tests {
         assert!(!token_matches("node", "codex"));
     }
 
-    fn tokset(parts: &[&str]) -> HashSet<String> {
+    fn tokset(parts: &[&str]) -> std::collections::HashSet<String> {
         parts.iter().map(|s| s.to_string()).collect()
     }
 
@@ -178,5 +362,167 @@ mod tests {
         assert_eq!(best_command(&tokset(&["agy"]), &cmds).unwrap().0, "agy");
         // No agent token → no match.
         assert!(best_command(&tokset(&["bash", "node"]), &cmds).is_none());
+    }
+
+    // --- Identity tokens: exe + interpreter script only, never other args -------
+
+    #[test]
+    fn node_shim_agent_identified_by_script_path() {
+        // `node …\@openai\codex\cli.js` → Codex, from the package folder.
+        let t = agent_tokens(
+            "node",
+            &argv(&[
+                "node",
+                "C:\\Users\\me\\npm\\node_modules\\@openai\\codex\\cli.js",
+            ]),
+        );
+        assert_eq!(best_command(&t, &catalog()).unwrap().0, "codex");
+
+        let t = agent_tokens(
+            "node",
+            &argv(&["node", "C:\\a\\@anthropic-ai\\claude-code\\cli.js"]),
+        );
+        assert_eq!(best_command(&t, &catalog()).unwrap().0, "claude");
+    }
+
+    #[test]
+    fn prompt_text_and_flags_do_not_identify_the_agent() {
+        // A user prompt mentioning other agents must not change identity.
+        let t = agent_tokens("codex", &argv(&["codex", "compare gemini and zero output"]));
+        assert_eq!(best_command(&t, &catalog()).unwrap().0, "codex");
+        // Inline node source (`-e`) has no script entrypoint → no false match.
+        let t = agent_tokens("node", &argv(&["node", "-e", "console.log('gemini')"]));
+        assert!(best_command(&t, &catalog()).is_none());
+    }
+
+    #[test]
+    fn native_agent_identified_by_exe_name() {
+        let t = agent_tokens("cursor-agent", &argv(&["C:\\tools\\cursor-agent.exe"]));
+        assert_eq!(best_command(&t, &catalog()).unwrap().0, "cursor-agent");
+    }
+
+    // --- Foreground-job discipline: descend through shells only -----------------
+
+    #[test]
+    fn ignores_agent_helpers_spawned_by_a_non_agent_foreground_job() {
+        // Shell → `node bridge/cli.js start` (NOT an agent) → `node zero.js acp`
+        // spawned as a background helper. The tab must stay unlabelled: the
+        // foreground job is the bridge, not Zero.
+        let mut procs = HashMap::new();
+        procs.insert(100, proc("cmd", &["cmd.exe"], None)); // root shell
+        procs.insert(
+            200,
+            proc(
+                "node",
+                &["node", ".\\bridge\\dist\\src\\cli.js", "start"],
+                Some(100),
+            ),
+        );
+        procs.insert(
+            300,
+            proc(
+                "node",
+                &["node", "C:\\npm\\zero\\zero.js", "acp"],
+                Some(200),
+            ),
+        );
+        assert_eq!(detect_in_tree(&procs, 100, &catalog()), None);
+    }
+
+    #[test]
+    fn detects_a_directly_launched_agent() {
+        let mut procs = HashMap::new();
+        procs.insert(100, proc("cmd", &["cmd.exe"], None));
+        procs.insert(
+            200,
+            proc(
+                "node",
+                &["node", "C:\\npm\\@openai\\codex\\cli.js"],
+                Some(100),
+            ),
+        );
+        assert_eq!(
+            detect_in_tree(&procs, 100, &catalog()).as_deref(),
+            Some("codex")
+        );
+    }
+
+    #[test]
+    fn sees_through_a_nested_shell_shim() {
+        // pwsh → cmd (running the `claude.cmd` shim) → node (the real claude CLI).
+        let mut procs = HashMap::new();
+        procs.insert(100, proc("pwsh", &["pwsh.exe"], None));
+        procs.insert(
+            200,
+            proc("cmd", &["cmd.exe", "/c", "claude.cmd"], Some(100)),
+        );
+        procs.insert(
+            300,
+            proc(
+                "node",
+                &["node", "C:\\a\\@anthropic-ai\\claude-code\\cli.js"],
+                Some(200),
+            ),
+        );
+        assert_eq!(
+            detect_in_tree(&procs, 100, &catalog()).as_deref(),
+            Some("claude")
+        );
+    }
+
+    #[test]
+    fn a_directly_launched_zero_is_still_detected() {
+        // The helper case must not suppress a real, user-launched Zero.
+        let mut procs = HashMap::new();
+        procs.insert(100, proc("cmd", &["cmd.exe"], None));
+        procs.insert(
+            200,
+            proc(
+                "node",
+                &["node", "C:\\npm\\zero\\zero.js", "acp"],
+                Some(100),
+            ),
+        );
+        assert_eq!(
+            detect_in_tree(&procs, 100, &catalog()).as_deref(),
+            Some("zero")
+        );
+    }
+
+    #[test]
+    fn a_plain_non_agent_command_matches_nothing() {
+        let mut procs = HashMap::new();
+        procs.insert(100, proc("cmd", &["cmd.exe"], None));
+        procs.insert(200, proc("git", &["git", "status"], Some(100)));
+        assert_eq!(detect_in_tree(&procs, 100, &catalog()), None);
+    }
+
+    #[test]
+    fn the_foreground_agent_wins_over_a_deeper_one() {
+        // Shell → claude (foreground) and, separately, a backgrounded shell that
+        // holds a gemini. The direct child (claude) is the launched agent.
+        let mut procs = HashMap::new();
+        procs.insert(100, proc("cmd", &["cmd.exe"], None));
+        procs.insert(
+            200,
+            proc(
+                "node",
+                &["node", "C:\\a\\@anthropic-ai\\claude-code\\cli.js"],
+                Some(100),
+            ),
+        );
+        procs.insert(300, proc("bash", &["bash"], Some(100)));
+        procs.insert(
+            400,
+            proc(
+                "node",
+                &["node", "C:\\a\\@google\\gemini-cli\\index.js"],
+                Some(300),
+            ),
+        );
+        assert_eq!(
+            detect_in_tree(&procs, 100, &catalog()).as_deref(),
+            Some("claude")
+        );
     }
 }


### PR DESCRIPTION
## Problem

Layer 3 process detection (`uxnandesktop/src-tauri/src/procscan.rs`) walked the terminal's **entire descendant tree** and labelled the tab with **any** known-agent process found anywhere below the shell.

- **Non-agent → mislabeled.** A non-agent foreground program that spawns an agent CLI as a background child mislabeled the tab. The clearest case: `node .\bridge\dist\src\cli.js start` — the bridge runs the real `zero` binary (`zero providers …` for model discovery, long-lived `zero acp` for a live turn) as a descendant, so the worktree card + tab adopted "Zero by Gitlawb" a few seconds later. This affected **every** bridge-driven agent (claude/codex/gemini/opencode/pi/zero), not just Zero, plus any script/tool that shells out to an agent.
- **Look-alike misidentification.** Matching tokenized the whole command line, so a prompt/flag mentioning another agent (`claude "compare with codex"`) or a colliding path segment could win the wrong identity.

## Fix

Detection now identifies only the shell's **foreground job**:

1. **Descend through shells only** — sees through `.cmd`/`.ps1`/shell shims that run the real agent as a child; a non-shell process is a dead end (its background helpers are never attributed to the terminal).
2. **Confined identity tokens** — a process is identified by its executable name and, for an interpreter, the path of the **script it runs** (`node …\@openai\codex\cli.js` → Codex). Prompt text / flags / cwd are ignored.

A launched tab still carries its launch identity, and a hook report still seals identity by the agent's self-declared type — neither path is affected.

## Verification

- **183 backend tests pass** (added 9 in `procscan.rs`, incl. regression tests for the bridge scenario and prompt-text immunity).
- `cargo clippy` clean · `cargo fmt --check` clean.

## Docs (same change set, spec-drift-controlled)

- `architecture/02d-agent-monitoring.md` §1.4 — rewritten (foreground-job rules)
- `CHANGELOG.md` — `[Unreleased]` Fixed entry
- `FOR-DEV.md` — backend test count 174 → 183
- `README.md` — `procscan.rs` label