### PR TITLE
build(desktop): bump version to 0.0.14 for the nightly release

### DIFF
--- a/uxnandesktop/package-lock.json
+++ b/uxnandesktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uxnan-desktop",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "uxnan-desktop",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "MPL-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/uxnandesktop/package.json
+++ b/uxnandesktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uxnan-desktop",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Uxnan Desktop — Agent Development Environment (ADE). Tauri 2 + Svelte 5.",
   "type": "module",
   "license": "MPL-2.0",

--- a/uxnandesktop/src-tauri/Cargo.lock
+++ b/uxnandesktop/src-tauri/Cargo.lock
@@ -5341,7 +5341,7 @@ dependencies = [
 
 [[package]]
 name = "uxnan-desktop"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/uxnandesktop/src-tauri/Cargo.toml
+++ b/uxnandesktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uxnan-desktop"
-version = "0.0.13"
+version = "0.0.14"
 description = "Uxnan Desktop — Agent Development Environment (ADE)."
 authors = ["Luis Donaldo Gamas Vazquez"]
 edition = "2021"

--- a/uxnandesktop/src-tauri/tauri.conf.json
+++ b/uxnandesktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Uxnan Desktop",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "identifier": "dev.luisgamas.uxnandesktop",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to numeric base `0.0.14` for the desktop nightly release `desktop-nightly-v0.0.14-nightly.20260716.1` (all four terminal/agent fixes from #66 + #67). Bumps all five version-bearing files in lockstep (tauri.conf.json, Cargo.toml, Cargo.lock, package.json, package-lock.json) per VERSIONS.md.