### PR TITLE
build: release shared, bridge and mobile 0.0.6-alpha.20260716

### DIFF
--- a/.github/whatsnew/whatsnew-en-US
+++ b/.github/whatsnew/whatsnew-en-US
@@ -1,7 +1,8 @@
 What's new in this update:
 
-• Choose Zero and Grok when starting a new AI conversation.
-• Agents can now ask you questions, show plans, and request approval directly in the chat.
-• Clearer error messages when an agent cannot finish a task, plus smoother Markdown and table reading.
+• Your profile now shows your stats: activity, agents used and tokens, with an Activity/Tokens view. They live on your PC, so they survive reinstalling the app — and you can back them up to an encrypted file.
+• See how much of each AI plan you have used, with credit and reset times.
+• Type "/" in the chat to run an agent's built-in commands.
+• Search files across your project and preview images and Markdown.
 
 Thanks for testing this alpha!

--- a/.github/whatsnew/whatsnew-es-ES
+++ b/.github/whatsnew/whatsnew-es-ES
@@ -1,7 +1,8 @@
 Novedades de esta actualización:
 
-• Elige Zero y Grok al iniciar una nueva conversación con IA.
-• Los agentes ya pueden hacerte preguntas, mostrar planes y pedir autorización directamente en el chat.
-• Mensajes de error más claros cuando un agente no termina una tarea y mejor lectura de Markdown y tablas.
+• Tu perfil ahora muestra tus estadísticas: actividad, agentes usados y tokens, con una vista Actividad/Tokens. Se guardan en tu PC, así sobreviven a reinstalar la app, y puedes respaldarlas cifradas.
+• Consulta cuánto has usado de cada plan de IA, con crédito y reinicios.
+• Escribe "/" en el chat para usar los comandos del agente.
+• Busca archivos de tu proyecto y previsualiza imágenes y Markdown.
 
 ¡Gracias por probar esta alfa!

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uxnan-bridge",
-  "version": "0.0.5-alpha.20260711",
+  "version": "0.0.6-alpha.20260716",
   "description": "Uxnan Bridge — local control-plane daemon connecting the Uxnan mobile app to the developer's PC over E2EE.",
   "license": "MPL-2.0",
   "author": "Luis Donaldo Gamas Vazquez",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "bridge": {
       "name": "uxnan-bridge",
-      "version": "0.0.5-alpha.20260711",
+      "version": "0.0.6-alpha.20260716",
       "license": "MPL-2.0",
       "dependencies": {
         "@uxnan/shared": "*",
@@ -2632,7 +2632,7 @@
     },
     "shared": {
       "name": "@uxnan/shared",
-      "version": "0.0.5-alpha.20260711",
+      "version": "0.0.6-alpha.20260716",
       "license": "MPL-2.0",
       "dependencies": {
         "ajv": "^8.17.1"

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uxnan/shared",
-  "version": "0.0.5-alpha.20260711",
+  "version": "0.0.6-alpha.20260716",
   "description": "Shared JSON-RPC and E2EE contracts for the Uxnan ecosystem (bridge, relay, mobile).",
   "license": "MPL-2.0",
   "author": "Luis Donaldo Gamas Vazquez",

--- a/uxnanmobile/pubspec.yaml
+++ b/uxnanmobile/pubspec.yaml
@@ -4,7 +4,7 @@ description: "Uxnan - remote control for AI coding agents (E2EE mobile client)"
 publish_to: 'none'
 
 # version: <build-name>+<build-number>
-version: 0.0.5-alpha.20260711+20260711
+version: 0.0.6-alpha.20260716+20260716
 
 environment:
   sdk: '>=3.4.0 <4.0.0'


### PR DESCRIPTION
Cuts the release for the three components touched by #69. `relay` and `desktop` are unchanged and stay on their own version lines.

## Versions

| Component | Version | Tag |
|---|---|---|
| shared | `0.0.6-alpha.20260716` | `shared-v0.0.6-alpha.20260716` |
| bridge | `0.0.6-alpha.20260716` | `bridge-v0.0.6-alpha.20260716` |
| mobile | `0.0.6-alpha.20260716+20260716` | `mobile-v0.0.6-alpha.20260716+20260716` |

## No manifest ↔ lockfile drift

Per `VERSIONS.md`, every version-bearing file is bumped **with its lockfile in this same commit** (the release workflows re-apply the version with `--allow-same-version`, which would otherwise mask a stale committed lock):

```
shared  pkg: 0.0.6-alpha.20260716   lock: 0.0.6-alpha.20260716   OK
bridge  pkg: 0.0.6-alpha.20260716   lock: 0.0.6-alpha.20260716   OK
```

`uxnanmobile/pubspec.yaml` → `0.0.6-alpha.20260716+20260716`, matching the mobile tag (`release-mobile.yml` fails the release on a mismatch).

## Play release notes

Rewritten for this version — user-facing and non-technical: profile stats that survive a reinstall + encrypted backup, per-plan usage & credit, agent slash commands, project file search and previews.

Both files pass Google Play's 500 limit **by characters and by bytes** (en-US 472/482, es-ES 468/483), so the workflow's `wc -m` check passes regardless of the runner's locale.

## After merge

Push the three tags → `release-npm.yml` / `release-mobile.yml`, validate each run is green and the artifact landed (npm `latest` dist-tag, Play open-testing), then record the History row in `VERSIONS.md`.