### PR TITLE
feat(ui): use the shared expressive loader for every indeterminate spinner

### DIFF
--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,24 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed — one loading language across the whole app
+- Every remaining `CircularProgressIndicator` is now the shared **`PolygonLoader`**
+  (the M3 Expressive shape morph), so loading looks the same everywhere instead of
+  splitting between the expressive loader on the redesigned screens and Material's
+  default spinner on the rest: **29 call sites across 16 files**, including the
+  conversation timeline, its "Agent responding…" cue, Git, the threads list and
+  tiles, new conversation, the profile stats/heatmap/usage, pairing discovery,
+  licenses, updates and theme import.
+- Each site keeps its own weight rather than a blanket size: 48 dp for full-screen
+  states, 32 dp for section blocks, 22–28 dp in sheets, 10–20 dp inline. Sites that
+  had a colored spinner keep their color.
+- **Two gauges intentionally stay `CircularProgressIndicator`:** the conversation's
+  context-usage ring and Settings ▸ Updates' download progress. Both draw a real
+  value (`percent`, `fraction`) and `PolygonLoader` is indeterminate by design, so
+  converting them would have thrown that number away. `loader_consistency_test.dart`
+  now enforces the rule in both directions — no stray spinner elsewhere, and those
+  two still reporting a `value:`.
+
 ### Changed — Composer palettes share a clear auxiliary hierarchy
 - Gave the `/` command and `@` workspace palettes the same M3 container,
   8 dp separation from the prompt pill and explicit trigger header. They read

--- a/uxnanmobile/docs/neural-expressive-design.md
+++ b/uxnanmobile/docs/neural-expressive-design.md
@@ -1600,6 +1600,27 @@ Because the canonical component owns a 48 dp canvas, Uxnan scales it through a
 proportions. The wrapper isolates repainting and disables its ticker under
 `MediaQuery.disableAnimations`, leaving the first expressive shape visible
 and semantic for reduced-motion users.
+
+**Every indeterminate spinner in the app is this widget.** `PolygonLoader` owns
+its own `SizedBox.square` + `RepaintBoundary`, so a call site passes `size`
+directly instead of wrapping it (its default is 18 dp — the repo lints a
+redundant `size: 18`). The sizes in use, by context:
+
+| Context | `size` |
+| --- | --- |
+| Full-screen / `SliverFillRemaining` empty state | 48 |
+| Section block (heatmap, provider cards, licenses) | `UxnanSpacing.xxl` (32) |
+| Sheet / picker | 22–28 |
+| Inline beside text, in a button, or a header action | 10–20 |
+
+**The one exception — a gauge is not a loader.** `PolygonLoader` is
+indeterminate *by design*: it has no `value`. Two call sites therefore keep a
+`CircularProgressIndicator`, because each draws a number the user reads — the
+conversation's **context-usage ring** (percent of the model window used) and
+Settings ▸ Updates' **download progress** (fraction of the APK fetched).
+Converting them would silently discard that information. `loader_consistency_test.dart`
+enforces both halves of this rule: no stray spinner anywhere else, and those two
+sites still passing a `value:`.
 ---
 
 ## 7. Governance, Accessibility, and Performance

--- a/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/conversation_screen.dart
@@ -36,6 +36,7 @@ import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
 import 'package:uxnan/presentation/widgets/agent_visuals.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
 import 'package:uxnan/presentation/widgets/measure_size.dart';
 import 'package:uxnan/presentation/widgets/message_scroll_rail.dart';
@@ -810,7 +811,7 @@ class _ConversationScreenState extends ConsumerState<ConversationScreen>
                     ),
                   if (snapshot == null)
                     const SliverFillRemaining(
-                      child: Center(child: CircularProgressIndicator()),
+                      child: Center(child: PolygonLoader(size: 48)),
                     )
                   else if (snapshot.messages.isEmpty)
                     const SliverFillRemaining(
@@ -1150,6 +1151,9 @@ class _ContextBadge extends StatelessWidget {
         child: Stack(
           alignment: Alignment.center,
           children: [
+            // Stays a CircularProgressIndicator on purpose: this is a gauge of
+            // a known value, not a loader. `PolygonLoader` is indeterminate by
+            // design, so it cannot draw `percent`.
             SizedBox(
               width: 22,
               height: 22,
@@ -1700,11 +1704,7 @@ class _IdRow extends StatelessWidget {
               ),
               const SizedBox(height: UxnanSpacing.xs),
               if (loading)
-                const SizedBox(
-                  width: 14,
-                  height: 14,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
+                const PolygonLoader(size: 14)
               else
                 Text(
                   hasValue ? value! : (placeholder ?? '—'),
@@ -1890,14 +1890,7 @@ class _LoginRequiredBanner extends ConsumerWidget {
           child: Row(
             children: [
               if (loginInProgress)
-                SizedBox(
-                  width: 18,
-                  height: 18,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: colors.onErrorContainer,
-                  ),
-                )
+                PolygonLoader(color: colors.onErrorContainer)
               else
                 Icon(
                   Icons.login_rounded,
@@ -1944,13 +1937,9 @@ class _LoginRequiredBanner extends ConsumerWidget {
                           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                         ),
                         child: checking
-                            ? SizedBox(
-                                width: 16,
-                                height: 16,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  color: colors.onErrorContainer,
-                                ),
+                            ? PolygonLoader(
+                                size: 16,
+                                color: colors.onErrorContainer,
                               )
                             : Text(l10n.agentCheckSignIn),
                       ),

--- a/uxnanmobile/lib/presentation/screens/conversation/files/file_viewer_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/files/file_viewer_screen.dart
@@ -290,11 +290,7 @@ class _FileViewerScreenState extends ConsumerState<FileViewerScreen> {
                             padding: EdgeInsets.symmetric(
                               horizontal: UxnanSpacing.md,
                             ),
-                            child: SizedBox(
-                              width: 20,
-                              height: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            ),
+                            child: PolygonLoader(size: 20),
                           )
                         else
                           IconSurface(

--- a/uxnanmobile/lib/presentation/screens/conversation/files/widgets/file_tree_tile.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/files/widgets/file_tree_tile.dart
@@ -5,6 +5,7 @@ import 'package:uxnan/domain/enums/git_file_status.dart';
 import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 
 /// The name/icon color for a file or folder by its [GitFileStatus].
 ///
@@ -307,11 +308,7 @@ class FileTreeTile extends StatelessWidget {
                   color: colors.onSurfaceVariant,
                 )
               else if (node.loading)
-                const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                ),
+                const PolygonLoader(size: 16),
             ],
           ),
         ),

--- a/uxnanmobile/lib/presentation/screens/conversation/git/git_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/git/git_screen.dart
@@ -12,6 +12,7 @@ import 'package:uxnan/presentation/screens/conversation/git/git_history_screen.d
 import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
 import 'package:uxnan/presentation/widgets/measure_size.dart';
 import 'package:uxnan/presentation/widgets/ne_surface.dart';
@@ -1731,7 +1732,7 @@ class _NoRepository extends StatelessWidget {
     final colors = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
     if (connecting) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: PolygonLoader(size: 48));
     }
     return Padding(
       padding: const EdgeInsets.all(UxnanSpacing.xl),
@@ -1902,11 +1903,7 @@ class _BranchPickerState extends State<_BranchPicker> {
                           padding: EdgeInsets.symmetric(
                             horizontal: UxnanSpacing.sm,
                           ),
-                          child: SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          ),
+                          child: PolygonLoader(size: 20),
                         )
                       : IconSurface(
                           icon: Icons.delete_outline_rounded,
@@ -2371,14 +2368,7 @@ class _PrimaryActionButton extends StatelessWidget {
     final foreground =
         enabled ? colors.onPrimary : colors.onPrimary.withValues(alpha: 0.5);
     final spinner = busy
-        ? SizedBox(
-            width: 16,
-            height: 16,
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              valueColor: AlwaysStoppedAnimation<Color>(foreground),
-            ),
-          )
+        ? PolygonLoader(size: 16, color: foreground)
         : Icon(icon, size: 20, color: foreground);
     return Tooltip(
       message: tooltip,

--- a/uxnanmobile/lib/presentation/screens/conversation/messages/message_content_view.dart
+++ b/uxnanmobile/lib/presentation/screens/conversation/messages/message_content_view.dart
@@ -24,6 +24,7 @@ import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/markdown.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 
 /// Renders a single [MessageContent] block. The enclosing bubble provides the
 /// background; this widget renders the block's body.
@@ -222,11 +223,7 @@ class _ApprovalActions extends StatelessWidget {
 
     Widget label(ApprovalDecision decision, String text) {
       if (sending && pending == decision) {
-        return const SizedBox(
-          width: 16,
-          height: 16,
-          child: CircularProgressIndicator(strokeWidth: 2),
-        );
+        return const PolygonLoader(size: 16);
       }
       return Text(text);
     }
@@ -837,11 +834,7 @@ class _QuestionActions extends StatelessWidget {
               child: FilledButton(
                 onPressed: acting && canSubmit ? onSubmit : null,
                 child: sending
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
+                    ? const PolygonLoader(size: 16)
                     : Text(l10n.questionSubmit),
               ),
             ),
@@ -1818,15 +1811,7 @@ class _AgentRespondingStatus extends StatelessWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        SizedBox.square(
-          dimension: 14,
-          child: RepaintBoundary(
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              color: colors.onSurfaceVariant,
-            ),
-          ),
-        ),
+        PolygonLoader(size: 14, color: colors.onSurfaceVariant),
         const SizedBox(width: UxnanSpacing.sm),
         Text(
           label,

--- a/uxnanmobile/lib/presentation/screens/pairing/bridge_discovery_sheet.dart
+++ b/uxnanmobile/lib/presentation/screens/pairing/bridge_discovery_sheet.dart
@@ -5,6 +5,7 @@ import 'package:uxnan/l10n/app_localizations.dart';
 import 'package:uxnan/presentation/providers/infrastructure_providers.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/theme/typography.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 
 /// Modal sheet that browses the LAN for bridges (mDNS `_uxnan._tcp`) and lets
 /// the user pick one — returning its `host:port` so the manual-pairing form can
@@ -98,11 +99,7 @@ class _Searching extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: UxnanSpacing.lg),
       child: Row(
         children: [
-          const SizedBox(
-            width: 18,
-            height: 18,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
+          const PolygonLoader(),
           const SizedBox(width: UxnanSpacing.md),
           Expanded(
             child: Text(

--- a/uxnanmobile/lib/presentation/screens/profile/agent_activity_section.dart
+++ b/uxnanmobile/lib/presentation/screens/profile/agent_activity_section.dart
@@ -15,6 +15,7 @@ import 'package:uxnan/presentation/widgets/activity_heatmap.dart';
 import 'package:uxnan/presentation/widgets/agent_visuals.dart';
 import 'package:uxnan/presentation/widgets/connected_button_group.dart';
 import 'package:uxnan/presentation/widgets/expressive_card.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/ne_card.dart';
 
 /// Which lens the agent-activity block reads through: everyday **activity**
@@ -204,7 +205,7 @@ class _AgentActivitySectionState extends ConsumerState<AgentActivitySection> {
     return ref.watch(activityHeatmapProvider(query)).when(
           loading: () => const Padding(
             padding: EdgeInsets.symmetric(vertical: UxnanSpacing.lg),
-            child: Center(child: CircularProgressIndicator()),
+            child: Center(child: PolygonLoader(size: UxnanSpacing.xxl)),
           ),
           error: (_, __) => Text(l10n.profileNoData),
           data: (counts) => ActivityHeatmap(

--- a/uxnanmobile/lib/presentation/screens/profile/pc_details_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/profile/pc_details_screen.dart
@@ -10,6 +10,7 @@ import 'package:uxnan/presentation/screens/profile/agent_activity_section.dart';
 import 'package:uxnan/presentation/screens/profile/profile_metrics_widgets.dart';
 import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/ne_card.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 
@@ -44,7 +45,7 @@ class PcDetailsScreen extends ConsumerWidget {
         loading: () => const [
           SliverFillRemaining(
             hasScrollBody: false,
-            child: Center(child: CircularProgressIndicator()),
+            child: Center(child: PolygonLoader(size: 48)),
           ),
         ],
         error: (_, __) => [

--- a/uxnanmobile/lib/presentation/screens/profile/profile_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/profile/profile_screen.dart
@@ -11,6 +11,7 @@ import 'package:uxnan/presentation/screens/profile/profile_backup_section.dart';
 import 'package:uxnan/presentation/screens/profile/profile_metrics_widgets.dart';
 import 'package:uxnan/presentation/screens/profile/usage_section.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/ne_card.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 import 'package:uxnan/presentation/widgets/profile_avatar_view.dart';
@@ -57,7 +58,7 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
         loading: () => const [
           SliverFillRemaining(
             hasScrollBody: false,
-            child: Center(child: CircularProgressIndicator()),
+            child: Center(child: PolygonLoader(size: 48)),
           ),
         ],
         error: (_, __) => [
@@ -152,11 +153,7 @@ class _StatsHeader extends ConsumerWidget {
         if (loading)
           const Padding(
             padding: EdgeInsets.all(UxnanSpacing.md),
-            child: SizedBox(
-              width: 18,
-              height: 18,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            ),
+            child: PolygonLoader(),
           )
         else
           IconButton.filledTonal(

--- a/uxnanmobile/lib/presentation/screens/profile/usage_section.dart
+++ b/uxnanmobile/lib/presentation/screens/profile/usage_section.dart
@@ -9,6 +9,7 @@ import 'package:uxnan/presentation/providers/application_providers.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/widgets/agent_visuals.dart';
 import 'package:uxnan/presentation/widgets/expressive_card.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 
 /// The "Usage & credit" block on the profile: per-provider quota windows, plan
 /// and credit read live from the connected PC (`agent/usageStats`). While
@@ -50,11 +51,7 @@ class UsageSection extends ConsumerWidget {
             if (loading)
               const Padding(
                 padding: EdgeInsets.all(UxnanSpacing.md),
-                child: SizedBox(
-                  width: 18,
-                  height: 18,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                ),
+                child: PolygonLoader(),
               )
             else
               IconButton.filledTonal(
@@ -78,7 +75,7 @@ class UsageSection extends ConsumerWidget {
         else if (loading)
           const Padding(
             padding: EdgeInsets.symmetric(vertical: UxnanSpacing.lg),
-            child: Center(child: CircularProgressIndicator()),
+            child: Center(child: PolygonLoader(size: UxnanSpacing.xxl)),
           )
         else
           Text(

--- a/uxnanmobile/lib/presentation/screens/settings/licenses/licenses_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/settings/licenses/licenses_screen.dart
@@ -5,6 +5,7 @@ import 'package:uxnan/presentation/providers/licenses_provider.dart';
 import 'package:uxnan/presentation/screens/settings/licenses/license_detail_screen.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/widgets/expressive_card.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 import 'package:uxnan/presentation/widgets/settings_tiles.dart';
 
@@ -41,7 +42,7 @@ class LicensesScreen extends ConsumerWidget {
             loading: () => const SliverToBoxAdapter(
               child: Padding(
                 padding: EdgeInsets.only(top: UxnanSpacing.xxl),
-                child: Center(child: CircularProgressIndicator()),
+                child: Center(child: PolygonLoader(size: UxnanSpacing.xxl)),
               ),
             ),
             error: (_, __) => SliverToBoxAdapter(

--- a/uxnanmobile/lib/presentation/screens/settings/sections/updates_section_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/settings/sections/updates_section_screen.dart
@@ -7,6 +7,7 @@ import 'package:uxnan/presentation/providers/app_info_provider.dart';
 import 'package:uxnan/presentation/providers/update_providers.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/widgets/expressive_card.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 import 'package:uxnan/presentation/widgets/settings_tiles.dart';
 
@@ -166,12 +167,12 @@ class _UpdateStateCard extends ConsumerWidget {
     switch (state.phase) {
       case AppUpdatePhase.checking:
       case AppUpdatePhase.installing:
-        return const SizedBox(
-          width: 20,
-          height: 20,
-          child: CircularProgressIndicator(strokeWidth: 2),
-        );
+        return const PolygonLoader(size: 20);
       case AppUpdatePhase.downloading:
+        // Stays a CircularProgressIndicator: it reports how much of the APK has
+        // actually downloaded. PolygonLoader is indeterminate by design and
+        // cannot draw `fraction`. (Play leaves `fraction` null until it knows
+        // the size, and the indicator spins on its own until then.)
         final fraction = state.install?.fraction;
         return SizedBox(
           width: 20,

--- a/uxnanmobile/lib/presentation/screens/settings/theme_sheets.dart
+++ b/uxnanmobile/lib/presentation/screens/settings/theme_sheets.dart
@@ -5,6 +5,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:uxnan/l10n/app_localizations.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 
@@ -325,13 +326,7 @@ class _ThemeImportScreenState extends State<ThemeImportScreen> {
                           child: OutlinedButton.icon(
                             onPressed: _busy ? null : _fromUrl,
                             icon: _busy
-                                ? const SizedBox(
-                                    width: 16,
-                                    height: 16,
-                                    child: CircularProgressIndicator(
-                                      strokeWidth: 2,
-                                    ),
-                                  )
+                                ? const PolygonLoader(size: 16)
                                 : const Icon(Icons.link_rounded, size: 18),
                             label: Text(l10n.themeImportFromUrl),
                           ),

--- a/uxnanmobile/lib/presentation/screens/threads/new_conversation_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/threads/new_conversation_screen.dart
@@ -16,6 +16,7 @@ import 'package:uxnan/presentation/theme/typography.dart';
 import 'package:uxnan/presentation/widgets/agent_logo_chip.dart';
 import 'package:uxnan/presentation/widgets/agent_visuals.dart';
 import 'package:uxnan/presentation/widgets/expressive_card.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
 import 'package:uxnan/presentation/widgets/ne_card.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
@@ -207,13 +208,7 @@ class _NewConversationScreenState extends ConsumerState<NewConversationScreen> {
         if (_starting)
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: UxnanSpacing.md),
-            child: Center(
-              child: SizedBox(
-                width: 18,
-                height: 18,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              ),
-            ),
+            child: Center(child: PolygonLoader()),
           )
         else
           Padding(
@@ -665,14 +660,7 @@ class _CheckSignInButton extends StatelessWidget {
         visualDensity: VisualDensity.compact,
       ),
       icon: checking
-          ? SizedBox(
-              width: 14,
-              height: 14,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: colors.error,
-              ),
-            )
+          ? PolygonLoader(size: 14, color: colors.error)
           : const Icon(Icons.login_rounded, size: 16),
       label: Text(l10n.agentCheckSignIn),
     );
@@ -819,11 +807,7 @@ class _ModelField extends StatelessWidget {
               ),
               const SizedBox(width: UxnanSpacing.sm),
               if (loading)
-                const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                )
+                const PolygonLoader(size: 16)
               else if (enabled && agentId != null)
                 Icon(
                   Icons.unfold_more_rounded,
@@ -864,13 +848,7 @@ class _Loading extends StatelessWidget {
   @override
   Widget build(BuildContext context) => const Padding(
         padding: EdgeInsets.all(UxnanSpacing.lg),
-        child: Center(
-          child: SizedBox(
-            width: 22,
-            height: 22,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ),
+        child: Center(child: PolygonLoader(size: 22)),
       );
 }
 

--- a/uxnanmobile/lib/presentation/screens/threads/thread_tile.dart
+++ b/uxnanmobile/lib/presentation/screens/threads/thread_tile.dart
@@ -14,6 +14,7 @@ import 'package:uxnan/presentation/theme/colors.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/widgets/agent_logo_chip.dart';
 import 'package:uxnan/presentation/widgets/agent_visuals.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/ne_card.dart';
 
 /// A per-thread action chosen from the long-press menu.
@@ -437,13 +438,9 @@ class _ActivityIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     switch (activity) {
       case ThreadActivity.running:
-        return SizedBox(
-          width: 10,
-          height: 10,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-            color: Theme.of(context).colorScheme.primary,
-          ),
+        return PolygonLoader(
+          size: 10,
+          color: Theme.of(context).colorScheme.primary,
         );
       case ThreadActivity.error:
         return const _Dot(color: UxnanColors.error);

--- a/uxnanmobile/lib/presentation/screens/threads/threads_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/threads/threads_screen.dart
@@ -18,6 +18,7 @@ import 'package:uxnan/presentation/screens/threads/thread_list_controls.dart';
 import 'package:uxnan/presentation/screens/threads/thread_tile.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
 import 'package:uxnan/presentation/widgets/agent_visuals.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 
 /// The threads of a connected PC (spec 02a §5.4.2). Lists the active bridge's
@@ -697,21 +698,9 @@ class _UpdateBanner extends ConsumerWidget {
   ) {
     switch (state.phase) {
       case AppUpdatePhase.downloading:
-        return const [
-          SizedBox(
-            width: 18,
-            height: 18,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ];
+        return const [PolygonLoader()];
       case AppUpdatePhase.installing:
-        return const [
-          SizedBox(
-            width: 18,
-            height: 18,
-            child: CircularProgressIndicator(strokeWidth: 2),
-          ),
-        ];
+        return const [PolygonLoader()];
       case AppUpdatePhase.downloaded:
         return [
           FilledButton(

--- a/uxnanmobile/test/unit/presentation/loader_consistency_test.dart
+++ b/uxnanmobile/test/unit/presentation/loader_consistency_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Guards the app's one loading language: every *indeterminate* spinner is the
+/// shared `PolygonLoader` (the M3 Expressive shape morph), and the only
+/// `CircularProgressIndicator`s left are the two that draw a **known value** —
+/// which `PolygonLoader` cannot do, being indeterminate by design.
+///
+/// This is a source scan rather than a widget test on purpose: the thing worth
+/// protecting is the *absence* of stray spinners across ~40 screens, which no
+/// single pumped widget can observe. It also stops a future well-meaning sweep
+/// from converting the two gauges and silently throwing away the numbers they
+/// report.
+void main() {
+  /// The only call sites allowed to keep a `CircularProgressIndicator`, each
+  /// because it renders a real fraction the user reads.
+  const determinateGauges = <String, String>{
+    'lib/presentation/screens/conversation/conversation_screen.dart':
+        'context-usage ring (percent of the model window used)',
+    'lib/presentation/screens/settings/sections/updates_section_screen.dart':
+        'APK download progress (fraction downloaded)',
+  };
+
+  test('every indeterminate spinner is the shared PolygonLoader', () {
+    final offenders = <String>[];
+
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final path = entity.path.replaceAll(r'\', '/');
+      if (determinateGauges.containsKey(path)) continue;
+
+      final lines = entity.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        // Skip the prose in comments that names the widget.
+        if (line.trimLeft().startsWith('//')) continue;
+        if (line.contains('CircularProgressIndicator')) {
+          offenders.add('$path:${i + 1}');
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'Use PolygonLoader for indeterminate loading. If a new site '
+          'truly reports a known value, add it to `determinateGauges` with '
+          'the reason.',
+    );
+  });
+
+  test('the determinate gauges still report a value', () {
+    determinateGauges.forEach((path, why) {
+      final source = File(path).readAsStringSync();
+      expect(
+        source.contains('CircularProgressIndicator'),
+        isTrue,
+        reason:
+            '$path no longer has the gauge it is exempted for ($why) — drop '
+            'it from `determinateGauges` if the gauge is genuinely gone.',
+      );
+      expect(
+        RegExp(r'value:\s').hasMatch(source),
+        isTrue,
+        reason:
+            '$path is exempted as a gauge ($why) but passes no `value:`. An '
+            'indeterminate spinner belongs in PolygonLoader.',
+      );
+    });
+  });
+}

--- a/uxnanmobile/test/widget/presentation/conversation_widgets_test.dart
+++ b/uxnanmobile/test/widget/presentation/conversation_widgets_test.dart
@@ -19,6 +19,7 @@ import 'package:uxnan/presentation/providers/infrastructure_providers.dart';
 import 'package:uxnan/presentation/screens/conversation/composer/composer_bar.dart';
 import 'package:uxnan/presentation/screens/conversation/messages/message_bubble.dart';
 import 'package:uxnan/presentation/screens/conversation/messages/message_content_view.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 
 Widget _wrap(Widget child) => ProviderScope(
       child: MaterialApp(
@@ -74,7 +75,7 @@ void main() {
     await tester.pumpWidget(_wrap(MessageBubble(message: message)));
     await tester.pump();
 
-    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byType(PolygonLoader), findsOneWidget);
     expect(find.text('Agent responding…'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Why

`PolygonLoader` (the M3 Expressive shape morph) landed with the file-viewer redesign (#73), but only the screens that redesign touched adopted it. Loading spoke two languages: the shape morph on those screens, Material's default spinner everywhere else — including the conversation timeline, the most-seen screen in the app.

## What

All **29** remaining `CircularProgressIndicator` call sites across **16 files** become `PolygonLoader`: the conversation timeline and its "Agent responding…" cue, approval/question buttons, Git, the threads list + tiles, new conversation, profile stats/heatmap/usage, pairing discovery, licenses, updates, theme import.

Each keeps its own weight rather than a blanket size, and colored spinners keep their color:

| Context | `size` |
| --- | --- |
| Full-screen / `SliverFillRemaining` | 48 |
| Section block (heatmap, provider cards, licenses) | `UxnanSpacing.xxl` (32) |
| Sheet / picker | 22–28 |
| Inline (beside text, in a button, header action) | 10–20 |

`PolygonLoader` owns its own `SizedBox.square` + `RepaintBoundary`, so each old spinner's wrapper is dropped rather than nested.

## The one judgement call: two gauges stay

`PolygonLoader` is **indeterminate by design** — it has no `value`. Two sites therefore keep `CircularProgressIndicator`, because each draws a number the user actually reads:

- the conversation's **context-usage ring** (`value: percent / 100`, with the percent rendered inside it);
- Settings ▸ Updates' **download progress** (`value: fraction` — how much of the APK has landed).

Converting those would have silently discarded that information. Both keep an inline comment explaining why they are exempt.

## Guard

`test/unit/presentation/loader_consistency_test.dart` enforces the rule in both directions — no stray spinner anywhere else, and those two sites still passing a `value:`. It is a source scan on purpose: what is worth protecting is the *absence* of stray spinners across ~40 screens, which no single pumped widget can observe, and it stops a future well-meaning sweep from converting the gauges.

Verified it actually fails on an injected stray spinner (naming the exact line), not just that it passes.

## Verification

**mobile 660 tests green** (+2), `dart analyze` clean, `dart format` clean.

Docs: `docs/neural-expressive-design.md` §6.6 gains the per-context size table and the gauge exception.