### PR TITLE
build: prepare bridge 0.0.7-alpha.20260716 + mobile 0.0.8-alpha.20260716

### DIFF
--- a/.github/whatsnew/whatsnew-en-US
+++ b/.github/whatsnew/whatsnew-en-US
@@ -1,5 +1,7 @@
 What's new in this update:
 
-• Fixed app updates. If an update downloaded but didn't install, the app would then tell you that you were up to date and never offer it again — the only way out was updating by hand from the Play Store. Now a downloaded update always comes back as "Install now", and one that is still downloading picks up where it left off.
+• A fresh look for files, Git history, onboarding and the composer, with one lively loading animation everywhere.
+• Profile stats now refresh whenever you open Profile, plus a refresh button — no more restarting the app to see them move. Pick automatic, timed or manual in Settings.
+• Backing up your stats works again without a passphrase, and tells you the real reason if it fails.
 
 Thanks for testing this alpha!

--- a/.github/whatsnew/whatsnew-es-ES
+++ b/.github/whatsnew/whatsnew-es-ES
@@ -1,5 +1,7 @@
 Novedades de esta actualización:
 
-• Arreglamos las actualizaciones de la app. Si una actualización se descargaba pero no se instalaba, la app te decía que estabas al día y no volvía a ofrecerla: solo quedaba actualizar a mano desde Play Store. Ahora una actualización descargada siempre vuelve como "Instalar ahora", y una que sigue descargando continúa donde se quedó.
+• Renovamos archivos, historial de Git, la bienvenida y el redactor, con una sola animación de carga en toda la app.
+• Tus estadísticas se actualizan al abrir Perfil, y añadimos un botón para hacerlo — ya no hace falta reiniciar la app. Elige automático, cada cierto tiempo o manual en Ajustes.
+• El respaldo de estadísticas vuelve a funcionar sin frase de contraseña, y te dice el motivo real si falla.
 
 ¡Gracias por probar esta alfa!

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the bridge daemon are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [0.0.7-alpha.20260716] - 2026-07-16
 
 ### Fixed — an omitted `params` no longer fails methods whose fields are all optional
 - **`metrics/export` with no passphrase now works.** JSON-RPC 2.0 makes the

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uxnan-bridge",
-  "version": "0.0.6-alpha.20260716",
+  "version": "0.0.7-alpha.20260716",
   "description": "Uxnan Bridge — local control-plane daemon connecting the Uxnan mobile app to the developer's PC over E2EE.",
   "license": "MPL-2.0",
   "author": "Luis Donaldo Gamas Vazquez",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "bridge": {
       "name": "uxnan-bridge",
-      "version": "0.0.6-alpha.20260716",
+      "version": "0.0.7-alpha.20260716",
       "license": "MPL-2.0",
       "dependencies": {
         "@uxnan/shared": "*",

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the `uxnanmobile` app are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.0.8-alpha.20260716] - 2026-07-16
 
 ### Changed — one loading language across the whole app
 - Every remaining `CircularProgressIndicator` is now the shared **`PolygonLoader`**

--- a/uxnanmobile/pubspec.yaml
+++ b/uxnanmobile/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 # The build-number is Play's versionCode and must strictly increase. 0.0.6 (cut
 # earlier today) already took 20260716, so this same-day release borrows the next
 # day — the same thing 0.0.2-alpha.20260628+20260629 did.
-version: 0.0.7-alpha.20260716+20260717
+version: 0.0.8-alpha.20260716+20260718
 
 environment:
   sdk: '>=3.4.0 <4.0.0'


### PR DESCRIPTION
Release prep for the three branches that landed today: #72 (metrics export fix + refresh control), #73 (Neural Expressive redesign + the M3 loader), #74 (loader adopted app-wide).

## Versions

| Component | Version | Why |
| --- | --- | --- |
| **bridge** | `0.0.7-alpha.20260716` | real source change (the omitted-`params` fix) |
| **mobile** | `0.0.8-alpha.20260716+20260718` | redesign + loaders + metrics refresh/export |
| shared | *unchanged* `0.0.6-alpha.20260716` | nothing in `shared/` changed — only its CHANGELOG heading |
| relay / desktop | *unchanged* | untouched this cycle |

## Checks against `VERSIONS.md`

- **No manifest↔lock drift:** `bridge/package.json` **and** the root `package-lock.json` both read `0.0.7-alpha.20260716` (the lock was re-synced explicitly — `npm version` updated the manifest but left the lock behind, which is exactly the silent drift `VERSIONS.md` warns about).
- **pubspec matches the tag:** `0.0.8-alpha.20260716+20260718`, so `release-mobile.yml`'s pubspec↔tag gate passes. Build number **20260718** because Play's versionCode must strictly increase and `0.0.7` already took `20260717` earlier today.
- **Play notes:** EN 452 / ES 487 chars — under the 500 limit the workflow enforces, non-technical, rewritten for what users actually see.
- **shared not re-published:** `release-npm.yml` pins `@uxnan/shared` to whatever is on npm's `latest`, so the bridge build resolves `0.0.6-alpha.20260716`. No shared tag needed.
- `[Unreleased]` rolled into each released heading.

`VERSIONS.md` is deliberately **not** in this PR: its history row asserts a release *shipped*, so it lands once the release workflows are green — the same split the 0.0.7 release used.

Tags follow once this is merged and green.