### PR TITLE
fix(security): constant-time compare secret tokens

### DIFF
--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -8,6 +8,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 ### Docs
 - Sync the JSON-RPC method-count badges, the AGENTS.md agent roster (add Grok), the npm publish status and the PR-template test count with the code.
 
+### Security
+- Use constant-time comparisons for LAN approval-hook tokens.
+
 ## [0.0.7-alpha.20260716] - 2026-07-16
 
 ### Fixed — an omitted `params` no longer fails methods whose fields are all optional

--- a/bridge/src/bridge.ts
+++ b/bridge/src/bridge.ts
@@ -31,6 +31,7 @@ import { startLanServer, type LanServerHandle } from './transport/lan-server.js'
 import { localHostPorts, localIPv4s } from './transport/local-hosts.js';
 import { MdnsAdvertiser } from './transport/mdns-advertiser.js';
 import { SessionRegistry } from './transport/session-registry.js';
+import { constantTimeEqual } from './transport/constant-time.js';
 import { ThreadStore } from './conversation/thread-store.js';
 import { MetricsService } from './metrics/metrics-service.js';
 import { AgentManager } from './agents/agent-manager.js';
@@ -563,7 +564,9 @@ export async function startBridge(options: StartBridgeOptions = {}): Promise<Bri
         // Claude PreToolUse approval hook: ask the user (on the phone) whether a
         // tool may run; hold the response until they answer (or it times out).
         onHookApproval: async (body, token) => {
-          if (token !== hookState.token) return { status: 403, json: { error: 'bad_token' } };
+          if (typeof token !== 'string' || !constantTimeEqual(token, hookState.token)) {
+            return { status: 403, json: { error: 'bad_token' } };
+          }
           const b = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
           const threadId = typeof b['threadId'] === 'string' ? (b['threadId'] as string) : '';
           if (!threadId) return { status: 400, json: { error: 'missing_thread' } };

--- a/bridge/src/transport/constant-time.ts
+++ b/bridge/src/transport/constant-time.ts
@@ -1,0 +1,9 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/** Constant-time string compare that never throws on length mismatch. */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a, 'utf-8');
+  const bb = Buffer.from(b, 'utf-8');
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}

--- a/bridge/test/transport/constant-time.test.ts
+++ b/bridge/test/transport/constant-time.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { constantTimeEqual } from '../../src/transport/constant-time.js';
+
+test('constantTimeEqual compares equal strings', () => {
+  assert.equal(constantTimeEqual('secret', 'secret'), true);
+});
+
+test('constantTimeEqual rejects different same-length strings', () => {
+  assert.equal(constantTimeEqual('secret', 'secreT'), false);
+});
+
+test('constantTimeEqual rejects different-length strings', () => {
+  assert.equal(constantTimeEqual('secret', 'secret-longer'), false);
+});
+
+test('constantTimeEqual accepts two empty strings', () => {
+  assert.equal(constantTimeEqual('', ''), true);
+});

--- a/relay/CHANGELOG.md
+++ b/relay/CHANGELOG.md
@@ -5,6 +5,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Security
+- Use constant-time comparisons for push notification secrets.
+
 ## [0.0.1-alpha.20260627] - 2026-06-27
 
 ### Changed — push notifications doc moved to the bridge

--- a/relay/src/constant-time.ts
+++ b/relay/src/constant-time.ts
@@ -1,0 +1,9 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/** Constant-time string compare that never throws on length mismatch. */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const ba = Buffer.from(a, 'utf-8');
+  const bb = Buffer.from(b, 'utf-8');
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}

--- a/relay/src/push.ts
+++ b/relay/src/push.ts
@@ -23,6 +23,7 @@ import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { PushNotifyRequest, PushPlatform } from '@uxnan/shared';
 import type { RelayLogger } from './relay-server.js';
+import { constantTimeEqual } from './constant-time.js';
 
 export interface PushPayload {
   title: string;
@@ -181,7 +182,11 @@ export class PushRegistry {
   /** Validate the secret, dedupe by (sessionId,turnId), then fan out to tokens. */
   async notify(req: PushNotifyRequest): Promise<NotifyOutcome> {
     const session = this.#sessions.get(req.sessionId);
-    if (!session || session.secret !== req.notificationSecret) {
+    if (
+      !session ||
+      typeof req.notificationSecret !== 'string' ||
+      !constantTimeEqual(session.secret, req.notificationSecret)
+    ) {
       return { delivered: false, recipients: 0, reason: 'unauthorized' };
     }
     const key = `${req.sessionId}:${req.turnId}`;


### PR DESCRIPTION
## Summary
- add constant-time string comparison helpers using Node timingSafeEqual
- protect the bridge approval-hook token and relay push notification secret
- add helper coverage and update bridge/relay changelogs

## Verification
- git diff --check passes
- local full npm/TypeScript suites were not run because the repository plan documents broken local workspace junctions; CI is the verification gate

No merge performed; CI should run on this pull request.