### PR TITLE
fix(svelte): guard stale git status responses

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — stale Git status responses cannot overwrite the active worktree
+
+- **Changes panel: a slow status response from a previously selected worktree
+  can no longer overwrite the list (or drive staging actions) for the current
+  one.**
+
 ### Fixed — browser-MCP config injection can no longer clobber a user's CLI configs
 
 - **The MCP config injector now writes each agent CLI's user-global config

--- a/uxnandesktop/src/lib/state/git.svelte.ts
+++ b/uxnandesktop/src/lib/state/git.svelte.ts
@@ -132,19 +132,23 @@ class GitStore {
     }
     this.loading = true;
     try {
-      this.files = (await gitStatus(path)).map(classify);
+      const files = (await gitStatus(path)).map(classify);
+      if (this.path !== path) return;
+      this.files = files;
       void this.loadNumstat(path);
       const st = await worktreeStatus(path);
+      if (this.path !== path) return;
       this.ahead = st.ahead;
       this.behind = st.behind;
       // Keep the project card badge in sync (e.g. after a commit clears it).
       projects.setStatus(path, st);
     } catch (e) {
+      if (this.path !== path) return;
       this.error = msg(e);
       toastError(e);
       this.files = [];
     } finally {
-      this.loading = false;
+      if (this.path === path) this.loading = false;
     }
   }
 


### PR DESCRIPTION
## Summary

- Guard `GitStore.load()` against stale `gitStatus` and `worktreeStatus` responses after a worktree switch.
- Prevent stale errors, spinner updates, file lists, ahead/behind metadata, and project badges from clobbering the active worktree.
- Update the changelog and mark Plan 002 as completed.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 187/187
- `npm run build` — passed
- `cargo fmt -- --check` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `cargo test` — 217/217

Manual visual QA was not run because it requires an interactive desktop session with two registered worktrees.

Please do not merge this PR from the implementing agent; a separate agent will inspect CI and address any failures.
