### PR TITLE
perf(e2ee): enable automatic native crypto acceleration

### DIFF
--- a/architecture/02b-contracts-and-requirements.md
+++ b/architecture/02b-contracts-and-requirements.md
@@ -581,12 +581,15 @@ Todos los paquetes listados son compatibles con Android e iOS. Se priorizan los 
 | Paquete | Version min. | Rol |
 |---|---|---|
 | `pointycastle` | ^3.9.0 | AES-256-GCM, HKDF, SHA-256 — puro Dart |
-| `cryptography` | ^2.7.0 | X25519, Ed25519, HKDF — con fallback nativo |
-| `cryptography_flutter` | ^2.3.0 | Aceleracion nativa de cryptography en iOS y Android |
+| `cryptography` | ^2.9.0 | X25519, Ed25519, HKDF — con fallback nativo |
+| `cryptography_flutter` | ^2.3.4 | Aceleracion nativa auto-registrada en iOS y Android |
 
 La combinacion `cryptography` + `cryptography_flutter` usa:
 - iOS: CryptoKit (Swift) para X25519 y Ed25519
 - Android: Android Keystore / JCE
+
+Flutter registra automaticamente `cryptography_flutter`; la app no debe agregar
+inicializacion criptografica manual durante el arranque.
 
 ### 2.6 UI y componentes visuales
 

--- a/architecture/02c-implementation-guide.md
+++ b/architecture/02c-implementation-guide.md
@@ -1666,8 +1666,8 @@ dependencies:
   path_provider: ^2.1.3
 
   # Criptografia
-  cryptography: ^2.7.0
-  cryptography_flutter: ^2.3.2
+  cryptography: ^2.9.0
+  cryptography_flutter: ^2.3.4 # Auto-registered by Flutter
   pointycastle: ^3.9.1
 
   # UI

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the `uxnanmobile` app are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Performance
+
+- Updated `cryptography` to `2.9.0` and `cryptography_flutter` to `2.3.4`, whose
+  auto-registered Flutter plugin enables native E2EE acceleration without the
+  deprecated manual bootstrap call.
+
 ## [0.0.8-alpha.20260716] - 2026-07-16
 
 ### Changed — one loading language across the whole app

--- a/uxnanmobile/pubspec.yaml
+++ b/uxnanmobile/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   async: ^2.11.0 # reactive stream helpers
   collection: ^1.18.0 # DeepCollectionEquality, etc.
   connectivity_plus: ^6.0.0 # network connectivity changes
-  cryptography: ^2.7.0 # X25519, Ed25519, HKDF
-  cryptography_flutter: ^2.3.0 # native crypto acceleration
+  cryptography: ^2.9.0 # X25519, Ed25519, HKDF
+  cryptography_flutter: ^2.3.4 # auto-registered native crypto acceleration
   cupertino_icons: ^1.0.8
   dio: ^5.4.0 # HTTP client for relay REST endpoints
   drift: ^2.18.0 # SQLite ORM (local persistence)


### PR DESCRIPTION
## Summary

- align cryptography constraints with cryptography 2.9.0 and cryptography_flutter 2.3.4
- rely on Flutter's automatic plugin registration instead of the deprecated FlutterCryptography.enable() bootstrap
- synchronize the mobile changelog and architecture dependency guidance

## Why

The original plan correctly targeted native E2EE acceleration, but its manual activation mechanism was outdated. cryptography_flutter has auto-registered through Flutter since 2.2.0, and 2.3.4 deprecates the explicit enable() call. The generated Dart plugin registrant invokes FlutterCryptography.registerWith() on Android, iOS, and macOS, preserving native acceleration without a lint suppression.

## Verification

- flutter analyze
- flutter test (660 tests)
- generated plugin registrant includes FlutterCryptography.registerWith() for Android, iOS, and macOS
- git diff --check