### PR TITLE
build(e2ee): bump crypto libs to latest, document native auto-activation

### DIFF
--- a/architecture/02b-contracts-and-requirements.md
+++ b/architecture/02b-contracts-and-requirements.md
@@ -581,12 +581,22 @@ Todos los paquetes listados son compatibles con Android e iOS. Se priorizan los 
 | Paquete | Version min. | Rol |
 |---|---|---|
 | `pointycastle` | ^3.9.0 | AES-256-GCM, HKDF, SHA-256 — puro Dart |
-| `cryptography` | ^2.7.0 | X25519, Ed25519, HKDF — con fallback nativo |
-| `cryptography_flutter` | ^2.3.0 | Aceleracion nativa de cryptography en iOS y Android |
+| `cryptography` | ^2.9.0 | X25519, Ed25519, HKDF — con fallback nativo |
+| `cryptography_flutter` | ^2.3.4 | Aceleracion nativa de cryptography en iOS y Android |
 
 La combinacion `cryptography` + `cryptography_flutter` usa:
 - iOS: CryptoKit (Swift) para X25519 y Ed25519
 - Android: Android Keystore / JCE
+
+La aceleracion nativa se activa de forma **automatica**, sin llamar a
+`FlutterCryptography.enable()`: desde `cryptography_flutter` 2.2.0 el plugin
+declara `dartPluginClass: FlutterCryptography`, por lo que Flutter lo registra
+como `Cryptography.instance` durante `WidgetsFlutterBinding.ensureInitialized()`
+en `main()`. `FlutterCryptography.enable()` quedo deprecado y es redundante con
+ese auto-registro, asi que no se invoca. En plataformas sin soporte nativo
+(p. ej. la Dart VM en tests) se usa el fallback puro-Dart de forma transparente;
+el formato wire de AES-256-GCM (nonce de 12 bytes + tag GCM de 16 bytes) no
+cambia, por lo que interopera byte a byte con el bridge.
 
 ### 2.6 UI y componentes visuales
 

--- a/architecture/02c-implementation-guide.md
+++ b/architecture/02c-implementation-guide.md
@@ -1666,8 +1666,8 @@ dependencies:
   path_provider: ^2.1.3
 
   # Criptografia
-  cryptography: ^2.7.0
-  cryptography_flutter: ^2.3.2
+  cryptography: ^2.9.0
+  cryptography_flutter: ^2.3.4
   pointycastle: ^3.9.1
 
   # UI

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to the `uxnanmobile` app are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed — crypto libraries bumped to latest; native-backend activation documented
+- Bumped the crypto dependencies to their latest published versions:
+  `cryptography` `^2.7.0` → `^2.9.0` and `cryptography_flutter` `^2.3.0` →
+  `^2.3.4`. Dependency resolution is unchanged (both already resolved to the
+  latest), so `pubspec.lock` is untouched — the bump only advances the declared
+  floor to match.
+- Documented that the E2EE envelope crypto already runs on the platform-native
+  backend on device — no `main()` activation call is required. Since
+  `cryptography_flutter` **2.2.0** the plugin registers its accelerated
+  `FlutterCryptography` as `Cryptography.instance` **automatically** (via its
+  `dartPluginClass`) during `WidgetsFlutterBinding.ensureInitialized()`, so
+  AES-256-GCM + HKDF for every envelope use the OS-native primitives rather than
+  the pure-Dart fallback.
+- `FlutterCryptography.enable()` is deprecated (a no-op made redundant by the
+  auto-registration) and is intentionally **not** called — adding it would only
+  trip `deprecated_member_use`. Non-native targets (e.g. the Dart VM under
+  `flutter test`) use the byte-identical pure-Dart backend, and the AES-GCM wire
+  format (12-byte nonce + 16-byte GCM tag) is unchanged, so the native backend
+  interoperates byte-for-byte with the bridge.
+
 ## [0.0.8-alpha.20260716] - 2026-07-16
 
 ### Changed — one loading language across the whole app

--- a/uxnanmobile/lib/main.dart
+++ b/uxnanmobile/lib/main.dart
@@ -17,6 +17,15 @@ import 'package:uxnan/infrastructure/notifications/push_notification_service.dar
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  // The E2EE envelope layer needs no explicit crypto activation here.
+  // `cryptography_flutter` auto-registers its accelerated
+  // `FlutterCryptography` as `Cryptography.instance` through its
+  // `dartPluginClass` during `ensureInitialized()` above, so AES-GCM and
+  // HKDF run on the OS-native backend on device (and on the
+  // byte-identical pure-Dart fallback elsewhere, e.g. in tests).
+  // `FlutterCryptography.enable()` has been redundant since
+  // cryptography_flutter 2.2.0 and is deprecated — do not add it.
+
   await _initFirebase();
 
   runApp(

--- a/uxnanmobile/pubspec.yaml
+++ b/uxnanmobile/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   async: ^2.11.0 # reactive stream helpers
   collection: ^1.18.0 # DeepCollectionEquality, etc.
   connectivity_plus: ^6.0.0 # network connectivity changes
-  cryptography: ^2.7.0 # X25519, Ed25519, HKDF
-  cryptography_flutter: ^2.3.0 # native crypto acceleration
+  cryptography: ^2.9.0 # X25519, Ed25519, HKDF
+  cryptography_flutter: ^2.3.4 # native crypto acceleration
   cupertino_icons: ^1.0.8
   dio: ^5.4.0 # HTTP client for relay REST endpoints
   drift: ^2.18.0 # SQLite ORM (local persistence)


### PR DESCRIPTION
## What

- Bump the crypto dependencies to their latest published versions:
  - `cryptography` `^2.7.0` → `^2.9.0`
  - `cryptography_flutter` `^2.3.0` → `^2.3.4`
- Document how the E2EE envelope crypto is activated on the native backend
  (code comment in `main()` + CHANGELOG + architecture).

Dependency resolution is unchanged — both already resolved to the latest — so
`pubspec.lock` is untouched; the bump only advances the declared floor.

## Key finding

The E2EE envelope layer (`EnvelopeCrypto`, AES-256-GCM + HKDF) already runs on
the OS-native backend on device. Since **`cryptography_flutter` 2.2.0** the
plugin registers its accelerated `FlutterCryptography` as `Cryptography.instance`
**automatically** via its `dartPluginClass` during
`WidgetsFlutterBinding.ensureInitialized()`. No `main()` activation call is
required, and `FlutterCryptography.enable()` is deprecated (a no-op made
redundant by the auto-registration) — calling it would only trip
`deprecated_member_use`, so it is intentionally **not** added. A comment in
`main()` records this so the deprecated call is never reintroduced.

## Verification

- `flutter analyze` → **0 issues**
- `flutter test` → **660 passing** (incl. the `EnvelopeCrypto` round-trip tests;
  the AES-GCM wire format — 12-byte nonce + 16-byte GCM tag — is unchanged)
- Toolchain: Flutter 3.44.4 / Dart 3.12.2

On-device byte-for-byte interop with the bridge is unaffected (wire format
unchanged), confirmed in the normal build loop.

## Docs updated (same change set)

- `uxnanmobile/CHANGELOG.md` — `[Unreleased]`
- `architecture/02b-contracts-and-requirements.md` — §2.5 crypto versions + auto-activation note
- `architecture/02c-implementation-guide.md` — pubspec crypto versions
