### PR TITLE
fix(drift): cascade-delete a thread's child rows + animate thread deletion

### DIFF
--- a/architecture/02c-implementation-guide.md
+++ b/architecture/02c-implementation-guide.md
@@ -2518,7 +2518,16 @@ class DriftThreadRepository implements IThreadRepository {
 
   @override
   Future<void> deleteThread(String id) async {
-    await (_db.delete(_db.threadsTable)..where((t) => t.id.equals(id))).go();
+    // mensajes/turns/borradores/log de git cuelgan de threadId sin cascada en
+    // la BD; se borran de forma explícita (hijos primero, luego el padre) en
+    // una transacción para no dejar filas huérfanas.
+    await _db.transaction(() async {
+      await (_db.delete(_db.messagesTable)..where((m) => m.threadId.equals(id))).go();
+      await (_db.delete(_db.turnsTable)..where((t) => t.threadId.equals(id))).go();
+      await (_db.delete(_db.composerDraftsTable)..where((d) => d.threadId.equals(id))).go();
+      await (_db.delete(_db.gitActionLogTable)..where((g) => g.threadId.equals(id))).go();
+      await (_db.delete(_db.threadsTable)..where((t) => t.id.equals(id))).go();
+    });
   }
 
   @override

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,16 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — smooth thread-delete animation
+- Deleting a conversation now animates the tile out instead of making it vanish
+  abruptly. On confirm, the card dims and floats the app's shape-morphing
+  `PolygonLoader` over it, then fades and collapses its height (≈320 ms, Material
+  3 Expressive easing) so the rows below slide up smoothly. The database delete
+  is committed only **after** the card has animated away, so the list mutates
+  while the slot is already invisible (no jarring pop). Honours the platform
+  "reduce motion" setting — the row is dropped without the animation. Applies to
+  both the active and archived thread lists.
+
 ### Changed — crypto libraries bumped to latest; native-backend activation documented
 - Bumped the crypto dependencies to their latest published versions:
   `cryptography` `^2.7.0` → `^2.9.0` and `cryptography_flutter` `^2.3.0` →

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -26,6 +26,20 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
   format (12-byte nonce + 16-byte GCM tag) is unchanged, so the native backend
   interoperates byte-for-byte with the bridge.
 
+### Fixed — deleting a thread now removes its dependent rows
+- Deleting a single thread (tile long-press / conversation menu) previously
+  removed only the thread row and left every dependent row behind forever. The
+  `messages`, `turns`, `composer_drafts` and `git_action_log` tables all key off
+  `threadId` with no database cascade, so those orphans were never re-synced or
+  garbage-collected — the local SQLite DB grew unbounded with dead data and the
+  message / git-action counts were inflated by rows with no thread. `deleteThread`
+  now clears all four child tables and the thread in a single transaction, so a
+  delete leaves nothing behind (mirrors the device-wide `deleteThreadsByDeviceId`
+  path).
+- Extended `deleteThreadsByDeviceId` (the "remove device" path) to also clear
+  `composer_drafts` and `git_action_log`; it previously wiped only `messages` and
+  `turns`, leaking the same two tables when a whole PC was unpaired.
+
 ## [0.0.8-alpha.20260716] - 2026-07-16
 
 ### Changed — one loading language across the whole app

--- a/uxnanmobile/docs/neural-expressive-design.md
+++ b/uxnanmobile/docs/neural-expressive-design.md
@@ -617,6 +617,26 @@ When swipe-to-dismissing an item:
 - Maximum neighbor displacement: 8–12 dp
 - Neighbor animation: `spatialDefault` (k=700, ζ=0.90)
 
+#### Deleting a List Item (fade → collapse → commit)
+
+When a row is deleted from a data-driven list (the thread list is the canonical
+case, `presentation/screens/threads/thread_tile.dart`), animate the row out
+**before** the underlying source drops it, so the list never pops:
+
+- On confirm, put the row in a *deleting* state: dim the card to ~0.4 opacity,
+  ignore pointer input, and float the shared `PolygonLoader` over it (the app's
+  one loading language — never a bare `CircularProgressIndicator`).
+- Play a single controller (~320 ms): **fade** the card over the first half
+  (`Interval(0, 0.5, easeOut)`), then **collapse** its height over the second
+  half (`Interval(0.3, 1, easeInOut)`, `SizeTransition` anchored
+  `Alignment.topCenter`) so the rows below slide up under it.
+- Commit the data mutation (e.g. the cascading repository delete) **only after**
+  the animation completes — the source list then rebuilds while this slot is
+  already invisible, so no neighbour jumps.
+- Give each row a stable `ValueKey(id)` so its animation state follows the item
+  rather than the list index, and honour `MediaQuery.disableAnimations` by
+  dropping the row without the transition.
+
 #### Expandable Cards
 
 - Expansion with `spatialSlow` (k=300, ζ=0.90) to maximize the sense of inertia

--- a/uxnanmobile/lib/domain/repositories/i_thread_repository.dart
+++ b/uxnanmobile/lib/domain/repositories/i_thread_repository.dart
@@ -15,11 +15,13 @@ abstract class IThreadRepository {
   /// Inserts or updates [thread].
   Future<void> saveThread(Thread thread);
 
-  /// Deletes the thread with the given [id].
+  /// Deletes the thread with the given [id] and all of its dependent rows
+  /// (messages, turns, composer draft, git action log) in one transaction.
   Future<void> deleteThread(String id);
 
-  /// Deletes every thread belonging to [deviceId] (a paired PC), along with
-  /// their messages and turns. Used when removing a device.
+  /// Deletes every thread belonging to [deviceId] (a paired PC), along with all
+  /// of their dependent rows (messages, turns, composer drafts, git action
+  /// logs). Used when removing a device.
   Future<void> deleteThreadsByDeviceId(String deviceId);
 
   /// Emits the thread list whenever it changes, optionally filtered by

--- a/uxnanmobile/lib/infrastructure/repositories/drift_thread_repository.dart
+++ b/uxnanmobile/lib/infrastructure/repositories/drift_thread_repository.dart
@@ -57,14 +57,30 @@ class DriftThreadRepository implements IThreadRepository {
 
   @override
   Future<void> deleteThread(String id) async {
-    await (_db.delete(_db.threadsTable)..where((t) => t.id.equals(id))).go();
+    // Messages/turns/composer-drafts/git-action-log key off threadId with no DB
+    // cascade, so clear them explicitly (children first, then the parent) in a
+    // transaction to avoid orphan rows — mirrors deleteThreadsByDeviceId.
+    await _db.transaction(() async {
+      await (_db.delete(_db.messagesTable)..where((m) => m.threadId.equals(id)))
+          .go();
+      await (_db.delete(_db.turnsTable)..where((t) => t.threadId.equals(id)))
+          .go();
+      await (_db.delete(_db.composerDraftsTable)
+            ..where((d) => d.threadId.equals(id)))
+          .go();
+      await (_db.delete(_db.gitActionLogTable)
+            ..where((g) => g.threadId.equals(id)))
+          .go();
+      await (_db.delete(_db.threadsTable)..where((t) => t.id.equals(id))).go();
+    });
   }
 
   @override
   Future<void> deleteThreadsByDeviceId(String deviceId) async {
     // Wipe the device's threads and their dependent rows in one transaction.
-    // Messages/turns key off threadId with no DB cascade, so clear them
-    // explicitly to avoid orphan rows when a whole PC is removed.
+    // Messages/turns/composer-drafts/git-action-log key off threadId with no DB
+    // cascade, so clear them explicitly to avoid orphan rows when a whole PC is
+    // removed.
     await _db.transaction(() async {
       final ids = await (_db.select(_db.threadsTable)
             ..where((t) => t.deviceId.equals(deviceId)))
@@ -74,6 +90,12 @@ class DriftThreadRepository implements IThreadRepository {
       await (_db.delete(_db.messagesTable)..where((m) => m.threadId.isIn(ids)))
           .go();
       await (_db.delete(_db.turnsTable)..where((t) => t.threadId.isIn(ids)))
+          .go();
+      await (_db.delete(_db.composerDraftsTable)
+            ..where((d) => d.threadId.isIn(ids)))
+          .go();
+      await (_db.delete(_db.gitActionLogTable)
+            ..where((g) => g.threadId.isIn(ids)))
           .go();
       await (_db.delete(_db.threadsTable)
             ..where((t) => t.deviceId.equals(deviceId)))

--- a/uxnanmobile/lib/presentation/screens/threads/archived_threads_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/threads/archived_threads_screen.dart
@@ -78,8 +78,11 @@ class _ArchivedThreadsScreenState extends ConsumerState<ArchivedThreadsScreen> {
               separatorBuilder: (_, __) => SizedBox(
                 height: compact ? UxnanSpacing.sm : UxnanSpacing.md,
               ),
-              itemBuilder: (context, index) =>
-                  ThreadTile(thread: visible[index], compact: compact),
+              itemBuilder: (context, index) => ThreadTile(
+                key: ValueKey('thread-${visible[index].id}'),
+                thread: visible[index],
+                compact: compact,
+              ),
             ),
           ),
       ],

--- a/uxnanmobile/lib/presentation/screens/threads/thread_tile.dart
+++ b/uxnanmobile/lib/presentation/screens/threads/thread_tile.dart
@@ -24,7 +24,7 @@ enum _ThreadAction { rename, copyId, archive, unarchive, delete }
 /// list. Tapping opens the conversation; long-pressing opens the actions menu
 /// (rename / copy id / archive · unarchive / delete), adapted to the thread's
 /// status.
-class ThreadTile extends ConsumerWidget {
+class ThreadTile extends ConsumerStatefulWidget {
   /// Creates a [ThreadTile].
   const ThreadTile({required this.thread, this.compact = false, super.key});
 
@@ -36,7 +36,61 @@ class ThreadTile extends ConsumerWidget {
   final bool compact;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ThreadTile> createState() => _ThreadTileState();
+}
+
+class _ThreadTileState extends ConsumerState<ThreadTile>
+    with SingleTickerProviderStateMixin {
+  /// Drives the delete exit: the card fades over the first half, then its
+  /// height collapses over the second half, so the neighbouring rows slide up
+  /// smoothly before the row is finally removed from the list.
+  late final AnimationController _removal = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 320),
+  );
+  late final Animation<double> _fade = CurvedAnimation(
+    parent: _removal,
+    curve: const Interval(0, 0.5, curve: Curves.easeOut),
+  );
+  late final Animation<double> _collapse = CurvedAnimation(
+    parent: _removal,
+    curve: const Interval(0.3, 1, curve: Curves.easeInOut),
+  );
+
+  /// True from the moment a delete is confirmed: the card dims, floats the
+  /// app's loader and stops taking taps while it animates out.
+  bool _deleting = false;
+
+  @override
+  void dispose() {
+    _removal.dispose();
+    super.dispose();
+  }
+
+  /// Confirms, plays the exit animation, then commits the delete. The DB row is
+  /// removed only after the card has animated away, so the list mutates while
+  /// this slot is already invisible (no abrupt disappearance). The repository
+  /// delete cascades to the thread's messages/turns/draft/git-log.
+  Future<void> _delete() async {
+    final confirmed = await _confirmDeleteThread(context, widget.thread);
+    if (!confirmed || !mounted) return;
+    // Honour the platform "reduce motion" setting: drop the row without the
+    // fade-collapse (the manager clears in-memory state and the list rebuilds).
+    final reduceMotion = MediaQuery.maybeDisableAnimationsOf(context) ?? false;
+    if (reduceMotion) {
+      await ref.read(threadManagerProvider).deleteThread(widget.thread.id);
+      return;
+    }
+    setState(() => _deleting = true);
+    await _removal.forward();
+    if (!mounted) return;
+    await ref.read(threadManagerProvider).deleteThread(widget.thread.id);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final thread = widget.thread;
+    final compact = widget.compact;
     final colors = Theme.of(context).colorScheme;
     final agent = AgentIdParsing.fromWireId(thread.agentId);
     // Live activity of the conversation (running/error), independent of the
@@ -50,7 +104,7 @@ class ThreadTile extends ConsumerWidget {
         ref.watch(authStatusProvider(thread.agentId)).value?.requiresLogin ??
             false;
 
-    return NeCard(
+    final card = NeCard(
       // An unread reply gently tints the card (primary over the calm base) so
       // it stands out without shouting.
       color: unread
@@ -66,7 +120,8 @@ class ThreadTile extends ConsumerWidget {
             )
           : const EdgeInsets.all(UxnanSpacing.md),
       onTap: () => context.push(AppRoutes.conversation(thread.id)),
-      onLongPress: () => showThreadActions(context, ref, thread),
+      onLongPress: () =>
+          showThreadActions(context, ref, thread, onDelete: _delete),
       child: Row(
         children: [
           _AgentAvatar(agent: agent, size: compact ? 34 : 44),
@@ -87,6 +142,29 @@ class ThreadTile extends ConsumerWidget {
                   ),
           ),
         ],
+      ),
+    );
+
+    // While deleting, dim the card and float the app's shape-morphing loader
+    // over it; the whole stack then fades and collapses via [_removal].
+    final content = _deleting
+        ? Stack(
+            alignment: Alignment.center,
+            children: [
+              Opacity(opacity: 0.4, child: IgnorePointer(child: card)),
+              const PolygonLoader(size: 22),
+            ],
+          )
+        : card;
+
+    // Wraps every row: at rest the reversed animations sit at 1 (full size and
+    // opacity), so this is a no-op until [_delete] drives [_removal] forward.
+    return SizeTransition(
+      alignment: Alignment.topCenter,
+      sizeFactor: ReverseAnimation(_collapse),
+      child: FadeTransition(
+        opacity: ReverseAnimation(_fade),
+        child: content,
       ),
     );
   }
@@ -244,12 +322,15 @@ String _subtitleFor(Thread thread) {
 }
 
 /// Shows the per-thread actions sheet on long-press. The archive / unarchive
-/// entry adapts to the thread's current status.
+/// entry adapts to the thread's current status. The delete entry defers to
+/// [onDelete], which the tile uses to confirm, animate the row out, then commit
+/// the (cascading) delete.
 Future<void> showThreadActions(
   BuildContext context,
   WidgetRef ref,
-  Thread thread,
-) async {
+  Thread thread, {
+  required Future<void> Function() onDelete,
+}) async {
   final l10n = AppLocalizations.of(context);
   final colors = Theme.of(context).colorScheme;
   final isArchived = thread.status == ThreadStatus.archived;
@@ -321,7 +402,7 @@ Future<void> showThreadActions(
     case _ThreadAction.unarchive:
       await ref.read(threadManagerProvider).unarchiveThread(thread.id);
     case _ThreadAction.delete:
-      await _confirmDeleteThread(context, ref, thread);
+      await onDelete();
   }
 }
 
@@ -363,10 +444,12 @@ Future<void> _promptRenameThread(
   await ref.read(threadManagerProvider).renameThread(thread.id, trimmed);
 }
 
-/// Confirms and deletes the thread via the thread manager.
-Future<void> _confirmDeleteThread(
+/// Shows the delete confirmation dialog and returns whether the user confirmed.
+/// The actual delete — and its exit animation — is driven by the caller so the
+/// row can animate out before the thread (and its cascading child rows) is
+/// removed.
+Future<bool> _confirmDeleteThread(
   BuildContext context,
-  WidgetRef ref,
   Thread thread,
 ) async {
   final l10n = AppLocalizations.of(context);
@@ -389,8 +472,7 @@ Future<void> _confirmDeleteThread(
       ],
     ),
   );
-  if (confirmed != true) return;
-  await ref.read(threadManagerProvider).deleteThread(thread.id);
+  return confirmed ?? false;
 }
 
 class _AgentAvatar extends StatelessWidget {

--- a/uxnanmobile/lib/presentation/screens/threads/threads_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/threads/threads_screen.dart
@@ -262,8 +262,11 @@ class _ThreadsScreenState extends ConsumerState<ThreadsScreen> {
               separatorBuilder: (_, __) => SizedBox(
                 height: compact ? UxnanSpacing.sm : UxnanSpacing.md,
               ),
-              itemBuilder: (context, index) =>
-                  ThreadTile(thread: visible[index], compact: compact),
+              itemBuilder: (context, index) => ThreadTile(
+                key: ValueKey('thread-${visible[index].id}'),
+                thread: visible[index],
+                compact: compact,
+              ),
             ),
           ),
       ],

--- a/uxnanmobile/test/unit/infrastructure/drift_thread_repository_test.dart
+++ b/uxnanmobile/test/unit/infrastructure/drift_thread_repository_test.dart
@@ -25,6 +25,67 @@ Thread _thread(
           : DateTime.fromMillisecondsSinceEpoch(lastActivityMs),
     );
 
+/// Inserts one row in each thread-owned child table for [threadId] (a message,
+/// a turn, the composer draft and a git-action-log entry) so cascade deletes
+/// can be asserted.
+Future<void> _insertChildren(UxnanDatabase db, String threadId) async {
+  await db.into(db.messagesTable).insert(
+        MessagesTableCompanion.insert(
+          id: 'm-$threadId',
+          threadId: threadId,
+          turnId: 'tn-$threadId',
+          role: 'user',
+          contentsJson: '[]',
+          deliveryState: 'sent',
+          orderIndex: 0,
+          createdAtMs: 0,
+        ),
+      );
+  await db.into(db.turnsTable).insert(
+        TurnsTableCompanion.insert(
+          id: 'tn-$threadId',
+          threadId: threadId,
+          status: 'completed',
+          startedAtMs: 0,
+        ),
+      );
+  await db.into(db.composerDraftsTable).insert(
+        ComposerDraftsTableCompanion.insert(
+          threadId: threadId,
+          draft: 'wip',
+          updatedAtMs: 0,
+        ),
+      );
+  await db.into(db.gitActionLogTable).insert(
+        GitActionLogTableCompanion.insert(
+          id: 'g-$threadId',
+          threadId: threadId,
+          kind: 'commit',
+          status: 'completed',
+          paramsJson: '{}',
+          startedAtMs: 0,
+        ),
+      );
+}
+
+/// Total number of child rows still keyed to [threadId] across all four
+/// dependent tables.
+Future<int> _childCount(UxnanDatabase db, String threadId) async {
+  final messages = await (db.select(db.messagesTable)
+        ..where((m) => m.threadId.equals(threadId)))
+      .get();
+  final turns = await (db.select(db.turnsTable)
+        ..where((t) => t.threadId.equals(threadId)))
+      .get();
+  final drafts = await (db.select(db.composerDraftsTable)
+        ..where((d) => d.threadId.equals(threadId)))
+      .get();
+  final gitLog = await (db.select(db.gitActionLogTable)
+        ..where((g) => g.threadId.equals(threadId)))
+      .get();
+  return messages.length + turns.length + drafts.length + gitLog.length;
+}
+
 void main() {
   late UxnanDatabase db;
   late DriftThreadRepository repo;
@@ -90,69 +151,45 @@ void main() {
       expect(all.length, 1);
     });
 
-    test('deleteThread removes the row', () async {
+    test('deleteThread cascades to every dependent table', () async {
       await repo.saveThread(_thread('t1', lastActivityMs: 1));
+      await _insertChildren(db, 't1');
+      expect(await _childCount(db, 't1'), 4);
+
       await repo.deleteThread('t1');
+
       expect(await repo.getThread('t1'), isNull);
+      expect(await _childCount(db, 't1'), 0);
     });
 
-    test('deleteThreadsByDeviceId wipes a device threads + messages + turns',
+    test('deleteThread leaves other threads and their rows intact', () async {
+      await repo.saveThread(_thread('t1', lastActivityMs: 1));
+      await repo.saveThread(_thread('t2', lastActivityMs: 2));
+      await _insertChildren(db, 't1');
+      await _insertChildren(db, 't2');
+
+      await repo.deleteThread('t1');
+
+      expect(await repo.getThread('t2'), isNotNull);
+      expect(await _childCount(db, 't1'), 0);
+      expect(await _childCount(db, 't2'), 4);
+    });
+
+    test('deleteThreadsByDeviceId wipes a device threads + all child rows',
         () async {
       await repo.saveThread(_thread('a', deviceId: 'mac-1', lastActivityMs: 1));
       await repo.saveThread(_thread('b', deviceId: 'mac-1', lastActivityMs: 2));
       await repo.saveThread(_thread('c', deviceId: 'mac-2', lastActivityMs: 3));
-      // A message + turn under a mac-1 thread (a) and a mac-2 thread (c).
-      await db.into(db.messagesTable).insert(
-            MessagesTableCompanion.insert(
-              id: 'm-a',
-              threadId: 'a',
-              turnId: 'tn-a',
-              role: 'user',
-              contentsJson: '[]',
-              deliveryState: 'sent',
-              orderIndex: 0,
-              createdAtMs: 0,
-            ),
-          );
-      await db.into(db.messagesTable).insert(
-            MessagesTableCompanion.insert(
-              id: 'm-c',
-              threadId: 'c',
-              turnId: 'tn-c',
-              role: 'user',
-              contentsJson: '[]',
-              deliveryState: 'sent',
-              orderIndex: 0,
-              createdAtMs: 0,
-            ),
-          );
-      await db.into(db.turnsTable).insert(
-            TurnsTableCompanion.insert(
-              id: 'tn-a',
-              threadId: 'a',
-              status: 'completed',
-              startedAtMs: 0,
-            ),
-          );
-      await db.into(db.turnsTable).insert(
-            TurnsTableCompanion.insert(
-              id: 'tn-c',
-              threadId: 'c',
-              status: 'completed',
-              startedAtMs: 0,
-            ),
-          );
+      // Child rows under a mac-1 thread (a) and a mac-2 thread (c).
+      await _insertChildren(db, 'a');
+      await _insertChildren(db, 'c');
 
       await repo.deleteThreadsByDeviceId('mac-1');
 
       // Only mac-2's thread and its dependent rows survive.
       expect((await repo.getThreads()).map((t) => t.id).toList(), ['c']);
-      final msgIds =
-          (await db.select(db.messagesTable).get()).map((m) => m.id).toList();
-      expect(msgIds, ['m-c']);
-      final turnIds =
-          (await db.select(db.turnsTable).get()).map((t) => t.id).toList();
-      expect(turnIds, ['tn-c']);
+      expect(await _childCount(db, 'a'), 0);
+      expect(await _childCount(db, 'c'), 4);
     });
 
     test('deleteThreadsByDeviceId is a no-op when no thread matches', () async {


### PR DESCRIPTION
## Summary

Two related changes to the single-thread delete on mobile (`uxnanmobile/`): a data-integrity fix and a UI polish pass on top of it.

### 1. `fix(drift)` — cascade-delete a thread's dependent rows
Deleting a single thread removed only the thread row and orphaned every dependent row. `messages`, `turns`, `composer_drafts` and `git_action_log` all key off `threadId` with **no DB cascade**, so those rows were never re-synced or garbage-collected — the local SQLite DB grew unbounded with dead data and message / git-action counts were inflated by rows with no thread.

- `deleteThread` now clears all four child tables and the thread in a **single transaction** (mirrors the existing `deleteThreadsByDeviceId`).
- `deleteThreadsByDeviceId` (the "remove device" path) is extended to also clear `composer_drafts` and `git_action_log`, which it previously missed.
- Contract doc comments updated; `architecture/02c-implementation-guide.md` §10.3 snippet synced to the transactional cascade.

### 2. `feat(ui)` — smooth thread-delete animation
Deleting a conversation no longer makes the tile vanish abruptly.

- On confirm, the card dims and floats the app's shared `PolygonLoader` over it, then fades and collapses its height (~320 ms, M3 Expressive easing) so the rows below slide up smoothly.
- The cascading DB delete is committed **only after** the card has animated away, so the list mutates while the slot is already invisible.
- `ThreadTile` becomes a `ConsumerStatefulWidget`; rows carry a stable `ValueKey(id)`. Honours the platform **reduce-motion** setting. Applies to both the active and archived lists.

## Verification
- `flutter analyze` → **exit 0, no issues**.
- `flutter test` → **661 passed** (drift repository cascade + isolation cases added and green).
- On-device visual review of the animation is pending (no emulator in this environment).

## Notes
- No `shared/` contract change — `IThreadRepository` is internal to mobile.
- Follow-ups (out of scope): one-time cleanup of already-orphaned rows from historical deletes; optional `ON DELETE CASCADE` FKs (needs a drift schema-version bump + migration).