### PR TITLE
perf(rust): single git scan per watcher tick, focus-gated agent scan, bounded icon fetch

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,31 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Changed — bounded the always-on backend watchers and the icon fetch
+
+Three always-on resource drains were trimmed, each behavior-preserving:
+
+- **The 3 s git watcher scans the working tree once per tick (was twice).** It
+  previously ran two full `repo.statuses()` walks — the expensive part, with
+  untracked recursion and rename detection — one for the file list
+  (`status_files`) and one for the summary (`worktree_status`), even though the
+  summary's `dirty` count is just the file list's length. A new
+  `git::status_with_summary` (fast path `gitfast::status_with_summary`, with the
+  same `git2`→CLI fallback shape as the standalone wrappers) returns the file
+  list and the ahead/behind summary from a single scan, halving the watcher's
+  git cost. The on-demand `git_status` command path is unchanged.
+- **The 2 s agent process scan pauses while the window is unfocused.** It
+  refreshed the whole OS process table *with command lines* every 2 s while any
+  terminal was live — even backgrounded. It now honors the same `focused` gate
+  the git watcher already had (re-scanning on the first tick after focus
+  returns), and the blocking, syscall-heavy `sysinfo` refresh now runs on a
+  blocking thread (`spawn_blocking`) instead of stalling a Tokio worker.
+- **Icon fetches from URLs are time- and size-bounded.** `image_fetch_data_url`
+  now builds its client with a 15 s timeout (matching the usage-stats client)
+  and streams the response body chunk-by-chunk, enforcing the 5 MiB cap as it
+  grows — so a server that lies about (or omits) `Content-Length` can no longer
+  hang the command or balloon memory.
+
 ### Security — hardened the local hook/MCP server (defense-in-depth)
 
 The in-process `axum` server (loopback, ephemeral port) that serves the
@@ -57,8 +82,8 @@ None fixed an active break — the posture was already loopback-bound, with a
   hunk, plus an invalid-patch error), and `commit` (message, `--amend` keeps the
   commit count, sign-off trailer, empty-index error). This guards the app's most
   destructive git surface against a silent argument-mapping regression. The
-  backend suite is now **235 tests** (was 217 — 12 added here, 6 from the
-  hook/MCP hardening above).
+  backend suite is now **236 tests** (was 217 — 12 added here, 6 from the
+  hook/MCP hardening above, 1 from the watcher change above).
 
 ### Fixed — debounced saves survive a window close, and a startup error can't wipe a restored layout
 

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -16,7 +16,7 @@ standalone app** (three-panel shell, PTY terminals + splits, git worktrees, git
 status/diff/stage/commit/history, agent monitoring with the axum hook server +
 OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
-engine**, **user quick commands**, **GitHub integration (`gh`-backed)**). 235 Rust backend tests + 192 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS is **unvalidated**
+engine**, **user quick commands**, **GitHub integration (`gh`-backed)**). 236 Rust backend tests + 192 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS is **unvalidated**
 (developed on Windows; CI is `{ubuntu, windows}`). **Phase 6 (embedded bridge /
 mobile pairing) is NOT started.**
 
@@ -459,7 +459,7 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
 
 - ✅ **Verify** — `.github/workflows/ci-desktop.yml` runs svelte-check + `npm test`
   (Vitest) + vite build + cargo fmt/clippy/test on `{ubuntu, windows}` (macOS
-  deferred with Apple). 235 Rust + 192 Vitest tests.
+  deferred with Apple). 236 Rust + 192 Vitest tests.
 - ✅ **`release-desktop.yml`** — exists: `tauri-action` bundles on a `desktop-v*` tag
   → draft GitHub Release, **and signs the updater artifacts** when the signing
   secrets are set. **Windows ships without OS code-signing for now; macOS deferred.**

--- a/uxnandesktop/architecture/03-implementation-guide.md
+++ b/uxnandesktop/architecture/03-implementation-guide.md
@@ -1297,6 +1297,12 @@ if !window_visible.load(Ordering::Relaxed) {
 
 Al volver a enfocar la ventana, se ejecuta inmediatamente un ciclo de polling para actualizar el estado.
 
+Ademas, cada tick del watcher realiza **un unico recorrido del working tree** (no dos): una sola funcion combinada (`git::status_with_summary`, ruta rapida `gitfast::status_with_summary` con el mismo fallback `git2`->CLI) devuelve tanto la lista de archivos como el resumen ahead/behind desde el mismo `statuses()`. El conteo `dirty` es la longitud de esa lista, por lo que no hace falta un segundo escaneo.
+
+#### Escaneo de Procesos de Agentes (focus-gated + off-worker)
+
+El watcher de deteccion de agentes (Layer 3, cada 2 segundos) comparte la misma pausa por foco que el polling de git: mientras la ventana no esta enfocada no refresca la tabla de procesos, y vuelve a escanear en el primer tick tras recuperar el foco. Como el refresco de `sysinfo` (con lineas de comando) es una llamada bloqueante y pesada en syscalls, se ejecuta en un hilo bloqueante (`spawn_blocking`, moviendo `sys` de ida y vuelta) en lugar de bloquear un worker de Tokio.
+
 #### Buffers de Terminal Limitados
 
 Los terminales ocultos (en tabs no activos) acumulan output en un buffer limitado de **2MB por terminal oculto**. Si el buffer se llena, los datos mas antiguos se descartan. Esto previene que terminales con output rapido y continuo (compilaciones, logs) consuman memoria indefinidamente:

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -18,7 +18,7 @@ cargo fmt --check              # formatting — must be clean (run `cargo fmt` t
 
 Unit tests live in-file under `#[cfg(test)]` (e.g. `model.rs`, `persistence.rs`,
 `git.rs`, `gitfast.rs`, `pty.rs`, `hooks.rs`, `agent_hooks.rs`, `procscan.rs`,
-`updater.rs`, `which.rs`); integration tests go in `src-tauri/tests/`. ~235
+`updater.rs`, `which.rs`); integration tests go in `src-tauri/tests/`. ~236
 backend tests cover the Serde model shape, persistence round-trip / atomicity /
 migration / backups, git + worktree ops (including staging, discard, hunk apply
 and commit against throwaway repos), the git2 fast path, the PTY lifecycle,

--- a/uxnandesktop/src-tauri/src/commands.rs
+++ b/uxnandesktop/src-tauri/src/commands.rs
@@ -874,6 +874,7 @@ pub async fn image_fetch_data_url(url: String) -> Result<String, CommandError> {
     }
     let client = reqwest::Client::builder()
         .user_agent("uxnan-desktop")
+        .timeout(std::time::Duration::from_secs(15))
         .build()
         .map_err(|e| CommandError::new("IMAGE_FETCH_FAILED", e.to_string()))?;
     let resp = client
@@ -899,15 +900,23 @@ pub async fn image_fetch_data_url(url: String) -> Result<String, CommandError> {
         .map(|s| s.split(';').next().unwrap_or(s).trim().to_string())
         .filter(|m| m.starts_with("image/"));
 
-    let bytes = resp
-        .bytes()
+    // Stream the body chunk-by-chunk, enforcing the cap as it grows: a server
+    // that lies about (or omits) Content-Length can't push more than
+    // MAX_ICON_BYTES into memory, and the client timeout bounds a slow trickle.
+    let mut bytes: Vec<u8> = Vec::new();
+    let mut resp = resp;
+    while let Some(chunk) = resp
+        .chunk()
         .await
-        .map_err(|e| CommandError::new("IMAGE_FETCH_FAILED", e.to_string()))?;
-    if bytes.len() as u64 > MAX_ICON_BYTES {
-        return Err(CommandError::new(
-            "IMAGE_FETCH_FAILED",
-            "the image is too large",
-        ));
+        .map_err(|e| CommandError::new("IMAGE_FETCH_FAILED", e.to_string()))?
+    {
+        if (bytes.len() + chunk.len()) as u64 > MAX_ICON_BYTES {
+            return Err(CommandError::new(
+                "IMAGE_FETCH_FAILED",
+                "the image is too large",
+            ));
+        }
+        bytes.extend_from_slice(&chunk);
     }
     // Prefer the server's content-type; else sniff from magic bytes. Refuse
     // anything that isn't a recognizable image so we never inline HTML/JSON.

--- a/uxnandesktop/src-tauri/src/git.rs
+++ b/uxnandesktop/src-tauri/src/git.rs
@@ -486,6 +486,29 @@ async fn worktree_status_cli(worktree_path: &str) -> Result<WorktreeStatus, AppE
     Ok(parse_status_porcelain(&out))
 }
 
+/// Combined [`status_files`] + [`worktree_status`] in a single working-tree
+/// scan — for the 3 s status watcher, which needs both and would otherwise walk
+/// the tree twice per tick. Fast path: one `git2` scan
+/// ([`crate::gitfast::status_with_summary`]). On a WSL path or a `git2` failure
+/// it falls back to running the two existing CLI fallbacks sequentially — the
+/// CLI path is the rare case, so paying for two scans there is acceptable.
+pub async fn status_with_summary(
+    worktree_path: &str,
+) -> Result<(Vec<FileChange>, WorktreeStatus), AppError> {
+    // WSL repos go straight to the CLI (routed through wsl.exe); see worktree_status.
+    if !crate::wsl::is_wsl_path(worktree_path) {
+        let p = worktree_path.to_string();
+        if let Ok(Ok(v)) =
+            tokio::task::spawn_blocking(move || crate::gitfast::status_with_summary(&p)).await
+        {
+            return Ok(v);
+        }
+    }
+    let files = status_files_cli(worktree_path).await?;
+    let status = worktree_status_cli(worktree_path).await?;
+    Ok((files, status))
+}
+
 /// Parse `git status --porcelain=v1 --branch` output: the first `## ` line
 /// carries the upstream ahead/behind (`[ahead N, behind M]`); every other
 /// non-empty line is one changed entry.

--- a/uxnandesktop/src-tauri/src/gitfast.rs
+++ b/uxnandesktop/src-tauri/src/gitfast.rs
@@ -157,6 +157,39 @@ pub fn worktree_status(path: &str) -> Result<WorktreeStatus, git2::Error> {
     })
 }
 
+/// One-scan combination of [`status_files`] + [`worktree_status`]: the file
+/// list, plus a summary whose `dirty` is the list's length (same `IGNORED`
+/// filter) and whose ahead/behind comes from the cheap graph walk — so the
+/// 3 s watcher pays for one working-tree scan, not two. Because both parts read
+/// from the same `statuses()` walk, `summary.dirty == files.len()` holds by
+/// construction.
+pub fn status_with_summary(path: &str) -> Result<(Vec<FileChange>, WorktreeStatus), git2::Error> {
+    let repo = Repository::open(path)?;
+    let mut opts = status_options();
+    let statuses = repo.statuses(Some(&mut opts))?;
+    let mut files = Vec::new();
+    for entry in statuses.iter() {
+        let s = entry.status();
+        if s.contains(Status::IGNORED) {
+            continue;
+        }
+        let Some(p) = entry.path() else { continue };
+        let (index, worktree) = map_status(s);
+        files.push(FileChange {
+            path: p.replace('\\', "/"),
+            index,
+            worktree,
+        });
+    }
+    let (ahead, behind) = ahead_behind(&repo);
+    let summary = WorktreeStatus {
+        dirty: files.len() as u32,
+        ahead,
+        behind,
+    };
+    Ok((files, summary))
+}
+
 /// Render a `git2::Diff` to a unified-diff string (the format the frontend's
 /// `diff.ts` parser expects).
 fn diff_to_string(diff: &git2::Diff) -> Result<String, git2::Error> {
@@ -433,6 +466,43 @@ mod tests {
         let st = worktree_status(&tmp.path().to_string_lossy()).unwrap();
         assert_eq!(st.dirty, 0);
         assert_eq!((st.ahead, st.behind), (0, 0));
+    }
+
+    /// The one-scan `status_with_summary` must return exactly what the two
+    /// separate `status_files` + `worktree_status` scans do — this pins the
+    /// "combined == parts" contract so the watcher's single scan can't silently
+    /// drift from the on-demand path. Also asserts `dirty == files.len()`, the
+    /// invariant that makes dropping the second scan sound.
+    #[test]
+    fn status_with_summary_matches_parts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let repo = Repository::init(dir).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Tester").unwrap();
+        cfg.set_str("user.email", "t@t").unwrap();
+
+        // One committed file, then a tracked modification + an untracked file so
+        // the working tree is genuinely dirty when we scan.
+        commit_file(&repo, dir, "a.txt", "one\ntwo\n", "init");
+        std::fs::write(dir.join("a.txt"), "one\nTWO\nthree\n").unwrap();
+        std::fs::write(dir.join("b.txt"), "new\n").unwrap();
+
+        let path = dir.to_string_lossy().to_string();
+        let (files, summary) = status_with_summary(&path).unwrap();
+        let parts_files = status_files(&path).unwrap();
+        let parts_status = worktree_status(&path).unwrap();
+
+        // The file list is identical to the standalone scan's.
+        assert_eq!(files, parts_files);
+        // dirty equals the list length (same IGNORED filter) — the invariant.
+        assert_eq!(summary.dirty as usize, files.len());
+        assert_eq!(summary.dirty, parts_status.dirty);
+        // ahead/behind matches the cheap graph walk of the standalone summary.
+        assert_eq!(
+            (summary.ahead, summary.behind),
+            (parts_status.ahead, parts_status.behind)
+        );
     }
 
     /// Commit a file to `repo`, returning the new commit oid. Stages the whole

--- a/uxnandesktop/src-tauri/src/lib.rs
+++ b/uxnandesktop/src-tauri/src/lib.rs
@@ -138,6 +138,7 @@ pub fn run() {
             // Background git watcher: poll the watched worktree every 3 s (paused
             // when unfocused) and emit `git:status-changed` only when it changes.
             let handle = app.handle().clone();
+            let focused_for_agent = focused.clone();
             tauri::async_runtime::spawn(async move {
                 let mut interval = tokio::time::interval(Duration::from_secs(3));
                 interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -150,8 +151,12 @@ pub fn run() {
                     let Some(path) = git_watch.read().await.clone() else {
                         continue;
                     };
-                    let files = crate::git::status_files(&path).await.unwrap_or_default();
-                    let status = crate::git::worktree_status(&path).await.unwrap_or_default();
+                    // One working-tree scan per tick: `status_with_summary`
+                    // returns the file list and the ahead/behind summary from a
+                    // single `git2` walk instead of two separate scans.
+                    let (files, status) = crate::git::status_with_summary(&path)
+                        .await
+                        .unwrap_or_default();
                     let payload = GitStatusEvent {
                         path,
                         files,
@@ -169,7 +174,9 @@ pub fn run() {
             // Background agent watcher: every 2 s scan each terminal's process
             // tree for a known agent command and emit `agent:detected` on change,
             // so a terminal that runs (or stops running) any agent updates its
-            // sidebar row + tab name — even one the user typed by hand.
+            // sidebar row + tab name — even one the user typed by hand. Paused
+            // while the window is unfocused (like the git watcher); a re-scan
+            // happens on the first tick after focus returns.
             let agent_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 let mut interval = tokio::time::interval(Duration::from_secs(2));
@@ -179,6 +186,9 @@ pub fn run() {
                     std::collections::HashMap::new();
                 loop {
                     interval.tick().await;
+                    if !focused_for_agent.load(Ordering::Relaxed) {
+                        continue;
+                    }
                     let state = agent_handle.state::<AppState>();
                     let pids = state.pty.live_pids();
                     if pids.is_empty() {
@@ -188,13 +198,21 @@ pub fn run() {
                     let commands = state.agent_commands.read().await.clone();
                     // Refresh WITH command lines — the default refresh only gives
                     // the exe name (`node`), so node-shim agents (codex/gemini/…)
-                    // would never match without their `…/agent.js` argument.
-                    sys.refresh_processes_specifics(
-                        sysinfo::ProcessesToUpdate::All,
-                        true,
-                        sysinfo::ProcessRefreshKind::nothing()
-                            .with_cmd(sysinfo::UpdateKind::Always),
-                    );
+                    // would never match without their `…/agent.js` argument. The
+                    // scan is a blocking, syscall-heavy walk of the whole process
+                    // table, so run it on a blocking thread (moving `sys` in and
+                    // back out) instead of stalling this Tokio worker.
+                    sys = tokio::task::spawn_blocking(move || {
+                        sys.refresh_processes_specifics(
+                            sysinfo::ProcessesToUpdate::All,
+                            true,
+                            sysinfo::ProcessRefreshKind::nothing()
+                                .with_cmd(sysinfo::UpdateKind::Always),
+                        );
+                        sys
+                    })
+                    .await
+                    .expect("agent scan task panicked");
                     let mut live = std::collections::HashSet::new();
                     for (pty_id, pid) in pids {
                         live.insert(pty_id.clone());


### PR DESCRIPTION
## What & why

Three always-on backend resource drains, each with a small, behavior-preserving fix.

### 1. The 3 s git watcher scans the working tree once per tick (was twice)
`status_files` and `worktree_status` each opened the repo and ran a full `repo.statuses()` walk (untracked recursion + rename detection — the expensive part), even though the summary's `dirty` count is just the file list's length. A new `git::status_with_summary` (fast path `gitfast::status_with_summary`) returns the file list **and** the ahead/behind summary from a single scan, with `dirty == files.len()` and ahead/behind from the cheap graph walk. It keeps the same `git2` → CLI fallback shape as the standalone wrappers (on the rare CLI path it runs the two existing CLI fallbacks sequentially). The on-demand `git_status` command path is untouched.

### 2. The 2 s agent process scan pauses while unfocused
It refreshed the whole OS process table *with command lines* every 2 s while any terminal was live — even backgrounded. It now honors the same `focused` gate the git watcher already had (re-scanning on the first tick after focus returns), and the blocking, syscall-heavy `sysinfo` refresh runs on a blocking thread (`spawn_blocking`, moving `sys` in and back out) instead of stalling a Tokio worker.

### 3. `image_fetch_data_url` is time- and size-bounded
The client now builds with a 15 s timeout (matching the usage-stats client) and streams the response body chunk-by-chunk, enforcing the 5 MiB cap as it grows — so a server that lies about (or omits) `Content-Length` can no longer hang the command or balloon memory. Replaces the whole-body `resp.bytes()` read.

## Tests

- New `gitfast::status_with_summary_matches_parts` pins the "combined == parts" contract (file list equals `status_files()`'s, `dirty == files.len()`, ahead/behind equals `worktree_status()`'s).
- Full suite: **236** `cargo test` passing.
- `cargo clippy --all-targets -- -D warnings` exit 0; `cargo fmt --check` exit 0.

## Docs (same change set)

- `CHANGELOG.md` `[Unreleased]` → `### Changed`.
- `FOR-DEV.md` (×2) + `docs/testing.md` test counts 235 → 236.
- `architecture/03-implementation-guide.md` §6.2 — single git scan per tick; agent process scan focus-gated + off-worker.

## Notes

Not merged intentionally. Manual GUI smoke test (open a large repo, confirm live status while focused; unfocus, run an agent, refocus → row updates next tick) is left for on-device verification.
