### PR TITLE
fix(svelte): self-heal the orphaned body pointer-events lock (global mouse freeze)

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,27 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — an orphaned modal lock could freeze the whole window to the mouse
+
+- **A modal layer torn down without its cleanup — classically a dialog opened from
+  a dropdown/context-menu item — could leave `document.body` stuck at
+  `pointer-events: none` with no owner.** Every click then died at `<body>` while
+  the keyboard kept working, and only killing the process recovered (losing any
+  un-flushed work and every live agent conversation). This is the well-documented
+  bits-ui/Radix "orphaned body pointer-lock" race: the dialog captures the closing
+  menu's `pointer-events: none` as the body's "initial" style and faithfully
+  restores it forever on close. Two defenses now ship. (1) An **app-level guard**
+  (`$lib/utils/pointerLock`, installed in the root layout) registers a
+  capture-phase `pointerdown` watchdog: on the first click during such a freeze it
+  detects that the body lock has no open-modal (`[data-state="open"]`) owner and —
+  after a short re-check that outlives the library's own ~24 ms cleanup window —
+  clears the inline `pointer-events`, so the first click heals the app and the
+  second lands normally. It never touches any other style (bits-ui still owns the
+  scroll-lock restore) and is idle until an actual freeze. (2) The **menu→dialog
+  flows now defer the dialog open past the menu's close** (project card, worktree
+  and branch row actions, file-tree context menu), and the New-worktree dialog can
+  no longer be unmounted while open — so the race is also prevented at the source.
+
 ## [0.0.16] - 2026-07-18
 
 ### Fixed — the window's Close (✕) button now actually closes the app

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -17,7 +17,7 @@ status/diff/stage/commit/history, agent monitoring with the axum hook server +
 OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
-with" external editors/IDEs**). 251 Rust backend tests + 192 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS is **unvalidated**
+with" external editors/IDEs**). 251 Rust backend tests + 197 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS is **unvalidated**
 (developed on Windows; CI is `{ubuntu, windows}`). **Phase 6 (embedded bridge /
 mobile pairing) is NOT started.**
 
@@ -449,7 +449,7 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
 
 - ✅ **Verify** — `.github/workflows/ci-desktop.yml` runs svelte-check + `npm test`
   (Vitest) + vite build + cargo fmt/clippy/test on `{ubuntu, windows}` (macOS
-  deferred with Apple). 251 Rust + 192 Vitest tests.
+  deferred with Apple). 251 Rust + 197 Vitest tests.
 - ✅ **`release-desktop.yml`** — exists: `tauri-action` bundles on a `desktop-v*` tag
   → draft GitHub Release, **and signs the updater artifacts** when the signing
   secrets are set. **Windows ships without OS code-signing for now; macOS deferred.**

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -44,8 +44,10 @@ normalization), `quickCommands.ts` (quick-command token substitution + scope
 filters), `terminalArbiter.ts` (terminal keyboard app-vs-TUI arbitration),
 `branchName.ts` (GitHub branch-name slugging), `markdown.ts` (GitHub-flavored
 Markdown: alerts, disclosures, hidden HTML comments), `relTime.ts` (localized
-relative dates) and `state/flushRegistry.ts` (the flush-on-close registry:
-register / unregister + `Promise.allSettled` fan-out) — 192 tests in
+relative dates), `state/flushRegistry.ts` (the flush-on-close registry:
+register / unregister + `Promise.allSettled` fan-out) and
+`utils/pointerLock.ts` (the orphaned-body-pointer-lock guard: orphan detection +
+deferred modal open) — 197 tests in
 `src/lib/**/*.test.ts`, config in
 `vitest.config.ts`. **Component tests** (Vitest + jsdom) and **E2E**
 (Playwright/WebdriverIO + tauri-driver) are still to come — see

--- a/uxnandesktop/src/lib/components/FileTreePanel.svelte
+++ b/uxnandesktop/src/lib/components/FileTreePanel.svelte
@@ -17,6 +17,7 @@
   import { revealPath } from "$lib/api";
   import { dropPathsIntoTerminal } from "$lib/terminal/terminalDrop";
   import { cn } from "$lib/utils";
+  import { deferModalOpen } from "$lib/utils/pointerLock";
   import { icon, iconButton, text } from "$lib/design";
   import { TooltipSimple } from "$lib/components/ui/tooltip";
   import { i18n } from "$lib/i18n";
@@ -168,15 +169,18 @@
     return i > 0 ? entry.path.slice(0, i) : entry.path;
   }
 
+  // Defer the dialog open until the context menu has fully closed, so the menu's
+  // teardown releases the body pointer-lock before the dialog captures it (else
+  // the dialog can restore `pointer-events: none` on close and freeze the mouse).
   function openPrompt(mode: PromptMode, entry: FsEntry): void {
     promptMode = mode;
     promptEntry = entry;
-    promptOpen = true;
+    deferModalOpen(() => (promptOpen = true));
   }
   function openDelete(entry: FsEntry): void {
     deleteTarget = entry;
     deleteError = null;
-    deleteOpen = true;
+    deferModalOpen(() => (deleteOpen = true));
   }
 
   async function submitPrompt(name: string): Promise<void> {

--- a/uxnandesktop/src/lib/components/ProjectCard.svelte
+++ b/uxnandesktop/src/lib/components/ProjectCard.svelte
@@ -14,6 +14,7 @@
   import { clipboardWrite } from "$lib/clipboard";
   import { revealPath } from "$lib/api";
   import { cn } from "$lib/utils";
+  import { deferModalOpen } from "$lib/utils/pointerLock";
   import { icon, iconButton, surface, text } from "$lib/design";
   import { TooltipSimple } from "$lib/components/ui/tooltip";
   import { i18n } from "$lib/i18n";
@@ -244,11 +245,14 @@
             {/if}
           </DropdownMenu.Item>
           <DropdownMenu.Separator />
-          <DropdownMenu.Item class={text.menu} onclick={() => (settingsOpen = true)}>
+          <!-- Defer each dialog open until this menu has fully closed, so its
+               teardown releases the body pointer-lock before the dialog captures
+               it (else the dialog can orphan the lock on close). -->
+          <DropdownMenu.Item class={text.menu} onclick={() => deferModalOpen(() => (settingsOpen = true))}>
             <SettingsIcon class={icon.button} />
             {i18n.t("project.settings")}
           </DropdownMenu.Item>
-          <DropdownMenu.Item class={text.menu} onclick={() => (iconPickerOpen = true)}>
+          <DropdownMenu.Item class={text.menu} onclick={() => deferModalOpen(() => (iconPickerOpen = true))}>
             <ImageIcon class={icon.button} />
             {i18n.t("project.changeIcon")}
           </DropdownMenu.Item>
@@ -286,7 +290,7 @@
           <DropdownMenu.Item
             variant="destructive"
             class={text.menu}
-            onclick={() => (confirmRemoveOpen = true)}
+            onclick={() => deferModalOpen(() => (confirmRemoveOpen = true))}
           >
             <Trash2Icon class={icon.button} />
             {i18n.t("project.removeProject")}

--- a/uxnandesktop/src/lib/components/RowActionsMenu.svelte
+++ b/uxnandesktop/src/lib/components/RowActionsMenu.svelte
@@ -14,6 +14,7 @@
   import { revealPath } from "$lib/api";
   import { agentLogoKey } from "$lib/agentCatalog";
   import { resolveBinding } from "$lib/keybindings";
+  import { deferModalOpen } from "$lib/utils/pointerLock";
   import { text } from "$lib/design";
   import { i18n } from "$lib/i18n";
   import KeyChord from "./KeyChord.svelte";
@@ -161,7 +162,9 @@
     {i18n.t("common.copyPath")}
   </ContextMenu.Item>
   {#if onChangeIcon}
-    <ContextMenu.Item class={text.menu} onclick={onChangeIcon}>
+    <!-- Defer the dialog open until this context menu has fully closed, so its
+         teardown releases the body pointer-lock before the dialog captures it. -->
+    <ContextMenu.Item class={text.menu} onclick={() => deferModalOpen(onChangeIcon)}>
       <ImageIcon />
       {i18n.t("worktree.changeIcon")}
     </ContextMenu.Item>
@@ -187,7 +190,7 @@
   {#if onRemove}
     <ContextMenu.Separator />
 
-    <ContextMenu.Item variant="destructive" class={text.menu} onclick={onRemove}>
+    <ContextMenu.Item variant="destructive" class={text.menu} onclick={() => deferModalOpen(onRemove)}>
       <Trash2Icon />
       {removeLabel}
     </ContextMenu.Item>

--- a/uxnandesktop/src/lib/utils/pointerLock.test.ts
+++ b/uxnandesktop/src/lib/utils/pointerLock.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { isOrphanedPointerLock, deferModalOpen } from "./pointerLock";
+
+describe("isOrphanedPointerLock", () => {
+  it("is orphaned when the body is locked with no open modal layer", () => {
+    expect(isOrphanedPointerLock("none", false)).toBe(true);
+  });
+
+  it("is NOT orphaned while a modal layer is open (legit lock)", () => {
+    expect(isOrphanedPointerLock("none", true)).toBe(false);
+  });
+
+  it("is NOT orphaned when the body carries no inline lock", () => {
+    expect(isOrphanedPointerLock("", false)).toBe(false);
+    expect(isOrphanedPointerLock("auto", false)).toBe(false);
+    expect(isOrphanedPointerLock("", true)).toBe(false);
+  });
+});
+
+describe("deferModalOpen", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens the modal on a later macrotask, never synchronously", () => {
+    vi.useFakeTimers();
+    const open = vi.fn();
+    deferModalOpen(open);
+    expect(open).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops on a nullish handler", () => {
+    vi.useFakeTimers();
+    expect(() => deferModalOpen(undefined)).not.toThrow();
+    expect(() => deferModalOpen(null)).not.toThrow();
+    vi.runAllTimers();
+  });
+});
+
+// `installPointerLockGuard` is DOM-driven (window/document, capture-phase
+// `pointerdown`); the Vitest harness runs in the node environment (see
+// vitest.config.ts), so it has no `document` to exercise. Its logic is the pure
+// `isOrphanedPointerLock` predicate covered above plus the 120 ms re-check; the
+// end-to-end freeze/recovery behavior is verified by manual DevTools QA. Add
+// jsdom + an installer test here if the harness gains a DOM env.

--- a/uxnandesktop/src/lib/utils/pointerLock.ts
+++ b/uxnandesktop/src/lib/utils/pointerLock.ts
@@ -1,0 +1,83 @@
+/**
+ * Recovery + prevention for the bits-ui "orphaned body pointer-lock".
+ *
+ * bits-ui sets `document.body.style.pointerEvents = "none"` while any modal layer
+ * (Dialog, AlertDialog, DropdownMenu, ContextMenu, Select) is open and restores
+ * the body style when the last lock is destroyed. If a layer is torn down without
+ * its cleanup running — or the restore snapshot itself captured the lock — the
+ * inline lock survives with no owner: every pointer event then dies at `<body>`
+ * while keyboard events (dispatched to the focused element regardless of
+ * hit-testing) keep flowing, and only killing the process recovers. The classic
+ * trigger is opening a dialog from a dropdown-menu item, where the two layers'
+ * body-style bookkeeping races (radix-ui/primitives#1241/#3645/#3317,
+ * shadcn-ui/ui#2214/#5586/#7929).
+ *
+ * Two defenses live here: `deferModalOpen` (prevention — let a menu fully close
+ * before its dialog opens) and `installPointerLockGuard` (recovery — heal an
+ * already-orphaned lock on the next click).
+ */
+
+/** True when the inline body pointer-events lock has no live owner and it is
+ *  safe to release it. `hasOpenLayer` = any `[data-state="open"]` element in the
+ *  document (bits-ui marks every open modal layer this way, so an open modal is
+ *  the only legitimate reason for the body lock to be present). */
+export function isOrphanedPointerLock(
+  bodyInlinePointerEvents: string,
+  hasOpenLayer: boolean,
+): boolean {
+  return bodyInlinePointerEvents === "none" && !hasOpenLayer;
+}
+
+/** Open a bits-ui modal (Dialog/AlertDialog) one macrotask after a menu item is
+ *  clicked, so the closing DropdownMenu/ContextMenu fully releases its own body
+ *  pointer-lock *before* the dialog snapshots the body style. Opening the dialog
+ *  synchronously in the same gesture makes it capture `pointer-events: none` as
+ *  its "initial" style and faithfully restore that on close — the classic
+ *  dropdown→dialog orphaned-lock race. A 0 ms timeout is the ecosystem-standard
+ *  defer; a nullish handler is a no-op (menu items are often conditionally
+ *  present). */
+export function deferModalOpen(open: (() => void) | undefined | null): void {
+  if (!open) return;
+  setTimeout(open, 0);
+}
+
+/**
+ * Install a capture-phase `pointerdown` watchdog that heals an orphaned body
+ * pointer-lock on the very first click of a freeze: the click that lands during a
+ * freeze schedules a re-check and, if the lock is *still* orphaned 120 ms later
+ * (long enough to outlive bits-ui's ~24 ms cleanup and any same-gesture modal
+ * open), it clears the inline `pointer-events` so the next click lands normally.
+ *
+ * It never touches any other style property — bits-ui's own cleanup still owns
+ * the full scroll-lock restore — and never acts while a modal is open, so the
+ * idle cost is a two-property read per click and there is no interference with
+ * normal use (it never calls `preventDefault`/`stopPropagation`). Returns an
+ * uninstaller.
+ */
+export function installPointerLockGuard(
+  win: Window = window,
+  doc: Document = document,
+): () => void {
+  const onPointerDown = (): void => {
+    const hasOpenLayer = doc.querySelector('[data-state="open"]') !== null;
+    if (!isOrphanedPointerLock(doc.body.style.pointerEvents, hasOpenLayer)) {
+      return;
+    }
+    // Re-check after the library's cleanup window + any same-gesture open so a
+    // legitimately just-closing modal is never disturbed; only a lock that is
+    // still orphaned then is a true leak.
+    win.setTimeout(() => {
+      const stillOrphaned = isOrphanedPointerLock(
+        doc.body.style.pointerEvents,
+        doc.querySelector('[data-state="open"]') !== null,
+      );
+      if (!stillOrphaned) return;
+      doc.body.style.removeProperty("pointer-events");
+      console.warn(
+        "[pointer-lock-guard] released an orphaned body pointer-events lock",
+      );
+    }, 120);
+  };
+  win.addEventListener("pointerdown", onPointerDown, true);
+  return () => win.removeEventListener("pointerdown", onPointerDown, true);
+}

--- a/uxnandesktop/src/routes/+layout.svelte
+++ b/uxnandesktop/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
   import { anyAgentWorking } from "$lib/state/agentDisplay";
   import { unread } from "$lib/state/unread.svelte";
   import { setPreventSleep } from "$lib/api";
+  import { installPointerLockGuard } from "$lib/utils/pointerLock";
   import { TooltipProvider } from "$lib/components/ui/tooltip";
 
   let { children } = $props();
@@ -25,6 +26,10 @@
     // Coming back to the window clears the "unread agent result" badges.
     const onFocus = () => unread.clearAll();
     window.addEventListener("focus", onFocus);
+    // App-level watchdog: heal an orphaned bits-ui body pointer-events lock (a
+    // modal torn down without its cleanup can leave the whole window deaf to the
+    // mouse) on the next click. Zero idle cost — see $lib/utils/pointerLock.
+    const uninstallPointerLockGuard = installPointerLockGuard();
     // Dismiss the pre-hydration brand splash (in `app.html`) once the shell
     // has painted its first frame, handing off to the real UI.
     requestAnimationFrame(() =>
@@ -33,7 +38,10 @@
           .__uxnanSplashDone?.(),
       ),
     );
-    return () => window.removeEventListener("focus", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      uninstallPointerLockGuard();
+    };
   });
 
   // Re-sync the agent commands to detect whenever the configured agents change.

--- a/uxnandesktop/src/routes/+page.svelte
+++ b/uxnandesktop/src/routes/+page.svelte
@@ -41,6 +41,7 @@
   import GithubStatusButton from "$lib/components/GithubStatusButton.svelte";
   import { Toaster } from "$lib/components/ui/sonner";
   import { initUpdateToast } from "$lib/updateToast.svelte";
+  import type { RepoData } from "$lib/types";
 
   // Resize bounds for each sidebar (px).
   const LEFT_MIN = 200;
@@ -184,6 +185,21 @@
     void openWith.ensureLoaded();
   });
 
+  // New-worktree dialog: hold a stable repo reference for as long as the dialog
+  // is open, so its bits-ui Dialog root is never *unmounted while open* (the
+  // `{#if}` below keys off this latch, not the live `activeRepo`). An abrupt
+  // unmount of an open modal can orphan the body pointer-events lock and freeze
+  // the whole window; latching on open and releasing only once fully closed keeps
+  // the root mounted through a normal close even if the active repo changes.
+  let newWorktreeRepo = $state<RepoData | null>(null);
+  $effect(() => {
+    if (projects.newWorktreeOpen) {
+      if (projects.activeRepo) newWorktreeRepo = projects.activeRepo;
+    } else {
+      newWorktreeRepo = null;
+    }
+  });
+
   // Drive the pinned, persistent update toast (replaces the old fixed banner):
   // shown while the updater has something actionable, re-shown on reload when a
   // staged download is restored, dismissed via the store. Native OS
@@ -262,11 +278,13 @@
   <!-- Add-project directory picker (Ctrl/Cmd+O; also from the sidebar) -->
   <DirectoryPicker bind:open={projects.pickerOpen} />
 
-  <!-- New-worktree dialog (Ctrl/Cmd+Shift+N; also the empty-state button). Mounted
-       once here so the shortcut works regardless of what the center shows; only
-       present when the active workspace is inside a repo to branch from. -->
-  {#if projects.activeRepo}
-    <NewWorktreeDialog repo={projects.activeRepo} bind:open={projects.newWorktreeOpen} />
+  <!-- New-worktree dialog (Ctrl/Cmd+Shift+N; also the empty-state button). Lives
+       here so the shortcut works regardless of what the center shows. Keyed off
+       the `newWorktreeRepo` latch (set in the script) rather than the live
+       `activeRepo`, so the Dialog root is never unmounted while open — it mounts
+       when the dialog opens and unmounts only after it has fully closed. -->
+  {#if newWorktreeRepo}
+    <NewWorktreeDialog repo={newWorktreeRepo} bind:open={projects.newWorktreeOpen} />
   {/if}
 
   <!-- Unsaved-edit prompt (driven by the saveDiscard service on tab close) -->


### PR DESCRIPTION
A modal layer torn down without running its cleanup (e.g. a dialog opened from a dropdown item) could leave `document.body` locked with `pointer-events: none` and no owner — every click died app-wide (window controls included) while the keyboard kept working; only killing the process recovered. Root cause confirmed live against a frozen production instance: inline body lock present, zero open layers, zero overlays.

**Fix (belt + suspenders):**
- `src/lib/utils/pointerLock.ts` — capture-phase `pointerdown` guard: when the inline body lock exists with no `[data-state=open]` layer, re-check after 120 ms and release it (one console warn). First click during a freeze heals the app.
- Menu-item dialog opens deferred one macrotask past the menu close (RowActionsMenu, ProjectCard, FileTreePanel context menu) — the classic body-lock race trigger.
- `NewWorktreeDialog` mount latched so it can never be unmounted while open.

**Gates:** `npm run check` 0/0 · 197 Vitest (+5) · build OK. No Rust touched.

**Owed on-device QA:** hardened menu→dialog flows open/close cleanly; DevTools freeze simulation (`document.body.style.pointerEvents = "none"` with no modal → first click heals, warn logged); guard silent while a real dialog is open.