### PR TITLE
fix(tauri): file editor rendered unstyled in packaged builds (CSP style nonce voided 'unsafe-inline')

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,29 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — the file editor rendered unstyled (oversized line numbers, invisible content) in packaged builds
+
+- **Opening a file's Edit view in a packaged build showed only giant, stacked
+  line numbers and no content** (Markdown preview and the diff views were fine,
+  and the bug never reproduced under `tauri dev`). Root cause: the main window
+  ships a Content-Security-Policy with `style-src 'self' 'unsafe-inline'`, but
+  `app.security.dangerousDisableAssetCspModification` was unset, so at build time
+  Tauri appended a style **nonce** (and style hashes) to `style-src`. Per the CSP
+  spec, once a `style-src` directive carries a nonce/hash source the browser
+  **ignores `'unsafe-inline'`** — which silently voided the very allowance the app
+  relies on. The file editor is CodeMirror 6, which injects **all** of its
+  structural and theme CSS at runtime as a plain, non-nonced `<style>` tag
+  (`style-mod`), so every editor style was blocked in production: the gutter
+  rendered as oversized stacked line numbers and the content was invisible. The
+  terminal (xterm), Markdown preview and diff views use compiled static CSS served
+  under `'self'`, so they were unaffected; in `tauri dev` no CSP applies, hence it
+  was invisible during development. Fix: `tauri.conf.json` → `app.security` now
+  sets `"dangerousDisableAssetCspModification": ["style-src"]`, exempting **only**
+  `style-src` from Tauri's build-time modification so the declared
+  `'unsafe-inline'` is what actually ships. `script-src` keeps its full nonce
+  hardening (it is not in the exempt list), and no CSP source was widened — the
+  policy shipped is exactly the one authored.
+
 ## [0.0.16] - 2026-07-18
 
 ### Fixed — the window's Close (✕) button now actually closes the app

--- a/uxnandesktop/src-tauri/tauri.conf.json
+++ b/uxnandesktop/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; media-src 'self'; connect-src 'self' ipc: http://ipc.localhost; object-src 'none'; base-uri 'self'; frame-src 'none'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: asset: http://asset.localhost; font-src 'self' data:; media-src 'self'; connect-src 'self' ipc: http://ipc.localhost; object-src 'none'; base-uri 'self'; frame-src 'none'",
+      "dangerousDisableAssetCspModification": ["style-src"]
     }
   },
   "bundle": {


### PR DESCRIPTION
Packaged builds only: opening a file's **Edit** view showed oversized stacked line numbers and no content; Markdown preview / diff / terminal were fine and `tauri dev` never reproduced it.

**Root cause:** `app.security.dangerousDisableAssetCspModification` was unset, so Tauri appended a style **nonce** to the served `style-src` at build time. Per the CSP spec, a nonce/hash in a directive makes the browser **ignore `'unsafe-inline'`** — silently voiding the allowance the app declares on purpose. CodeMirror 6 injects all of its structural + theme CSS at runtime as a plain non-nonced `<style>` tag (`style-mod`), so every editor style was blocked in production. Verified against Tauri 2.11.2's CSP pipeline and the installed binary's embedded policy.

**Fix:** exempt **only** `style-src` from the build-time modification (`"dangerousDisableAssetCspModification": ["style-src"]`). `script-src` keeps its full nonce hardening; no CSP source was widened — the shipped policy is exactly the authored one.

**Gates:** `npm run check` 0/0 · Vitest unchanged · `npm run build` OK · `tauri build --debug` completes (config schema validated). **Owed on-device QA:** open a file's Edit view in the packaged build and confirm it renders.