### PR TITLE
fix: recover the full agent turn after a mid-turn app reopen + never split a sentence with an activity card

### DIFF
--- a/architecture/02b-contracts-and-requirements.md
+++ b/architecture/02b-contracts-and-requirements.md
@@ -115,7 +115,7 @@ thread/setAccessMode    -> persistir el modo de acceso/aprobacion por hilo. Para
 thread/archive          -> archivar thread (status -> archived, reversible)
 thread/unarchive        -> restaurar thread archivado (status -> active)
 thread/delete           -> eliminar thread y sus turns
-turn/list               -> turnos de un thread; paginacion por cursor offset (oldest->newest). Params: { threadId, cursor?, limit?, fromEnd? }. Result: { turns, nextCursor?, total?, activeTurnId? }. `fromEnd:true` devuelve la pagina mas reciente (ultimos `limit` turnos); `total` permite paginar hacia atras (newest-first) calculando offsets sin traer todo el thread. **`activeTurnId?`**: el turno EN VUELO ahora mismo para el thread (estado vivo de `AgentManager.#activeTurnByThread`), presente solo si hay uno. Es la fuente autoritativa de "¿hay turno corriendo AHORA?" — a diferencia del `status:'streaming'` de un turno guardado, queda ausente tras un restart del bridge (el proceso del agente CLI murio). El telefono lo usa al reconectar/resync para **re-attachear** su vista de streaming (indicador "respondiendo…" + boton Stop) a un turno que dejo de rastrear estando en background, en vez de darlo por terminado.
+turn/list               -> turnos de un thread; paginacion por cursor offset (oldest->newest). Params: { threadId, cursor?, limit?, fromEnd? }. Result: { turns, nextCursor?, total?, activeTurnId? }. `fromEnd:true` devuelve la pagina mas reciente (ultimos `limit` turnos); `total` permite paginar hacia atras (newest-first) calculando offsets sin traer todo el thread. **`activeTurnId?`**: el turno EN VUELO ahora mismo para el thread (estado vivo de `AgentManager.#activeTurnByThread`), presente solo si hay uno. Es la fuente autoritativa de "¿hay turno corriendo AHORA?" — a diferencia del `status:'streaming'` de un turno guardado, queda ausente tras un restart del bridge (el proceso del agente CLI murio). El telefono lo usa al reconectar/resync para **re-attachear** su vista de streaming (indicador "respondiendo…" + boton Stop) a un turno que dejo de rastrear estando en background, en vez de darlo por terminado. **Semantica de recuperacion (2026-07):** al re-attachear, el telefono **re-siembra SIEMPRE** su buffer en vivo desde los `segments`/`content` acumulados que este `turn/list` reporta para el turno en vuelo — incluso si ya rastreaba ese `turnId` (los primeros deltas post-reconexion recrean el buffer solo con la cola nueva; el snapshot del bridge es superconjunto de todo lo ya notificado porque el bridge persiste cada delta/bloque ANTES de notificarlo, asi que reemplazar nunca pierde datos). El replay de catch-up del transporte es una ventana acotada en memoria (500 frames / 10 MiB) y NO alcanza para una ausencia larga: la re-siembra via `turn/list` es el unico camino que recupera lo producido con la app cerrada. Al completarse el turno, el telefono ademas **reconcilia** el mensaje persistido contra el registro autoritativo del bridge con un `turn/read` (best-effort), de modo que la conversacion guardada converge siempre al intercalado exacto del bridge aunque la vista en vivo haya sido imperfecta.
 turn/read               -> datos de un turno especifico
 turn/send               -> enviar contenido a un turno activo (texto opcional, attachments, options, approvalResponse, questionResponse, command). `command` ({ name, args? }) invoca un comando anunciado por `agent/commands` en vez de texto libre: el bridge lo resuelve al prompt que corre el agente (plantilla custom expandida, o la forma nativa `/name args`). Cuando hay `command`, `text` es opcional.
 turn/cancel             -> cancelar turno en curso
@@ -289,7 +289,7 @@ bridge/removeTrustedDevice       -> revocar confianza + drop session + drop push
 stream/turn/started         -> TurnStartedParams  { threadId, turnId }
 stream/message/delta        -> MessageDeltaParams { threadId, turnId, messageId, delta }
 stream/thinking/delta       -> ThinkingDeltaParams { threadId, turnId, messageId, delta }   (NUEVO 2026-06)
-stream/content/block        -> ContentBlockParams { threadId, turnId, messageId, content }  (NUEVO 2026-06)
+stream/content/block        -> ContentBlockParams { threadId, turnId, messageId, content, beforeText? }  (NUEVO 2026-06; beforeText 2026-07)
 stream/turn/completed       -> TurnCompletedParams { threadId, turnId, messageId, text, usage? }  (usage es TurnUsage)
 stream/turn/error           -> TurnErrorParams     { threadId, turnId, error: { code, message } }
 stream/turn/aborted         -> TurnAbortedParams   { threadId, turnId }
@@ -307,6 +307,16 @@ stream/model/resolved       -> ModelResolvedParams { threadId, turnId, model }  
   el mismo codec que `Message.blocks` y lo proyecta en el **Work log** /
   **Changed files** de la respuesta. Asi los comandos/herramientas/diffs
   del agente se renderizan en vivo y sobreviven a un `turn/list` re-sync.
+  - `beforeText?` (2026-07, aditivo): `true` cuando el bloque proviene de una
+    actividad **paralela/en background** (p.ej. la herramienta de un subagente
+    Task de Claude Code) que llego mientras el texto principal del asistente
+    seguia streameando. El cliente debe insertarlo ANTES de la corrida de
+    texto abierta, no despues — anexarlo cortaria la corrida y la frase se
+    renderizaria partida a media palabra por una tarjeta de actividad. El
+    bridge aplica la misma colocacion al persistir `Message.segments`
+    (`thread-store.appendBlock`), de modo que la vista en vivo y el re-sync
+    rinden el intercalado identico. Ausente/false = caso secuencial (el
+    bloque cae en una frontera real de texto y se anexa en orden de llegada).
 - `Message.segments?`: en el re-sync (`turn/list`) el bridge ya no entrega el
   texto (`content`) y los bloques (`blocks`) por separado — eso perdia el
   ORDEN en que se intercalaron y hacia que un turno recuperado mostrara todo

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -5,6 +5,33 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — parallel subagent activity no longer corrupts the text↔work-log order
+- **Claude Code subagent (Task) events are now recognized and ordered correctly.**
+  With parallel subagents, `claude --output-format stream-json` interleaves the
+  subagent's `assistant`/`user` lines (marked `parent_tool_use_id`) with the main
+  loop's partial text deltas. The adapter treated them as main-loop events, so a
+  subagent tool result landing mid-delta severed the open text run — the stored
+  `Message.segments` (and the live phone view) rendered the sentence **split
+  mid-word by a Work-log card** (verified against a real session: 3 mid-word cuts
+  in one 355-segment turn). Now (`claude-adapter.ts`):
+  - the parser surfaces `parent_tool_use_id` plus `content_block_start/stop`
+    boundaries, and the adapter tracks whether a MAIN text run is open;
+  - a block emitted while the run is open is flagged **`beforeText`** — the store
+    (`thread-store.appendBlock`) and the `stream/content/block` notification both
+    slot it BEFORE the open run, so the run is never severed and live/re-sync
+    order match; sequential blocks keep plain arrival order;
+  - subagent **text** never folds into the main message (the no-partials
+    `assistant_text` fallback previously could) and subagent **usage** no longer
+    overwrites the main context-meter fallback. Subagent tool results still feed
+    the Work log.
+- **`completeTurn` keeps the interleave when the final text merely extends the
+  streamed deltas.** `reconcileSegmentsWithText` now folds an unstreamed tail
+  onto the trailing text run instead of collapsing the whole turn to
+  blocks-first + one merged paragraph; only a genuinely divergent final text
+  still falls back (`thread-store.ts`).
+- Tests: +7 → **482** (subagent parsing/flagging ×3, store placement ×2,
+  completion-tail reconcile, wire flag end-to-end through `AgentManager`).
+
 ### Docs
 - Sync the JSON-RPC method-count badges, the AGENTS.md agent roster (add Grok), the npm publish status and the PR-template test count with the code.
 

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -32,6 +32,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 - Tests: +7 → **482** (subagent parsing/flagging ×3, store placement ×2,
   completion-tail reconcile, wire flag end-to-end through `AgentManager`).
 
+### Fixed — `turn/list` clears `activeTurnId` atomically with turn completion
+- **A just-completed turn could momentarily still report as active.** In
+  `AgentManager`'s `turn_completed` handling, `store.completeTurn` flips the
+  turn's persisted status while `#activeTurnByThread` — the map `turn/list`
+  derives `activeTurnId` from — was only cleared several `await`s later
+  (`#assistantText`, `setUsage`, `notify`). A `turn/list` that raced into that
+  window saw the turn as **completed yet still active**, so the phone briefly
+  kept the "responding…" indicator on an idle thread. The in-flight marker is
+  now deleted synchronously the instant the turn is persisted as completed, so
+  the store status and `activeTurnId` flip together (`agent-manager.ts`). This
+  makes the existing `turn/list … clears it on completion` handler test
+  deterministic (it was timing-dependent and flaked under load).
+
 ### Docs
 - Sync the JSON-RPC method-count badges, the AGENTS.md agent roster (add Grok), the npm publish status and the PR-template test count with the code.
 

--- a/bridge/FOR-DEV.md
+++ b/bridge/FOR-DEV.md
@@ -35,6 +35,11 @@ push validation (FOR-HUMAN).
   `Message.segments` interleave (text runs + work-log/diff/tool blocks in
   production order) so a `turn/list` re-sync renders the work log inline with
   the response instead of stacking all activity above one merged paragraph.
+  Parallel-activity blocks (e.g. a Claude Code subagent's tool landing while the
+  main text streams) are flagged `beforeText` and slotted BEFORE the open text
+  run — in the store and on the `stream/content/block` wire — so a text run is
+  never severed mid-word, live and re-synced order always match, and subagent
+  text/usage never folds into the main message.
 - **7 real agents wired** — OpenCode (default), Claude Code, Codex, pi,
   Gemini CLI, Zero, and Grok. Each drives its **official local CLI** with
   `shell:false`, parses the native stream, and emits structured

--- a/bridge/src/adapters/claude-adapter.ts
+++ b/bridge/src/adapters/claude-adapter.ts
@@ -175,6 +175,24 @@ export interface ClaudeEvent {
   kind: 'init' | 'delta' | 'thinking' | 'assistant_text' | 'tool_result' | 'result' | 'other';
   sessionId?: string;
   text?: string;
+  /**
+   * The `parent_tool_use_id` of the line, set when the event belongs to a
+   * SUBAGENT (Task-tool) turn running in parallel with the main loop rather
+   * than to the top-level session. Subagent lines arrive interleaved with the
+   * main stream (their tools while the main text is mid-delta), so the adapter
+   * must not fold their text/usage into the main message and must order their
+   * blocks before the open text run (`beforeText`).
+   */
+  parentToolUseId?: string;
+  /**
+   * Only for `stream_event` lines that mark a content-block boundary: the raw
+   * SSE event type, used to track whether a main-loop text run is open.
+   */
+  streamType?: 'content_block_start' | 'content_block_stop';
+  /** Only for `stream_event` lines: the content-block index the event addresses. */
+  blockIndex?: number;
+  /** Only for `content_block_start`: the starting block's type (`text`, `tool_use`, …). */
+  blockType?: string;
   /** Only set for `init`: the concrete model id the run resolved the alias to. */
   model?: string;
   /**
@@ -229,7 +247,14 @@ export function parseClaudeLine(line: string): ClaudeEvent | null {
     return null;
   }
   const sessionId = typeof parsed['session_id'] === 'string' ? parsed['session_id'] : undefined;
-  const base = { sessionId } as const;
+  // Lines produced by a parallel SUBAGENT (Task) turn carry the spawning
+  // tool_use id — the adapter keys its main-vs-subagent handling off this.
+  const parentToolUseId =
+    typeof parsed['parent_tool_use_id'] === 'string' ? parsed['parent_tool_use_id'] : undefined;
+  const base = {
+    sessionId,
+    ...(parentToolUseId !== undefined ? { parentToolUseId } : {}),
+  } as const;
   switch (parsed['type']) {
     case 'system': {
       const model = typeof parsed['model'] === 'string' ? parsed['model'] : undefined;
@@ -245,16 +270,37 @@ export function parseClaudeLine(line: string): ClaudeEvent | null {
     }
     case 'stream_event': {
       const event = isRecord(parsed['event']) ? parsed['event'] : undefined;
+      const blockIndex =
+        event && typeof event['index'] === 'number' ? (event['index'] as number) : undefined;
+      const withIndex = blockIndex !== undefined ? { blockIndex } : {};
       if (event && event['type'] === 'content_block_delta') {
         const delta = isRecord(event['delta']) ? event['delta'] : undefined;
         if (delta && delta['type'] === 'text_delta' && typeof delta['text'] === 'string') {
-          return { kind: 'delta', ...base, text: delta['text'] };
+          return { kind: 'delta', ...base, ...withIndex, text: delta['text'] };
         }
         // Extended-thinking output streams as `thinking_delta` blocks (the
         // signature_delta blocks that follow carry no readable text → ignored).
         if (delta && delta['type'] === 'thinking_delta' && typeof delta['thinking'] === 'string') {
-          return { kind: 'thinking', ...base, text: delta['thinking'] };
+          return { kind: 'thinking', ...base, ...withIndex, text: delta['thinking'] };
         }
+      }
+      // Content-block boundaries — surfaced so the adapter can track whether a
+      // main-loop text run is currently open (a parallel subagent block landing
+      // mid-run must be ordered before it, not spliced into it).
+      if (event && event['type'] === 'content_block_start') {
+        const block = isRecord(event['content_block']) ? event['content_block'] : undefined;
+        const blockType =
+          block && typeof block['type'] === 'string' ? (block['type'] as string) : undefined;
+        return {
+          kind: 'other',
+          ...base,
+          streamType: 'content_block_start',
+          ...withIndex,
+          ...(blockType !== undefined ? { blockType } : {}),
+        };
+      }
+      if (event && event['type'] === 'content_block_stop') {
+        return { kind: 'other', ...base, streamType: 'content_block_stop', ...withIndex };
       }
       return { kind: 'other', ...base };
     }
@@ -463,11 +509,22 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
     // tool_use id → its (complete) invocation, until the matching tool_result
     // arrives and the two are paired into a structured content block.
     const pendingTools = new Map<string, ClaudeToolUse>();
+    // Index of the MAIN-loop text content block currently streaming deltas, or
+    // undefined when no text run is open. Parallel subagent (Task) lines arrive
+    // interleaved with the main stream; a block emitted while a text run is
+    // open is flagged `beforeText` so the store/phone order it BEFORE the run
+    // instead of severing it (which rendered sentences split mid-word by an
+    // activity card). `-1` stands in when the CLI omits the block index.
+    let openTextIndex: number | undefined;
 
     const reader = createInterface({ input: child.stdout });
     reader.on('line', (line) => {
       const event = parseClaudeLine(line);
       if (!event) return;
+      // Lines carrying `parent_tool_use_id` belong to a parallel SUBAGENT turn:
+      // their tool blocks still feed the work log, but their text/usage must
+      // never fold into the main message or close the main text run.
+      const subagent = event.parentToolUseId !== undefined;
       if (event.sessionId) this.#sessionByThread.set(threadId, event.sessionId);
       // Cache the CLI's advertised slash commands for `agent/commands` discovery.
       if (event.slashCommands) this.#slashCommands = event.slashCommands;
@@ -475,12 +532,25 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       if (event.toolUses) {
         for (const tool of event.toolUses) pendingTools.set(tool.id, tool);
       }
-      // Track the latest assistant-message usage as a completion fallback.
-      if (event.kind === 'assistant_text' && event.usage !== undefined) {
+      // Track the latest MAIN assistant-message usage as a completion fallback
+      // (a subagent's usage is its own context, not this conversation's).
+      if (!subagent && event.kind === 'assistant_text' && event.usage !== undefined) {
         lastUsage = event.usage;
       }
+      // Main-loop text-run boundaries: a text block opens on its start (or
+      // defensively on its first delta below); any other block starting, its
+      // stop, or the message envelope closes it.
+      if (!subagent && event.streamType === 'content_block_start') {
+        openTextIndex = event.blockType === 'text' ? (event.blockIndex ?? -1) : undefined;
+      } else if (!subagent && event.streamType === 'content_block_stop') {
+        if (openTextIndex === (event.blockIndex ?? -1)) openTextIndex = undefined;
+      } else if (!subagent && event.kind === 'assistant_text') {
+        openTextIndex = undefined;
+      }
       // A tool_result completes a tool → emit a structured block (command/diff/
-      // tool) for the Work log / Changed files sections.
+      // tool) for the Work log / Changed files sections. When it lands while the
+      // main text is mid-run (only parallel subagent/background activity can),
+      // `beforeText` orders it before the open run.
       if (event.kind === 'tool_result' && event.toolResults) {
         for (const result of event.toolResults) {
           const tool = pendingTools.get(result.toolUseId);
@@ -490,10 +560,14 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
             type: 'block',
             threadId,
             turnId,
-            data: { content: toolUseToBlock(tool, result) },
+            data: {
+              content: toolUseToBlock(tool, result),
+              ...(openTextIndex !== undefined ? { beforeText: true } : {}),
+            },
           });
         }
       }
+      if (subagent) return; // everything below folds into the MAIN message only
       if (event.kind === 'init' && event.model && !sawModel) {
         // Surface the concrete model the alias resolved to (e.g. `opus` →
         // `claude-opus-4-8`) so the phone can show the exact version in use.
@@ -503,6 +577,7 @@ export class ClaudeCodeAdapter extends BaseAgentAdapter {
       } else if (event.kind === 'delta' && event.text) {
         sawPartial = true;
         full += event.text;
+        openTextIndex = event.blockIndex ?? -1;
         this.emit({ type: 'delta', threadId, turnId, data: { text: event.text } });
       } else if (event.kind === 'thinking' && event.text) {
         // Reasoning chunk — streamed to the phone (and persisted) separately from

--- a/bridge/src/agents/agent-manager.ts
+++ b/bridge/src/agents/agent-manager.ts
@@ -642,6 +642,13 @@ export class AgentManager {
         case 'turn_completed': {
           const provided = readOptionalText(event.data);
           await this.#options.store.completeTurn(threadId, turnId, provided, now);
+          // Clear the in-flight marker the instant the turn is persisted as
+          // completed — BEFORE the awaits below (`#assistantText`, `setUsage`)
+          // yield to the event loop. `turn/list` derives `activeTurnId` from
+          // this map, so a poll that has just observed the store status flip to
+          // `completed` must not still see the turn as active: the store status
+          // and `activeTurnId` have to flip together.
+          this.#activeTurnByThread.delete(threadId);
           const text = await this.#assistantText(turnId, provided);
           const usage = readUsage(event.data);
           if (usage) await this.#options.store.setUsage(threadId, turnId, usage, now);
@@ -655,7 +662,6 @@ export class AgentManager {
             }),
           );
           this.#assistantByTurn.delete(turnId);
-          this.#activeTurnByThread.delete(threadId);
           void this.#cleanupAttachments(turnId);
           await this.#persistAgentSession(threadId, now);
           this.#options.onTurnEnd?.({ threadId, turnId, status: 'completed', text });

--- a/bridge/src/agents/agent-manager.ts
+++ b/bridge/src/agents/agent-manager.ts
@@ -620,13 +620,20 @@ export class AgentManager {
         case 'block': {
           const content = readContent(event.data);
           if (content !== undefined) {
-            await this.#options.store.appendBlock(threadId, turnId, content, now);
+            // A block flagged `beforeText` came from a parallel/background
+            // activity while the main text was still streaming: the store slots
+            // it before the open text run (never severing it), and the flag
+            // rides on the notification so the phone's live buffer applies the
+            // identical placement — live view and re-sync render the same order.
+            const beforeText = readBeforeText(event.data);
+            await this.#options.store.appendBlock(threadId, turnId, content, now, beforeText);
             this.#options.notify(
               makeNotification(StreamNotification.ContentBlock, {
                 threadId,
                 turnId,
                 messageId,
                 content,
+                ...(beforeText ? { beforeText } : {}),
               }),
             );
           }
@@ -763,6 +770,20 @@ function readContent(data: unknown): unknown {
     return (data as { content: unknown }).content;
   }
   return undefined;
+}
+
+/**
+ * Extract a block event's `beforeText` marker: `true` when the adapter emitted
+ * the block while the assistant's main text was still streaming (a parallel/
+ * background activity), so it must be ordered before the open text run.
+ */
+function readBeforeText(data: unknown): boolean {
+  return (
+    data !== null &&
+    typeof data === 'object' &&
+    'beforeText' in data &&
+    (data as { beforeText: unknown }).beforeText === true
+  );
 }
 
 function readOptionalText(data: unknown): string | undefined {

--- a/bridge/src/conversation/thread-store.ts
+++ b/bridge/src/conversation/thread-store.ts
@@ -375,12 +375,34 @@ export class ThreadStore {
     });
   }
 
-  /** Appends a structured content block (command/diff/tool) to the message. */
-  appendBlock(threadId: string, turnId: string, content: unknown, now: number): Promise<void> {
+  /**
+   * Appends a structured content block (command/diff/tool) to the message.
+   *
+   * [beforeText] marks a block that arrived from a **parallel/background**
+   * activity (e.g. a Claude Code subagent's tool run) while the assistant's
+   * main text was still streaming: it is inserted BEFORE the trailing open
+   * text run instead of after it, so the run is never severed — appending
+   * would make the next delta open a new run and render the sentence split
+   * mid-word by an activity card. Sequential blocks (the default) land at a
+   * real text-run boundary and keep plain arrival-order append.
+   */
+  appendBlock(
+    threadId: string,
+    turnId: string,
+    content: unknown,
+    now: number,
+    beforeText = false,
+  ): Promise<void> {
     return this.#mutate(async (threads) => {
       const assistant = this.#assistantMessage(threads, threadId, turnId);
       assistant.blocks = [...(assistant.blocks ?? []), content];
-      (assistant.segments ??= []).push(content);
+      const segments = (assistant.segments ??= []);
+      const last = segments[segments.length - 1];
+      if (beforeText && isTextSegment(last)) {
+        segments.splice(segments.length - 1, 0, content);
+      } else {
+        segments.push(content);
+      }
       this.#touch(threads, threadId, now);
     });
   }
@@ -664,16 +686,30 @@ function appendTextSegment(assistant: StoredMessage, delta: string): void {
  * Make the ordered `segments` agree with the turn's authoritative [finalText]
  * (the `turn/completed` text, which replaces the streamed deltas). When the
  * streamed text runs already concatenate to [finalText] — the normal case — the
- * interleave is left untouched. Otherwise the text runs are dropped and a single
- * trailing text run is appended after the blocks (the best we can do when the
- * final text diverges from, or arrived without, streamed deltas). A no-op when
- * no `segments` were ever built (a plain-text turn with no blocks).
+ * interleave is left untouched. When they concatenate to a strict PREFIX of
+ * [finalText] (the completion text carries a tail the deltas never streamed,
+ * e.g. an adapter that reports a fuller final message), the missing tail is
+ * appended as/onto the trailing text run so the interleave survives intact.
+ * Only when the final text genuinely diverges are the text runs dropped and a
+ * single trailing text run appended after the blocks (the best possible order
+ * without streamed positions). A no-op when no `segments` were ever built (a
+ * plain-text turn with no blocks).
  */
 function reconcileSegmentsWithText(assistant: StoredMessage, finalText: string): void {
   const segments = assistant.segments;
   if (!segments || segments.length === 0) return;
   const streamed = segments.filter(isTextSegment).reduce((acc, s) => acc + s.text, '');
   if (streamed === finalText) return;
+  if (streamed.length > 0 && finalText.startsWith(streamed)) {
+    const tail = finalText.slice(streamed.length);
+    const last = segments[segments.length - 1];
+    if (isTextSegment(last)) {
+      last.text += tail;
+    } else {
+      segments.push({ type: 'text', text: tail });
+    }
+    return;
+  }
   const blocks = segments.filter((s) => !isTextSegment(s));
   assistant.segments =
     finalText.length > 0 ? [...blocks, { type: 'text', text: finalText }] : blocks;

--- a/bridge/test/adapters/claude-adapter.test.ts
+++ b/bridge/test/adapters/claude-adapter.test.ts
@@ -632,3 +632,98 @@ test('interactive approvals stay off until the hook URL resolves (LAN not starte
   assert.equal(last().args.includes('--settings'), false);
   assert.equal(last().env, undefined);
 });
+
+test('parseClaudeLine surfaces subagent parentage and content-block boundaries', () => {
+  // subagent lines carry parent_tool_use_id
+  assert.equal(
+    parseClaudeLine(
+      '{"type":"user","session_id":"s","parent_tool_use_id":"task_1","message":{"content":[{"type":"tool_result","tool_use_id":"tu_9","content":"x"}]}}',
+    )?.parentToolUseId,
+    'task_1',
+  );
+  // content_block_start/stop expose the index + block type for text-run tracking
+  assert.deepEqual(
+    parseClaudeLine(
+      '{"type":"stream_event","session_id":"s","event":{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}}',
+    ),
+    {
+      kind: 'other',
+      sessionId: 's',
+      streamType: 'content_block_start',
+      blockIndex: 1,
+      blockType: 'text',
+    },
+  );
+  assert.deepEqual(
+    parseClaudeLine(
+      '{"type":"stream_event","session_id":"s","event":{"type":"content_block_stop","index":1}}',
+    ),
+    { kind: 'other', sessionId: 's', streamType: 'content_block_stop', blockIndex: 1 },
+  );
+  // delta events carry their content-block index
+  assert.equal(
+    parseClaudeLine(
+      '{"type":"stream_event","session_id":"s","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hi"}}}',
+    )?.blockIndex,
+    1,
+  );
+});
+
+test('ClaudeCodeAdapter flags a subagent block landing mid-text as beforeText', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new ClaudeCodeAdapter({ binaryPath: 'claude', spawnFn });
+  const { done } = collect(adapter);
+
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'go' });
+  last().feed([
+    // a parallel subagent (Task) registers its own tool_use…
+    '{"type":"assistant","session_id":"s","parent_tool_use_id":"task_1","message":{"content":[{"type":"tool_use","id":"tu_sub","name":"Bash","input":{"command":"ls"}}]}}',
+    // …the main text starts streaming
+    '{"type":"stream_event","session_id":"s","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}',
+    '{"type":"stream_event","session_id":"s","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"y si re"}}}',
+    // …and the subagent result arrives MID-RUN (parallel activity)
+    '{"type":"user","session_id":"s","parent_tool_use_id":"task_1","message":{"content":[{"type":"tool_result","tool_use_id":"tu_sub","content":"ok"}]}}',
+    '{"type":"stream_event","session_id":"s","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"porta"}}}',
+    '{"type":"stream_event","session_id":"s","event":{"type":"content_block_stop","index":0}}',
+    // a sequential MAIN tool after the text closed keeps plain arrival order
+    '{"type":"assistant","session_id":"s","message":{"content":[{"type":"text","text":"y si reporta"},{"type":"tool_use","id":"tu_main","name":"Bash","input":{"command":"pwd"}}]}}',
+    '{"type":"user","session_id":"s","message":{"content":[{"type":"tool_result","tool_use_id":"tu_main","content":"/"}]}}',
+    '{"type":"result","subtype":"success","is_error":false,"result":"y si reporta","session_id":"s"}',
+  ]);
+
+  const events = await done;
+  const blocks = events.filter((e) => e.type === 'block');
+  assert.equal(blocks.length, 2);
+  // the subagent block that landed mid-run is flagged beforeText…
+  assert.equal((blocks[0]!.data as { beforeText?: boolean }).beforeText, true);
+  // …the sequential main block is not
+  assert.equal((blocks[1]!.data as { beforeText?: boolean }).beforeText, undefined);
+  // and the main text run streamed whole, never polluted by subagent content
+  const deltas = events
+    .filter((e) => e.type === 'delta')
+    .map((e) => (e.data as { text: string }).text);
+  assert.deepEqual(deltas, ['y si re', 'porta']);
+});
+
+test('ClaudeCodeAdapter never folds subagent text or usage into the main message', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new ClaudeCodeAdapter({ binaryPath: 'claude', spawnFn });
+  const { done } = collect(adapter);
+
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'go' });
+  last().feed([
+    '{"type":"assistant","session_id":"s","message":{"content":[{"type":"text","text":"main answer"}],"usage":{"input_tokens":10,"output_tokens":5}}}',
+    // subagent narration + usage after the main message: neither may leak into
+    // the main deltas (the no-partials fallback) or the usage fallback
+    '{"type":"assistant","session_id":"s","parent_tool_use_id":"task_1","message":{"content":[{"type":"text","text":"subagent inner monologue"}],"usage":{"input_tokens":999999}}}',
+    '{"type":"result","subtype":"success","is_error":false,"session_id":"s"}',
+  ]);
+
+  const events = await done;
+  const deltas = events
+    .filter((e) => e.type === 'delta')
+    .map((e) => (e.data as { text: string }).text);
+  assert.deepEqual(deltas, ['main answer']);
+  const completed = events.find((e) => e.type === 'turn_completed');
+  assert.equal((completed?.data as { usage?: { tokens: number } }).usage?.tokens, 15);
+});

--- a/bridge/test/agents/agent-manager.test.ts
+++ b/bridge/test/agents/agent-manager.test.ts
@@ -670,3 +670,60 @@ test('command invocation without an expander: the agent runs the native /name ar
   assert.equal(adapter.lastText, '/compact');
   await rm(baseDir, { recursive: true, force: true });
 });
+
+/** ControlledAdapter that can also stream deltas and (flagged) blocks. */
+class StreamingAdapter extends ControlledAdapter {
+  delta(threadId: string, turnId: string, text: string): void {
+    this.emit({ type: 'delta', threadId, turnId, data: { text } });
+  }
+  block(threadId: string, turnId: string, content: unknown, beforeText?: boolean): void {
+    this.emit({
+      type: 'block',
+      threadId,
+      turnId,
+      data: { content, ...(beforeText ? { beforeText } : {}) },
+    });
+  }
+}
+
+baseTest('a beforeText block is stored before the open run and flagged on the wire', async () => {
+  const baseDir = join(tmpdir(), `uxnan-am-btx-${randomUUID()}`);
+  const store = new ThreadStore(new DaemonState(baseDir));
+  const notifications: { method: string; params?: Record<string, unknown> }[] = [];
+  const manager = new AgentManager({
+    store,
+    notify: (m) => notifications.push(m as { method: string; params?: Record<string, unknown> }),
+    now: () => 1000,
+    logger: createLogger('test', 'error'),
+    defaultAgent: 'echo',
+  });
+  const adapter = new StreamingAdapter();
+  manager.register(adapter);
+
+  const thread = await store.startThread({ projectId: 'p' }, 1);
+  const { turnId } = await manager.sendTurn(thread.id, 'go');
+  adapter.delta(thread.id, turnId, 'y si re');
+  // a parallel-activity block lands while the text run is open…
+  adapter.block(thread.id, turnId, { type: 'tool', name: 'Read' }, true);
+  adapter.delta(thread.id, turnId, 'porta');
+  // …and a sequential one after (no flag)
+  adapter.block(thread.id, turnId, { type: 'tool', name: 'Bash' });
+  adapter.complete(thread.id, turnId, 'y si reporta');
+  await waitFor(async () => (await store.getTurn(turnId)).status === 'completed');
+
+  // Stored order: the open run stayed whole, the flagged block sits before it.
+  const assistant = (await store.getTurn(turnId)).messages.find((m) => m.role === 'assistant');
+  assert.deepEqual(assistant?.segments, [
+    { type: 'tool', name: 'Read' },
+    { type: 'text', text: 'y si reporta' },
+    { type: 'tool', name: 'Bash' },
+  ]);
+  // Wire: the flag rides only on the flagged block's notification, so the
+  // phone's live buffer applies the identical placement.
+  const blockNotes = notifications.filter((n) => n.method === StreamNotification.ContentBlock);
+  assert.equal(blockNotes.length, 2);
+  assert.equal(blockNotes[0]?.params?.['beforeText'], true);
+  assert.equal('beforeText' in (blockNotes[1]?.params ?? {}), false);
+
+  await rm(baseDir, { recursive: true, force: true });
+});

--- a/bridge/test/conversation/thread-store.test.ts
+++ b/bridge/test/conversation/thread-store.test.ts
@@ -293,3 +293,74 @@ test('fork copies a thread; unknown ids reject', async () => {
   await assert.rejects(store.getTurn('nope'), RpcError);
   await rm(baseDir, { recursive: true, force: true });
 });
+
+test('appendBlock beforeText slots the block before the open text run', async () => {
+  const { store, baseDir } = newStore();
+  const thread = await store.startThread({ projectId: 'p' }, 1);
+  const { turnId } = await store.startTurn(thread.id, 'ask', 2);
+
+  // main text mid-run when a parallel (subagent) block lands
+  await store.appendDelta(thread.id, turnId, 'y si re', 3);
+  await store.appendBlock(thread.id, turnId, { type: 'tool', name: 'Read' }, 4, true);
+  await store.appendDelta(thread.id, turnId, 'porta tokens', 5);
+  // a sequential block (text run closed) keeps plain arrival order
+  await store.appendBlock(thread.id, turnId, { type: 'tool', name: 'Bash' }, 6);
+  await store.completeTurn(thread.id, turnId, undefined, 7);
+
+  const turn = await store.getTurn(turnId);
+  const assistant = turn.messages.find((m) => m.role === 'assistant');
+  // the run was never severed: block first, then one whole text run, then the
+  // sequential block after it
+  assert.deepEqual(assistant?.segments, [
+    { type: 'tool', name: 'Read' },
+    { type: 'text', text: 'y si reporta tokens' },
+    { type: 'tool', name: 'Bash' },
+  ]);
+  assert.equal(assistant?.content, 'y si reporta tokens');
+  // `blocks` keeps plain arrival order regardless
+  assert.deepEqual(assistant?.blocks, [
+    { type: 'tool', name: 'Read' },
+    { type: 'tool', name: 'Bash' },
+  ]);
+  await rm(baseDir, { recursive: true, force: true });
+});
+
+test('appendBlock beforeText with no open text run appends normally', async () => {
+  const { store, baseDir } = newStore();
+  const thread = await store.startThread({ projectId: 'p' }, 1);
+  const { turnId } = await store.startTurn(thread.id, 'ask', 2);
+
+  await store.appendBlock(thread.id, turnId, { type: 'tool', name: 'Read' }, 3, true);
+  await store.appendDelta(thread.id, turnId, 'after', 4);
+
+  const turn = await store.getTurn(turnId);
+  const assistant = turn.messages.find((m) => m.role === 'assistant');
+  assert.deepEqual(assistant?.segments, [
+    { type: 'tool', name: 'Read' },
+    { type: 'text', text: 'after' },
+  ]);
+  await rm(baseDir, { recursive: true, force: true });
+});
+
+test('completeTurn extends the trailing run when the final text has an unstreamed tail', async () => {
+  const { store, baseDir } = newStore();
+  const thread = await store.startThread({ projectId: 'p' }, 1);
+  const { turnId } = await store.startTurn(thread.id, 'ask', 2);
+
+  await store.appendDelta(thread.id, turnId, 'first ', 3);
+  await store.appendBlock(thread.id, turnId, { type: 'tool', name: 'Bash' }, 4);
+  await store.appendDelta(thread.id, turnId, 'second', 5);
+  // the completion text carries a tail the deltas never streamed: the
+  // interleave must survive, with the tail folded onto the trailing run
+  await store.completeTurn(thread.id, turnId, 'first second and tail', 6);
+
+  const turn = await store.getTurn(turnId);
+  const assistant = turn.messages.find((m) => m.role === 'assistant');
+  assert.deepEqual(assistant?.segments, [
+    { type: 'text', text: 'first ' },
+    { type: 'tool', name: 'Bash' },
+    { type: 'text', text: 'second and tail' },
+  ]);
+  assert.equal(assistant?.content, 'first second and tail');
+  await rm(baseDir, { recursive: true, force: true });
+});

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — `ContentBlockParams.beforeText` (ordering hint for parallel-activity blocks)
+- **`stream/content/block` gains an optional `beforeText?: boolean`**
+  (`src/jsonrpc/notifications.ts`). `true` marks a block produced by a
+  **parallel/background** activity (e.g. a Claude Code subagent's tool run) that
+  arrived while the assistant's main text was still streaming: the client must
+  insert it BEFORE the currently-open text run instead of appending it, so the
+  run is never severed (appending rendered sentences split mid-word by a Work-log
+  card). Additive and backward-compatible: absent/false keeps today's sequential
+  append. The bridge applies the identical placement when persisting
+  `Message.segments`, so the live view and a `turn/list` re-sync render the same
+  interleave. Spec: `architecture/02b` §1.4.
+
 ### Docs
 - Sync the JSON-RPC method-count badges, the AGENTS.md agent roster (add Grok), the npm publish status and the PR-template test count with the code.
 

--- a/shared/src/jsonrpc/notifications.ts
+++ b/shared/src/jsonrpc/notifications.ts
@@ -51,6 +51,18 @@ export interface ContentBlockParams {
   turnId: string;
   messageId: string;
   content: unknown;
+  /**
+   * `true` when the block arrived from a **parallel/background** activity (e.g.
+   * a Claude Code subagent's tool run) while the assistant's main text was
+   * still streaming. The client must then insert the block BEFORE the
+   * currently-open text run instead of appending it after — appending would
+   * sever the run and render the sentence split mid-word by an activity card.
+   * Absent/false for the sequential case (the block lands at a real text-run
+   * boundary and is appended in arrival order). Mirrors how the bridge itself
+   * orders the block inside the persisted `Message.segments`, so the live view
+   * and a later `turn/list` re-sync render the identical interleave.
+   */
+  beforeText?: boolean;
 }
 
 /**

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,49 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed — a session closed and reopened mid-turn recovers the FULL agent reply
+- **The reopen race that silently dropped everything produced while the app was
+  closed is fixed at the root.** On reopen, the first post-reconnect deltas
+  re-created the live buffer for the in-flight turn (with only the new tail),
+  and the re-sync's seed guard (`turnId != activeTurnId`) then saw a match and
+  **skipped seeding** — so the user saw their prompt but none of the output the
+  agent had produced while the app was away, and `_finishTurn` later persisted
+  that truncation for good. `_resyncThread` now **re-seeds unconditionally**
+  from the bridge's accumulated `turn/list` record (which persists every
+  delta/block BEFORE notifying, so the snapshot is a superset of anything the
+  phone already applied — replacing never loses data). Applies to every agent:
+  the recovery path is agent-agnostic (`thread_manager.dart`).
+- **A turn's finalized bubble now always carries the bridge's authoritative
+  final text.** `_finishTurn` previously preferred the live buffer whenever it
+  held ANY text — a tail-only buffer became the permanent message. It now keeps
+  the live interleave when the buffer matches (or is a prefix of) the final
+  text, and otherwise falls back to the authoritative text with the live blocks.
+- **Every completed turn reconciles against the bridge record** (best-effort
+  `turn/read` after `turn/completed`): the persisted message is rewritten to the
+  bridge's exact ordered `segments` whenever the live view diverged (a delta in
+  transit during a re-sync, a re-attach that missed early blocks), so the stored
+  conversation always converges to the bridge's truth.
+- **Re-sync now also runs on every (re)established connection** (new
+  `connectionPhases` wiring): the bridge's catch-up replay is a bounded window
+  (500 frames / 10 MiB), so a long disconnection mid-turn — a network blip with
+  the screen on, a cold start whose first re-sync timed out — is only
+  recoverable through a `turn/list` re-pull.
+- **A replayed `stream/turn/started` no longer wipes the live buffer** for a
+  turn already being tracked (the reconnect replay could re-deliver it right
+  after the seed).
+
+### Fixed — activity cards no longer split a sentence mid-word
+- **Blocks flagged `beforeText` by the bridge** (a parallel/background activity
+  — e.g. a Claude Code subagent's tool — that landed while the main answer was
+  still streaming) are now inserted BEFORE the open text run in the live buffer,
+  so the run keeps extending in place and the Work-log card sits above the
+  paragraph instead of cutting it mid-word. Sequential blocks keep today's
+  arrival-order append (`ContentBlockEvent.beforeText`,
+  `incoming_message_processor.dart`, `_LiveTurn.addBlock`).
+- Tests: +8 → **669** (reopen-race re-seed, replayed turn/started guard,
+  beforeText placement ×2, authoritative finalize ×2, turn/read reconcile,
+  processor flag parsing).
+
 ### Added — smooth thread-delete animation
 - Deleting a conversation now animates the tile out instead of making it vanish
   abruptly. On confirm, the card dims and floats the app's shape-morphing

--- a/uxnanmobile/FOR-DEV.md
+++ b/uxnanmobile/FOR-DEV.md
@@ -52,7 +52,17 @@ connected to live bridge data, validated on-device against a real bridge.
   (per-thread in-memory buffers + `turn/list` re-sync) with a per-thread
   **"Responding…"** activity indicator. Timeline auto-follow yields to manual
   scrolling, stays detached while older content is being read, and resumes at
-  the bottom or through an explicit jump/send action.
+  the bottom or through an explicit jump/send action. **Full mid-turn recovery**:
+  closing/killing the app during a turn and reopening restores everything the
+  agent produced while away — the resync **re-seeds the live buffer
+  unconditionally** from the bridge's accumulated record (which persists before
+  notifying, so replacing never loses data), a resync also fires on **every
+  (re)established connection** (the bridge's catch-up replay window is bounded),
+  the finalized bubble always carries the **authoritative final text**, and every
+  completed turn **reconciles via `turn/read`** so the stored message converges
+  to the bridge's exact text↔work-log interleave. `beforeText`-flagged blocks
+  (parallel/subagent activity) slot before the open text run, never splitting a
+  sentence mid-word.
 - **Message scroll rail** — a reusable, dependency-free right-edge minimap
   (`message_scroll_rail.dart`, one faint tick per user message) that is hidden
   while the timeline sits at the bottom and slides in from the right edge when

--- a/uxnanmobile/lib/application/managers/thread_manager.dart
+++ b/uxnanmobile/lib/application/managers/thread_manager.dart
@@ -14,6 +14,7 @@ import 'package:uxnan/domain/entities/project.dart';
 import 'package:uxnan/domain/entities/thread.dart';
 import 'package:uxnan/domain/enums/approval_decision.dart';
 import 'package:uxnan/domain/enums/approval_mode.dart';
+import 'package:uxnan/domain/enums/connection_phase.dart';
 import 'package:uxnan/domain/enums/message_delivery_state.dart';
 import 'package:uxnan/domain/enums/message_role.dart';
 import 'package:uxnan/domain/enums/system_content_kind.dart';
@@ -45,6 +46,7 @@ class ThreadManager {
     required IMessageRepository messageRepository,
     required Stream<DomainEvent> domainEvents,
     required RpcSend sendRequest,
+    Stream<ConnectionPhase>? connectionPhases,
     String? Function()? foregroundThreadId,
     Uuid? uuid,
     Duration resyncTimeout = const Duration(seconds: 8),
@@ -55,6 +57,7 @@ class ThreadManager {
         _uuid = uuid ?? const Uuid(),
         _resyncTimeout = resyncTimeout {
     _eventsSub = domainEvents.listen(_applyEvent);
+    _phaseSub = connectionPhases?.listen(_onConnectionPhase);
   }
 
   final IThreadRepository _threadRepository;
@@ -138,6 +141,27 @@ class ThreadManager {
   String? _activeThreadId;
   StreamSubscription<List<Message>>? _messagesSub;
   late final StreamSubscription<DomainEvent> _eventsSub;
+  StreamSubscription<ConnectionPhase>? _phaseSub;
+
+  /// Last observed connection phase, to detect transitions INTO connected.
+  ConnectionPhase? _lastPhase;
+
+  /// Re-syncs the active thread every time the channel (re)connects. The
+  /// bridge's catch-up replay is a bounded in-memory window (it evicts old
+  /// frames), so a long disconnection mid-turn can NOT be recovered from the
+  /// stream alone — only a `turn/list` re-pull restores the output produced
+  /// while the phone was away. This also covers the reconnect paths that don't
+  /// go through an app-lifecycle resume (a network blip with the screen on)
+  /// and retries a cold-start resync that timed out while the channel was
+  /// still coming up.
+  void _onConnectionPhase(ConnectionPhase phase) {
+    final was = _lastPhase;
+    _lastPhase = phase;
+    if (phase == ConnectionPhase.connected &&
+        was != ConnectionPhase.connected) {
+      unawaited(resyncActive());
+    }
+  }
 
   /// Reactive list of threads.
   Stream<List<Thread>> get threadsStream => _threadRepository.watchThreads();
@@ -652,15 +676,30 @@ class ThreadManager {
     // message. `activeTurnId` is the bridge's authoritative in-flight state
     // (absent after a bridge restart), so it never resurrects an ended turn.
     final activeTurnId = page.activeTurnId;
-    if (activeTurnId != null && _live[threadId]?.turnId != activeTurnId) {
-      // Seed the live buffer with the partial assistant output the bridge has
-      // already accumulated for this in-flight turn (it stores deltas as they
-      // stream — see AgentManager.#onEvent `appendDelta`), so the text the
-      // agent produced *before* we reconnected isn't lost. Without seeding, the
-      // buffer starts empty and only output that streams *after* the reconnect
-      // shows up — the earlier reply (e.g. "on it, let me check…") silently
-      // vanishes from the bubble even though the bridge still has it.
-      _live[threadId] = _seedLiveTurn(activeTurnId, page.turns);
+    if (activeTurnId != null) {
+      // Rebuild the live buffer from the bridge's accumulated record for this
+      // in-flight turn (it persists every delta/block BEFORE notifying — see
+      // AgentManager.#onEvent — so the snapshot is a superset of everything
+      // already streamed to this phone). Replacing UNCONDITIONALLY — even when
+      // we already track this turnId — is the fix for the reopen race: after a
+      // kill+reopen the first post-reconnect deltas re-create the buffer with
+      // only the new tail, and the old `turnId != activeTurnId` guard then
+      // skipped the seed, silently dropping everything the agent produced
+      // while the app was closed (the bridge's catch-up replay is a bounded
+      // window and cannot cover a long absence). Deltas that arrive after this
+      // snapshot append cleanly to its trailing run; `_finishTurn` +
+      // `_reconcileTurn` converge the final message to the bridge's exact
+      // record either way. The only case that keeps the current buffer is a
+      // snapshot page that doesn't contain the active turn at all (nothing to
+      // seed from).
+      final seeded = _seedLiveTurn(activeTurnId, page.turns);
+      final current = _live[threadId];
+      final tracking = current != null && current.turnId == activeTurnId;
+      if (!tracking ||
+          seeded.segments.isNotEmpty ||
+          seeded.thinking.isNotEmpty) {
+        _live[threadId] = seeded;
+      }
       _setActivity(threadId, ThreadActivity.running);
     }
     await _persistTurns(threadId, page.turns, trackLatestUsage: true);
@@ -1038,6 +1077,7 @@ class ThreadManager {
   Future<void> dispose() async {
     await _eventsSub.cancel();
     await _messagesSub?.cancel();
+    await _phaseSub?.cancel();
     await _timeline.close();
     await _resolvedModels.close();
     await _activity.close();
@@ -1067,7 +1107,13 @@ class ThreadManager {
 
     switch (event) {
       case TurnStartedEvent(:final turnId):
-        _live[threadId] = _LiveTurn(turnId: turnId);
+        // Never wipe a buffer we already hold for this same turn: the bridge
+        // emits `turn/started` once per turn, so a second one can only be the
+        // reconnect catch-up replay re-delivering it — after the re-sync may
+        // have just seeded the buffer with the turn's accumulated output.
+        if (_live[threadId]?.turnId != turnId) {
+          _live[threadId] = _LiveTurn(turnId: turnId);
+        }
         _setActivity(threadId, ThreadActivity.running);
         if (threadId == _activeThreadId) _rebuildActiveTimeline();
       case MessageDeltaEvent(:final turnId, :final delta):
@@ -1076,8 +1122,8 @@ class ThreadManager {
       case ThinkingDeltaEvent(:final turnId, :final delta):
         _ensureLive(threadId, turnId).thinking += delta;
         if (threadId == _activeThreadId) _rebuildActiveTimeline();
-      case ContentBlockEvent(:final turnId, :final content):
-        _ensureLive(threadId, turnId).segments.add(content);
+      case ContentBlockEvent(:final turnId, :final content, :final beforeText):
+        _ensureLive(threadId, turnId).addBlock(content, beforeText: beforeText);
         if (threadId == _activeThreadId) _rebuildActiveTimeline();
       case TurnCompletedEvent(
           :final turnId,
@@ -1095,7 +1141,12 @@ class ThreadManager {
         // A reply landing in a thread the user isn't viewing is unread.
         if (threadId != _foregroundThreadId?.call()) _markUnread(threadId);
         unawaited(
-          _finishTurn(threadId, turnId, failed: false, finalText: text),
+          // After finalizing from the live buffer, reconcile the persisted
+          // message against the bridge's authoritative ordered record — the
+          // live view can be imperfect (a delta in transit during a re-sync, a
+          // re-attach that missed early blocks); the bridge's is not.
+          _finishTurn(threadId, turnId, failed: false, finalText: text)
+              .then((_) => _reconcileTurn(threadId, turnId)),
         );
       case TurnErrorEvent(:final turnId, :final message):
         unawaited(
@@ -1141,26 +1192,40 @@ class ThreadManager {
     final live = _live.remove(threadId);
     _setActivity(threadId, failed ? ThreadActivity.error : ThreadActivity.idle);
     if (live == null) return;
-    // Normally the finalized message is the live buffer's interleaved text +
-    // work-log blocks. But if we re-attached to a turn already in flight
-    // (after reconnecting while backgrounded) the buffer may hold no streamed
-    // text — in that case fall back to the bridge's authoritative final
-    // [finalText] so the bubble is never empty/partial, keeping live blocks.
-    final liveHasText =
-        live.segments.any((c) => c is TextContent && c.text.isNotEmpty);
-    final baseContents =
-        (!liveHasText && finalText != null && finalText.isNotEmpty)
-            ? _assistantContents(
-                finalText,
-                live.thinking,
-                live.segments.where((c) => c is! TextContent).toList(),
-                streaming: false,
-              )
-            : _assistantContentsOrdered(
-                live.thinking,
-                live.segments,
-                streaming: false,
-              );
+    // The finalized message must carry the bridge's AUTHORITATIVE final text
+    // ([finalText], the full answer), never just whatever the live buffer
+    // happened to catch — a buffer rebuilt after a mid-turn reconnect may hold
+    // only the post-reconnect tail. Reconcile the two:
+    //  - buffer text == finalText → the live interleave is complete; keep it.
+    //  - buffer text is a strict PREFIX of finalText → only the tail was
+    //    missed; extend the trailing run so the interleave survives intact.
+    //  - anything else (buffer empty, or it holds only a mid-turn tail) → use
+    //    finalText with the live blocks (blocks-first); `_reconcileTurn` then
+    //    restores the bridge's exact interleave right after.
+    final liveText =
+        live.segments.whereType<TextContent>().map((t) => t.text).join();
+    final List<MessageContent> baseContents;
+    if (finalText == null || finalText.isEmpty || liveText == finalText) {
+      baseContents = _assistantContentsOrdered(
+        live.thinking,
+        live.segments,
+        streaming: false,
+      );
+    } else if (liveText.isNotEmpty && finalText.startsWith(liveText)) {
+      live.appendText(finalText.substring(liveText.length));
+      baseContents = _assistantContentsOrdered(
+        live.thinking,
+        live.segments,
+        streaming: false,
+      );
+    } else {
+      baseContents = _assistantContents(
+        finalText,
+        live.thinking,
+        live.segments.where((c) => c is! TextContent).toList(),
+        streaming: false,
+      );
+    }
     // On a failed turn, surface the bridge's error text as an inline error
     // banner so the user sees *why* the turn ended (e.g. a quota / "usage
     // balance exhausted" error) instead of the "responding…" cue just
@@ -1193,6 +1258,32 @@ class ThreadManager {
       _rebuildActiveTimeline();
     }
     await _messageRepository.saveMessage(finalized);
+  }
+
+  /// Re-pulls one just-completed turn (`turn/read`) and reconciles the locally
+  /// persisted assistant message against the bridge's authoritative record —
+  /// the bridge persists every delta/block in production order BEFORE
+  /// notifying, so its `segments` are exact even when the phone's live view
+  /// was not (output streamed while the app was closed, a delta in transit
+  /// during a re-sync). Runs through [_persistTurns], which rewrites the
+  /// stored message only when content or order actually differs. Best-effort:
+  /// a failure (older bridge, transient drop) keeps the local copy — the next
+  /// thread re-sync repairs it the same way.
+  Future<void> _reconcileTurn(String threadId, String turnId) async {
+    try {
+      final response = await _sendRequest('turn/read', {'turnId': turnId})
+          .timeout(_resyncTimeout);
+      final turn = response.result;
+      if (turn is! Map) return;
+      await _persistTurns(threadId, [turn], trackLatestUsage: false);
+      if (threadId == _activeThreadId) _rebuildActiveTimeline();
+    } on Object catch (error, stackTrace) {
+      AppLogger.warn(
+        'turn/read reconcile failed (kept local)',
+        error,
+        stackTrace,
+      );
+    }
   }
 
   /// Rebuilds the active timeline from persisted messages plus any in-flight
@@ -1436,6 +1527,20 @@ class _LiveTurn {
       segments[segments.length - 1] = TextContent(last.text + delta);
     } else {
       segments.add(TextContent(delta));
+    }
+  }
+
+  /// Adds a structured block. When [beforeText] is set (the block came from a
+  /// parallel/background activity while the main text was still streaming —
+  /// see `ContentBlockEvent.beforeText`) it is inserted BEFORE the trailing
+  /// open text run, so the run is never severed and the next delta keeps
+  /// extending it in place; otherwise it appends in arrival order.
+  void addBlock(MessageContent content, {bool beforeText = false}) {
+    final last = segments.isNotEmpty ? segments.last : null;
+    if (beforeText && last is TextContent) {
+      segments.insert(segments.length - 1, content);
+    } else {
+      segments.add(content);
     }
   }
 }

--- a/uxnanmobile/lib/application/processors/domain_event.dart
+++ b/uxnanmobile/lib/application/processors/domain_event.dart
@@ -80,6 +80,7 @@ class ContentBlockEvent extends DomainEvent {
     required this.turnId,
     required this.content,
     this.threadId,
+    this.beforeText = false,
   });
 
   /// The turn that produced the block.
@@ -91,8 +92,17 @@ class ContentBlockEvent extends DomainEvent {
   /// The decoded content block.
   final MessageContent content;
 
+  /// `true` when the block came from a parallel/background activity (e.g. a
+  /// Claude Code subagent's tool run) while the assistant's main text was
+  /// still streaming: it must be inserted BEFORE the open text run instead of
+  /// appended after it, so the run is never severed (appending would render
+  /// the sentence split mid-word by an activity card). Mirrors the order the
+  /// bridge persists in `Message.segments`, keeping live view and re-sync
+  /// identical.
+  final bool beforeText;
+
   @override
-  List<Object?> get props => [turnId, threadId, content];
+  List<Object?> get props => [turnId, threadId, content, beforeText];
 }
 
 /// A turn finished successfully.

--- a/uxnanmobile/lib/application/processors/incoming_message_processor.dart
+++ b/uxnanmobile/lib/application/processors/incoming_message_processor.dart
@@ -33,8 +33,12 @@ class IncomingMessageProcessor {
           threadId: threadId,
           delta: params['delta'] is String ? params['delta'] as String : '',
         ),
-      'stream/content/block' =>
-        _contentBlock(turnId, threadId, params['content']),
+      'stream/content/block' => _contentBlock(
+          turnId,
+          threadId,
+          params['content'],
+          beforeText: params['beforeText'] == true,
+        ),
       'stream/turn/completed' => TurnCompletedEvent(
           turnId: turnId,
           threadId: threadId,
@@ -72,12 +76,20 @@ class IncomingMessageProcessor {
 
   /// Decodes a `stream/content/block` payload into a [ContentBlockEvent], or an
   /// [UnknownDomainEvent] when the content isn't a decodable block.
-  DomainEvent _contentBlock(String turnId, String? threadId, Object? content) {
+  /// [beforeText] marks a block from a parallel/background activity that must
+  /// be ordered before the open text run (see [ContentBlockEvent.beforeText]).
+  DomainEvent _contentBlock(
+    String turnId,
+    String? threadId,
+    Object? content, {
+    bool beforeText = false,
+  }) {
     if (content is Map) {
       return ContentBlockEvent(
         turnId: turnId,
         threadId: threadId,
         content: MessageContent.fromJson(content.cast<String, dynamic>()),
+        beforeText: beforeText,
       );
     }
     return const UnknownDomainEvent(method: 'stream/content/block');

--- a/uxnanmobile/lib/presentation/providers/application_providers.dart
+++ b/uxnanmobile/lib/presentation/providers/application_providers.dart
@@ -644,6 +644,10 @@ final threadManagerProvider = Provider<ThreadManager>((ref) {
     messageRepository: ref.watch(messageRepositoryProvider),
     domainEvents: processor.bind(coordinator.incomingMessages),
     sendRequest: coordinator.sendRequest,
+    // Every (re)established channel re-syncs the active thread: the bridge's
+    // catch-up replay is a bounded window, so a long disconnection mid-turn is
+    // only recoverable through a `turn/list` re-pull.
+    connectionPhases: coordinator.connectionPhaseStream,
     // A reply in a thread the user isn't viewing is marked unread.
     foregroundThreadId: () => ref.read(foregroundThreadProvider),
   );

--- a/uxnanmobile/test/unit/application/incoming_message_processor_test.dart
+++ b/uxnanmobile/test/unit/application/incoming_message_processor_test.dart
@@ -71,6 +71,33 @@ void main() {
       expect(event, isA<UnknownDomainEvent>());
     });
 
+    test('stream/content/block carries the beforeText placement flag', () {
+      final flagged = processor.classify(
+        note('stream/content/block', {
+          'turnId': 't1',
+          'content': {
+            'type': 'command_execution',
+            'command': 'ls',
+            'status': 'completed',
+          },
+          'beforeText': true,
+        }),
+      ) as ContentBlockEvent;
+      expect(flagged.beforeText, isTrue);
+      // Absent (or non-boolean) → false, the sequential default.
+      final plain = processor.classify(
+        note('stream/content/block', {
+          'turnId': 't1',
+          'content': {
+            'type': 'command_execution',
+            'command': 'ls',
+            'status': 'completed',
+          },
+        }),
+      ) as ContentBlockEvent;
+      expect(plain.beforeText, isFalse);
+    });
+
     test('stream/turn/completed', () {
       final event = processor.classify(
         note('stream/turn/completed', {'turnId': 't1'}),

--- a/uxnanmobile/test/unit/application/thread_manager_test.dart
+++ b/uxnanmobile/test/unit/application/thread_manager_test.dart
@@ -52,6 +52,8 @@ void main() {
   Map<String, dynamic>? turnSendParams;
   // Test-settable `turn/list` result (null → empty, the no-op resync default).
   Object? turnListResult;
+  // Test-settable `turn/read` result (null → empty, the no-op reconcile).
+  Object? turnReadResult;
   late ThreadManager manager;
 
   setUp(() {
@@ -62,6 +64,7 @@ void main() {
     sentMethods = [];
     turnSendParams = null;
     turnListResult = null;
+    turnReadResult = null;
     manager = ThreadManager(
       threadRepository: threadRepo,
       messageRepository: messageRepo,
@@ -71,6 +74,7 @@ void main() {
         if (method == 'turn/send') turnSendParams = params;
         final result = switch (method) {
           'turn/list' => turnListResult ?? <String, dynamic>{},
+          'turn/read' => turnReadResult ?? <String, dynamic>{},
           'thread/list' => [
               {
                 'id': 'th1',
@@ -291,6 +295,307 @@ void main() {
     final finalized =
         manager.timeline.messages.firstWhere((m) => m.id == 'stream-turnZ');
     expect(_text(finalized), 'on it, let me check now');
+  });
+
+  test(
+      'resync re-seeds even when the live turn is already tracked '
+      '(reopen race: post-reconnect deltas arrive before turn/list)', () async {
+    await manager.selectThread('th1');
+    await _settle();
+
+    // After a kill+reopen the first post-reconnect deltas re-create the live
+    // buffer for the in-flight turn — with only the new tail.
+    events
+      ..add(const TurnStartedEvent(turnId: 'turnZ', threadId: 'th1'))
+      ..add(
+        const MessageDeltaEvent(
+          turnId: 'turnZ',
+          threadId: 'th1',
+          delta: 'tail',
+        ),
+      );
+    await _settle();
+
+    // The turn/list re-sync then lands, carrying the bridge's FULL accumulated
+    // record (it persists every delta before notifying, so the snapshot is a
+    // superset of anything already applied). The old guard skipped the seed
+    // because the turnId matched — silently dropping everything produced while
+    // the app was closed. It must re-seed unconditionally.
+    turnListResult = {
+      'turns': [
+        {
+          'id': 'turnZ',
+          'messages': [
+            {'role': 'assistant', 'content': 'head produced while away. tail'},
+          ],
+        },
+      ],
+      'total': 1,
+      'activeTurnId': 'turnZ',
+    };
+    await manager.resyncActive();
+    await _settle();
+
+    final reattached =
+        manager.timeline.messages.firstWhere((m) => m.id == 'stream-turnZ');
+    expect(_text(reattached), 'head produced while away. tail');
+
+    // Later deltas keep extending the re-seeded run in place.
+    events.add(
+      const MessageDeltaEvent(turnId: 'turnZ', threadId: 'th1', delta: ' end'),
+    );
+    await _settle();
+    final streamed =
+        manager.timeline.messages.firstWhere((m) => m.id == 'stream-turnZ');
+    expect(_text(streamed), 'head produced while away. tail end');
+  });
+
+  test('a replayed turn/started never wipes the tracked live buffer', () async {
+    await manager.selectThread('th1');
+    await _settle();
+
+    events
+      ..add(const TurnStartedEvent(turnId: 'turnZ', threadId: 'th1'))
+      ..add(
+        const MessageDeltaEvent(
+          turnId: 'turnZ',
+          threadId: 'th1',
+          delta: 'kept text',
+        ),
+      );
+    await _settle();
+
+    // The reconnect catch-up replay re-delivers the turn's `turn/started`
+    // (the bridge emits it once live; a duplicate can only be the replay). It
+    // must not reset the buffer that may have just been seeded/streamed.
+    events.add(const TurnStartedEvent(turnId: 'turnZ', threadId: 'th1'));
+    await _settle();
+
+    final streaming =
+        manager.timeline.messages.firstWhere((m) => m.id == 'stream-turnZ');
+    expect(_text(streaming), 'kept text');
+  });
+
+  test('a beforeText block lands before the open text run (never severs it)',
+      () async {
+    await manager.selectThread('th1');
+    await _settle();
+
+    events
+      ..add(const TurnStartedEvent(turnId: 'turnB', threadId: 'th1'))
+      ..add(
+        const MessageDeltaEvent(
+          turnId: 'turnB',
+          threadId: 'th1',
+          delta: 'y si re',
+        ),
+      )
+      // A parallel-activity block (e.g. a subagent tool) arrives mid-run,
+      // flagged by the bridge: it must slot BEFORE the open run…
+      ..add(
+        const ContentBlockEvent(
+          turnId: 'turnB',
+          threadId: 'th1',
+          content: CommandExecutionContent(
+            command: 'ls',
+            status: CommandStatus.completed,
+          ),
+          beforeText: true,
+        ),
+      )
+      // …so the next delta keeps extending the same run in place.
+      ..add(
+        const MessageDeltaEvent(
+          turnId: 'turnB',
+          threadId: 'th1',
+          delta: 'porta',
+        ),
+      );
+    await _settle();
+
+    final streaming =
+        manager.timeline.messages.firstWhere((m) => m.id == 'stream-turnB');
+    expect(streaming.contents.length, 2);
+    expect(streaming.contents[0], isA<CommandExecutionContent>());
+    expect(streaming.contents[1], isA<TextContent>());
+    expect((streaming.contents[1] as TextContent).text, 'y si reporta');
+  });
+
+  test('an unflagged block still breaks the run at a real boundary', () async {
+    await manager.selectThread('th1');
+    await _settle();
+
+    events
+      ..add(const TurnStartedEvent(turnId: 'turnB', threadId: 'th1'))
+      ..add(
+        const MessageDeltaEvent(
+          turnId: 'turnB',
+          threadId: 'th1',
+          delta: 'First.',
+        ),
+      )
+      ..add(
+        const ContentBlockEvent(
+          turnId: 'turnB',
+          threadId: 'th1',
+          content: CommandExecutionContent(
+            command: 'ls',
+            status: CommandStatus.completed,
+          ),
+        ),
+      )
+      ..add(
+        const MessageDeltaEvent(
+          turnId: 'turnB',
+          threadId: 'th1',
+          delta: 'Then.',
+        ),
+      );
+    await _settle();
+
+    final streaming =
+        manager.timeline.messages.firstWhere((m) => m.id == 'stream-turnB');
+    expect(streaming.contents.length, 3);
+    expect((streaming.contents[0] as TextContent).text, 'First.');
+    expect(streaming.contents[1], isA<CommandExecutionContent>());
+    expect((streaming.contents[2] as TextContent).text, 'Then.');
+  });
+
+  test(
+      'finalizes with the authoritative text when the live buffer holds only '
+      'a mid-turn tail', () async {
+    await manager.selectThread('th1');
+    await _settle();
+
+    // Re-attached mid-turn without a seed (e.g. the resync failed): the buffer
+    // holds only the post-reconnect tail.
+    events.add(
+      const MessageDeltaEvent(
+        turnId: 'turnT',
+        threadId: 'th1',
+        delta: 'only the tail',
+      ),
+    );
+    await _settle();
+
+    // The completion text is the bridge's FULL answer. The old code preferred
+    // the live buffer whenever it held any text — persisting the truncation
+    // for good. The final bubble must carry the authoritative text.
+    events.add(
+      const TurnCompletedEvent(
+        turnId: 'turnT',
+        threadId: 'th1',
+        text: 'the head the phone never saw, and only the tail',
+      ),
+    );
+    await _settle();
+
+    final finalized =
+        manager.timeline.messages.firstWhere((m) => m.id == 'stream-turnT');
+    final text = finalized.contents.whereType<TextContent>().single;
+    expect(text.text, 'the head the phone never saw, and only the tail');
+  });
+
+  test('finalizing extends the trailing run when the final text adds a tail',
+      () async {
+    await manager.selectThread('th1');
+    await _settle();
+
+    events
+      ..add(const TurnStartedEvent(turnId: 'turnP', threadId: 'th1'))
+      ..add(
+        const MessageDeltaEvent(
+          turnId: 'turnP',
+          threadId: 'th1',
+          delta: 'first ',
+        ),
+      )
+      ..add(
+        const ContentBlockEvent(
+          turnId: 'turnP',
+          threadId: 'th1',
+          content: CommandExecutionContent(
+            command: 'ls',
+            status: CommandStatus.completed,
+          ),
+        ),
+      )
+      ..add(
+        const MessageDeltaEvent(
+          turnId: 'turnP',
+          threadId: 'th1',
+          delta: 'second',
+        ),
+      )
+      // The final text carries a tail the deltas never streamed: the
+      // interleave must survive, with the tail folded onto the trailing run.
+      ..add(
+        const TurnCompletedEvent(
+          turnId: 'turnP',
+          threadId: 'th1',
+          text: 'first second and tail',
+        ),
+      );
+    await _settle();
+
+    final finalized =
+        manager.timeline.messages.firstWhere((m) => m.id == 'stream-turnP');
+    expect(finalized.contents.length, 3);
+    expect((finalized.contents[0] as TextContent).text, 'first ');
+    expect(finalized.contents[1], isA<CommandExecutionContent>());
+    expect((finalized.contents[2] as TextContent).text, 'second and tail');
+  });
+
+  test(
+      'a completed turn reconciles against the bridge record (turn/read) so '
+      'the stored message converges to the authoritative interleave', () async {
+    await manager.selectThread('th1');
+    await _settle();
+
+    // The live view was imperfect: it only caught the tail of the answer.
+    events.add(
+      const MessageDeltaEvent(turnId: 'turnQ', threadId: 'th1', delta: 'Done.'),
+    );
+    await _settle();
+
+    // The bridge's authoritative record for the turn: the full ordered
+    // interleave (text → work log → text).
+    turnReadResult = {
+      'id': 'turnQ',
+      'threadId': 'th1',
+      'status': 'completed',
+      'messages': [
+        {
+          'role': 'assistant',
+          'content': 'Let me check.Done.',
+          'segments': [
+            {'type': 'text', 'text': 'Let me check.'},
+            {
+              'type': 'command_execution',
+              'command': 'ls',
+              'status': 'completed',
+            },
+            {'type': 'text', 'text': 'Done.'},
+          ],
+        },
+      ],
+    };
+    events.add(
+      const TurnCompletedEvent(
+        turnId: 'turnQ',
+        threadId: 'th1',
+        text: 'Let me check.Done.',
+      ),
+    );
+    await _settle();
+
+    expect(sentMethods, contains('turn/read'));
+    final repaired =
+        manager.timeline.messages.firstWhere((m) => m.id == 'stream-turnQ');
+    expect(repaired.contents.length, 3);
+    expect((repaired.contents[0] as TextContent).text, 'Let me check.');
+    expect(repaired.contents[1], isA<CommandExecutionContent>());
+    expect((repaired.contents[2] as TextContent).text, 'Done.');
   });
 
   test('resync renders history segments interleaved (work log inline)',


### PR DESCRIPTION
## Problem

Two related conversation-integrity bugs, reproduced with a real session (`b11b84c3…`, thread *Add Antigravity - Mobile*):

1. **Output produced while the app was closed was lost.** Closing/killing the app mid-turn and reopening re-attached the streaming view, but only output produced *after* the reconnect showed. The bridge had the FULL turn persisted (355 ordered segments in `threads.json`) — the loss was a phone-side race: the first post-reconnect deltas re-created the live buffer with only the new tail, the resync seed guard (`turnId != activeTurnId`) then saw a match and **skipped seeding**, and `_finishTurn` persisted the truncation for good. The transport catch-up replay (bounded 500-frame / 10 MiB window) cannot cover a long absence.
2. **Activity cards split sentences mid-word** (`…y si re` │ *Work log · Read* │ `porta uso de tokens…`). The CLI's own session log shows the paragraph intact — the corruption was born in the bridge: with parallel Task subagents, `claude --output-format stream-json` interleaves subagent lines (`parent_tool_use_id`) with main-loop text deltas, and the adapter appended their tool blocks mid-run, severing the open text run in `Message.segments` and in the live view.

## Fix (root-cause, agent-agnostic)

**Contract (`shared/`)** — additive `ContentBlockParams.beforeText`: a block from a parallel/background activity that lands while the main text is streaming must be inserted **before** the open text run, never splitting it. Spec: `architecture/02b` §1.4 + `turn/list` recovery semantics.

**Bridge** — the Claude adapter now recognizes `parent_tool_use_id` and `content_block_start/stop` boundaries, tracks whether a main text run is open, and flags mid-run blocks `beforeText` (applied identically by `ThreadStore.appendBlock` and on the wire, so live and re-synced order always match). Subagent text/usage no longer folds into the main message; subagent tools still feed the Work log. `reconcileSegmentsWithText` preserves the interleave when the completion text merely extends the streamed deltas.

**Mobile** — the bridge is the source of truth and the phone converges to it:
- `_resyncThread` re-seeds the live buffer **unconditionally** from the accumulated `turn/list` record (the bridge persists before notifying, so the snapshot is a superset of anything already applied — replacing never loses data).
- A resync also fires on **every (re)established connection**, covering reconnects without an app-lifecycle resume and cold starts whose first resync timed out.
- The finalized bubble always carries the **authoritative final text**; every completed turn reconciles best-effort via `turn/read`, so the stored conversation converges to the bridge's exact text↔work-log interleave.
- A replayed `stream/turn/started` no longer wipes a tracked buffer; `beforeText` blocks insert before the open run.

A previously-truncated stored message self-repairs on the next thread open (the resync rewrite path replaces it with the bridge's full record).

## How was it tested?

- `bridge`: `tsc` clean, **482/482** tests (+7 new: subagent parsing/flagging, store placement, completion-tail reconcile, wire flag end-to-end). Prettier clean.
- `shared` / `relay`: build + suites green.
- `uxnanmobile`: `dart analyze` no issues, `dart format` clean, **669/669** tests (+8 new, including the exact reopen-race regression).
- Diagnosis validated against the real persisted bridge store and the CLI's own session jsonl (ground truth for event order).

## Docs (same change set)

- `shared/CHANGELOG.md`, `bridge/CHANGELOG.md`, `uxnanmobile/CHANGELOG.md` (`[Unreleased]`).
- `architecture/02b-contracts-and-requirements.md`: `stream/content/block` signature + `beforeText` note; `turn/list` recovery semantics.
- `bridge/FOR-DEV.md` / `uxnanmobile/FOR-DEV.md` `## Status` refreshed. The pre-existing on-disk history-fallback item (blocks-first after a lost `threads.json`) remains open and is unchanged by this PR.