### PR TITLE
feat(desktop): show progress for async actions

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Changed — asynchronous actions now show in-place progress
+
+- Added the shadcn-svelte `Spinner` primitive and a consistent pending-action
+  pattern: the control that started a longer filesystem, Git, GitHub, agent-hook,
+  theme, or project operation is disabled, keeps a stable compact footprint, and
+  shows an inline spinner with its existing localized progress label.
+- Applied the pattern to shared destructive confirmations and the create, add,
+  rename, save, import, stage/unstage, commit, push/pull, hook-management, and
+  GitHub action surfaces. Multi-action views now retain the pending operation's
+  identity so unrelated disabled controls do not appear to be running too.
+
 ## [0.0.18] - 2026-07-19
 
 ### Fixed — agent session resume now works end-to-end
@@ -207,7 +218,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   risked closing the whole dialog) to dismiss it; reopen the picker to add more.
   Implemented as an opt-in `closeOnSelect` on the shared `MultiSelect` component,
   enabled by `LauncherDialog`.
-
 ### Security — main-window CSP + an http(s)-only integrated browser (defense-in-depth)
 
 Two layered-defense hardenings around the webviews. Neither closes an active

--- a/uxnandesktop/docs/design-tokens.md
+++ b/uxnandesktop/docs/design-tokens.md
@@ -103,6 +103,36 @@ on top of the base.
   (`icon.decorative`) is lighter than an icon inside a clickable button
   (`icon.button`).
 
+## Asynchronous action feedback
+
+Actions that wait for filesystem, Git, GitHub, agent, or other backend I/O use
+the shared shadcn-svelte `Spinner` inside the control that started the work:
+
+```svelte
+<script lang="ts">
+  import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
+  import { i18n } from "$lib/i18n";
+</script>
+
+<Button disabled={saving} onclick={save}>
+  {#if saving}
+    <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+  {/if}
+  {saving ? i18n.t("editor.saving") : i18n.t("editor.save")}
+</Button>
+```
+
+- Disable the initiating control while its promise is pending and keep the
+  existing localized action/progress label visible; motion alone is not enough.
+- Track an operation id when several actions share one busy gate, so only the
+  initiating control shows the spinner (`push` vs. `pull`, a specific file, or a
+  specific install/uninstall action).
+- Use `data-icon="inline-start"` in text buttons. In icon-only controls, replace
+  the action glyph with `Spinner` so dimensions stay stable.
+- Keep immediate UI-only actions (selection, navigation, opening a dialog) free
+  of spinners. Loading feedback is for work whose completion the user waits for.
+
 ## Adding/changing a token
 Edit `src/lib/design.ts` (and this table). Because components reference the
 tokens, the change applies everywhere consistently.

--- a/uxnandesktop/src/lib/components/AddProjectDialog.svelte
+++ b/uxnandesktop/src/lib/components/AddProjectDialog.svelte
@@ -6,6 +6,7 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
   import { Checkbox } from "$lib/components/ui/checkbox";
+  import { Spinner } from "$lib/components/ui/spinner";
   import Kbd from "./Kbd.svelte";
   import { projects } from "$lib/state/projects.svelte";
   import { cn } from "$lib/utils";
@@ -33,7 +34,7 @@
 
   /** Paths ticked to be added as separate projects. */
   let selected = $state<Set<string>>(new Set());
-  let busy = $state(false);
+  let busy = $state<"parent" | "selected" | null>(null);
   let error = $state<string | null>(null);
 
   // Seed the selection each time the dialog opens: pre-check the git repos (the
@@ -43,7 +44,7 @@
     if (open) {
       selected = new Set(entries.filter((e) => e.isRepo).map((e) => e.path));
       error = null;
-      busy = false;
+      busy = null;
     }
   });
 
@@ -63,10 +64,10 @@
   }
 
   async function addParent() {
-    busy = true;
+    busy = "parent";
     error = null;
     const ok = await projects.addProjectPath(folderPath);
-    busy = false;
+    busy = null;
     if (ok) {
       open = false;
       onadded?.();
@@ -77,12 +78,12 @@
 
   async function addSelected() {
     if (selectedCount === 0) return;
-    busy = true;
+    busy = "selected";
     error = null;
     // Preserve the listing order for a predictable result.
     const paths = entries.filter((e) => selected.has(e.path)).map((e) => e.path);
     const { added } = await projects.addProjectPaths(paths);
-    busy = false;
+    busy = null;
     if (added > 0) {
       open = false;
       onadded?.();
@@ -181,11 +182,17 @@
         </span>
       </div>
       <div class="flex shrink-0 items-center gap-2">
-        <Button variant="outline" size="sm" disabled={busy} onclick={addParent}>
+        <Button variant="outline" size="sm" disabled={busy !== null} onclick={addParent}>
+          {#if busy === "parent"}
+            <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+          {/if}
           {i18n.t("addProject.addParent")}
         </Button>
-        <Button size="sm" disabled={busy || selectedCount === 0} onclick={addSelected}>
-          {busy
+        <Button size="sm" disabled={busy !== null || selectedCount === 0} onclick={addSelected}>
+          {#if busy === "selected"}
+            <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+          {/if}
+          {busy === "selected"
             ? i18n.t("common.adding")
             : i18n.t("addProject.addSelected", { count: String(selectedCount) })}
         </Button>

--- a/uxnandesktop/src/lib/components/AgentHooksPanel.svelte
+++ b/uxnandesktop/src/lib/components/AgentHooksPanel.svelte
@@ -16,6 +16,7 @@
   import * as Collapsible from "$lib/components/ui/collapsible";
   import * as Tabs from "$lib/components/ui/tabs";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Badge } from "$lib/components/ui/badge";
   import { Switch } from "$lib/components/ui/switch";
   import * as Card from "$lib/components/ui/card";
@@ -121,6 +122,7 @@
     pi: null,
   });
   let busy = $state<AgentId | "all" | null>(null);
+  let busyOperation = $state<"install" | "uninstall" | null>(null);
   let activeAgent = $state<AgentId>("claude");
   // Per-agent "show installed config" toggle (JSON for Claude/Gemini/Codex, the
   // plugin/extension source for OpenCode/Pi).
@@ -190,6 +192,7 @@
 
   async function doInstall(id: AgentId) {
     busy = id;
+    busyOperation = "install";
     try {
       statuses = { ...statuses, [id]: await INSTALLERS[id]() };
     } catch (err) {
@@ -204,11 +207,13 @@
       };
     } finally {
       busy = null;
+      busyOperation = null;
     }
   }
 
   async function doUninstall(id: AgentId) {
     busy = id;
+    busyOperation = "uninstall";
     try {
       statuses = { ...statuses, [id]: await UNINSTALLERS[id]() };
     } catch (err) {
@@ -223,6 +228,7 @@
       };
     } finally {
       busy = null;
+      busyOperation = null;
     }
   }
 
@@ -233,10 +239,12 @@
     void app.persistSettings();
     if (on) {
       busy = "all";
+      busyOperation = "install";
       try {
         await installAllHooks();
       } finally {
         busy = null;
+        busyOperation = null;
       }
       await refreshAll();
     } else {
@@ -356,6 +364,7 @@
         </div>
         <div class="flex shrink-0 items-center gap-2 pt-0.5">
           {#if busy === "all"}
+            <Spinner aria-label={i18n.t("common.loading")} />
             <span class={text.meta}>{i18n.t("hooks.installing")}</span>
           {/if}
           <Switch
@@ -416,6 +425,9 @@
                   disabled={busy !== null || !featureOn}
                   onclick={() => doInstall(id)}
                 >
+                  {#if busy === id && busyOperation === "install"}
+                    <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                  {/if}
                   {busy === id ? i18n.t("hooks.installing") : i18n.t("hooks.install")}
                 </Button>
                 <Button
@@ -424,6 +436,9 @@
                   disabled={busy !== null || !statusFor(id)?.installed}
                   onclick={() => doUninstall(id)}
                 >
+                  {#if busy === id && busyOperation === "uninstall"}
+                    <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                  {/if}
                   {i18n.t("hooks.uninstall")}
                 </Button>
                 {#if !featureOn && !degraded}

--- a/uxnandesktop/src/lib/components/AgentProfileEditor.svelte
+++ b/uxnandesktop/src/lib/components/AgentProfileEditor.svelte
@@ -2,6 +2,7 @@
   import { untrack } from "svelte";
   import { Input } from "$lib/components/ui/input";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import * as Select from "$lib/components/ui/select";
   import { app } from "$lib/state/app.svelte";
   import { agentLogoKey } from "$lib/agentCatalog";
@@ -65,6 +66,7 @@
 
   // Custom logo: pick an image, store it inline (data URL) on `agent.icon`.
   let fileInput = $state<HTMLInputElement>();
+  let processingLogo = $state(false);
   const hasCustomLogo = $derived(isCustomLogo(agent.icon));
 
   async function onPickLogo(e: Event) {
@@ -72,11 +74,14 @@
     const file = input.files?.[0];
     input.value = ""; // allow re-picking the same file
     if (!file) return;
+    processingLogo = true;
     try {
       agent.icon = await fileToLogoDataUrl(file);
       onchange();
     } catch {
       // Ignore an unreadable/non-image file.
+    } finally {
+      processingLogo = false;
     }
   }
 
@@ -97,9 +102,14 @@
             type="button"
             class="flex size-7 items-center justify-center rounded-md border border-border/60 hover:bg-accent/50"
             aria-label={i18n.t("agentEditor.chooseLogo")}
+            disabled={processingLogo}
             onclick={() => fileInput?.click()}
           >
-            <AgentLogo logo={agentLogoKey(agent.icon, agent.command)} />
+            {#if processingLogo}
+              <Spinner aria-label={i18n.t("common.loading")} />
+            {:else}
+              <AgentLogo logo={agentLogoKey(agent.icon, agent.command)} />
+            {/if}
           </button>
         {/snippet}
       </TooltipSimple>

--- a/uxnandesktop/src/lib/components/ChangesPanel.svelte
+++ b/uxnandesktop/src/lib/components/ChangesPanel.svelte
@@ -3,6 +3,7 @@
   // per-file stage / unstage / discard, a commit composer, push/pull, and a diff
   // viewer. Status updates live via the backend `git:status-changed` event.
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Switch } from "$lib/components/ui/switch";
   import { Textarea } from "$lib/components/ui/textarea";
   import { Input } from "$lib/components/ui/input";
@@ -207,7 +208,11 @@
                 void git.unstage(f.path);
               }}
             >
-              <MinusIcon class={icon.button} />
+              {#if git.busyAction?.kind === "unstage" && git.busyAction.file === f.path}
+                <Spinner aria-label={i18n.t("common.loading")} />
+              {:else}
+                <MinusIcon class={icon.button} />
+              {/if}
             </Button>
           {/snippet}
         </TooltipSimple>
@@ -225,7 +230,11 @@
                 void git.stage(f.path);
               }}
             >
-              <PlusIcon class={icon.button} />
+              {#if git.busyAction?.kind === "stage" && git.busyAction.file === f.path}
+                <Spinner aria-label={i18n.t("common.loading")} />
+              {:else}
+                <PlusIcon class={icon.button} />
+              {/if}
             </Button>
           {/snippet}
         </TooltipSimple>
@@ -249,6 +258,9 @@
       disabled={git.busy}
       onclick={() => void (area === "staged" ? git.unstageAll() : git.stageAll())}
     >
+      {#if git.busyAction?.kind === (area === "staged" ? "unstage" : "stage") && git.busyAction.file === "*"}
+        <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+      {/if}
       {area === "staged" ? i18n.t("rightPanel.unstageAll") : i18n.t("rightPanel.stageAll")}
     </Button>
   </div>
@@ -345,10 +357,11 @@
                 disabled={git.aiGenerating || git.committing}
                 onclick={() => void git.generateMessage()}
               >
-                <SparklesIcon
-                  data-icon="inline-start"
-                  class={cn(git.aiGenerating && "animate-pulse")}
-                />
+                {#if git.aiGenerating}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <SparklesIcon data-icon="inline-start" />
+                {/if}
                 {git.aiGenerating ? i18n.t("rightPanel.generating") : i18n.t("rightPanel.generateAi")}
               </Button>
             {/snippet}
@@ -452,7 +465,11 @@
         disabled={!canCommit}
         onclick={() => void git.commit()}
       >
-        <GitCommitIcon data-icon="inline-start" />
+        {#if git.committing}
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+        {:else}
+          <GitCommitIcon data-icon="inline-start" />
+        {/if}
         {git.committing
           ? i18n.t("rightPanel.committing")
           : git.amend
@@ -472,7 +489,11 @@
                 disabled={git.syncing || git.behind === 0}
                 onclick={() => void git.pull()}
               >
-                <ArrowDownIcon data-icon="inline-start" />
+                {#if git.syncingAction === "pull"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <ArrowDownIcon data-icon="inline-start" />
+                {/if}
                 {i18n.t("rightPanel.pull")}
                 {#if git.behind > 0}<span class={text.indicator}>{git.behind}</span>{/if}
               </Button>
@@ -488,7 +509,11 @@
                 disabled={git.syncing || git.ahead === 0}
                 onclick={() => void git.push()}
               >
-                <ArrowUpIcon data-icon="inline-start" />
+                {#if git.syncingAction === "push"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <ArrowUpIcon data-icon="inline-start" />
+                {/if}
                 {i18n.t("rightPanel.push")}
                 {#if git.ahead > 0}<span class={text.indicator}>{git.ahead}</span>{/if}
               </Button>

--- a/uxnandesktop/src/lib/components/ConfirmDialog.svelte
+++ b/uxnandesktop/src/lib/components/ConfirmDialog.svelte
@@ -6,6 +6,7 @@
   // open (e.g. a remove that failed and now offers a force option).
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { i18n } from "$lib/i18n";
   import { cn } from "$lib/utils";
   import { icon, text } from "$lib/design";
@@ -84,8 +85,11 @@
     {/if}
 
     <Dialog.Footer class="min-w-0">
-      <Button variant="ghost" onclick={cancel}>{i18n.t("common.cancel")}</Button>
+      <Button variant="ghost" disabled={busy} onclick={cancel}>{i18n.t("common.cancel")}</Button>
       <Button variant={danger ? "destructive" : "default"} disabled={busy} onclick={confirm}>
+        {#if busy}
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+        {/if}
         {confirmLabel}
       </Button>
     </Dialog.Footer>

--- a/uxnandesktop/src/lib/components/CreatePrForm.svelte
+++ b/uxnandesktop/src/lib/components/CreatePrForm.svelte
@@ -19,12 +19,12 @@
   import type { PrBranches } from "$lib/types";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Textarea } from "$lib/components/ui/textarea";
   import { Switch } from "$lib/components/ui/switch";
   import Combobox, { type ComboGroup } from "./Combobox.svelte";
   import ConfirmDialog from "./ConfirmDialog.svelte";
   import SparklesIcon from "@lucide/svelte/icons/sparkles";
-  import LoaderIcon from "@lucide/svelte/icons/loader-circle";
   import GitBranchIcon from "@lucide/svelte/icons/git-branch";
   import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
 
@@ -232,7 +232,7 @@
         onclick={draftBody}
       >
         {#if aiDrafting}
-          <LoaderIcon class="size-3 animate-spin" />
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
         {:else}
           <SparklesIcon class="size-3" />
         {/if}
@@ -248,7 +248,12 @@
     {#if onCancel}
       <Button variant="ghost" size="sm" onclick={onCancel}>{i18n.t("common.cancel")}</Button>
     {/if}
-    <Button size="sm" disabled={!canSubmit} onclick={submit}>{i18n.t("github.pr.create")}</Button>
+    <Button size="sm" disabled={!canSubmit} onclick={submit}>
+      {#if busy}
+        <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+      {/if}
+      {i18n.t("github.pr.create")}
+    </Button>
   </div>
 </div>
 

--- a/uxnandesktop/src/lib/components/DirectoryPicker.svelte
+++ b/uxnandesktop/src/lib/components/DirectoryPicker.svelte
@@ -2,6 +2,7 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { browseDirs } from "$lib/api";
   import { projects } from "$lib/state/projects.svelte";
   import { cn } from "$lib/utils";
@@ -23,7 +24,7 @@
   let pathInput = $state("");
   let loading = $state(false);
   let error = $state<string | null>(null);
-  let busy = $state(false);
+  let busyPath = $state<string | null>(null);
   /** Highlighted sub-folder index, for keyboard navigation. */
   let activeIdx = $state(0);
   /** The scroll region, so the active row can be kept in view. */
@@ -80,7 +81,7 @@
    *  ↑/↓ move the highlight, Enter opens the highlighted folder (or a typed path),
    *  Mod+Enter runs the primary "add this folder" action. */
   function onDialogKey(e: KeyboardEvent) {
-    if (busy || loading) return;
+    if (busyPath || loading) return;
     const entries = listing?.entries ?? [];
     const mod = e.metaKey || e.ctrlKey;
 
@@ -114,15 +115,15 @@
       if (!listing) void go(undefined);
     } else {
       error = null;
-      busy = false;
+      busyPath = null;
     }
   });
 
   /** Add a single folder as a project (the per-row "Add" action). */
   async function add(path: string) {
-    busy = true;
+    busyPath = path;
     const ok = await projects.addProjectPath(path);
-    busy = false;
+    busyPath = null;
     if (ok) open = false;
     else error = projects.error;
   }
@@ -195,7 +196,10 @@
          flagged with a git-folder icon and a quiet primary tag, plus a hover Add. -->
     <div bind:this={listEl} class="uxnan-scroll h-64 overflow-y-auto p-2">
       {#if loading}
-        <div class={cn("py-10 text-center", text.meta)}>{i18n.t("common.loading")}</div>
+        <div class={cn("flex items-center justify-center gap-2 py-10", text.meta)}>
+          <Spinner aria-label={i18n.t("common.loading")} />
+          {i18n.t("common.loading")}
+        </div>
       {:else if listing && listing.entries.length === 0}
         <div class="flex flex-col items-center gap-2.5 py-10 text-center">
           <FolderIcon class="size-6 text-muted-foreground/40" />
@@ -239,10 +243,15 @@
               variant={entry.isRepo ? "secondary" : "ghost"}
               size="sm"
               class="h-7 shrink-0 px-2.5 text-[11px] opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
-              disabled={busy}
+              disabled={busyPath !== null}
               onclick={() => add(entry.path)}
             >
-              {i18n.t("common.add")}
+              {#if busyPath === entry.path}
+                <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {i18n.t("common.adding")}
+              {:else}
+                {i18n.t("common.add")}
+              {/if}
             </Button>
           </div>
         {/each}
@@ -277,8 +286,13 @@
         </span>
       </div>
       <div class="flex shrink-0 items-center gap-2">
-        <Button size="sm" disabled={!listing || busy} onclick={addFolder}>
-          {busy ? i18n.t("common.adding") : i18n.t("picker.addFolder")}
+        <Button size="sm" disabled={!listing || busyPath !== null} onclick={addFolder}>
+          {#if listing && busyPath === listing.path}
+            <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+          {/if}
+          {listing && busyPath === listing.path
+            ? i18n.t("common.adding")
+            : i18n.t("picker.addFolder")}
         </Button>
       </div>
     </div>

--- a/uxnandesktop/src/lib/components/FileNamePromptDialog.svelte
+++ b/uxnandesktop/src/lib/components/FileNamePromptDialog.svelte
@@ -6,6 +6,7 @@
   // the field re-seeds from `initial` each time it opens.
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Input } from "$lib/components/ui/input";
   import { cn } from "$lib/utils";
   import { text } from "$lib/design";
@@ -126,7 +127,12 @@
     </div>
 
     <Dialog.Footer>
-      <Button disabled={!canSubmit} onclick={submit}>{submitLabel}</Button>
+      <Button disabled={!canSubmit} onclick={submit}>
+        {#if busy}
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+        {/if}
+        {submitLabel}
+      </Button>
     </Dialog.Footer>
   </Dialog.Content>
 </Dialog.Root>

--- a/uxnandesktop/src/lib/components/FileTabView.svelte
+++ b/uxnandesktop/src/lib/components/FileTabView.svelte
@@ -14,6 +14,7 @@
   import { cn } from "$lib/utils";
   import { icon, text } from "$lib/design";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { TooltipSimple } from "$lib/components/ui/tooltip";
   import { i18n } from "$lib/i18n";
   import FileEditor from "./FileEditor.svelte";
@@ -122,7 +123,11 @@
             disabled={!fileState.dirty || fileState.saving}
             onclick={() => void fileState.save(fileState.content)}
           >
-            <SaveIcon data-icon="inline-start" />
+            {#if fileState.saving}
+              <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+            {:else}
+              <SaveIcon data-icon="inline-start" />
+            {/if}
             {fileState.saving ? i18n.t("editor.saving") : i18n.t("editor.save")}
           </Button>
         {/snippet}

--- a/uxnandesktop/src/lib/components/GitHub.svelte
+++ b/uxnandesktop/src/lib/components/GitHub.svelte
@@ -56,6 +56,7 @@
   import { splitCommitDiff } from "$lib/diffParse";
   import { relTimeLong } from "$lib/relTime";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Input } from "$lib/components/ui/input";
   import { Textarea } from "$lib/components/ui/textarea";
   import { Switch } from "$lib/components/ui/switch";
@@ -160,6 +161,7 @@
   }
   let runsBranchOnly = $state(false);
   let busy = $state(false);
+  let busyAction = $state<string | null>(null);
 
   function clearDetail() {
     prDetail = null;
@@ -256,6 +258,7 @@
     const n = kind === "pr" ? prDetail?.number : issueDetail?.number;
     if (!p || n === undefined || !editTitle.trim()) return;
     busy = true;
+    busyAction = "edit";
     try {
       const edit = kind === "pr" ? githubPrEdit : githubIssueEdit;
       await edit(p, String(n), editTitle.trim(), editBody);
@@ -272,6 +275,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
   // The PR timeline (comments + reviews + commits + events). Loaded separately from
@@ -299,6 +303,7 @@
     const p = path();
     if (!p || !prDetail || !commentBody.trim()) return;
     busy = true;
+    busyAction = "pr-comment";
     try {
       await githubPrComment(p, String(prDetail.number), commentBody.trim());
       commentBody = "";
@@ -308,6 +313,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -368,6 +374,7 @@
     const p = path();
     if (!p || !prDetail) return;
     busy = true;
+    busyAction = `pr-review-${verb}`;
     try {
       await githubPrReview(p, String(prDetail.number), verb, reviewBody.trim() || null);
       reviewBody = "";
@@ -377,6 +384,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -454,10 +462,15 @@
    *  the actions whose whole job is to answer something the merge panel says —
    *  "update it before merging", "auto-merge is on", "this is a draft" — so each
    *  one lands back on a panel that reflects the new state. */
-  async function prAction(fn: (p: string, n: string) => Promise<void>, toastKey: MessageKey) {
+  async function prAction(
+    fn: (p: string, n: string) => Promise<void>,
+    toastKey: MessageKey,
+    action: string = toastKey,
+  ) {
     const p = path();
     if (!p || !prDetail) return;
     busy = true;
+    busyAction = action;
     try {
       await fn(p, String(prDetail.number));
       toast.success(i18n.t(toastKey));
@@ -467,6 +480,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -482,6 +496,7 @@
     const p = path();
     if (!p || !prDetail) return false;
     busy = true;
+    busyAction = opts.admin ? "merge-admin" : opts.auto ? "merge-auto" : "merge";
     try {
       await githubPrMerge(p, String(prDetail.number), {
         method: mergeMethod,
@@ -505,6 +520,7 @@
       return false;
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -513,6 +529,7 @@
     const p = path();
     if (!p || !prDetail) return;
     busy = true;
+    busyAction = "pr-state";
     const open = prDetail.state.toUpperCase() === "OPEN";
     try {
       if (open) await githubPrClose(p, String(prDetail.number));
@@ -524,6 +541,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -597,6 +615,7 @@
     const p = path();
     if (!p || !issueDetail || !issueCommentBody.trim()) return;
     busy = true;
+    busyAction = "issue-comment";
     try {
       await githubIssueComment(p, String(issueDetail.number), issueCommentBody.trim());
       issueCommentBody = "";
@@ -606,6 +625,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -614,6 +634,7 @@
     const p = path();
     if (!p || !issueDetail) return;
     busy = true;
+    busyAction = "issue-state";
     const open = issueDetail.state.toUpperCase() === "OPEN";
     try {
       if (open) await githubIssueClose(p, String(issueDetail.number));
@@ -625,6 +646,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -662,6 +684,7 @@
     const p = path();
     if (!p || !newIssueTitle.trim()) return;
     busy = true;
+    busyAction = "issue-create";
     try {
       const url = await githubIssueCreate(
         p,
@@ -682,6 +705,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -698,6 +722,7 @@
       .filter(Boolean);
     if (logins.length === 0) return;
     busy = true;
+    busyAction = "reviewers";
     try {
       await githubPrAddReviewers(p, String(prDetail.number), logins);
       reviewerInput = "";
@@ -707,6 +732,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -739,6 +765,7 @@
     const p = path();
     if (!p) return;
     busy = true;
+    busyAction = failed ? "run-rerun-failed" : "run-rerun";
     try {
       await githubRunRerun(p, String(id), failed);
       toast.success(i18n.t("github.toast.rerun"));
@@ -746,6 +773,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -753,6 +781,7 @@
     const p = path();
     if (!p) return;
     busy = true;
+    busyAction = "run-cancel";
     try {
       await githubRunCancel(p, String(id));
       toast.success(i18n.t("github.toast.cancelled"));
@@ -761,6 +790,7 @@
       toastError(e);
     } finally {
       busy = false;
+      busyAction = null;
     }
   }
 
@@ -1289,6 +1319,9 @@
     <div class="flex justify-end gap-2">
       <Button variant="ghost" size="sm" onclick={() => (editOpen = false)}>{i18n.t("common.cancel")}</Button>
       <Button size="sm" disabled={busy || !editTitle.trim()} onclick={() => saveEdit(kind)}>
+        {#if busyAction === "edit"}
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+        {/if}
         {i18n.t("common.save")}
       </Button>
     </div>
@@ -1725,6 +1758,9 @@
                 onkeydown={(e) => e.key === "Enter" && requestReviewers()}
               />
               <Button variant="outline" size="sm" class="h-7" disabled={busy || !reviewerInput.trim()} onclick={requestReviewers}>
+                {#if busyAction === "reviewers"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {/if}
                 {i18n.t("github.pr.addReviewer")}
               </Button>
             </div>
@@ -1856,7 +1892,12 @@
         <div class="space-y-2">
           <Textarea placeholder={i18n.t("github.pr.commentPlaceholder")} bind:value={commentBody} rows={2} />
           <div class="flex flex-wrap items-center gap-2">
-            <Button size="sm" disabled={busy || !commentBody.trim()} onclick={postComment}>{i18n.t("github.pr.postComment")}</Button>
+            <Button size="sm" disabled={busy || !commentBody.trim()} onclick={postComment}>
+              {#if busyAction === "pr-comment"}
+                <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+              {/if}
+              {i18n.t("github.pr.postComment")}
+            </Button>
             <div class="flex-1"></div>
             <Button variant="outline" size="sm" disabled={busy} onclick={() => requestWorktree("pr", pr.number, pr.title)}>
               <GitBranchIcon class={icon.button} />{i18n.t("github.pr.checkout")}
@@ -1865,20 +1906,40 @@
                  nothing in the app could take it out of draft. -->
             {#if isOpen && pr.isDraft}
               <Button variant="outline" size="sm" disabled={busy} class="gap-1" onclick={() => prAction((p, n) => githubPrReady(p, n, false), "github.toast.prReady")}>
-                <CheckIcon class="size-3.5" />{i18n.t("github.pr.markReady")}
+                {#if busyAction === "github.toast.prReady"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <CheckIcon data-icon="inline-start" />
+                {/if}
+                {i18n.t("github.pr.markReady")}
               </Button>
             {:else if isOpen}
               <Button variant="ghost" size="sm" disabled={busy} class="gap-1" title={i18n.t("github.pr.markDraftTip")} onclick={() => prAction((p, n) => githubPrReady(p, n, true), "github.toast.prDrafted")}>
-                <GitPullRequestDraftIcon class="size-3.5" />{i18n.t("github.pr.markDraft")}
+                {#if busyAction === "github.toast.prDrafted"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <GitPullRequestDraftIcon data-icon="inline-start" />
+                {/if}
+                {i18n.t("github.pr.markDraft")}
               </Button>
             {/if}
             {#if isOpen}
               <Button variant="outline" size="sm" disabled={busy} class="gap-1 text-red-600 dark:text-red-400" onclick={togglePrState}>
-                <CircleSlashIcon class="size-3.5" />{i18n.t("github.pr.close")}
+                {#if busyAction === "pr-state"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <CircleSlashIcon data-icon="inline-start" />
+                {/if}
+                {i18n.t("github.pr.close")}
               </Button>
             {:else if isClosed}
               <Button variant="outline" size="sm" disabled={busy} onclick={togglePrState}>
-                <CircleDotIcon class="size-3.5" />{i18n.t("github.pr.reopen")}
+                {#if busyAction === "pr-state"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <CircleDotIcon data-icon="inline-start" />
+                {/if}
+                {i18n.t("github.pr.reopen")}
               </Button>
             {/if}
           </div>
@@ -1890,12 +1951,25 @@
             <Textarea placeholder={i18n.t("github.pr.reviewBody")} bind:value={reviewBody} rows={2} />
             <div class="flex flex-wrap gap-2">
               <Button variant="outline" size="sm" disabled={busy} class="gap-1 text-emerald-600 dark:text-emerald-400" onclick={() => submitReview("approve")}>
-                <CheckIcon class="size-3.5" /> {i18n.t("github.pr.approve")}
+                {#if busyAction === "pr-review-approve"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <CheckIcon data-icon="inline-start" />
+                {/if}
+                {i18n.t("github.pr.approve")}
               </Button>
               <Button variant="outline" size="sm" disabled={busy} class="gap-1 text-red-600 dark:text-red-400" onclick={() => submitReview("request-changes")}>
-                <XIcon class="size-3.5" /> {i18n.t("github.pr.requestChanges")}
+                {#if busyAction === "pr-review-request-changes"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <XIcon data-icon="inline-start" />
+                {/if}
+                {i18n.t("github.pr.requestChanges")}
               </Button>
               <Button variant="outline" size="sm" disabled={busy || !reviewBody.trim()} onclick={() => submitReview("comment")}>
+                {#if busyAction === "pr-review-comment"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {/if}
                 {i18n.t("github.pr.comment")}
               </Button>
             </div>
@@ -1909,6 +1983,9 @@
               <span class="flex-1">{i18n.t("github.merge.autoArmed")}</span>
               <!-- Armed auto-merge was a one-way door: this turns it back off. -->
               <Button variant="ghost" size="sm" class="-my-1 h-6" disabled={busy} onclick={() => prAction(githubPrDisableAutoMerge, "github.toast.autoMergeOff")}>
+                {#if busyAction === "github.toast.autoMergeOff"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {/if}
                 {i18n.t("github.merge.autoDisable")}
               </Button>
             </div>
@@ -1945,10 +2022,18 @@
                    Update-branch button; without this the message was a dead end. -->
               {#if mergeStatus === "BEHIND"}
                 <div class="ml-5 flex gap-2 pt-0.5">
-                  <Button variant="outline" size="sm" class="h-6 gap-1" disabled={busy} onclick={() => prAction((p, n) => githubPrUpdateBranch(p, n, false), "github.toast.branchUpdated")}>
-                    <RefreshCwIcon class="size-3" />{i18n.t("github.merge.updateBranch")}
+                  <Button variant="outline" size="sm" class="h-6 gap-1" disabled={busy} onclick={() => prAction((p, n) => githubPrUpdateBranch(p, n, false), "github.toast.branchUpdated", "branch-update")}>
+                    {#if busyAction === "branch-update"}
+                      <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                    {:else}
+                      <RefreshCwIcon data-icon="inline-start" />
+                    {/if}
+                    {i18n.t("github.merge.updateBranch")}
                   </Button>
-                  <Button variant="ghost" size="sm" class="h-6" disabled={busy} title={i18n.t("github.merge.updateRebaseTip")} onclick={() => prAction((p, n) => githubPrUpdateBranch(p, n, true), "github.toast.branchUpdated")}>
+                  <Button variant="ghost" size="sm" class="h-6" disabled={busy} title={i18n.t("github.merge.updateRebaseTip")} onclick={() => prAction((p, n) => githubPrUpdateBranch(p, n, true), "github.toast.branchUpdated", "branch-rebase")}>
+                    {#if busyAction === "branch-rebase"}
+                      <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                    {/if}
                     {i18n.t("github.merge.updateRebase")}
                   </Button>
                 </div>
@@ -1972,7 +2057,12 @@
                  (auto-merge) before overriding them (admin bypass). -->
             {#if canAutoMerge}
               <Button variant="outline" size="sm" disabled={busy} class="gap-1" title={i18n.t("github.merge.autoTip")} onclick={() => mergePr({ auto: true })}>
-                <ClockIcon class="size-3.5" />{i18n.t("github.merge.auto")}
+                {#if busyAction === "merge-auto"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <ClockIcon data-icon="inline-start" />
+                {/if}
+                {i18n.t("github.merge.auto")}
               </Button>
             {/if}
             {#if canBypass}
@@ -2094,7 +2184,12 @@
 
             <div class="flex justify-end gap-2">
               <Button variant="ghost" size="sm" onclick={() => (showCreateIssue = false)}>{i18n.t("common.cancel")}</Button>
-              <Button size="sm" disabled={busy || !newIssueTitle.trim()} onclick={createIssue}>{i18n.t("github.issue.create")}</Button>
+              <Button size="sm" disabled={busy || !newIssueTitle.trim()} onclick={createIssue}>
+                {#if busyAction === "issue-create"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {/if}
+                {i18n.t("github.issue.create")}
+              </Button>
             </div>
           </div>
         {/if}
@@ -2206,18 +2301,33 @@
         <div class="space-y-2.5 border-t border-border/50 p-4">
           <Textarea placeholder={i18n.t("github.pr.commentPlaceholder")} bind:value={issueCommentBody} rows={2} />
           <div class="flex flex-wrap items-center gap-2">
-            <Button size="sm" disabled={busy || !issueCommentBody.trim()} onclick={postIssueComment}>{i18n.t("github.pr.postComment")}</Button>
+            <Button size="sm" disabled={busy || !issueCommentBody.trim()} onclick={postIssueComment}>
+              {#if busyAction === "issue-comment"}
+                <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+              {/if}
+              {i18n.t("github.pr.postComment")}
+            </Button>
             <div class="flex-1"></div>
             <Button variant="outline" size="sm" disabled={busy} title={i18n.t("github.issue.startWorkTip")} onclick={() => requestWorktree("issue", issue.number, issue.title)}>
               <GitBranchIcon class={icon.button} />{i18n.t("github.issue.startWork")}
             </Button>
             {#if issueOpen}
               <Button variant="outline" size="sm" disabled={busy} class="gap-1 text-purple-600 dark:text-purple-400" onclick={toggleIssueState}>
-                <CheckCircle2Icon class="size-3.5" />{i18n.t("github.issue.close")}
+                {#if busyAction === "issue-state"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <CheckCircle2Icon data-icon="inline-start" />
+                {/if}
+                {i18n.t("github.issue.close")}
               </Button>
             {:else}
               <Button variant="outline" size="sm" disabled={busy} onclick={toggleIssueState}>
-                <CircleDotIcon class="size-3.5" />{i18n.t("github.issue.reopen")}
+                {#if busyAction === "issue-state"}
+                  <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+                {:else}
+                  <CircleDotIcon data-icon="inline-start" />
+                {/if}
+                {i18n.t("github.issue.reopen")}
               </Button>
             {/if}
           </div>
@@ -2236,9 +2346,18 @@
       {#if selectedRunTitle}<h2 class={cn(text.subheading, "truncate")}>{selectedRunTitle}</h2>{/if}
       {#if selectedRunId}
         <div class="flex flex-wrap gap-2">
-          <Button variant="outline" size="sm" disabled={busy} onclick={() => selectedRunId && rerunRun(selectedRunId, false)}>{i18n.t("github.actions.rerun")}</Button>
-          <Button variant="outline" size="sm" disabled={busy} onclick={() => selectedRunId && rerunRun(selectedRunId, true)}>{i18n.t("github.actions.rerunFailed")}</Button>
-          <Button variant="outline" size="sm" disabled={busy} onclick={() => selectedRunId && cancelRun(selectedRunId)}>{i18n.t("github.actions.cancel")}</Button>
+          <Button variant="outline" size="sm" disabled={busy} onclick={() => selectedRunId && rerunRun(selectedRunId, false)}>
+            {#if busyAction === "run-rerun"}<Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />{/if}
+            {i18n.t("github.actions.rerun")}
+          </Button>
+          <Button variant="outline" size="sm" disabled={busy} onclick={() => selectedRunId && rerunRun(selectedRunId, true)}>
+            {#if busyAction === "run-rerun-failed"}<Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />{/if}
+            {i18n.t("github.actions.rerunFailed")}
+          </Button>
+          <Button variant="outline" size="sm" disabled={busy} onclick={() => selectedRunId && cancelRun(selectedRunId)}>
+            {#if busyAction === "run-cancel"}<Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />{/if}
+            {i18n.t("github.actions.cancel")}
+          </Button>
         </div>
       {/if}
       {#if runLogLoading}

--- a/uxnandesktop/src/lib/components/GithubWorktreeDialog.svelte
+++ b/uxnandesktop/src/lib/components/GithubWorktreeDialog.svelte
@@ -9,6 +9,7 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import Combobox, { type ComboGroup } from "./Combobox.svelte";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Input } from "$lib/components/ui/input";
   import { projects } from "$lib/state/projects.svelte";
   import { app } from "$lib/state/app.svelte";
@@ -198,6 +199,9 @@
     <Dialog.Footer>
       <Button variant="ghost" onclick={() => (open = false)}>{i18n.t("common.cancel")}</Button>
       <Button onclick={submit} disabled={!branch.trim() || busy || !repoId}>
+        {#if busy}
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+        {/if}
         {busy ? i18n.t("common.creating") : i18n.t("newWorktree.create")}
       </Button>
     </Dialog.Footer>

--- a/uxnandesktop/src/lib/components/HistoryPanel.svelte
+++ b/uxnandesktop/src/lib/components/HistoryPanel.svelte
@@ -20,6 +20,7 @@
   import type { CommitInfo } from "$lib/types";
   import VirtualList from "./VirtualList.svelte";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import * as HoverCard from "$lib/components/ui/hover-card";
   import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import SearchIcon from "@lucide/svelte/icons/search";
@@ -481,6 +482,9 @@
           disabled={history.loadingMore}
           onclick={() => void history.loadMore()}
         >
+          {#if history.loadingMore}
+            <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+          {/if}
           {history.loadingMore ? i18n.t("common.loading") : i18n.t("history.loadMore")}
         </Button>
       </div>

--- a/uxnandesktop/src/lib/components/IconPicker.svelte
+++ b/uxnandesktop/src/lib/components/IconPicker.svelte
@@ -10,6 +10,7 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
   import { Input } from "$lib/components/ui/input";
+  import { Spinner } from "$lib/components/ui/spinner";
   import type { Snippet } from "svelte";
   import { cn } from "$lib/utils";
   import { icon, text } from "$lib/design";
@@ -23,7 +24,6 @@
   import UploadIcon from "@lucide/svelte/icons/upload";
   import LinkIcon from "@lucide/svelte/icons/link";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
-  import Loader2Icon from "@lucide/svelte/icons/loader-circle";
   import BanIcon from "@lucide/svelte/icons/ban";
   import PipetteIcon from "@lucide/svelte/icons/pipette";
 
@@ -54,6 +54,7 @@
   let currentColor = $state<string | null>(null);
   let urlInput = $state("");
   let busy = $state(false);
+  let busySource = $state<"file" | "avatar" | "url" | null>(null);
   let error = $state<string | null>(null);
   // Resolved git-host avatar URL (null until/unless a repo origin resolves one).
   let avatarUrl = $state<string | null>(null);
@@ -73,6 +74,7 @@
     urlInput = "";
     error = null;
     busy = false;
+    busySource = null;
     avatarUrl = null;
     if (repoId) {
       repoRemoteOwner(repoId)
@@ -117,18 +119,21 @@
     if (!file) return;
     error = null;
     busy = true;
+    busySource = "file";
     try {
       pending = await fileToLogoDataUrl(file, PREVIEW_SIZE);
     } catch {
       error = i18n.t("iconPicker.fileError");
     } finally {
       busy = false;
+      busySource = null;
     }
   }
 
-  async function fetchInto(url: string) {
+  async function fetchInto(url: string, source: "avatar" | "url") {
     error = null;
     busy = true;
+    busySource = source;
     try {
       const dataUrl = await imageFetchDataUrl(url);
       pending = await rasterizeToSquarePng(dataUrl, PREVIEW_SIZE);
@@ -136,6 +141,7 @@
       error = e instanceof Error ? e.message : i18n.t("iconPicker.urlError");
     } finally {
       busy = false;
+      busySource = null;
     }
   }
 
@@ -172,9 +178,6 @@
                 : i18n.t("iconPicker.sourceDefault")}
           </div>
         </div>
-        {#if busy}
-          <Loader2Icon class={cn(icon.button, "ml-auto shrink-0 animate-spin text-muted-foreground")} />
-        {/if}
       </div>
 
       <!-- Built-in glyphs + accent color. -->
@@ -264,11 +267,18 @@
         <span class={text.section}>{i18n.t("iconPicker.custom")}</span>
         <div class="flex flex-wrap gap-2">
           <Button variant="outline" size="sm" disabled={busy} onclick={() => fileInput?.click()}>
-            <UploadIcon class={icon.button} />
+            {#if busySource === "file"}
+              <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+            {:else}
+              <UploadIcon data-icon="inline-start" />
+            {/if}
             {i18n.t("iconPicker.fromFile")}
           </Button>
           {#if avatarUrl}
-            <Button variant="outline" size="sm" disabled={busy} onclick={() => fetchInto(avatarUrl!)}>
+            <Button variant="outline" size="sm" disabled={busy} onclick={() => fetchInto(avatarUrl!, "avatar")}>
+              {#if busySource === "avatar"}
+                <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+              {/if}
               {i18n.t("iconPicker.fromAvatar")}
             </Button>
           {/if}
@@ -282,15 +292,18 @@
               bind:value={urlInput}
               autocomplete="off"
               spellcheck={false}
-              onkeydown={(e) => e.key === "Enter" && urlInput.trim() && fetchInto(urlInput.trim())}
+              onkeydown={(e) => e.key === "Enter" && urlInput.trim() && fetchInto(urlInput.trim(), "url")}
             />
           </div>
           <Button
             variant="outline"
             size="sm"
             disabled={busy || !urlInput.trim()}
-            onclick={() => fetchInto(urlInput.trim())}
+            onclick={() => fetchInto(urlInput.trim(), "url")}
           >
+            {#if busySource === "url"}
+              <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+            {/if}
             {i18n.t("iconPicker.fetch")}
           </Button>
         </div>

--- a/uxnandesktop/src/lib/components/LauncherDialog.svelte
+++ b/uxnandesktop/src/lib/components/LauncherDialog.svelte
@@ -8,6 +8,7 @@
   // (terminals ↔ agents ↔ worktree) is preserved.
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Input } from "$lib/components/ui/input";
   import Combobox, { type ComboGroup, type ComboItem } from "./Combobox.svelte";
   import MultiSelect from "./MultiSelect.svelte";
@@ -302,6 +303,9 @@
         {i18n.t("agent.configure")}
       </button>
       <Button onclick={submit} disabled={!canSubmit || busy || (isNew && loadingBranches)}>
+        {#if busy}
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+        {/if}
         {busy ? i18n.t("common.creating") : primaryLabel}
       </Button>
     </Dialog.Footer>

--- a/uxnandesktop/src/lib/components/NewWorktreeDialog.svelte
+++ b/uxnandesktop/src/lib/components/NewWorktreeDialog.svelte
@@ -2,6 +2,7 @@
   import * as Dialog from "$lib/components/ui/dialog";
   import Combobox, { type ComboGroup } from "./Combobox.svelte";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Input } from "$lib/components/ui/input";
   import { projects } from "$lib/state/projects.svelte";
   import { app } from "$lib/state/app.svelte";
@@ -182,6 +183,9 @@
     <Dialog.Footer>
       <Button variant="ghost" onclick={() => (open = false)}>{i18n.t("common.cancel")}</Button>
       <Button onclick={submit} disabled={!branch.trim() || busy || loading}>
+        {#if busy}
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+        {/if}
         {busy ? i18n.t("common.creating") : i18n.t("newWorktree.create")}
       </Button>
     </Dialog.Footer>

--- a/uxnandesktop/src/lib/components/ProjectSettingsDialog.svelte
+++ b/uxnandesktop/src/lib/components/ProjectSettingsDialog.svelte
@@ -6,6 +6,7 @@
   // committed on Save.
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Input } from "$lib/components/ui/input";
   import { projects } from "$lib/state/projects.svelte";
   import { repoRemoteOwner, revealPath } from "$lib/api";
@@ -163,7 +164,12 @@
     </div>
 
     <Dialog.Footer>
-      <Button disabled={busy || !dirty} onclick={saveName}>{i18n.t("common.save")}</Button>
+      <Button disabled={busy || !dirty} onclick={saveName}>
+        {#if busy}
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+        {/if}
+        {i18n.t("common.save")}
+      </Button>
     </Dialog.Footer>
   </Dialog.Content>
 </Dialog.Root>

--- a/uxnandesktop/src/lib/components/TabRenameDialog.svelte
+++ b/uxnandesktop/src/lib/components/TabRenameDialog.svelte
@@ -6,6 +6,7 @@
   // dropped. Mounted only while a tab is being renamed (keyed by the parent).
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Input } from "$lib/components/ui/input";
   import { terminals, tabDisplayTitle, type GroupTab } from "$lib/state/terminals.svelte";
   import { cn } from "$lib/utils";
@@ -123,6 +124,9 @@
 
     <Dialog.Footer>
       <Button disabled={!canSubmit} onclick={submit}>
+        {#if busy}
+          <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+        {/if}
         {isFile ? i18n.t("common.rename") : i18n.t("common.save")}
       </Button>
     </Dialog.Footer>

--- a/uxnandesktop/src/lib/components/ThemeSettings.svelte
+++ b/uxnandesktop/src/lib/components/ThemeSettings.svelte
@@ -9,6 +9,7 @@
   import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
+  import { Spinner } from "$lib/components/ui/spinner";
   import { Input } from "$lib/components/ui/input";
   import { Textarea } from "$lib/components/ui/textarea";
   import { Switch } from "$lib/components/ui/switch";
@@ -203,6 +204,7 @@
   let pasteOpen = $state(false);
   let pasteText = $state("");
   let pasteKind: "theme" | "terminal" = "theme";
+  let importingKind = $state<"theme" | "terminal" | null>(null);
 
   function openPaste(kind: "theme" | "terminal") {
     pasteKind = kind;
@@ -214,6 +216,7 @@
   async function importFile(kind: "theme" | "terminal") {
     error = null;
     notice = null;
+    importingKind = kind;
     try {
       const { open } = await import("@tauri-apps/plugin-dialog");
       // Multi-select: each file may itself carry one theme or a whole list.
@@ -229,6 +232,8 @@
       importRaws(kind, raws);
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
+    } finally {
+      importingKind = null;
     }
   }
   /** Single-source paste import (one text blob that may hold one theme or a list). */
@@ -415,7 +420,14 @@
       <SettingsRow label={i18n.t("appearance.themesLabel")} description={i18n.t("appearance.themesRowDesc")}>
         {#snippet control()}
           <div class="flex flex-wrap items-center justify-end gap-1.5">
-            <Button variant="outline" size="sm" onclick={() => importFile("theme")}><UploadIcon data-icon="inline-start" />{i18n.t("appearance.import")}</Button>
+            <Button variant="outline" size="sm" disabled={importingKind !== null} onclick={() => importFile("theme")}>
+              {#if importingKind === "theme"}
+                <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+              {:else}
+                <UploadIcon data-icon="inline-start" />
+              {/if}
+              {i18n.t("appearance.import")}
+            </Button>
             <Button variant="outline" size="sm" onclick={() => openPaste("theme")}><ClipboardPasteIcon data-icon="inline-start" />{i18n.t("appearance.paste")}</Button>
             <Button size="sm" onclick={newTheme}><PlusIcon data-icon="inline-start" />{i18n.t("appearance.newTheme")}</Button>
           </div>
@@ -475,7 +487,14 @@
       <SettingsRow label={i18n.t("appearance.themesLabel")} description={i18n.t("appearance.termThemesRowDesc")}>
         {#snippet control()}
           <div class="flex flex-wrap items-center justify-end gap-1.5">
-            <Button variant="outline" size="sm" onclick={() => importFile("terminal")}><UploadIcon data-icon="inline-start" />{i18n.t("appearance.import")}</Button>
+            <Button variant="outline" size="sm" disabled={importingKind !== null} onclick={() => importFile("terminal")}>
+              {#if importingKind === "terminal"}
+                <Spinner data-icon="inline-start" aria-label={i18n.t("common.loading")} />
+              {:else}
+                <UploadIcon data-icon="inline-start" />
+              {/if}
+              {i18n.t("appearance.import")}
+            </Button>
             <Button variant="outline" size="sm" onclick={() => openPaste("terminal")}><ClipboardPasteIcon data-icon="inline-start" />{i18n.t("appearance.paste")}</Button>
             <Button size="sm" onclick={newTermTheme}><PlusIcon data-icon="inline-start" />{i18n.t("appearance.newTheme")}</Button>
           </div>

--- a/uxnandesktop/src/lib/components/ui/spinner/index.ts
+++ b/uxnandesktop/src/lib/components/ui/spinner/index.ts
@@ -1,0 +1,1 @@
+export { default as Spinner } from "./spinner.svelte";

--- a/uxnandesktop/src/lib/components/ui/spinner/spinner.svelte
+++ b/uxnandesktop/src/lib/components/ui/spinner/spinner.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { cn } from "$lib/utils.js";
+	import Loader2Icon from '@lucide/svelte/icons/loader-2';
+	import type { SVGAttributes } from "svelte/elements";
+
+	let {
+		class: className,
+		role = "status",
+		// we add name, color, and stroke for compatibility with different icon libraries props
+		name,
+		color,
+		stroke,
+		"aria-label": ariaLabel = "Loading",
+		...restProps
+	}: SVGAttributes<SVGSVGElement> = $props();
+</script>
+
+<Loader2Icon {role} name={name === null ? undefined : name} color={color === null ? undefined : color} stroke={stroke === null ? undefined : stroke} aria-label={ariaLabel} class={cn("size-4 animate-spin", className)} {...restProps} />

--- a/uxnandesktop/src/lib/state/git.svelte.ts
+++ b/uxnandesktop/src/lib/state/git.svelte.ts
@@ -64,6 +64,7 @@ class GitStore {
   loading = $state(false);
   /** A staging/commit action is in flight (disables the action buttons). */
   busy = $state(false);
+  busyAction = $state<{ kind: "stage" | "unstage" | "discard"; file: string } | null>(null);
   error = $state<string | null>(null);
   /** Commit message composer: subject line. */
   message = $state("");
@@ -83,6 +84,7 @@ class GitStore {
   behind = $state(0);
   /** A push/pull is in flight. */
   syncing = $state(false);
+  syncingAction = $state<"push" | "pull" | null>(null);
   private listening = false;
 
   /** Files with a staged change / with a working-tree (or untracked) change. */
@@ -172,10 +174,14 @@ class GitStore {
   }
 
   /** Run a staging action then refresh, surfacing any error. */
-  private async op(fn: (path: string) => Promise<void>): Promise<void> {
+  private async op(
+    action: { kind: "stage" | "unstage" | "discard"; file: string },
+    fn: (path: string) => Promise<void>,
+  ): Promise<void> {
     const path = this.path;
     if (!path) return;
     this.busy = true;
+    this.busyAction = action;
     this.error = null;
     try {
       await fn(path);
@@ -185,23 +191,24 @@ class GitStore {
       toastError(e);
     } finally {
       this.busy = false;
+      this.busyAction = null;
     }
   }
 
   stage(file: string): Promise<void> {
-    return this.op((p) => gitStage(p, file));
+    return this.op({ kind: "stage", file }, (p) => gitStage(p, file));
   }
   unstage(file: string): Promise<void> {
-    return this.op((p) => gitUnstage(p, file));
+    return this.op({ kind: "unstage", file }, (p) => gitUnstage(p, file));
   }
   stageAll(): Promise<void> {
-    return this.op((p) => gitStageAll(p));
+    return this.op({ kind: "stage", file: "*" }, (p) => gitStageAll(p));
   }
   unstageAll(): Promise<void> {
-    return this.op((p) => gitUnstageAll(p));
+    return this.op({ kind: "unstage", file: "*" }, (p) => gitUnstageAll(p));
   }
   discard(file: string, untracked: boolean): Promise<void> {
-    return this.op((p) => gitDiscard(p, file, untracked));
+    return this.op({ kind: "discard", file }, (p) => gitDiscard(p, file, untracked));
   }
 
   /** Reload the status if the panel is currently showing `path` (used by a diff
@@ -288,10 +295,15 @@ class GitStore {
 
   /** Push or pull the current branch, then refresh ahead/behind + status, and
    *  toast `okMsg` on success. */
-  private async sync(fn: (path: string) => Promise<void>, okMsg: string): Promise<void> {
+  private async sync(
+    action: "push" | "pull",
+    fn: (path: string) => Promise<void>,
+    okMsg: string,
+  ): Promise<void> {
     const path = this.path;
     if (!path) return;
     this.syncing = true;
+    this.syncingAction = action;
     this.error = null;
     try {
       await fn(path);
@@ -303,14 +315,15 @@ class GitStore {
       toastError(e);
     } finally {
       this.syncing = false;
+      this.syncingAction = null;
     }
   }
   async push(): Promise<void> {
-    await this.sync((p) => gitPush(p), i18n.t("toast.pushed"));
+    await this.sync("push", (p) => gitPush(p), i18n.t("toast.pushed"));
     await this.offerCreatePr();
   }
   pull(): Promise<void> {
-    return this.sync((p) => gitPull(p), i18n.t("toast.pulled"));
+    return this.sync("pull", (p) => gitPull(p), i18n.t("toast.pulled"));
   }
 
   /** After a push, if the branch is a GitHub repo with no PR yet, offer a "Create


### PR DESCRIPTION
## Summary

Adds consistent in-place loading feedback to asynchronous desktop actions so users can identify which control is still working without changing the established compact layout. The initiating control now uses the shared shadcn-svelte Spinner, retains localized progress text, and tracks operation identity in multi-action surfaces.

## Affected component(s)

- [ ] `shared` — contracts / JSON-RPC / E2EE schemas
- [ ] `bridge` — PC daemon (uxnan-bridge)
- [ ] `relay` — E2EE relay server (uxnan-relay)
- [x] `uxnandesktop` — Tauri desktop app
- [ ] `uxnanmobile` — Flutter mobile app
- [ ] Cross-cutting / tooling / CI / docs

## Type of change

- [ ] `fix` — bug fix
- [x] `feat` — new feature
- [ ] `refactor` — no behavior change
- [ ] `docs`
- [ ] `test`
- [ ] `chore` / `ci` / `build`

## How was it tested?

1. `cd uxnandesktop && npm run check` on Windows → runes/version checks and `svelte-check` pass with 0 errors and 0 warnings.
2. `cd uxnandesktop && npm test` on Windows → 21 test files and 212 tests pass.
3. `cd uxnandesktop && npm run build` on Windows → production SvelteKit build succeeds; only the repository's existing chunk-size and Tauri window import warnings remain.
4. Manual review on Windows → verified the desktop layout in the native Tauri app; maintainer approved proceeding with the PR and will continue broader visual coverage from this branch.

## Checklist

- [x] Lint/format pass for the touched component(s) (see `CONTRIBUTING.md`).
- [x] No new pure-logic seam was introduced; the existing 212-test suite passes.
- [x] `CHANGELOG.md` updated for each affected component (technical detail).
- [x] Docs / `architecture/` updated if behavior or a contract changed (spec-drift control).
- [x] Commits follow Conventional Commits — `type(scope): message`.
- [x] **If this is a `uxnanmobile` release:** not applicable; this PR only touches `uxnandesktop`.
- [x] If a `shared` contract changed, all consumers (bridge/relay/mobile) were updated in the same change — not applicable; no shared contract changed.