### PR TITLE
feat(mobile): network-path badge + pairing-code disclosure fix

### DIFF
--- a/architecture/02a-system-architecture.md
+++ b/architecture/02a-system-architecture.md
@@ -1155,12 +1155,29 @@ QrScannerScreen
 > LAN `/trusted-session/resolve` que el whitepaper original proponía — la
 > variante bridge-first cubre el caso LAN; para acceso fuera-de-LAN se usa
 > Tailscale o un relay genérico de WebSocket con la sesión E2EE.
+>
+> **Cambio (2026-07):** el resolve del lado móvil ya no depende de un único
+> host tecleado. `ManualPairingService.resolveAny` corre el
+> `GET /pair/resolve?code=` en paralelo contra el host tecleado **y** contra
+> cualquier bridge descubierto por mDNS mientras la pantalla está abierta
+> (descubrimiento pasivo, no solo al abrir la hoja "Browse nearby bridges") —
+> gana el primero en responder `2xx`, con la misma filosofía de carrera que
+> `DirectTransportSelector` ya usa para la conexión WS. Si todos fallan, se
+> muestra el error más informativo entre los intentos (una respuesta
+> definitiva de un bridge alcanzado vence a un simple "inalcanzable"). Esto no
+> cambia el contrato — sigue siendo el mismo `GET /pair/resolve?code=` por
+> candidato — solo la estrategia de marcado del lado del teléfono. El caso
+> totalmente fuera de red (el teléfono sin ruta directa alguna al bridge)
+> sigue sin cubrirse; queda registrado como trabajo pendiente en
+> `uxnanmobile/FOR-DEV.md`.
 
 ```
 ManualCodeScreen
 ├── Campo de texto para el codigo (8 chars Crockford base32, 10 min TTL)
 │   y campo para host:port (autocompletable via mDNS si está disponible)
 ├── GET http://<bridge-host>:<port>/pair/resolve?code=<code>
+│   ├── Corrido en paralelo contra el host tecleado + candidatos mDNS
+│   │   (resolveAny, gana el primer 2xx)
 │   ├── Validación constant-time + rate-limit por IP
 │   └── Respuesta: PairingPayload completo (identico al del QR)
 └── Continua igual que QR bootstrap (proceso de handshake E2EE)

--- a/architecture/02a-system-architecture.md
+++ b/architecture/02a-system-architecture.md
@@ -1156,28 +1156,28 @@ QrScannerScreen
 > variante bridge-first cubre el caso LAN; para acceso fuera-de-LAN se usa
 > Tailscale o un relay genérico de WebSocket con la sesión E2EE.
 >
-> **Cambio (2026-07):** el resolve del lado móvil ya no depende de un único
-> host tecleado. `ManualPairingService.resolveAny` corre el
-> `GET /pair/resolve?code=` en paralelo contra el host tecleado **y** contra
-> cualquier bridge descubierto por mDNS mientras la pantalla está abierta
-> (descubrimiento pasivo, no solo al abrir la hoja "Browse nearby bridges") —
-> gana el primero en responder `2xx`, con la misma filosofía de carrera que
-> `DirectTransportSelector` ya usa para la conexión WS. Si todos fallan, se
-> muestra el error más informativo entre los intentos (una respuesta
-> definitiva de un bridge alcanzado vence a un simple "inalcanzable"). Esto no
-> cambia el contrato — sigue siendo el mismo `GET /pair/resolve?code=` por
-> candidato — solo la estrategia de marcado del lado del teléfono. El caso
-> totalmente fuera de red (el teléfono sin ruta directa alguna al bridge)
-> sigue sin cubrirse; queda registrado como trabajo pendiente en
-> `uxnanmobile/FOR-DEV.md`.
+> **Seguridad (2026-07): el código va a UN solo host, el que el usuario eligió.**
+> El código de emparejamiento es un secreto compartido que se lee de la pantalla
+> del PC, y un `/pair/resolve` exitoso **abre la ventana de bootstrap** del bridge
+> (ver §5.9). Por eso el teléfono lo manda exclusivamente al host que el usuario
+> nombró — tecleado, o elegido en la hoja "Browse nearby bridges", que rellena ese
+> campo. Nunca se reparte entre candidatos descubiertos: los registros mDNS no
+> están autenticados y cualquier dispositivo de la red puede publicarlos, así que
+> repartirlo revelaría el código a quien publicó el registro y permitiría que el
+> primero en responder suplantara al PC. La hoja de descubrimiento sigue
+> existiendo, pero es una **elección explícita** del usuario, y el hint TXT `addr`
+> solo se honra si es una IP literal en rango privado/CGNAT/loopback (el resto de
+> casos usan la dirección resuelta por SRV). El caso totalmente fuera de red (el
+> teléfono sin ruta directa alguna al bridge) sigue sin cubrirse; queda registrado
+> como trabajo pendiente en `uxnanmobile/FOR-DEV.md`.
 
 ```
 ManualCodeScreen
 ├── Campo de texto para el codigo (8 chars Crockford base32, 10 min TTL)
 │   y campo para host:port (autocompletable via mDNS si está disponible)
 ├── GET http://<bridge-host>:<port>/pair/resolve?code=<code>
-│   ├── Corrido en paralelo contra el host tecleado + candidatos mDNS
-│   │   (resolveAny, gana el primer 2xx)
+│   ├── Dirigido SOLO al host elegido por el usuario (nunca repartido
+│   │   entre candidatos mDNS — el código es un secreto)
 │   ├── Validación constant-time + rate-limit por IP
 │   └── Respuesta: PairingPayload completo (identico al del QR)
 └── Continua igual que QR bootstrap (proceso de handshake E2EE)

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -37,25 +37,26 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
   entirely client-side from data the bridge already advertises (`hosts`,
   `relayUrl`).
 
-### Fixed — manual-code pairing no longer dead-ends on a single unreachable host
-- Manual pairing (`ManualCodeScreen`) used to resolve the pairing code with a
-  single blind HTTP GET against whatever host the user typed. If that one
-  host wasn't reachable on the phone's *current* network — a stale/typo'd LAN
-  IP, or the PC only reachable via Tailscale while the phone types the LAN
-  address shown on screen — pairing failed outright and the (already
-  multi-host-capable) WebSocket connection race never even got a chance to
-  run. `ManualPairingService` gained `resolveAny`, which races the typed host
-  concurrently against every bridge discovered via mDNS in the background
-  (the screen now runs passive `BridgeDiscoveryService` discovery for its
-  whole lifetime, not just while the "Browse nearby bridges" sheet is open) —
-  the first bridge to answer `HTTP 2xx` wins, mirroring how
-  `DirectTransportSelector` already races the paired device's advertised
-  hosts for the live connection. When every candidate fails, the single most
-  actionable error surfaces (a definitive "wrong code" from a bridge that
-  *was* reached always outranks a plain "unreachable" from one that wasn't),
-  and the network-failure copy now actively guides the user: try the PC's
-  Tailscale `100.x` address, or its LAN IP if on the same Wi-Fi, and notes the
-  connection can also fall back to the relay once paired.
+### Security — the pairing code is sent to exactly one host, the one you chose
+- Manual pairing resolves the code with a single `GET /pair/resolve?code=`
+  against the host the user named — typed, or picked in the "Browse nearby
+  bridges" sheet (which fills the host field). It is deliberately **never**
+  fanned out across mDNS-discovered candidates. The code is a shared secret
+  read off the PC screen, and a successful resolve both hands out the pairing
+  payload and **arms the bridge's `qr_bootstrap` window** (see the `bridge`
+  CHANGELOG), so disclosing it to an unauthenticated, spoofable mDNS record
+  would let any device on the same network harvest it — or answer first and be
+  trusted as "your PC" with no confirmation. Covered by tests asserting that a
+  second reachable bridge is never dialed, and that an empty host is rejected
+  before any request leaves the device.
+- Discovery is hardened as defense in depth: the mDNS TXT `addr` hint is only
+  honored when it is a literal IP in private / CGNAT / loopback space
+  (`isLocalAddressLiteral`), never a hostname and never a public address; the
+  SRV-resolved address wins otherwise. A discovered bridge is still only ever
+  contacted after the user explicitly picks it.
+- The network-failure copy now guides the user: try the PC's Tailscale `100.x`
+  address, or its LAN IP if on the same Wi-Fi, and notes the connection can
+  fall back to the relay once paired.
 - Deferred: resolving a pairing code with **no direct network path to the PC
   at all** (e.g. the phone on cellular data, the PC not yet joined to
   Tailscale) still isn't possible — it would need fetching the payload

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,54 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — network-path badge (LAN / Tailscale / Direct / Relay) on the connected PC
+- The devices screen now labels **how** a live connection actually reaches the
+  PC, not just whether it's "connected": a small animated pill next to the
+  status dot reads **LAN**, **Tailscale**, **Direct** or **Relay**, with a
+  **"Detecting…"** loading state while a connect attempt is in flight and the
+  path isn't known yet. A new pure `NetworkKind` classifier
+  (`domain/enums/network_kind.dart`) buckets the live channel's actual
+  endpoint by IP range — `100.64.0.0/10` → Tailscale; `10.0.0.0/8`,
+  `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16` → LAN; any other
+  reachable address → Direct; a host match against the paired device's
+  `relayUrl` → Relay — and is exposed through a new `networkKindProvider`
+  derived from the session coordinator's real `connectedDevice` +
+  `connectedEndpoint` streams. This **replaces** the previous Relay/Direct
+  text, which read the *global* `bridge/status.relayConnected` flag: that
+  field can't distinguish LAN from Tailscale and isn't guaranteed to be scoped
+  to the endpoint actually in use, so the label could misreport during a
+  reconnect. The new `TransportBadge` widget (`presentation/widgets/`)
+  cross-fades between states with `AnimatedSwitcher` (respecting reduced
+  motion) and follows the same type-specific icon + color-pill pattern as the
+  existing `CommitRefChip`. No wire/contract change — the classification is
+  entirely client-side from data the bridge already advertises (`hosts`,
+  `relayUrl`).
+
+### Fixed — manual-code pairing no longer dead-ends on a single unreachable host
+- Manual pairing (`ManualCodeScreen`) used to resolve the pairing code with a
+  single blind HTTP GET against whatever host the user typed. If that one
+  host wasn't reachable on the phone's *current* network — a stale/typo'd LAN
+  IP, or the PC only reachable via Tailscale while the phone types the LAN
+  address shown on screen — pairing failed outright and the (already
+  multi-host-capable) WebSocket connection race never even got a chance to
+  run. `ManualPairingService` gained `resolveAny`, which races the typed host
+  concurrently against every bridge discovered via mDNS in the background
+  (the screen now runs passive `BridgeDiscoveryService` discovery for its
+  whole lifetime, not just while the "Browse nearby bridges" sheet is open) —
+  the first bridge to answer `HTTP 2xx` wins, mirroring how
+  `DirectTransportSelector` already races the paired device's advertised
+  hosts for the live connection. When every candidate fails, the single most
+  actionable error surfaces (a definitive "wrong code" from a bridge that
+  *was* reached always outranks a plain "unreachable" from one that wasn't),
+  and the network-failure copy now actively guides the user: try the PC's
+  Tailscale `100.x` address, or its LAN IP if on the same Wi-Fi, and notes the
+  connection can also fall back to the relay once paired.
+- Deferred: resolving a pairing code with **no direct network path to the PC
+  at all** (e.g. the phone on cellular data, the PC not yet joined to
+  Tailscale) still isn't possible — it would need fetching the payload
+  through the relay instead of a direct GET, which needs new relay+bridge
+  contract work. See `FOR-DEV.md`.
+
 ## [0.0.9-alpha.20260719+20260719] - 2026-07-19
 
 ### Added — Antigravity agent (Google's `agy`) rendering

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,12 +6,20 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Simplified device-card connection feedback: connecting devices show a single
+  `Detecting…` status, while the LAN/Tailscale/direct/relay badge appears only
+  after a live connection is established. The Connect button retains its
+  existing `Connecting…` busy state and behavior.
+
 ### Added — network-path badge (LAN / Tailscale / Direct / Relay) on the connected PC
 - The devices screen now labels **how** a live connection actually reaches the
   PC, not just whether it's "connected": a small animated pill next to the
   status dot reads **LAN**, **Tailscale**, **Direct** or **Relay**, with a
-  **"Detecting…"** loading state while a connect attempt is in flight and the
-  path isn't known yet. A new pure `NetworkKind` classifier
+  **"Detecting…"** status while a connect attempt is in flight and the path
+  isn't known yet; the network badge itself appears only after connection. A
+  new pure `NetworkKind` classifier
   (`domain/enums/network_kind.dart`) buckets the live channel's actual
   endpoint by IP range — `100.64.0.0/10` → Tailscale; `10.0.0.0/8`,
   `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16` → LAN; any other

--- a/uxnanmobile/FOR-DEV.md
+++ b/uxnanmobile/FOR-DEV.md
@@ -20,9 +20,10 @@ connected to live bridge data, validated on-device against a real bridge.
   handshake, seq/replay, outbound buffer, reconnect loop).
 - **Pairing & onboarding** — `OnboardingScreen`, `QrScannerScreen`,
   `MyDevicesScreen`, **`ManualCodeScreen`** (bridge-first manual-code pairing,
-  `GET /pair/resolve?code=`, host typed or via mDNS discover; **the resolve
-  itself races the typed host against every mDNS-discovered candidate**,
-  first `2xx` wins). The devices screen shows a **network-path badge** (LAN /
+  `GET /pair/resolve?code=`, host typed or picked from mDNS discovery; the
+  code is sent to **only** the host the user chose — never fanned out to
+  discovered candidates, since it is a shared secret and mDNS records are
+  spoofable). The devices screen shows a **network-path badge** (LAN /
   Tailscale / Direct / Relay, `NetworkKind`) on the connected PC, derived from
   the actual live endpoint rather than the coarser relay/direct
   `bridge/status` flag.
@@ -203,11 +204,10 @@ shipping.
 ## App-side pending work (needs relay/bridge changes to start)
 
 - [ ] **Manual pairing over the relay for a phone with no direct path to the
-      PC at all.** `ManualPairingService.resolveAny`
-      (`infrastructure/pairing/manual_pairing_service.dart`) already races the
-      typed host against every bridge discovered via mDNS, but every
-      candidate still needs a direct HTTP path (LAN or Tailscale) reachable
-      from the phone right now. A phone with neither — cellular data only,
+      PC at all.** `ManualPairingService.resolve`
+      (`infrastructure/pairing/manual_pairing_service.dart`) needs a direct
+      HTTP path (LAN or Tailscale) to the chosen host, reachable from the
+      phone right now. A phone with neither — cellular data only,
       the PC not yet joined to Tailscale — can't resolve a pairing code at
       all. Fetching the payload through the relay instead of the current
       direct `GET /pair/resolve` would remove that requirement entirely, but

--- a/uxnanmobile/FOR-DEV.md
+++ b/uxnanmobile/FOR-DEV.md
@@ -20,7 +20,12 @@ connected to live bridge data, validated on-device against a real bridge.
   handshake, seq/replay, outbound buffer, reconnect loop).
 - **Pairing & onboarding** — `OnboardingScreen`, `QrScannerScreen`,
   `MyDevicesScreen`, **`ManualCodeScreen`** (bridge-first manual-code pairing,
-  `GET /pair/resolve?code=`, host typed or via mDNS discover).
+  `GET /pair/resolve?code=`, host typed or via mDNS discover; **the resolve
+  itself races the typed host against every mDNS-discovered candidate**,
+  first `2xx` wins). The devices screen shows a **network-path badge** (LAN /
+  Tailscale / Direct / Relay, `NetworkKind`) on the connected PC, derived from
+  the actual live endpoint rather than the coarser relay/direct
+  `bridge/status` flag.
 - **Direct LAN/Tailscale transport** — `DirectTransportSelector` tries each direct
   `hosts` entry from the QR first, falls back to the relay.
 - **Multi-PC connection-targeting** — all live actions target the PC we actually
@@ -194,6 +199,20 @@ shipping.
       exists for it yet.
 - [ ] **Adopt `freezed`/`json_serializable`** if/when entity boilerplate warrants it.
       Optional.
+
+## App-side pending work (needs relay/bridge changes to start)
+
+- [ ] **Manual pairing over the relay for a phone with no direct path to the
+      PC at all.** `ManualPairingService.resolveAny`
+      (`infrastructure/pairing/manual_pairing_service.dart`) already races the
+      typed host against every bridge discovered via mDNS, but every
+      candidate still needs a direct HTTP path (LAN or Tailscale) reachable
+      from the phone right now. A phone with neither — cellular data only,
+      the PC not yet joined to Tailscale — can't resolve a pairing code at
+      all. Fetching the payload through the relay instead of the current
+      direct `GET /pair/resolve` would remove that requirement entirely, but
+      needs a new relay+bridge+shared contract (the relay has no route to
+      reach an unpaired bridge on the phone's behalf today). Not started.
 
 ## App+bridge seams (need a live bridge to finish/verify)
 

--- a/uxnanmobile/README.md
+++ b/uxnanmobile/README.md
@@ -47,7 +47,10 @@ this app:
   can also **discover nearby bridges** automatically over mDNS or accept a short
   manual code — no addresses to memorize, no compile-time configuration. A
   transport indicator always tells you whether you are connected **directly** (LAN
-  / Tailscale) or **through the relay**.
+  / Tailscale) or **through the relay**. On the Devices screen, a connection in
+  progress has one `Detecting…` status; the LAN/Tailscale/direct/relay badge is
+  shown only after the live channel is established, while the Connect button
+  keeps its own `Connecting…` busy state.
 - **Parity with the bridge's main capabilities.** Streaming conversations with
   structured agent turns, interactive approvals, model and reasoning-effort
   selection, a live context-usage indicator, a message scroll rail to jump

--- a/uxnanmobile/docs/architecture.md
+++ b/uxnanmobile/docs/architecture.md
@@ -61,6 +61,20 @@ Rule of thumb: `domain` never imports Flutter; `presentation` never reaches into
   `onboarding/`, `pairing/`. `presentation/router/app_router.dart` is the flat
   GoRouter table. `presentation/theme/` holds the design tokens.
 
+The Devices screen keeps connection feedback scoped to the actual PC card:
+
+- A live session renders `Connected` plus the classified network badge (`LAN`,
+  `Tailscale`, `Direct`, or `Relay`) derived from the winning endpoint.
+- A PC whose connection attempt is in flight renders one `Detecting…` status.
+  The badge is intentionally hidden until the channel is live because the
+  network path is not known yet.
+- A disconnected PC renders no network badge. Its `Connect` button remains
+  disabled with `Connecting…` only while its own attempt is active.
+
+This presentation logic lives in `_StatusLine` within
+`presentation/screens/devices/my_devices_screen.dart`; the underlying
+`networkKindProvider` and session streams remain unchanged.
+
 ## Dependency injection / provider graph
 
 Manual Riverpod. Infrastructure is constructed in `infrastructure_providers.dart`

--- a/uxnanmobile/l10n/app_en.arb
+++ b/uxnanmobile/l10n/app_en.arb
@@ -28,6 +28,18 @@
   "@connectionDirect": {
     "description": "Transport indicator: the live connection is a direct LAN/Tailscale link."
   },
+  "transportLan": "LAN",
+  "@transportLan": {
+    "description": "Network-path badge: the live connection is a direct address on the same local network (Wi-Fi/Ethernet) as the PC."
+  },
+  "transportTailscale": "Tailscale",
+  "@transportTailscale": {
+    "description": "Network-path badge: the live connection is a Tailscale (or compatible virtual-network) address."
+  },
+  "transportDetecting": "Detecting…",
+  "@transportDetecting": {
+    "description": "Network-path badge shown while a connection attempt is in flight and its transport isn't known yet."
+  },
 
   "onboardingSkip": "Skip",
   "onboardingNext": "Next",
@@ -1058,7 +1070,7 @@
   "bridgeDiscoverySearching": "Searching your network…",
   "bridgeDiscoveryEmpty": "No bridges found yet. Make sure the bridge is running on the same Wi-Fi, or type the host below.",
   "manualCodeErrorInvalidInput": "Enter the bridge host and the pairing code.",
-  "manualCodeErrorNetwork": "Couldn't reach the bridge. Check the host and that the bridge is running on the same network.",
+  "manualCodeErrorNetwork": "Couldn't reach the bridge at any of the tried addresses. If the PC is on Tailscale, enter its 100.x address; if you're on the same Wi-Fi, use its local network IP. Once paired, the connection can also fall back to the relay.",
   "manualCodeErrorInvalidCode": "That code is wrong or has expired. Generate a new one on your PC.",
   "manualCodeErrorRateLimited": "Too many attempts. Wait a moment and try again.",
   "manualCodeErrorServer": "The bridge couldn't complete pairing. Try again.",

--- a/uxnanmobile/l10n/app_en.arb
+++ b/uxnanmobile/l10n/app_en.arb
@@ -38,7 +38,7 @@
   },
   "transportDetecting": "Detecting…",
   "@transportDetecting": {
-    "description": "Network-path badge shown while a connection attempt is in flight and its transport isn't known yet."
+    "description": "Device-card status shown while a connection attempt is in flight and its network path isn't known yet."
   },
 
   "onboardingSkip": "Skip",

--- a/uxnanmobile/l10n/app_es.arb
+++ b/uxnanmobile/l10n/app_es.arb
@@ -10,6 +10,9 @@
   "connectionReconnecting": "Reconectando…",
   "connectionRelay": "Relay",
   "connectionDirect": "Directa",
+  "transportLan": "LAN",
+  "transportTailscale": "Tailscale",
+  "transportDetecting": "Detectando…",
 
   "onboardingSkip": "Omitir",
   "onboardingNext": "Siguiente",
@@ -743,7 +746,7 @@
   "bridgeDiscoverySearching": "Buscando en tu red…",
   "bridgeDiscoveryEmpty": "Aún no se encontraron bridges. Asegúrate de que el bridge corre en la misma red Wi-Fi, o escribe el host abajo.",
   "manualCodeErrorInvalidInput": "Ingresa el host del bridge y el código de emparejamiento.",
-  "manualCodeErrorNetwork": "No se pudo contactar al bridge. Revisa el host y que el bridge esté corriendo en la misma red.",
+  "manualCodeErrorNetwork": "No se pudo contactar al bridge en ninguna de las direcciones probadas. Si tu PC está en Tailscale, ingresa su dirección 100.x; si están en la misma red Wi-Fi, usa su IP de red local. Una vez emparejado, la conexión también puede usar el relay como respaldo.",
   "manualCodeErrorInvalidCode": "El código es incorrecto o expiró. Genera uno nuevo en tu PC.",
   "manualCodeErrorRateLimited": "Demasiados intentos. Espera un momento e inténtalo de nuevo.",
   "manualCodeErrorServer": "El bridge no pudo completar el emparejamiento. Inténtalo de nuevo.",

--- a/uxnanmobile/lib/domain/enums/network_kind.dart
+++ b/uxnanmobile/lib/domain/enums/network_kind.dart
@@ -1,0 +1,115 @@
+/// How the phone's LIVE channel reaches the bridge, classified from the
+/// endpoint the connection actually settled on
+/// (`SessionCoordinator.connectedEndpoint`).
+///
+/// The E2EE semantics and the dial race itself (spec 02a §5.9.3) are
+/// unchanged by this — [DirectTransportSelector] already races every
+/// advertised host and falls back to the relay; this only labels which of
+/// those paths won, so the devices screen can show something more useful than
+/// a raw IP. Purely informational, purely client-side: no wire/contract
+/// change backs it.
+enum NetworkKind {
+  /// A private LAN address (RFC 1918 / link-local) — same network as the PC.
+  lan,
+
+  /// A Tailscale (or compatible CGNAT, `100.64.0.0/10`) address.
+  tailscale,
+
+  /// A direct address that isn't a recognized private/Tailscale range (a
+  /// public IP or a plain hostname) — reachable directly, just not on a
+  /// private network the phone can identify.
+  direct,
+
+  /// The hosted relay fallback.
+  relay,
+
+  /// Not connected yet, or the endpoint couldn't be classified (e.g. it was
+  /// empty). Distinct from "connecting" — callers that care about an
+  /// in-flight attempt track that separately (`connectingDeviceProvider`) and
+  /// show a detecting/loading state instead of this value.
+  unknown,
+}
+
+/// Classifies [endpointUrl] — the URL the live channel is actually served
+/// through — against [relayUrl] (the paired device's advertised relay). Pure
+/// and side-effect free (no DNS/host resolution, no I/O), so it's trivially
+/// unit-testable; the UI derives the transport badge from this.
+///
+/// Rules (checked in order):
+/// 1. A null/empty [endpointUrl] → [NetworkKind.unknown].
+/// 2. [endpointUrl] equal to [relayUrl], or sharing its host →
+///    [NetworkKind.relay].
+/// 3. An IPv4 literal host is bucketed by range:
+///    - `100.64.0.0/10` (100.64.x.x – 100.127.x.x) → [NetworkKind.tailscale].
+///    - `10.0.0.0/8`, `172.16.0.0/12` (172.16.x.x – 172.31.x.x),
+///      `192.168.0.0/16`, `169.254.0.0/16` → [NetworkKind.lan].
+///    - any other IPv4 → [NetworkKind.direct].
+/// 4. A non-IP host (a hostname) that isn't the relay → [NetworkKind.direct].
+NetworkKind classifyEndpoint(String? endpointUrl, {required String relayUrl}) {
+  if (endpointUrl == null || endpointUrl.isEmpty) return NetworkKind.unknown;
+  if (_isRelayEndpoint(endpointUrl, relayUrl)) return NetworkKind.relay;
+
+  final host = _hostOf(endpointUrl);
+  if (host == null || host.isEmpty) return NetworkKind.direct;
+
+  final octets = _ipv4Octets(host);
+  if (octets == null) {
+    return NetworkKind.direct; // a hostname, not an IPv4 literal
+  }
+
+  final a = octets[0];
+  final b = octets[1];
+  if (a == 100 && b >= 64 && b <= 127) return NetworkKind.tailscale;
+  if (a == 10) return NetworkKind.lan;
+  if (a == 172 && b >= 16 && b <= 31) return NetworkKind.lan;
+  if (a == 192 && b == 168) return NetworkKind.lan;
+  if (a == 169 && b == 254) return NetworkKind.lan;
+  return NetworkKind.direct;
+}
+
+/// Whether [endpointUrl] is the relay: an exact match, or the same host as
+/// [relayUrl] (a direct dial can't land on the relay's own host, so a host
+/// match is a reliable — and scheme/port-tolerant — signal).
+bool _isRelayEndpoint(String endpointUrl, String relayUrl) {
+  if (relayUrl.isEmpty) return false;
+  if (endpointUrl == relayUrl) return true;
+  final endpointHost = _hostOf(endpointUrl);
+  final relayHost = _hostOf(relayUrl);
+  return endpointHost != null &&
+      endpointHost.isNotEmpty &&
+      endpointHost == relayHost;
+}
+
+/// Extracts the host from a `scheme://host[:port][/path]` URL or a bare
+/// `host[:port]` string (the shape [DirectTransportSelector] dials when a
+/// device's advertised host carries no explicit scheme). `Uri.tryParse`
+/// alone isn't enough for the bare form: a dotted hostname like
+/// `host.local:9000` is itself valid URI-scheme syntax, so Dart parses
+/// `host.local` as the *scheme* and returns an empty host — hence the
+/// explicit scheme check before delegating to [Uri.tryParse].
+String? _hostOf(String url) {
+  final hasScheme = RegExp('^[a-zA-Z][a-zA-Z0-9+.-]*://').hasMatch(url);
+  if (hasScheme) {
+    final uri = Uri.tryParse(url);
+    return (uri != null && uri.host.isNotEmpty) ? uri.host : null;
+  }
+  final withoutPath = url.split('/').first.split('?').first.trim();
+  if (withoutPath.isEmpty) return null;
+  final colon = withoutPath.lastIndexOf(':');
+  return colon > 0 ? withoutPath.substring(0, colon) : withoutPath;
+}
+
+/// Parses [host] as a strict 4-octet IPv4 literal (each octet `0`–`255`), or
+/// `null` when it isn't one (a hostname, or an IPv6 literal — neither is in
+/// scope for this classifier).
+List<int>? _ipv4Octets(String host) {
+  final parts = host.split('.');
+  if (parts.length != 4) return null;
+  final octets = <int>[];
+  for (final part in parts) {
+    final value = int.tryParse(part);
+    if (value == null || value < 0 || value > 255) return null;
+    octets.add(value);
+  }
+  return octets;
+}

--- a/uxnanmobile/lib/infrastructure/discovery/bridge_discovery_service.dart
+++ b/uxnanmobile/lib/infrastructure/discovery/bridge_discovery_service.dart
@@ -89,10 +89,22 @@ DiscoveredBridge? bridgeFromService(Service service) => parseDiscoveredBridge(
       txt: service.txt ?? const <String, Uint8List?>{},
     );
 
-/// Builds a [DiscoveredBridge] from the raw discovery fields. Prefers the TXT
-/// `addr`/`port` hints the bridge advertises, then falls back to the first
-/// resolved IPv4 address and the SRV port. Returns `null` when no usable host
-/// or port can be determined (such a service can't be paired with).
+/// Builds a [DiscoveredBridge] from the raw discovery fields.
+///
+/// Address precedence is deliberately **resolved-address first**: the TXT
+/// `addr` hint is an unsigned string that any device on the network can
+/// publish, so it is only honored when it is a literal IP in a private,
+/// CGNAT/Tailscale or loopback range (see [isLocalAddressLiteral]) — never a
+/// hostname and never a public address. Otherwise the SRV-resolved IPv4 wins.
+/// The port hint is harmless (it only narrows where on that host we knock).
+///
+/// This bounds the damage of a spoofed record: a discovered bridge is still
+/// only ever contacted after the user explicitly picks it, and the pairing
+/// code is only ever sent to that one chosen host
+/// (`ManualPairingService.resolve`).
+///
+/// Returns `null` when no usable host or port can be determined (such a
+/// service can't be paired with).
 DiscoveredBridge? parseDiscoveredBridge({
   String? name,
   String? host,
@@ -109,9 +121,10 @@ DiscoveredBridge? parseDiscoveredBridge({
             addresses.isNotEmpty ? addresses.first : InternetAddress.anyIPv4,
       )
       .address;
-  final resolvedHost = (txtAddr != null && txtAddr.isNotEmpty)
-      ? txtAddr
-      : (addresses.isNotEmpty ? firstV4 : (host ?? '').trim());
+  final trustedTxtAddr =
+      (txtAddr != null && isLocalAddressLiteral(txtAddr)) ? txtAddr : null;
+  final resolvedHost =
+      addresses.isNotEmpty ? firstV4 : (trustedTxtAddr ?? (host ?? '').trim());
   final resolvedPort = txtPort ?? port;
   if (resolvedHost.isEmpty || resolvedPort == null || resolvedPort <= 0) {
     return null;
@@ -136,4 +149,33 @@ String? _txtValue(Map<String, Uint8List?> txt, String key) {
   } on FormatException {
     return null;
   }
+}
+
+/// Whether [value] is a literal IP address on a network the phone could
+/// plausibly share with the PC: RFC 1918 private space, CGNAT/Tailscale
+/// (`100.64/10`), link-local (`169.254/16`) or loopback.
+///
+/// Used to decide whether an mDNS TXT `addr` hint may be honored at all.
+/// Hostnames always fail this check on purpose — resolving one would hand an
+/// attacker who can publish a TXT record an arbitrary destination.
+bool isLocalAddressLiteral(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) return false;
+  final parts = trimmed.split('.');
+  if (parts.length != 4) return false;
+  final octets = <int>[];
+  for (final part in parts) {
+    final n = int.tryParse(part);
+    if (n == null || n < 0 || n > 255 || (part.length > 1 && part[0] == '0')) {
+      return false;
+    }
+    octets.add(n);
+  }
+  final [a, b, _, _] = octets;
+  if (a == 10 || a == 127) return true;
+  if (a == 192 && b == 168) return true;
+  if (a == 172 && b >= 16 && b <= 31) return true;
+  if (a == 100 && b >= 64 && b <= 127) return true;
+  if (a == 169 && b == 254) return true;
+  return false;
 }

--- a/uxnanmobile/lib/infrastructure/pairing/manual_pairing_service.dart
+++ b/uxnanmobile/lib/infrastructure/pairing/manual_pairing_service.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
@@ -125,13 +126,41 @@ PairingPayload parsePairResolveResponse(int statusCode, Object? data) {
   }
 }
 
+/// Normalizes and de-duplicates candidate hosts for
+/// [ManualPairingService.resolveAny], preserving first-seen order — so the
+/// user's typed host (placed first by the caller) breaks ties over a
+/// rediscovered duplicate. Entries that don't normalize to a usable
+/// `host:port` (per [normalizeHostInput]) are dropped rather than raced.
+List<String> dedupeResolveHosts(Iterable<String> hosts) {
+  final seen = <String>{};
+  final result = <String>[];
+  for (final host in hosts) {
+    final normalized = normalizeHostInput(host);
+    if (normalized != null && seen.add(normalized)) result.add(normalized);
+  }
+  return result;
+}
+
+/// Ranks [ManualPairingErrorKind]s by how actionable they are for
+/// [ManualPairingService.resolveAny] — lower is more useful to show the user.
+/// A definitive answer FROM a reached bridge (wrong/expired code, rate
+/// limited, a malformed/server reply) always outranks a plain "unreachable":
+/// the latter just means *this one candidate* never answered, not that
+/// pairing itself is broken, so it should only surface when nothing reached
+/// any bridge at all.
+int resolveErrorPriority(ManualPairingErrorKind kind) => switch (kind) {
+      ManualPairingErrorKind.invalidOrExpiredCode => 0,
+      ManualPairingErrorKind.rateLimited => 1,
+      ManualPairingErrorKind.malformedPayload => 2,
+      ManualPairingErrorKind.server => 3,
+      ManualPairingErrorKind.network => 4,
+      ManualPairingErrorKind.invalidInput => 5,
+    };
+
 /// Resolves a manual pairing code into a [PairingPayload] by calling the
 /// **bridge** directly (`GET /pair/resolve?code=`), bypassing the QR scan. The
 /// returned payload is fed into the normal pairing handshake
 /// (`SessionCoordinator.processPairingPayload`).
-///
-/// FOR-DEV: discovery is manual (the user types the host shown on the PC).
-/// mDNS browse (`_uxnan._tcp`) to auto-list bridges is a follow-up.
 class ManualPairingService {
   /// Creates a [ManualPairingService] over [_dio].
   ManualPairingService(this._dio);
@@ -161,5 +190,70 @@ class ManualPairingService {
     } on DioException catch (e) {
       throw ManualPairingException(ManualPairingErrorKind.network, e.message);
     }
+  }
+
+  // FOR-DEV: `resolveAny` only reaches hosts directly dialable from the phone
+  // right now (the typed host + LAN mDNS candidates) — a phone with no
+  // LAN/Tailscale path to the PC at all (e.g. cellular data only, PC not yet
+  // joined to Tailscale) still can't resolve a code. Fetching the payload
+  // through the relay instead of this direct GET would let pairing work with
+  // no direct reachability at all, but needs a new relay+bridge+shared
+  // contract (the relay has no route to reach an unpaired bridge on the
+  // phone's behalf today). See FOR-DEV.md.
+  /// Resolves [code] by racing it concurrently against every candidate in
+  /// [hosts] (deduplicated via [dedupeResolveHosts]) — the first `HTTP 2xx`
+  /// wins. Built so a stale or wrong typed host doesn't dead-end pairing: the
+  /// caller mixes in any bridges discovered via mDNS
+  /// (`BridgeDiscoveryService`), and whichever one actually answers wins,
+  /// exactly like [DirectTransportSelector] already races the paired device's
+  /// advertised hosts for the live WS connection.
+  ///
+  /// On failure, throws the single most actionable [ManualPairingException]
+  /// across every attempt (see [resolveErrorPriority]) — so, for example, a
+  /// wrong/expired code reported by one reachable bridge is shown instead of
+  /// a generic "unreachable" from a different candidate that never answered.
+  Future<PairingPayload> resolveAny({
+    required Iterable<String> hosts,
+    required String code,
+  }) async {
+    final candidates = dedupeResolveHosts(hosts);
+    if (candidates.isEmpty) {
+      throw const ManualPairingException(ManualPairingErrorKind.invalidInput);
+    }
+
+    final completer = Completer<PairingPayload>();
+    var pending = candidates.length;
+    ManualPairingException? bestError;
+
+    void fail(ManualPairingException error) {
+      if (bestError == null ||
+          resolveErrorPriority(error.kind) <
+              resolveErrorPriority(bestError!.kind)) {
+        bestError = error;
+      }
+      pending--;
+      if (pending == 0 && !completer.isCompleted) {
+        completer.completeError(
+          bestError ??
+              const ManualPairingException(ManualPairingErrorKind.network),
+        );
+      }
+    }
+
+    for (final host in candidates) {
+      unawaited(
+        resolve(host: host, code: code).then((payload) {
+          if (!completer.isCompleted) completer.complete(payload);
+        }).catchError((Object error) {
+          fail(
+            error is ManualPairingException
+                ? error
+                : const ManualPairingException(ManualPairingErrorKind.network),
+          );
+        }),
+      );
+    }
+
+    return completer.future;
   }
 }

--- a/uxnanmobile/lib/infrastructure/pairing/manual_pairing_service.dart
+++ b/uxnanmobile/lib/infrastructure/pairing/manual_pairing_service.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
@@ -126,41 +125,18 @@ PairingPayload parsePairResolveResponse(int statusCode, Object? data) {
   }
 }
 
-/// Normalizes and de-duplicates candidate hosts for
-/// [ManualPairingService.resolveAny], preserving first-seen order — so the
-/// user's typed host (placed first by the caller) breaks ties over a
-/// rediscovered duplicate. Entries that don't normalize to a usable
-/// `host:port` (per [normalizeHostInput]) are dropped rather than raced.
-List<String> dedupeResolveHosts(Iterable<String> hosts) {
-  final seen = <String>{};
-  final result = <String>[];
-  for (final host in hosts) {
-    final normalized = normalizeHostInput(host);
-    if (normalized != null && seen.add(normalized)) result.add(normalized);
-  }
-  return result;
-}
-
-/// Ranks [ManualPairingErrorKind]s by how actionable they are for
-/// [ManualPairingService.resolveAny] — lower is more useful to show the user.
-/// A definitive answer FROM a reached bridge (wrong/expired code, rate
-/// limited, a malformed/server reply) always outranks a plain "unreachable":
-/// the latter just means *this one candidate* never answered, not that
-/// pairing itself is broken, so it should only surface when nothing reached
-/// any bridge at all.
-int resolveErrorPriority(ManualPairingErrorKind kind) => switch (kind) {
-      ManualPairingErrorKind.invalidOrExpiredCode => 0,
-      ManualPairingErrorKind.rateLimited => 1,
-      ManualPairingErrorKind.malformedPayload => 2,
-      ManualPairingErrorKind.server => 3,
-      ManualPairingErrorKind.network => 4,
-      ManualPairingErrorKind.invalidInput => 5,
-    };
-
 /// Resolves a manual pairing code into a [PairingPayload] by calling the
 /// **bridge** directly (`GET /pair/resolve?code=`), bypassing the QR scan. The
 /// returned payload is fed into the normal pairing handshake
 /// (`SessionCoordinator.processPairingPayload`).
+///
+/// The code is a shared secret read off the PC screen, and a successful
+/// resolve both hands out the pairing payload and arms the bridge's
+/// `qr_bootstrap` window. So it is sent to exactly ONE host — the one the user
+/// named — and never fanned out across candidates: mDNS records are
+/// unauthenticated and spoofable by any device on the network, so racing
+/// discovered hosts would disclose the code to them and let the first
+/// responder impersonate the PC.
 class ManualPairingService {
   /// Creates a [ManualPairingService] over [_dio].
   ManualPairingService(this._dio);
@@ -190,70 +166,5 @@ class ManualPairingService {
     } on DioException catch (e) {
       throw ManualPairingException(ManualPairingErrorKind.network, e.message);
     }
-  }
-
-  // FOR-DEV: `resolveAny` only reaches hosts directly dialable from the phone
-  // right now (the typed host + LAN mDNS candidates) — a phone with no
-  // LAN/Tailscale path to the PC at all (e.g. cellular data only, PC not yet
-  // joined to Tailscale) still can't resolve a code. Fetching the payload
-  // through the relay instead of this direct GET would let pairing work with
-  // no direct reachability at all, but needs a new relay+bridge+shared
-  // contract (the relay has no route to reach an unpaired bridge on the
-  // phone's behalf today). See FOR-DEV.md.
-  /// Resolves [code] by racing it concurrently against every candidate in
-  /// [hosts] (deduplicated via [dedupeResolveHosts]) — the first `HTTP 2xx`
-  /// wins. Built so a stale or wrong typed host doesn't dead-end pairing: the
-  /// caller mixes in any bridges discovered via mDNS
-  /// (`BridgeDiscoveryService`), and whichever one actually answers wins,
-  /// exactly like [DirectTransportSelector] already races the paired device's
-  /// advertised hosts for the live WS connection.
-  ///
-  /// On failure, throws the single most actionable [ManualPairingException]
-  /// across every attempt (see [resolveErrorPriority]) — so, for example, a
-  /// wrong/expired code reported by one reachable bridge is shown instead of
-  /// a generic "unreachable" from a different candidate that never answered.
-  Future<PairingPayload> resolveAny({
-    required Iterable<String> hosts,
-    required String code,
-  }) async {
-    final candidates = dedupeResolveHosts(hosts);
-    if (candidates.isEmpty) {
-      throw const ManualPairingException(ManualPairingErrorKind.invalidInput);
-    }
-
-    final completer = Completer<PairingPayload>();
-    var pending = candidates.length;
-    ManualPairingException? bestError;
-
-    void fail(ManualPairingException error) {
-      if (bestError == null ||
-          resolveErrorPriority(error.kind) <
-              resolveErrorPriority(bestError!.kind)) {
-        bestError = error;
-      }
-      pending--;
-      if (pending == 0 && !completer.isCompleted) {
-        completer.completeError(
-          bestError ??
-              const ManualPairingException(ManualPairingErrorKind.network),
-        );
-      }
-    }
-
-    for (final host in candidates) {
-      unawaited(
-        resolve(host: host, code: code).then((payload) {
-          if (!completer.isCompleted) completer.complete(payload);
-        }).catchError((Object error) {
-          fail(
-            error is ManualPairingException
-                ? error
-                : const ManualPairingException(ManualPairingErrorKind.network),
-          );
-        }),
-      );
-    }
-
-    return completer.future;
   }
 }

--- a/uxnanmobile/lib/l10n/app_localizations.dart
+++ b/uxnanmobile/lib/l10n/app_localizations.dart
@@ -170,7 +170,7 @@ abstract class AppLocalizations {
   /// **'Tailscale'**
   String get transportTailscale;
 
-  /// Network-path badge shown while a connection attempt is in flight and its transport isn't known yet.
+  /// Device-card status shown while a connection attempt is in flight and its network path isn't known yet.
   ///
   /// In en, this message translates to:
   /// **'Detecting…'**

--- a/uxnanmobile/lib/l10n/app_localizations.dart
+++ b/uxnanmobile/lib/l10n/app_localizations.dart
@@ -158,6 +158,24 @@ abstract class AppLocalizations {
   /// **'Direct'**
   String get connectionDirect;
 
+  /// Network-path badge: the live connection is a direct address on the same local network (Wi-Fi/Ethernet) as the PC.
+  ///
+  /// In en, this message translates to:
+  /// **'LAN'**
+  String get transportLan;
+
+  /// Network-path badge: the live connection is a Tailscale (or compatible virtual-network) address.
+  ///
+  /// In en, this message translates to:
+  /// **'Tailscale'**
+  String get transportTailscale;
+
+  /// Network-path badge shown while a connection attempt is in flight and its transport isn't known yet.
+  ///
+  /// In en, this message translates to:
+  /// **'Detecting…'**
+  String get transportDetecting;
+
   /// No description provided for @onboardingSkip.
   ///
   /// In en, this message translates to:
@@ -3983,7 +4001,7 @@ abstract class AppLocalizations {
   /// No description provided for @manualCodeErrorNetwork.
   ///
   /// In en, this message translates to:
-  /// **'Couldn\'t reach the bridge. Check the host and that the bridge is running on the same network.'**
+  /// **'Couldn\'t reach the bridge at any of the tried addresses. If the PC is on Tailscale, enter its 100.x address; if you\'re on the same Wi-Fi, use its local network IP. Once paired, the connection can also fall back to the relay.'**
   String get manualCodeErrorNetwork;
 
   /// No description provided for @manualCodeErrorInvalidCode.

--- a/uxnanmobile/lib/l10n/app_localizations_en.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_en.dart
@@ -40,6 +40,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get connectionDirect => 'Direct';
 
   @override
+  String get transportLan => 'LAN';
+
+  @override
+  String get transportTailscale => 'Tailscale';
+
+  @override
+  String get transportDetecting => 'Detecting…';
+
+  @override
   String get onboardingSkip => 'Skip';
 
   @override
@@ -2131,7 +2140,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get manualCodeErrorNetwork =>
-      'Couldn\'t reach the bridge. Check the host and that the bridge is running on the same network.';
+      'Couldn\'t reach the bridge at any of the tried addresses. If the PC is on Tailscale, enter its 100.x address; if you\'re on the same Wi-Fi, use its local network IP. Once paired, the connection can also fall back to the relay.';
 
   @override
   String get manualCodeErrorInvalidCode =>

--- a/uxnanmobile/lib/l10n/app_localizations_es.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_es.dart
@@ -40,6 +40,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get connectionDirect => 'Directa';
 
   @override
+  String get transportLan => 'LAN';
+
+  @override
+  String get transportTailscale => 'Tailscale';
+
+  @override
+  String get transportDetecting => 'Detectando…';
+
+  @override
   String get onboardingSkip => 'Omitir';
 
   @override
@@ -2142,7 +2151,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get manualCodeErrorNetwork =>
-      'No se pudo contactar al bridge. Revisa el host y que el bridge esté corriendo en la misma red.';
+      'No se pudo contactar al bridge en ninguna de las direcciones probadas. Si tu PC está en Tailscale, ingresa su dirección 100.x; si están en la misma red Wi-Fi, usa su IP de red local. Una vez emparejado, la conexión también puede usar el relay como respaldo.';
 
   @override
   String get manualCodeErrorInvalidCode =>

--- a/uxnanmobile/lib/presentation/providers/application_providers.dart
+++ b/uxnanmobile/lib/presentation/providers/application_providers.dart
@@ -28,6 +28,7 @@ import 'package:uxnan/domain/enums/agent_id.dart';
 import 'package:uxnan/domain/enums/connection_phase.dart';
 import 'package:uxnan/domain/enums/context_indicator_mode.dart';
 import 'package:uxnan/domain/enums/metrics_refresh_interval.dart';
+import 'package:uxnan/domain/enums/network_kind.dart';
 import 'package:uxnan/domain/enums/thread_activity.dart';
 import 'package:uxnan/domain/enums/usage_refresh_interval.dart';
 import 'package:uxnan/domain/services/pairing_validator.dart';
@@ -124,6 +125,25 @@ final connectingDeviceProvider = StreamProvider<TrustedDevice?>(
 final connectedEndpointProvider = StreamProvider<String?>(
   (ref) => ref.watch(sessionCoordinatorProvider).connectedEndpointStream,
 );
+
+/// The network path the LIVE channel is actually using — LAN, Tailscale, a
+/// direct address, or the relay — classified client-side from
+/// [connectedEndpointProvider] against the connected device's advertised
+/// `relayUrl` (see [classifyEndpoint]). [NetworkKind.unknown] while no device
+/// holds the live channel.
+///
+/// Deliberately NOT derived from [bridgeStatusProvider].relayConnected: that
+/// field only distinguishes relay vs. direct and can't tell LAN from
+/// Tailscale, and it's keyed to whichever PC last answered `bridge/status`
+/// rather than the endpoint actually in use. This is a pure, synchronous
+/// derivation of the two streams that already track the real connection, so
+/// the transport badge never lags or misreports during a reconnect.
+final networkKindProvider = Provider<NetworkKind>((ref) {
+  final device = ref.watch(connectedDeviceProvider).value;
+  if (device == null) return NetworkKind.unknown;
+  final endpoint = ref.watch(connectedEndpointProvider).value;
+  return classifyEndpoint(endpoint, relayUrl: device.relayUrl);
+});
 
 /// The connected bridge's status (`bridge/status`), refreshed whenever the
 /// connected device changes. Null while not connected or against an older

--- a/uxnanmobile/lib/presentation/screens/devices/my_devices_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/devices/my_devices_screen.dart
@@ -605,7 +605,7 @@ class _StatusLine extends StatelessWidget {
     final (label, color) = isConnected
         ? (l10n.connectionConnected, UxnanColors.connected)
         : isConnecting
-            ? (l10n.connectionConnecting, UxnanColors.connecting)
+            ? (l10n.transportDetecting, UxnanColors.connecting)
             : (l10n.connectionDisconnected, UxnanColors.disconnected);
 
     return Row(
@@ -624,16 +624,13 @@ class _StatusLine extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ),
-        // The network path badge: LAN / Tailscale / direct / relay while
-        // connected, a "detecting…" loading pill while this PC's own connect
-        // attempt is in flight, and nothing otherwise.
-        if (isConnected || isConnecting) ...[
+        // The network path badge is meaningful only after the live channel has
+        // been established. During detection, the status label above is the
+        // single progress indicator; while disconnected, no network path is
+        // shown.
+        if (isConnected) ...[
           const SizedBox(width: UxnanSpacing.xs),
-          TransportBadge(
-            kind: networkKind,
-            detecting: isConnecting && !isConnected,
-            dense: true,
-          ),
+          TransportBadge(kind: networkKind, dense: true),
         ],
       ],
     );

--- a/uxnanmobile/lib/presentation/screens/devices/my_devices_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/devices/my_devices_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:uxnan/domain/entities/trusted_device.dart';
+import 'package:uxnan/domain/enums/network_kind.dart';
 import 'package:uxnan/l10n/app_localizations.dart';
 import 'package:uxnan/presentation/providers/application_providers.dart';
 import 'package:uxnan/presentation/providers/infrastructure_providers.dart';
@@ -16,6 +17,7 @@ import 'package:uxnan/presentation/theme/typography.dart';
 import 'package:uxnan/presentation/widgets/icon_surface.dart';
 import 'package:uxnan/presentation/widgets/ne_card.dart';
 import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
+import 'package:uxnan/presentation/widgets/transport_badge.dart';
 
 /// The app's home: the list of paired PCs (trusted bridges). The app keeps one
 /// active connection at a time; tapping a PC opens its threads and "Connect"
@@ -129,11 +131,12 @@ class MyDevicesScreen extends ConsumerWidget {
     // never makes it appear connected when it isn't reachable.
     final connectedId = ref.watch(connectedDeviceProvider).value?.macDeviceId;
     final connectingId = ref.watch(connectingDeviceProvider).value?.macDeviceId;
-    // Whether the live connection runs over the relay (vs direct LAN/Tailscale),
-    // as reported by `bridge/status`. Null until known; only the connected PC
-    // shows it.
-    final relayConnected =
-        ref.watch(bridgeStatusProvider).value?.relayConnected;
+    // The classified network path of the LIVE channel — LAN, Tailscale, a
+    // direct address, or the relay — derived client-side from the actual
+    // connected endpoint (never from `bridge/status.relayConnected`, which
+    // can't tell LAN from Tailscale and lags the real per-session transport).
+    // Only the connected PC shows it.
+    final networkKind = ref.watch(networkKindProvider);
     // The endpoint the live channel is ACTUALLY served through (the winning
     // direct host, or the relay), so the connected card shows the real address
     // in use — not the first advertised host (a lexicographic guess that is
@@ -201,8 +204,9 @@ class MyDevicesScreen extends ConsumerWidget {
                 device: device,
                 isConnected: device.macDeviceId == connectedId,
                 isConnecting: device.macDeviceId == connectingId,
-                relayConnected:
-                    device.macDeviceId == connectedId ? relayConnected : null,
+                networkKind: device.macDeviceId == connectedId
+                    ? networkKind
+                    : NetworkKind.unknown,
                 connectedEndpoint: device.macDeviceId == connectedId
                     ? connectedEndpoint
                     : null,
@@ -237,7 +241,7 @@ class _DeviceCard extends StatelessWidget {
     required this.device,
     required this.isConnected,
     required this.isConnecting,
-    required this.relayConnected,
+    required this.networkKind,
     required this.connectedEndpoint,
     required this.onStats,
     required this.onOpen,
@@ -251,9 +255,10 @@ class _DeviceCard extends StatelessWidget {
   final bool isConnected;
   final bool isConnecting;
 
-  /// For the connected PC: whether the live channel runs over the relay (true)
-  /// or direct LAN/Tailscale (false); null when unknown / not connected.
-  final bool? relayConnected;
+  /// For the connected PC: the classified network path of the live channel
+  /// (LAN / Tailscale / direct / relay); [NetworkKind.unknown] when not this
+  /// card's connected PC.
+  final NetworkKind networkKind;
 
   /// For the connected PC: the URL the live channel is actually served through
   /// (the winning direct host, or the relay); null when unknown / not connected.
@@ -397,7 +402,7 @@ class _DeviceCard extends StatelessWidget {
                 child: _StatusLine(
                   isConnected: isConnected,
                   isConnecting: isConnecting,
-                  relayConnected: relayConnected,
+                  networkKind: networkKind,
                 ),
               ),
               if (!isConnected)
@@ -583,16 +588,15 @@ class _StatusLine extends StatelessWidget {
   const _StatusLine({
     required this.isConnected,
     required this.isConnecting,
-    this.relayConnected,
+    required this.networkKind,
   });
   final bool isConnected;
   final bool isConnecting;
-  final bool? relayConnected;
+  final NetworkKind networkKind;
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final colors = Theme.of(context).colorScheme;
     final textTheme = Theme.of(context).textTheme;
 
     // Truthful per-device status: connected only when this PC holds the live
@@ -620,15 +624,15 @@ class _StatusLine extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ),
-        // How we're connected: relay vs direct LAN/Tailscale (connected only).
-        if (isConnected && relayConnected != null) ...[
+        // The network path badge: LAN / Tailscale / direct / relay while
+        // connected, a "detecting…" loading pill while this PC's own connect
+        // attempt is in flight, and nothing otherwise.
+        if (isConnected || isConnecting) ...[
           const SizedBox(width: UxnanSpacing.xs),
-          Text(
-            '· '
-            '${relayConnected! ? l10n.connectionRelay : l10n.connectionDirect}',
-            style: textTheme.bodySmall?.copyWith(
-              color: colors.onSurfaceVariant,
-            ),
+          TransportBadge(
+            kind: networkKind,
+            detecting: isConnecting && !isConnected,
+            dense: true,
           ),
         ],
       ],

--- a/uxnanmobile/lib/presentation/screens/pairing/manual_code_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/pairing/manual_code_screen.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:uxnan/core/utils/logger.dart';
+import 'package:uxnan/domain/entities/discovered_bridge.dart';
+import 'package:uxnan/infrastructure/discovery/bridge_discovery_service.dart';
 import 'package:uxnan/infrastructure/pairing/manual_pairing_service.dart';
 import 'package:uxnan/l10n/app_localizations.dart';
 import 'package:uxnan/presentation/providers/application_providers.dart';
@@ -23,9 +27,13 @@ import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 /// bridge's `GET /pair/resolve` endpoint, then runs the normal pairing
 /// handshake (`SessionCoordinator.processPairingPayload`).
 ///
-/// A **Browse nearby bridges** action runs mDNS discovery
-/// ([BridgeDiscoverySheet]) so the user can pick a bridge instead of typing the
-/// host; manual entry stays the fallback.
+/// The resolve itself races the typed host against any bridge the screen has
+/// passively discovered via mDNS in the background (`resolveAny`), so a
+/// stale/wrong typed address — or one that just isn't reachable on the
+/// phone's *current* network — doesn't dead-end pairing when the right
+/// bridge is otherwise reachable. A **Browse nearby bridges** action
+/// ([BridgeDiscoverySheet]) additionally lets the user pick a bridge instead
+/// of typing the host at all; manual entry stays the fallback either way.
 ///
 /// Chrome follows the Neural Expressive language (guide §4.1–4.3): a
 /// transparent [NeTopBar] with a scroll veil over an [IconSurface] back, an
@@ -46,10 +54,32 @@ class _ManualCodeScreenState extends ConsumerState<ManualCodeScreen> {
   bool _connecting = false;
   String? _error;
 
+  // Passive LAN discovery for the connect-time host race: a private
+  // BridgeDiscoveryService (not the shared, sheet-scoped
+  // bridgeDiscoveryProvider) started as soon as this screen opens, so nearby
+  // bridges are already known by the time the user taps Connect — without
+  // adding latency to the happy path (typing a host + a code takes longer
+  // than mDNS needs to answer). Best-effort: an empty/failed discovery just
+  // leaves the typed host as the only candidate, exactly like before this
+  // feature existed.
+  final BridgeDiscoveryService _discovery = BridgeDiscoveryService();
+  List<DiscoveredBridge> _discovered = const [];
+  StreamSubscription<List<DiscoveredBridge>>? _discoverySub;
+
+  @override
+  void initState() {
+    super.initState();
+    _discoverySub =
+        _discovery.bridges.listen((bridges) => _discovered = bridges);
+    unawaited(_discovery.start());
+  }
+
   @override
   void dispose() {
     _host.dispose();
     _code.dispose();
+    unawaited(_discoverySub?.cancel());
+    unawaited(_discovery.dispose());
     super.dispose();
   }
 
@@ -79,10 +109,18 @@ class _ManualCodeScreenState extends ConsumerState<ManualCodeScreen> {
       _connecting = true;
       _error = null;
     });
+    // The typed host first (so it wins ties in `resolveAny`'s dedupe), then
+    // whatever the passive mDNS scan has found by now — so a stale/wrong
+    // typed address doesn't dead-end pairing when the right bridge is
+    // discoverable on the same network.
+    final candidates = <String>[
+      _host.text,
+      for (final bridge in _discovered) bridge.hostPort,
+    ];
     try {
       final payload = await ref
           .read(manualPairingServiceProvider)
-          .resolve(host: _host.text, code: _code.text);
+          .resolveAny(hosts: candidates, code: _code.text);
       await ref.read(sessionCoordinatorProvider).processPairingPayload(payload);
       if (mounted) context.go(AppRoutes.home);
     } on ManualPairingException catch (error, stackTrace) {

--- a/uxnanmobile/lib/presentation/screens/pairing/manual_code_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/pairing/manual_code_screen.dart
@@ -1,11 +1,7 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:uxnan/core/utils/logger.dart';
-import 'package:uxnan/domain/entities/discovered_bridge.dart';
-import 'package:uxnan/infrastructure/discovery/bridge_discovery_service.dart';
 import 'package:uxnan/infrastructure/pairing/manual_pairing_service.dart';
 import 'package:uxnan/l10n/app_localizations.dart';
 import 'package:uxnan/presentation/providers/application_providers.dart';
@@ -27,13 +23,11 @@ import 'package:uxnan/presentation/widgets/ne_top_bar.dart';
 /// bridge's `GET /pair/resolve` endpoint, then runs the normal pairing
 /// handshake (`SessionCoordinator.processPairingPayload`).
 ///
-/// The resolve itself races the typed host against any bridge the screen has
-/// passively discovered via mDNS in the background (`resolveAny`), so a
-/// stale/wrong typed address — or one that just isn't reachable on the
-/// phone's *current* network — doesn't dead-end pairing when the right
-/// bridge is otherwise reachable. A **Browse nearby bridges** action
-/// ([BridgeDiscoverySheet]) additionally lets the user pick a bridge instead
-/// of typing the host at all; manual entry stays the fallback either way.
+/// The code is resolved against **one** host: the one the user chose. A
+/// **Browse nearby bridges** action ([BridgeDiscoverySheet]) lets them pick a
+/// discovered bridge instead of typing the address, which fills the host field
+/// — an explicit choice either way. The code is deliberately never fanned out
+/// to hosts the user did not name (see `_connect`).
 ///
 /// Chrome follows the Neural Expressive language (guide §4.1–4.3): a
 /// transparent [NeTopBar] with a scroll veil over an [IconSurface] back, an
@@ -54,32 +48,10 @@ class _ManualCodeScreenState extends ConsumerState<ManualCodeScreen> {
   bool _connecting = false;
   String? _error;
 
-  // Passive LAN discovery for the connect-time host race: a private
-  // BridgeDiscoveryService (not the shared, sheet-scoped
-  // bridgeDiscoveryProvider) started as soon as this screen opens, so nearby
-  // bridges are already known by the time the user taps Connect — without
-  // adding latency to the happy path (typing a host + a code takes longer
-  // than mDNS needs to answer). Best-effort: an empty/failed discovery just
-  // leaves the typed host as the only candidate, exactly like before this
-  // feature existed.
-  final BridgeDiscoveryService _discovery = BridgeDiscoveryService();
-  List<DiscoveredBridge> _discovered = const [];
-  StreamSubscription<List<DiscoveredBridge>>? _discoverySub;
-
-  @override
-  void initState() {
-    super.initState();
-    _discoverySub =
-        _discovery.bridges.listen((bridges) => _discovered = bridges);
-    unawaited(_discovery.start());
-  }
-
   @override
   void dispose() {
     _host.dispose();
     _code.dispose();
-    unawaited(_discoverySub?.cancel());
-    unawaited(_discovery.dispose());
     super.dispose();
   }
 
@@ -109,18 +81,17 @@ class _ManualCodeScreenState extends ConsumerState<ManualCodeScreen> {
       _connecting = true;
       _error = null;
     });
-    // The typed host first (so it wins ties in `resolveAny`'s dedupe), then
-    // whatever the passive mDNS scan has found by now — so a stale/wrong
-    // typed address doesn't dead-end pairing when the right bridge is
-    // discoverable on the same network.
-    final candidates = <String>[
-      _host.text,
-      for (final bridge in _discovered) bridge.hostPort,
-    ];
+    // The pairing code goes to EXACTLY ONE host: the one the user chose —
+    // typed here, or picked in the discovery sheet (which fills this field).
+    // It must never be fanned out to hosts the user did not name: the code is
+    // a shared secret, mDNS records are unauthenticated and spoofable by any
+    // device on the network, and whoever holds the code can pull the pairing
+    // payload AND arm the bridge's bootstrap window (see the bridge's
+    // `PairingCodeService.resolve`). See `docs/architecture.md`.
     try {
       final payload = await ref
           .read(manualPairingServiceProvider)
-          .resolveAny(hosts: candidates, code: _code.text);
+          .resolve(host: _host.text, code: _code.text);
       await ref.read(sessionCoordinatorProvider).processPairingPayload(payload);
       if (mounted) context.go(AppRoutes.home);
     } on ManualPairingException catch (error, stackTrace) {

--- a/uxnanmobile/lib/presentation/widgets/transport_badge.dart
+++ b/uxnanmobile/lib/presentation/widgets/transport_badge.dart
@@ -2,35 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:uxnan/domain/enums/network_kind.dart';
 import 'package:uxnan/l10n/app_localizations.dart';
 import 'package:uxnan/presentation/theme/spacing.dart';
-import 'package:uxnan/presentation/widgets/expressive_progress.dart';
 
 /// A small pill that labels the network path a live connection is using —
 /// LAN, Tailscale, a direct address, or the relay — following the same
 /// "type-specific icon + color pill" pattern as `CommitRefChip`
-/// (`git/widgets/commit_ref_chip.dart`). While a connection attempt is in
-/// flight and the kind isn't known yet, pass [detecting] instead of relying
-/// on [kind] for a loading state; when neither applies ([kind] is
-/// [NetworkKind.unknown] and [detecting] is false), the badge renders nothing.
+/// (`git/widgets/commit_ref_chip.dart`). When the path isn't known ([kind] is
+/// [NetworkKind.unknown] — including while a connection attempt is still in
+/// flight) the badge renders nothing; the in-flight state is carried by the
+/// card's own status line, not by this pill.
 ///
 /// Cross-fades between states with [AnimatedSwitcher] — honoring reduced
 /// motion — so a kind flip mid-session (e.g. a reconnect that falls back from
 /// Tailscale to the relay) reads as a transition, not a jump cut.
 class TransportBadge extends StatelessWidget {
-  /// Creates a [TransportBadge] for [kind], or a loading pill when
-  /// [detecting] is true (in which case [kind] is ignored).
-  const TransportBadge({
-    required this.kind,
-    this.detecting = false,
-    this.dense = false,
-    super.key,
-  });
+  /// Creates a [TransportBadge] for [kind].
+  const TransportBadge({required this.kind, this.dense = false, super.key});
 
-  /// The classified network path. Ignored while [detecting] is true.
+  /// The classified network path.
   final NetworkKind kind;
-
-  /// Shows a spinner + "Detecting…" pill instead of [kind] — for a connection
-  /// attempt in flight whose path isn't resolved yet.
-  final bool detecting;
 
   /// A tighter variant for dense rows.
   final bool dense;
@@ -42,19 +31,7 @@ class TransportBadge extends StatelessWidget {
     final reduceMotion = MediaQuery.disableAnimationsOf(context);
 
     final Widget child;
-    if (detecting) {
-      child = _Pill(
-        key: const ValueKey('detecting'),
-        dense: dense,
-        background: colors.surfaceContainerHigh,
-        foreground: colors.onSurfaceVariant,
-        leading: PolygonLoader(
-          size: dense ? 11 : 13,
-          color: colors.onSurfaceVariant,
-        ),
-        label: l10n.transportDetecting,
-      );
-    } else if (kind == NetworkKind.unknown) {
+    if (kind == NetworkKind.unknown) {
       child = const SizedBox.shrink(key: ValueKey('hidden'));
     } else {
       final (icon, label) = _labelFor(kind, l10n);

--- a/uxnanmobile/lib/presentation/widgets/transport_badge.dart
+++ b/uxnanmobile/lib/presentation/widgets/transport_badge.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:uxnan/domain/enums/network_kind.dart';
+import 'package:uxnan/l10n/app_localizations.dart';
+import 'package:uxnan/presentation/theme/spacing.dart';
+import 'package:uxnan/presentation/widgets/expressive_progress.dart';
+
+/// A small pill that labels the network path a live connection is using —
+/// LAN, Tailscale, a direct address, or the relay — following the same
+/// "type-specific icon + color pill" pattern as `CommitRefChip`
+/// (`git/widgets/commit_ref_chip.dart`). While a connection attempt is in
+/// flight and the kind isn't known yet, pass [detecting] instead of relying
+/// on [kind] for a loading state; when neither applies ([kind] is
+/// [NetworkKind.unknown] and [detecting] is false), the badge renders nothing.
+///
+/// Cross-fades between states with [AnimatedSwitcher] — honoring reduced
+/// motion — so a kind flip mid-session (e.g. a reconnect that falls back from
+/// Tailscale to the relay) reads as a transition, not a jump cut.
+class TransportBadge extends StatelessWidget {
+  /// Creates a [TransportBadge] for [kind], or a loading pill when
+  /// [detecting] is true (in which case [kind] is ignored).
+  const TransportBadge({
+    required this.kind,
+    this.detecting = false,
+    this.dense = false,
+    super.key,
+  });
+
+  /// The classified network path. Ignored while [detecting] is true.
+  final NetworkKind kind;
+
+  /// Shows a spinner + "Detecting…" pill instead of [kind] — for a connection
+  /// attempt in flight whose path isn't resolved yet.
+  final bool detecting;
+
+  /// A tighter variant for dense rows.
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final colors = Theme.of(context).colorScheme;
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+
+    final Widget child;
+    if (detecting) {
+      child = _Pill(
+        key: const ValueKey('detecting'),
+        dense: dense,
+        background: colors.surfaceContainerHigh,
+        foreground: colors.onSurfaceVariant,
+        leading: PolygonLoader(
+          size: dense ? 11 : 13,
+          color: colors.onSurfaceVariant,
+        ),
+        label: l10n.transportDetecting,
+      );
+    } else if (kind == NetworkKind.unknown) {
+      child = const SizedBox.shrink(key: ValueKey('hidden'));
+    } else {
+      final (icon, label) = _labelFor(kind, l10n);
+      final (background, foreground) = _colorsFor(kind, colors);
+      child = _Pill(
+        key: ValueKey(kind),
+        dense: dense,
+        background: background,
+        foreground: foreground,
+        leading: Icon(icon, size: dense ? 11 : 13, color: foreground),
+        label: label,
+      );
+    }
+
+    return AnimatedSwitcher(
+      duration:
+          reduceMotion ? Duration.zero : const Duration(milliseconds: 240),
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      transitionBuilder: (child, animation) =>
+          FadeTransition(opacity: animation, child: child),
+      child: child,
+    );
+  }
+
+  (IconData, String) _labelFor(NetworkKind kind, AppLocalizations l10n) {
+    return switch (kind) {
+      NetworkKind.lan => (Icons.router_rounded, l10n.transportLan),
+      NetworkKind.tailscale => (
+          Icons.shield_rounded,
+          l10n.transportTailscale,
+        ),
+      NetworkKind.direct => (Icons.link_rounded, l10n.connectionDirect),
+      NetworkKind.relay => (Icons.cloud_outlined, l10n.connectionRelay),
+      NetworkKind.unknown => (Icons.help_outline_rounded, ''),
+    };
+  }
+
+  (Color, Color) _colorsFor(NetworkKind kind, ColorScheme colors) {
+    return switch (kind) {
+      NetworkKind.lan => (
+          colors.tertiaryContainer,
+          colors.onTertiaryContainer,
+        ),
+      NetworkKind.tailscale => (
+          colors.primaryContainer,
+          colors.onPrimaryContainer,
+        ),
+      NetworkKind.direct => (
+          colors.secondaryContainer,
+          colors.onSecondaryContainer,
+        ),
+      NetworkKind.relay => (
+          colors.surfaceContainerHighest,
+          colors.onSurfaceVariant,
+        ),
+      NetworkKind.unknown => (
+          colors.surfaceContainerHighest,
+          colors.onSurfaceVariant,
+        ),
+    };
+  }
+}
+
+class _Pill extends StatelessWidget {
+  const _Pill({
+    required this.background,
+    required this.foreground,
+    required this.leading,
+    required this.label,
+    required this.dense,
+    super.key,
+  });
+
+  final Color background;
+  final Color foreground;
+  final Widget leading;
+  final String label;
+  final bool dense;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: dense ? UxnanSpacing.xs : UxnanSpacing.sm,
+        vertical: 2,
+      ),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: const BorderRadius.all(UxnanRadius.full),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          leading,
+          const SizedBox(width: UxnanSpacing.xs),
+          Text(
+            label,
+            style: (dense ? textTheme.labelSmall : textTheme.labelMedium)
+                ?.copyWith(color: foreground, fontWeight: FontWeight.w600),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/uxnanmobile/test/unit/domain/network_kind_test.dart
+++ b/uxnanmobile/test/unit/domain/network_kind_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uxnan/domain/enums/network_kind.dart';
+
+void main() {
+  const relayUrl = 'wss://relay.uxnan.dev';
+
+  group('classifyEndpoint — unknown', () {
+    test('null or empty endpoint is unknown', () {
+      expect(classifyEndpoint(null, relayUrl: relayUrl), NetworkKind.unknown);
+      expect(classifyEndpoint('', relayUrl: relayUrl), NetworkKind.unknown);
+    });
+  });
+
+  group('classifyEndpoint — relay', () {
+    test('an exact match with relayUrl is relay', () {
+      expect(
+        classifyEndpoint(relayUrl, relayUrl: relayUrl),
+        NetworkKind.relay,
+      );
+    });
+
+    test('a different scheme/port on the same relay host is still relay', () {
+      expect(
+        classifyEndpoint(
+          'wss://relay.uxnan.dev:443/socket',
+          relayUrl: relayUrl,
+        ),
+        NetworkKind.relay,
+      );
+    });
+
+    test('an empty relayUrl never classifies as relay', () {
+      expect(
+        classifyEndpoint('ws://192.168.1.5:19850', relayUrl: ''),
+        isNot(NetworkKind.relay),
+      );
+    });
+  });
+
+  group('classifyEndpoint — tailscale (100.64.0.0/10)', () {
+    test('the low boundary 100.64.x.x is tailscale', () {
+      expect(
+        classifyEndpoint('ws://100.64.0.1:19850', relayUrl: relayUrl),
+        NetworkKind.tailscale,
+      );
+    });
+
+    test('the high boundary 100.127.x.x is tailscale', () {
+      expect(
+        classifyEndpoint('ws://100.127.255.255:19850', relayUrl: relayUrl),
+        NetworkKind.tailscale,
+      );
+    });
+
+    test('a mid-range address (100.100.x.x) is tailscale', () {
+      expect(
+        classifyEndpoint('ws://100.100.1.2:19850', relayUrl: relayUrl),
+        NetworkKind.tailscale,
+      );
+    });
+
+    test('just below the range (100.63.x.x) is NOT tailscale', () {
+      expect(
+        classifyEndpoint('ws://100.63.255.255:19850', relayUrl: relayUrl),
+        NetworkKind.direct,
+      );
+    });
+
+    test('just above the range (100.128.x.x) is NOT tailscale', () {
+      expect(
+        classifyEndpoint('ws://100.128.0.0:19850', relayUrl: relayUrl),
+        NetworkKind.direct,
+      );
+    });
+  });
+
+  group('classifyEndpoint — lan (RFC 1918 + link-local)', () {
+    test('10.0.0.0/8 is lan', () {
+      expect(
+        classifyEndpoint('ws://10.0.0.1:19850', relayUrl: relayUrl),
+        NetworkKind.lan,
+      );
+      expect(
+        classifyEndpoint('ws://10.255.255.255:19850', relayUrl: relayUrl),
+        NetworkKind.lan,
+      );
+    });
+
+    test('172.16.0.0/12 boundaries are lan (172.16.x – 172.31.x)', () {
+      expect(
+        classifyEndpoint('ws://172.16.0.1:19850', relayUrl: relayUrl),
+        NetworkKind.lan,
+      );
+      expect(
+        classifyEndpoint('ws://172.31.255.255:19850', relayUrl: relayUrl),
+        NetworkKind.lan,
+      );
+    });
+
+    test('172.15.x.x and 172.32.x.x are NOT lan (outside the /12)', () {
+      expect(
+        classifyEndpoint('ws://172.15.0.1:19850', relayUrl: relayUrl),
+        NetworkKind.direct,
+      );
+      expect(
+        classifyEndpoint('ws://172.32.0.1:19850', relayUrl: relayUrl),
+        NetworkKind.direct,
+      );
+    });
+
+    test('192.168.0.0/16 is lan', () {
+      expect(
+        classifyEndpoint('ws://192.168.1.5:19850', relayUrl: relayUrl),
+        NetworkKind.lan,
+      );
+    });
+
+    test('169.254.0.0/16 (link-local) is lan', () {
+      expect(
+        classifyEndpoint('ws://169.254.1.1:19850', relayUrl: relayUrl),
+        NetworkKind.lan,
+      );
+    });
+  });
+
+  group('classifyEndpoint — direct', () {
+    test('a public IPv4 is direct', () {
+      expect(
+        classifyEndpoint('ws://203.0.113.7:19850', relayUrl: relayUrl),
+        NetworkKind.direct,
+      );
+    });
+
+    test('a plain hostname that is not the relay is direct', () {
+      expect(
+        classifyEndpoint('ws://my-pc.local:19850', relayUrl: relayUrl),
+        NetworkKind.direct,
+      );
+    });
+
+    test('a bare host:port with no scheme is classified the same way', () {
+      expect(
+        classifyEndpoint('192.168.1.5:19850', relayUrl: relayUrl),
+        NetworkKind.lan,
+      );
+      expect(
+        classifyEndpoint('100.64.1.2:19850', relayUrl: relayUrl),
+        NetworkKind.tailscale,
+      );
+    });
+  });
+}

--- a/uxnanmobile/test/unit/infrastructure/discovery/bridge_discovery_parse_test.dart
+++ b/uxnanmobile/test/unit/infrastructure/discovery/bridge_discovery_parse_test.dart
@@ -8,7 +8,10 @@ import 'package:uxnan/infrastructure/discovery/bridge_discovery_service.dart';
 Uint8List _txt(String value) => Uint8List.fromList(utf8.encode(value));
 
 void main() {
-  test('prefers the advertised TXT addr/port hints', () {
+  test('prefers the SRV-resolved address over the TXT addr hint', () {
+    // TXT records are unsigned and any device on the network can publish them,
+    // so the resolved address wins. The TXT `port` hint is still honored — it
+    // only narrows where on that host we knock.
     final bridge = parseDiscoveredBridge(
       name: 'studio-pc',
       host: 'studio-pc.local',
@@ -22,11 +25,65 @@ void main() {
       },
     );
     expect(bridge, isNotNull);
-    expect(bridge!.host, '192.168.1.50');
+    expect(bridge!.host, '10.0.0.9');
     expect(bridge.port, 19850);
     expect(bridge.name, 'studio-pc');
     expect(bridge.deviceId, 'mac-abc');
-    expect(bridge.hostPort, '192.168.1.50:19850');
+    expect(bridge.hostPort, '10.0.0.9:19850');
+  });
+
+  test('honors a TXT addr hint only when nothing was resolved and it is local',
+      () {
+    final bridge = parseDiscoveredBridge(
+      name: 'studio-pc',
+      port: 19850,
+      txt: {'addr': _txt('192.168.1.50')},
+    );
+    expect(bridge!.host, '192.168.1.50');
+  });
+
+  test('ignores a TXT addr pointing off-network, even with nothing resolved',
+      () {
+    // The attack this blocks: a spoofed mDNS record naming an attacker host.
+    // With no resolved address and no usable SRV host, the service is dropped
+    // rather than contacted.
+    for (final hostile in ['evil.example.com', '8.8.8.8', 'localhost']) {
+      expect(
+        parseDiscoveredBridge(port: 19850, txt: {'addr': _txt(hostile)}),
+        isNull,
+        reason: 'must not accept a TXT addr of "$hostile"',
+      );
+    }
+  });
+
+  test('isLocalAddressLiteral accepts private/CGNAT/loopback IPs only', () {
+    for (final ok in [
+      '10.0.0.9',
+      '192.168.1.50',
+      '172.16.0.1',
+      '172.31.255.254',
+      '100.64.0.1',
+      '100.127.255.254',
+      '169.254.1.1',
+      '127.0.0.1',
+    ]) {
+      expect(isLocalAddressLiteral(ok), isTrue, reason: ok);
+    }
+    for (final no in [
+      '8.8.8.8',
+      '172.15.0.1',
+      '172.32.0.1',
+      '100.63.255.255',
+      '100.128.0.1',
+      'evil.example.com',
+      'pc.local',
+      '192.168.1',
+      '192.168.1.256',
+      '',
+      '  ',
+    ]) {
+      expect(isLocalAddressLiteral(no), isFalse, reason: no);
+    }
   });
 
   test('falls back to the first IPv4 address + SRV port without TXT addr', () {

--- a/uxnanmobile/test/unit/infrastructure/manual_pairing_service_test.dart
+++ b/uxnanmobile/test/unit/infrastructure/manual_pairing_service_test.dart
@@ -1,5 +1,78 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:uxnan/infrastructure/pairing/manual_pairing_service.dart';
+
+/// A canned HTTP response for [_FakeAdapter].
+class _FakeResponse {
+  const _FakeResponse({
+    required this.statusCode,
+    this.body,
+    this.delay = Duration.zero,
+  });
+
+  final int statusCode;
+  final Object? body;
+  final Duration delay;
+}
+
+/// A minimal [HttpClientAdapter] that answers per-host from [responses] and
+/// counts how many requests each host received, so `resolveAny`'s dedup and
+/// racing can be verified without a real network. A host absent from
+/// [responses] simulates "unreachable" (throws a [DioException]), matching
+/// what a real timed-out/refused connection surfaces to [ManualPairingService].
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this.responses);
+
+  final Map<String, _FakeResponse> responses;
+  final Map<String, int> callCounts = {};
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final host = options.uri.host;
+    callCounts[host] = (callCounts[host] ?? 0) + 1;
+    final response = responses[host];
+    if (response == null) {
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.connectionError,
+        message: 'no fake route for $host',
+      );
+    }
+    if (response.delay > Duration.zero) {
+      await Future<void>.delayed(response.delay);
+    }
+    return ResponseBody.fromBytes(
+      utf8.encode(jsonEncode(response.body)),
+      response.statusCode,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+}
+
+/// A valid decoded `/pair/resolve` body, shared by [parsePairResolveResponse]
+/// and [ManualPairingService.resolveAny] tests below.
+final validPayload = <String, dynamic>{
+  'v': 1,
+  'sessionId': 'sess-1',
+  'macDeviceId': 'dev-1',
+  'macIdentityPublicKey':
+      '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff',
+  'expiresAt': 9999999999999,
+  'displayName': 'My PC',
+  'hosts': <String>['192.168.1.5:19850'],
+};
 
 void main() {
   group('normalizeHostInput', () {
@@ -36,17 +109,6 @@ void main() {
   });
 
   group('parsePairResolveResponse', () {
-    final validPayload = <String, dynamic>{
-      'v': 1,
-      'sessionId': 'sess-1',
-      'macDeviceId': 'dev-1',
-      'macIdentityPublicKey':
-          '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff',
-      'expiresAt': 9999999999999,
-      'displayName': 'My PC',
-      'hosts': <String>['192.168.1.5:19850'],
-    };
-
     test('200 with a valid body decodes to a PairingPayload', () {
       final payload = parsePairResolveResponse(200, validPayload);
       expect(payload.displayName, 'My PC');
@@ -114,6 +176,144 @@ void main() {
         throwsA(
           isA<ManualPairingException>()
               .having((e) => e.kind, 'kind', ManualPairingErrorKind.server),
+        ),
+      );
+    });
+  });
+
+  group('dedupeResolveHosts', () {
+    test('normalizes, dedupes, and preserves first-seen order', () {
+      expect(
+        dedupeResolveHosts(
+          ['192.168.1.5', '192.168.1.5:19850', '10.0.0.2:8080'],
+        ),
+        ['192.168.1.5:19850', '10.0.0.2:8080'],
+      );
+    });
+
+    test('drops entries that do not normalize to a usable host:port', () {
+      expect(dedupeResolveHosts(['', '   ', 'host:notaport']), isEmpty);
+    });
+  });
+
+  group('resolveErrorPriority', () {
+    test('a definitive answer from a reached bridge outranks "unreachable"',
+        () {
+      expect(
+        resolveErrorPriority(ManualPairingErrorKind.invalidOrExpiredCode),
+        lessThan(resolveErrorPriority(ManualPairingErrorKind.network)),
+      );
+      expect(
+        resolveErrorPriority(ManualPairingErrorKind.rateLimited),
+        lessThan(resolveErrorPriority(ManualPairingErrorKind.network)),
+      );
+      expect(
+        resolveErrorPriority(ManualPairingErrorKind.malformedPayload),
+        lessThan(resolveErrorPriority(ManualPairingErrorKind.network)),
+      );
+      expect(
+        resolveErrorPriority(ManualPairingErrorKind.server),
+        lessThan(resolveErrorPriority(ManualPairingErrorKind.network)),
+      );
+    });
+
+    test('"unreachable" still outranks a caller input error', () {
+      expect(
+        resolveErrorPriority(ManualPairingErrorKind.network),
+        lessThan(resolveErrorPriority(ManualPairingErrorKind.invalidInput)),
+      );
+    });
+  });
+
+  group('ManualPairingService.resolveAny', () {
+    test('an empty candidate list throws invalidInput without any request', () {
+      final service = ManualPairingService(Dio());
+      expect(
+        () => service.resolveAny(hosts: const [], code: 'ABC'),
+        throwsA(
+          isA<ManualPairingException>().having(
+            (e) => e.kind,
+            'kind',
+            ManualPairingErrorKind.invalidInput,
+          ),
+        ),
+      );
+    });
+
+    test('the first host to answer 2xx wins, even over a slower one', () async {
+      final adapter = _FakeAdapter({
+        'slow.local': _FakeResponse(
+          statusCode: 200,
+          body: {...validPayload, 'displayName': 'Slow PC'},
+          delay: const Duration(milliseconds: 150),
+        ),
+        'fast.local': _FakeResponse(
+          statusCode: 200,
+          body: {...validPayload, 'displayName': 'Fast PC'},
+        ),
+      });
+      final service = ManualPairingService(Dio()..httpClientAdapter = adapter);
+      final payload = await service.resolveAny(
+        hosts: ['slow.local:19850', 'fast.local:19850'],
+        code: 'ABC',
+      );
+      expect(payload.displayName, 'Fast PC');
+    });
+
+    test('duplicate candidates that normalize the same are dialed once',
+        () async {
+      final adapter = _FakeAdapter({
+        'pc.local': _FakeResponse(statusCode: 200, body: validPayload),
+      });
+      final service = ManualPairingService(Dio()..httpClientAdapter = adapter);
+      await service.resolveAny(
+        // The default-port form and the explicit-port form normalize to the
+        // same `host:port`, so only one dial should ever go out.
+        hosts: ['pc.local', 'pc.local:19850', 'pc.local:19850'],
+        code: 'ABC',
+      );
+      expect(adapter.callCounts['pc.local'], 1);
+    });
+
+    test(
+        'when every candidate fails, a definitive answer wins over '
+        '"unreachable"', () async {
+      final adapter = _FakeAdapter({
+        'wrong-code.local': const _FakeResponse(statusCode: 403),
+        // 'unreachable.local' is deliberately absent from the response map,
+        // so the fake adapter throws a connection error for it.
+      });
+      final service = ManualPairingService(Dio()..httpClientAdapter = adapter);
+      await expectLater(
+        service.resolveAny(
+          hosts: ['wrong-code.local:19850', 'unreachable.local:19850'],
+          code: 'ABC',
+        ),
+        throwsA(
+          isA<ManualPairingException>().having(
+            (e) => e.kind,
+            'kind',
+            ManualPairingErrorKind.invalidOrExpiredCode,
+          ),
+        ),
+      );
+    });
+
+    test('when nothing is reachable at all, the error kind is network',
+        () async {
+      final adapter = _FakeAdapter(const {});
+      final service = ManualPairingService(Dio()..httpClientAdapter = adapter);
+      await expectLater(
+        service.resolveAny(
+          hosts: ['a.local:19850', 'b.local:19850'],
+          code: 'ABC',
+        ),
+        throwsA(
+          isA<ManualPairingException>().having(
+            (e) => e.kind,
+            'kind',
+            ManualPairingErrorKind.network,
+          ),
         ),
       );
     });

--- a/uxnanmobile/test/unit/infrastructure/manual_pairing_service_test.dart
+++ b/uxnanmobile/test/unit/infrastructure/manual_pairing_service_test.dart
@@ -7,20 +7,15 @@ import 'package:uxnan/infrastructure/pairing/manual_pairing_service.dart';
 
 /// A canned HTTP response for [_FakeAdapter].
 class _FakeResponse {
-  const _FakeResponse({
-    required this.statusCode,
-    this.body,
-    this.delay = Duration.zero,
-  });
+  const _FakeResponse({required this.statusCode, this.body});
 
   final int statusCode;
   final Object? body;
-  final Duration delay;
 }
 
 /// A minimal [HttpClientAdapter] that answers per-host from [responses] and
-/// counts how many requests each host received, so `resolveAny`'s dedup and
-/// racing can be verified without a real network. A host absent from
+/// counts how many requests each host received, so it can be asserted that the
+/// pairing code goes to exactly one host. A host absent from
 /// [responses] simulates "unreachable" (throws a [DioException]), matching
 /// what a real timed-out/refused connection surfaces to [ManualPairingService].
 class _FakeAdapter implements HttpClientAdapter {
@@ -48,9 +43,6 @@ class _FakeAdapter implements HttpClientAdapter {
         message: 'no fake route for $host',
       );
     }
-    if (response.delay > Duration.zero) {
-      await Future<void>.delayed(response.delay);
-    }
     return ResponseBody.fromBytes(
       utf8.encode(jsonEncode(response.body)),
       response.statusCode,
@@ -62,7 +54,7 @@ class _FakeAdapter implements HttpClientAdapter {
 }
 
 /// A valid decoded `/pair/resolve` body, shared by [parsePairResolveResponse]
-/// and [ManualPairingService.resolveAny] tests below.
+/// and [ManualPairingService.resolve] tests below.
 final validPayload = <String, dynamic>{
   'v': 1,
   'sessionId': 'sess-1',
@@ -181,133 +173,35 @@ void main() {
     });
   });
 
-  group('dedupeResolveHosts', () {
-    test('normalizes, dedupes, and preserves first-seen order', () {
-      expect(
-        dedupeResolveHosts(
-          ['192.168.1.5', '192.168.1.5:19850', '10.0.0.2:8080'],
-        ),
-        ['192.168.1.5:19850', '10.0.0.2:8080'],
-      );
-    });
-
-    test('drops entries that do not normalize to a usable host:port', () {
-      expect(dedupeResolveHosts(['', '   ', 'host:notaport']), isEmpty);
-    });
-  });
-
-  group('resolveErrorPriority', () {
-    test('a definitive answer from a reached bridge outranks "unreachable"',
-        () {
-      expect(
-        resolveErrorPriority(ManualPairingErrorKind.invalidOrExpiredCode),
-        lessThan(resolveErrorPriority(ManualPairingErrorKind.network)),
-      );
-      expect(
-        resolveErrorPriority(ManualPairingErrorKind.rateLimited),
-        lessThan(resolveErrorPriority(ManualPairingErrorKind.network)),
-      );
-      expect(
-        resolveErrorPriority(ManualPairingErrorKind.malformedPayload),
-        lessThan(resolveErrorPriority(ManualPairingErrorKind.network)),
-      );
-      expect(
-        resolveErrorPriority(ManualPairingErrorKind.server),
-        lessThan(resolveErrorPriority(ManualPairingErrorKind.network)),
-      );
-    });
-
-    test('"unreachable" still outranks a caller input error', () {
-      expect(
-        resolveErrorPriority(ManualPairingErrorKind.network),
-        lessThan(resolveErrorPriority(ManualPairingErrorKind.invalidInput)),
-      );
-    });
-  });
-
-  group('ManualPairingService.resolveAny', () {
-    test('an empty candidate list throws invalidInput without any request', () {
-      final service = ManualPairingService(Dio());
-      expect(
-        () => service.resolveAny(hosts: const [], code: 'ABC'),
-        throwsA(
-          isA<ManualPairingException>().having(
-            (e) => e.kind,
-            'kind',
-            ManualPairingErrorKind.invalidInput,
-          ),
-        ),
-      );
-    });
-
-    test('the first host to answer 2xx wins, even over a slower one', () async {
-      final adapter = _FakeAdapter({
-        'slow.local': _FakeResponse(
-          statusCode: 200,
-          body: {...validPayload, 'displayName': 'Slow PC'},
-          delay: const Duration(milliseconds: 150),
-        ),
-        'fast.local': _FakeResponse(
-          statusCode: 200,
-          body: {...validPayload, 'displayName': 'Fast PC'},
-        ),
-      });
-      final service = ManualPairingService(Dio()..httpClientAdapter = adapter);
-      final payload = await service.resolveAny(
-        hosts: ['slow.local:19850', 'fast.local:19850'],
-        code: 'ABC',
-      );
-      expect(payload.displayName, 'Fast PC');
-    });
-
-    test('duplicate candidates that normalize the same are dialed once',
-        () async {
+  group('ManualPairingService.resolve — the code reaches ONE host only', () {
+    test('dials exactly the host it was given, and no other', () async {
       final adapter = _FakeAdapter({
         'pc.local': _FakeResponse(statusCode: 200, body: validPayload),
+        // A second bridge that is reachable and would happily answer. It must
+        // never be dialed: mDNS records are unauthenticated, so fanning the
+        // code out to a discovered host would disclose it to whoever published
+        // that record and let the first responder impersonate the PC.
+        'rogue.local': _FakeResponse(statusCode: 200, body: validPayload),
       });
-      final service = ManualPairingService(Dio()..httpClientAdapter = adapter);
-      await service.resolveAny(
-        // The default-port form and the explicit-port form normalize to the
-        // same `host:port`, so only one dial should ever go out.
-        hosts: ['pc.local', 'pc.local:19850', 'pc.local:19850'],
-        code: 'ABC',
-      );
+      final dio = Dio()..httpClientAdapter = adapter;
+
+      final payload = await ManualPairingService(dio)
+          .resolve(host: 'pc.local', code: '0123-ABCD');
+
+      expect(payload.sessionId, 'sess-1');
       expect(adapter.callCounts['pc.local'], 1);
+      expect(adapter.callCounts.containsKey('rogue.local'), isFalse);
     });
 
-    test(
-        'when every candidate fails, a definitive answer wins over '
-        '"unreachable"', () async {
-      final adapter = _FakeAdapter({
-        'wrong-code.local': const _FakeResponse(statusCode: 403),
-        // 'unreachable.local' is deliberately absent from the response map,
-        // so the fake adapter throws a connection error for it.
-      });
-      final service = ManualPairingService(Dio()..httpClientAdapter = adapter);
-      await expectLater(
-        service.resolveAny(
-          hosts: ['wrong-code.local:19850', 'unreachable.local:19850'],
-          code: 'ABC',
-        ),
-        throwsA(
-          isA<ManualPairingException>().having(
-            (e) => e.kind,
-            'kind',
-            ManualPairingErrorKind.invalidOrExpiredCode,
-          ),
-        ),
-      );
-    });
-
-    test('when nothing is reachable at all, the error kind is network',
+    test('an unreachable host fails as network, without trying anywhere else',
         () async {
-      final adapter = _FakeAdapter(const {});
-      final service = ManualPairingService(Dio()..httpClientAdapter = adapter);
+      final adapter = _FakeAdapter({
+        'rogue.local': _FakeResponse(statusCode: 200, body: validPayload),
+      });
+      final dio = Dio()..httpClientAdapter = adapter;
+
       await expectLater(
-        service.resolveAny(
-          hosts: ['a.local:19850', 'b.local:19850'],
-          code: 'ABC',
-        ),
+        ManualPairingService(dio).resolve(host: 'pc.local', code: '0123-ABCD'),
         throwsA(
           isA<ManualPairingException>().having(
             (e) => e.kind,
@@ -316,6 +210,26 @@ void main() {
           ),
         ),
       );
+      expect(adapter.callCounts.containsKey('rogue.local'), isFalse);
+    });
+
+    test('an empty host is rejected before any request goes out', () async {
+      final adapter = _FakeAdapter({
+        'rogue.local': _FakeResponse(statusCode: 200, body: validPayload),
+      });
+      final dio = Dio()..httpClientAdapter = adapter;
+
+      await expectLater(
+        ManualPairingService(dio).resolve(host: '  ', code: '0123-ABCD'),
+        throwsA(
+          isA<ManualPairingException>().having(
+            (e) => e.kind,
+            'kind',
+            ManualPairingErrorKind.invalidInput,
+          ),
+        ),
+      );
+      expect(adapter.callCounts, isEmpty);
     });
   });
 }

--- a/uxnanmobile/test/widget/presentation/my_devices_screen_test.dart
+++ b/uxnanmobile/test/widget/presentation/my_devices_screen_test.dart
@@ -4,17 +4,20 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:uxnan/domain/entities/bridge_status.dart';
 import 'package:uxnan/domain/entities/trusted_device.dart';
 import 'package:uxnan/l10n/app_localizations.dart';
 import 'package:uxnan/presentation/providers/application_providers.dart';
 import 'package:uxnan/presentation/screens/devices/my_devices_screen.dart';
 
+/// The relay host every [_device] advertises, so a test can drive the relay
+/// network-kind badge by passing `connectedEndpoint: kRelayUrl`.
+const kRelayUrl = 'wss://relay.uxnan.dev';
+
 TrustedDevice _device(String id, String name) => TrustedDevice(
       macDeviceId: id,
       displayName: name,
       macIdentityPublicKey: Uint8List(32),
-      relayUrl: 'wss://relay.uxnan.dev',
+      relayUrl: kRelayUrl,
       sessionId: 's-$id',
       pairedAt: DateTime(2026, 6, 3),
       lastSeen: DateTime(2026, 6, 6, 9),
@@ -23,7 +26,7 @@ TrustedDevice _device(String id, String name) => TrustedDevice(
 Widget _wrap({
   required List<TrustedDevice> devices,
   TrustedDevice? connected,
-  BridgeStatus? bridgeStatus,
+  TrustedDevice? connecting,
   String? connectedEndpoint,
 }) {
   final router = GoRouter(
@@ -35,10 +38,9 @@ Widget _wrap({
     overrides: [
       trustedDevicesProvider.overrideWith((ref) => Stream.value(devices)),
       connectedDeviceProvider.overrideWith((ref) => Stream.value(connected)),
-      connectingDeviceProvider.overrideWith((ref) => Stream.value(null)),
+      connectingDeviceProvider.overrideWith((ref) => Stream.value(connecting)),
       connectedEndpointProvider
           .overrideWith((ref) => Stream.value(connectedEndpoint)),
-      bridgeStatusProvider.overrideWith((ref) async => bridgeStatus),
     ],
     child: MaterialApp.router(
       routerConfig: router,
@@ -91,24 +93,25 @@ void main() {
     expect(find.text("Jorge's MacBook"), findsOneWidget);
   });
 
-  testWidgets('shows the transport (relay vs direct) on the connected PC', (
-    tester,
-  ) async {
+  testWidgets(
+      'shows the network-kind badge derived from the actual endpoint, '
+      'not bridge/status', (tester) async {
     final device = _device('mac-1', 'My Mac');
     await tester.pumpWidget(
       _wrap(
         devices: [device],
         connected: device,
-        bridgeStatus: const BridgeStatus(relayConnected: true),
+        // The live channel is served through the device's own relay host.
+        connectedEndpoint: kRelayUrl,
       ),
     );
     await tester.pump();
 
     expect(find.text('Connected'), findsOneWidget);
-    expect(find.text('· Relay'), findsOneWidget);
+    expect(find.text('Relay'), findsOneWidget);
   });
 
-  testWidgets('shows a direct transport when not over the relay', (
+  testWidgets('shows a LAN badge for a private-network endpoint', (
     tester,
   ) async {
     final device = _device('mac-1', 'My Mac');
@@ -116,12 +119,59 @@ void main() {
       _wrap(
         devices: [device],
         connected: device,
-        bridgeStatus: const BridgeStatus(relayConnected: false),
+        connectedEndpoint: 'ws://192.168.1.42:8765',
       ),
     );
     await tester.pump();
 
-    expect(find.text('· Direct'), findsOneWidget);
+    expect(find.text('LAN'), findsOneWidget);
+  });
+
+  testWidgets('shows a Tailscale badge for a 100.64.0.0/10 endpoint', (
+    tester,
+  ) async {
+    final device = _device('mac-1', 'My Mac');
+    await tester.pumpWidget(
+      _wrap(
+        devices: [device],
+        connected: device,
+        connectedEndpoint: 'ws://100.90.10.5:8765',
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Tailscale'), findsOneWidget);
+  });
+
+  testWidgets('shows a Direct badge for a public/other endpoint', (
+    tester,
+  ) async {
+    final device = _device('mac-1', 'My Mac');
+    await tester.pumpWidget(
+      _wrap(
+        devices: [device],
+        connected: device,
+        connectedEndpoint: 'ws://203.0.113.5:8765',
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Direct'), findsOneWidget);
+  });
+
+  testWidgets('shows a detecting badge while this PC is connecting', (
+    tester,
+  ) async {
+    final device = _device('mac-1', 'My Mac');
+    await tester.pumpWidget(
+      _wrap(devices: [device], connecting: device),
+    );
+    await tester.pump();
+
+    // "Connecting…" appears twice (the status label and the Connect button's
+    // busy state); the badge under test is the "Detecting…" pill.
+    expect(find.text('Connecting…'), findsNWidgets(2));
+    expect(find.text('Detecting…'), findsOneWidget);
   });
 
   testWidgets('shows the real connected endpoint, not the advertised host', (
@@ -135,7 +185,6 @@ void main() {
         // The live channel actually won a direct LAN host; the card must show
         // it (host:port) rather than the paired relay host.
         connectedEndpoint: 'ws://192.168.1.42:8765',
-        bridgeStatus: const BridgeStatus(relayConnected: false),
       ),
     );
     await tester.pump();

--- a/uxnanmobile/test/widget/presentation/my_devices_screen_test.dart
+++ b/uxnanmobile/test/widget/presentation/my_devices_screen_test.dart
@@ -159,7 +159,7 @@ void main() {
     expect(find.text('Direct'), findsOneWidget);
   });
 
-  testWidgets('shows a detecting badge while this PC is connecting', (
+  testWidgets('shows one detecting status while this PC is connecting', (
     tester,
   ) async {
     final device = _device('mac-1', 'My Mac');
@@ -168,9 +168,9 @@ void main() {
     );
     await tester.pump();
 
-    // "Connecting…" appears twice (the status label and the Connect button's
-    // busy state); the badge under test is the "Detecting…" pill.
-    expect(find.text('Connecting…'), findsNWidgets(2));
+    // The status uses "Detecting…" as the single card-level progress state;
+    // the button keeps its normal busy label and behavior.
+    expect(find.text('Connecting…'), findsOneWidget);
     expect(find.text('Detecting…'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary

Simplifies the paired-device card feedback while a PC connection is being established. The card now shows one `Detecting…` status during the attempt, hides the network-path badge until the channel is live, and preserves the Connect button's existing `Connecting…` disabled state.

## Affected component(s)

- [x] `uxnanmobile` — Flutter mobile app

## Type of change

- [x] `fix` — bug fix

## How was it tested?

1. `flutter test test/widget/presentation/my_devices_screen_test.dart` → all 11 widget tests passed.
2. `dart analyze` → no issues found.
3. `dart format` was run on the touched Dart files.
4. The widget test verifies the connected network badges remain available and the connecting state has exactly one `Detecting…` status plus the button's `Connecting…` label.
5. On-device visual review was completed before commit.

## Documentation

- Updated `uxnanmobile/CHANGELOG.md` with the behavioral change.
- Updated `uxnanmobile/README.md` with the user-facing connection-card behavior.
- Updated `uxnanmobile/docs/architecture.md` with the as-built rendering rules.

## Checklist

- [x] Lint/format pass for the touched component(s).
- [x] Tests added or updated, and the focused suite passes.
- [x] `CHANGELOG.md` updated for the affected component.
- [x] Docs updated for the behavior change.
- [x] Commit follows Conventional Commits.