### PR TITLE
fix(bridge): retry the atomic-write rename so a refused swap can't hang a turn

### DIFF
--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -5,6 +5,30 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — a refused atomic write could hang a turn forever (Windows)
+- **`DaemonState.writeJson` now retries the `rename`.** Renaming over an existing
+  file is intermittently refused on Windows with `EPERM` (also `EBUSY`/`EACCES`)
+  when anything holds a momentary handle on the target — antivirus, the Search
+  indexer, a backup agent. POSIX `rename` has no such window, which is why this
+  only ever bit on Windows. The write itself was fine; only the swap was refused.
+  A short capped backoff (5/15/40/100/250 ms, ~410 ms worst case) turns the
+  spurious failure into a successful write; a non-transient error (e.g. `ENOSPC`)
+  still surfaces immediately, and the temp sibling is cleaned up either way.
+- **Why it mattered beyond a flaky test.** `ThreadStore` persists every streamed
+  turn through `writeJson`, and `AgentManager` swallows event-handling errors, so
+  a single refused rename on the `turn_completed` write left the turn stuck at
+  `streaming` **forever** — the phone sat on "responding…" until the app was
+  killed. It is also the long-standing "Windows CI flake": the bridge suite would
+  burn its full 120 s `waitFor` budget on a different test each run, and it
+  reddened `main` and a release run during the 0.0.9 cycle. Reproduced locally,
+  root-caused from the actual `EPERM` stack, and the previously-hanging file now
+  passes 3/3 consecutive runs (full suite 535/535).
+- **Defense in depth:** if a terminal event (`turn_completed`/`turn_error`/
+  `turn_aborted`) still throws, `AgentManager` now fails the turn and notifies the
+  phone instead of leaving it `streaming` — a visible error beats a silent hang.
+- `renameWithRetry` is exported with an injectable rename so the retry policy is
+  unit-tested without provoking a real `EPERM`.
+
 ## [0.0.9-alpha.20260720] - 2026-07-20
 
 ### Security

--- a/bridge/FOR-DEV.md
+++ b/bridge/FOR-DEV.md
@@ -12,7 +12,7 @@ only a human can provide.)
 ## Status
 
 The bridge is **alpha-functional** on its primary path (LAN/Tailscale-direct,
-standalone). It builds clean and the suite is green (bridge 529, shared 36, relay
+standalone). It builds clean and the suite is green (bridge 535, shared 36, relay
 30). The **npm releases shipped** — `uxnan-bridge` is published to npm; releases
 publish to the **`latest`** dist-tag (`@uxnan/shared` pinned to the same version by
 the release workflow). Nothing below blocks LAN/Tailscale-direct use; the remaining
@@ -334,11 +334,13 @@ successful run. Remaining post-publish hardening:
 - [ ] **Echo-agent E2E flaky on Windows CI** — the end-to-end turn-routing + approval
       round-trip tests in `bridge/test/handlers/thread-handlers.test.ts` intermittently
       never report `completed` on **Windows CI runners** (time out even at 120s), while
-      passing reliably on Linux CI and on local Windows (the approval test runs in
-      ~33 ms locally). Skipped on Windows CI only via `SKIP_ECHO_E2E_ON_WIN_CI`.
-      Investigate the Windows stdio approval race (`src/agents/`,
-      `ProcessAgentAdapter`'s stdin write + the approval round-trip) and remove the
-      guard once fixed.
+      passing reliably on Linux CI. Skipped on Windows CI only via
+      `SKIP_ECHO_E2E_ON_WIN_CI`. **Note:** a large share of the historical Windows
+      `waitFor timed out` failures — including the ones that hit `agent-manager.test.ts`
+      and reddened a release run — were NOT this: they were a refused atomic-write
+      `rename` (EPERM), now retried in `DaemonState.writeJson`. Re-check whether this
+      guard is still needed before investigating the stdio path further; it may already
+      be fixed.
 
 ## Relay hardening (relay-only)
 

--- a/bridge/src/agents/agent-manager.ts
+++ b/bridge/src/agents/agent-manager.ts
@@ -716,9 +716,41 @@ export class AgentManager {
           break;
       }
     } catch (err) {
-      this.#options.logger.warn(
-        `agent event handling failed: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      const message = err instanceof Error ? err.message : String(err);
+      this.#options.logger.warn(`agent event handling failed: ${message}`);
+      // A non-terminal event failing is survivable — the turn keeps streaming
+      // and the next event can still finish it. A TERMINAL one failing is not:
+      // nothing else will ever move this turn out of `streaming`, so the phone
+      // would sit on "responding…" until the app is killed. Persistence is
+      // already retried where it is flaky (`DaemonState.writeJson`); this is the
+      // last resort when it fails anyway — surface it instead of hanging.
+      if (
+        event.type === 'turn_completed' ||
+        event.type === 'turn_error' ||
+        event.type === 'turn_aborted'
+      ) {
+        this.#activeTurnByThread.delete(threadId);
+        this.#assistantByTurn.delete(turnId);
+        try {
+          await this.#options.store.failTurn(threadId, turnId, now);
+          this.#options.notify(
+            makeNotification(StreamNotification.TurnError, {
+              threadId,
+              turnId,
+              error: {
+                code: JsonRpcErrorCode.BridgeError,
+                message: `the turn ended but could not be finalized: ${message}`,
+              },
+            }),
+          );
+        } catch (failErr) {
+          this.#options.logger.error(
+            `could not fail a turn whose terminal event threw: ${
+              failErr instanceof Error ? failErr.message : String(failErr)
+            }`,
+          );
+        }
+      }
     }
   }
 

--- a/bridge/src/daemon-state.ts
+++ b/bridge/src/daemon-state.ts
@@ -8,7 +8,7 @@
  */
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { DEFAULT_DAEMON_CONFIG, resolveDaemonConfig, type DaemonConfig } from './daemon-config.js';
 
@@ -26,6 +26,48 @@ export const DAEMON_FILES = {
   updateCheck: 'update-check.json',
   metrics: 'metrics.json',
 } as const;
+
+/**
+ * Backoff for {@link renameWithRetry}, in ms. Worst case ~410ms before giving up.
+ */
+const RENAME_RETRY_DELAYS_MS = [5, 15, 40, 100, 250];
+
+/**
+ * `rename` over an EXISTING file fails intermittently on Windows with `EPERM`
+ * (also `EBUSY`/`EACCES`) when anything holds a transient handle on the target —
+ * antivirus, the Search indexer, a backup agent, or the handle we just closed
+ * ourselves. POSIX `rename` has no such window, which is why this only ever bit
+ * on Windows. The write is fine; only the swap is momentarily refused, so a
+ * short retry turns a spurious failure into a successful write.
+ *
+ * This matters far beyond a flaky test: `ThreadStore` persists every streamed
+ * turn through {@link DaemonState.writeJson}, and `AgentManager` swallows event
+ * handling errors. A single refused rename on the `turn_completed` write left
+ * the turn stuck at `streaming` forever — the phone sat on "responding…" until
+ * the app was killed, and the bridge test suite hung for its full 120s `waitFor`
+ * budget (the long-standing "Windows CI flake").
+ *
+ * `doRename` is injectable so the retry policy can be unit-tested without
+ * provoking a real EPERM (the ESM namespace object can't be monkey-patched).
+ */
+export async function renameWithRetry(
+  from: string,
+  to: string,
+  doRename: (from: string, to: string) => Promise<void> = rename,
+): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await doRename(from, to);
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      const transient = code === 'EPERM' || code === 'EBUSY' || code === 'EACCES';
+      const delay = RENAME_RETRY_DELAYS_MS[attempt];
+      if (!transient || delay === undefined) throw err;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
 
 export class DaemonState {
   readonly baseDir: string;
@@ -63,7 +105,13 @@ export class DaemonState {
     const target = this.pathFor(file);
     const tmp = `${target}.${randomUUID()}.tmp`;
     await writeFile(tmp, JSON.stringify(data, null, 2), 'utf-8');
-    await rename(tmp, target);
+    try {
+      await renameWithRetry(tmp, target);
+    } catch (err) {
+      // Never leave a temp sibling behind next to the real state file.
+      await rm(tmp, { force: true }).catch(() => undefined);
+      throw err;
+    }
   }
 
   async readConfig(): Promise<DaemonConfig> {

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -21,7 +21,7 @@ export {
 
 export { HandlerRouter, type RpcHandler } from './handler-router.js';
 export type { BridgeContext } from './bridge-context.js';
-export { DaemonState, DAEMON_FILES } from './daemon-state.js';
+export { DaemonState, renameWithRetry, DAEMON_FILES } from './daemon-state.js';
 export {
   DEFAULT_DAEMON_CONFIG,
   resolveDaemonConfig,

--- a/bridge/test/agents/agent-manager.test.ts
+++ b/bridge/test/agents/agent-manager.test.ts
@@ -727,3 +727,45 @@ baseTest('a beforeText block is stored before the open run and flagged on the wi
 
   await rm(baseDir, { recursive: true, force: true });
 });
+
+baseTest('a terminal event that throws ends the turn instead of hanging it', async () => {
+  // Defense in depth for the Windows atomic-write failure fixed in
+  // `DaemonState.writeJson`: `#onEvent` catches everything and only logged, so a
+  // throw on a TERMINAL event left the turn `streaming` forever — the phone sat
+  // on "responding…" and the suite burned its full 120s `waitFor` budget.
+  const baseDir = join(tmpdir(), `uxnan-am-terminal-${randomUUID()}`);
+  const store = new ThreadStore(new DaemonState(baseDir));
+  const notifications: { method: string; params?: Record<string, unknown> }[] = [];
+  const manager = new AgentManager({
+    store,
+    notify: (m) => notifications.push(m as { method: string; params?: Record<string, unknown> }),
+    now: () => 1000,
+    logger: createLogger('test', 'error'),
+    defaultAgent: 'echo',
+  });
+  const adapter = new StreamingAdapter();
+  manager.register(adapter);
+
+  const thread = await store.startThread({ projectId: 'p' }, 1);
+  const { turnId } = await manager.sendTurn(thread.id, 'go');
+
+  // Break ONLY the completion path, exactly as a refused rename would. An own
+  // property shadows the prototype method while `this` stays the real store, so
+  // its private fields and every other method keep working.
+  const original = store.completeTurn.bind(store);
+  Object.defineProperty(store, 'completeTurn', {
+    configurable: true,
+    value: () => Promise.reject(new Error('simulated persistence failure')),
+  });
+
+  adapter.complete(thread.id, turnId, 'partial');
+
+  // It must reach a TERMINAL state — the whole point is that it does not hang.
+  await waitFor(async () => (await store.getTurn(turnId)).status === 'error');
+  const errorNote = notifications.find((n) => n.method === StreamNotification.TurnError);
+  assert.ok(errorNote, 'the phone must be told the turn ended');
+  assert.match(JSON.stringify(errorNote?.params ?? {}), /could not be finalized/);
+
+  Object.defineProperty(store, 'completeTurn', { configurable: true, value: original });
+  await rm(baseDir, { recursive: true, force: true });
+});

--- a/bridge/test/daemon-state.test.ts
+++ b/bridge/test/daemon-state.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { rm } from 'node:fs/promises';
-import { DaemonState, DEFAULT_DAEMON_CONFIG } from '../src/index.js';
+import { DaemonState, DEFAULT_DAEMON_CONFIG, renameWithRetry } from '../src/index.js';
 
 function freshState(): DaemonState {
   return new DaemonState(join(tmpdir(), `uxnan-test-${randomUUID()}`));
@@ -54,5 +54,80 @@ test('initConfig does not freeze the seeded model lists to disk', async () => {
     typeof m === 'string' ? m : m.id,
   );
   assert.ok(ids.includes('claude-sonnet-5'));
+  await rm(state.baseDir, { recursive: true, force: true });
+});
+
+test('renameWithRetry retries a transient EPERM and eventually succeeds', async () => {
+  // `rename` over an existing file is intermittently refused on Windows (EPERM /
+  // EBUSY / EACCES) when anything holds a momentary handle on the target —
+  // antivirus, the Search indexer, a backup agent. Without a retry the error
+  // propagated into `ThreadStore`, `AgentManager` swallowed it, and the turn was
+  // left `streaming` forever (the long-standing "Windows CI flake").
+  let calls = 0;
+  await renameWithRetry('a', 'b', async () => {
+    calls += 1;
+    if (calls <= 3) {
+      const err = new Error('EPERM: operation not permitted, rename') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    }
+  });
+  assert.equal(calls, 4, 'it retried the refused renames rather than giving up');
+});
+
+test('renameWithRetry retries EBUSY and EACCES too', async () => {
+  for (const code of ['EBUSY', 'EACCES']) {
+    let calls = 0;
+    await renameWithRetry('a', 'b', async () => {
+      calls += 1;
+      if (calls === 1) {
+        const err = new Error(code) as NodeJS.ErrnoException;
+        err.code = code;
+        throw err;
+      }
+    });
+    assert.equal(calls, 2, `${code} must be treated as transient`);
+  }
+});
+
+test('renameWithRetry rethrows a non-transient error immediately', async () => {
+  let calls = 0;
+  await assert.rejects(
+    renameWithRetry('a', 'b', async () => {
+      calls += 1;
+      const err = new Error('ENOSPC: no space left on device') as NodeJS.ErrnoException;
+      err.code = 'ENOSPC';
+      throw err;
+    }),
+    /ENOSPC/,
+  );
+  assert.equal(calls, 1, 'a real failure must not be retried');
+});
+
+test('renameWithRetry gives up after the backoff is exhausted', async () => {
+  let calls = 0;
+  await assert.rejects(
+    renameWithRetry('a', 'b', async () => {
+      calls += 1;
+      const err = new Error('EPERM') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    }),
+    /EPERM/,
+  );
+  // 5 backoff steps → 6 attempts, then the error surfaces rather than looping.
+  assert.equal(calls, 6);
+});
+
+test('writeJson leaves no temp sibling when the rename ultimately fails', async () => {
+  const state = freshState();
+  await state.writeJson('threads.json', { v: 1 });
+  // Point the state dir at a path whose rename target is a directory, so the
+  // rename fails for a real, non-transient reason.
+  await assert.rejects(state.writeJson('.', { v: 2 }));
+  const { readdir } = await import('node:fs/promises');
+  const left = (await readdir(state.baseDir)).filter((f) => f.endsWith('.tmp'));
+  assert.deepEqual(left, [], 'the temp file is cleaned up on failure');
+  assert.deepEqual(await state.readJson('threads.json'), { v: 1 });
   await rm(state.baseDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary

`rename` over an existing file is intermittently refused on **Windows** with `EPERM`
(also `EBUSY`/`EACCES`) when anything holds a momentary handle on the target —
antivirus, the Search indexer, a backup agent. POSIX `rename` has no such window,
which is why this only ever bit on Windows. **The write itself was fine; only the
swap was refused.**

This is not a test problem. `ThreadStore` persists every streamed turn through
`DaemonState.writeJson`, and `AgentManager` swallows event-handling errors — so a
single refused rename on the `turn_completed` write left the turn stuck at
`streaming` **forever**: the phone sat on "responding…" until the app was killed.

It is also the long-standing **"Windows CI flake"**. During the `0.0.9-alpha.20260720`
cycle it hit four times, on *different* tests each run, reddened `main`, and skipped
the `publish` job of the `shared` release run — a release that simply didn't happen
until the leg was re-run.

## Affected component(s)

- [ ] `shared` · [x] `bridge` · [ ] `relay` · [ ] `uxnandesktop` · [ ] `uxnanmobile`

## Type of change

- [x] `fix` — bug fix

## What changed

- **`DaemonState.writeJson` retries the rename** with a capped backoff
  (5/15/40/100/250 ms → ~410 ms worst case). A **non-transient** error (e.g. `ENOSPC`)
  still surfaces immediately with no retry, and the temp sibling is removed on failure
  so a `.tmp` file is never left beside the real state file.
- **Defense in depth in `AgentManager`:** if a *terminal* event (`turn_completed` /
  `turn_error` / `turn_aborted`) still throws, the turn is failed and the phone
  notified, instead of being left `streaming`. A visible error beats a silent hang.
- `renameWithRetry` is exported with an **injectable rename** so the retry policy is
  unit-testable without provoking a real `EPERM` (the ESM namespace object can't be
  monkey-patched).

## How it was diagnosed

Worth recording, because **my first hypothesis was wrong and I tested it rather than
shipping it**:

1. Hypothesized that `void this.#onEvent(event)` let a burst of adapter events run
   concurrently, so `turn_completed` could land before the `delta` that creates the
   assistant message. Implemented per-thread serialization.
2. The hang **still reproduced** — and reproduced **without** the change too
   (baseline, whole-file run: `beforeText` hung 120 s; in isolation it passed 3/3).
   So ordering was **not** the cause. Reverted it rather than keeping a plausible-
   looking change with no evidence behind it.
3. Instrumented the swallowed `catch` and got the real stack:

```
[ev] THREW on delta -> Error: EPERM: operation not permitted, rename
  'threads.json.<uuid>.tmp' -> 'threads.json'
    at async DaemonState.writeJson (src/daemon-state.js:60:9)
    at async src/conversation/thread-store.js:413:13
```

The local reproduction is itself a first: the bridge suite could not previously be run
in the main checkout (broken workspace junctions).

## How was it tested?

- **6 new tests.** `renameWithRetry`: retries `EPERM` and succeeds; treats `EBUSY` and
  `EACCES` as transient too; rethrows `ENOSPC` **immediately without retrying**; gives
  up after the backoff is exhausted (6 attempts, no infinite loop). `writeJson`: leaves
  no `.tmp` sibling and preserves the previous content when the rename ultimately
  fails. `AgentManager`: a terminal event that throws ends the turn as `error` and
  emits `turn/error`, instead of hanging.
- **The previously-hanging file now passes 3/3 consecutive runs** (it hung on run 1 of
  the baseline).
- **Full bridge suite: 535/535 locally** (529 before + 6 new), plus `prettier --check`
  and `tsc --noEmit` clean.

## Known gaps

- **The `SKIP_ECHO_E2E_ON_WIN_CI` guard is left in place.** Those echo-agent E2E tests
  run a real subprocess over stdio, which is a *different* suspected race; this fix may
  well have cured them too, but I have no evidence, so I did not quietly re-enable
  them. `FOR-DEV.md` now records that a large share of the historical `waitFor`
  failures were this bug, and that the guard should be re-checked before anyone
  investigates the stdio path further.
- The backoff is fixed, not adaptive. Under sustained contention (a heavy scanner) a
  write could still exhaust it — which now surfaces as a failed turn rather than a
  hang, the intended behavior.
- No test forces a *real* `EPERM` from the filesystem; the policy is tested through the
  injected seam, and the end-to-end evidence is the 3/3 reproduction result.

## Checklist

- [x] Lint/format pass — `prettier --check` clean.
- [x] Tests added, and the suite passes (535/535 locally; CI on this PR).
- [x] `bridge/CHANGELOG.md` updated under `[Unreleased]`.
- [x] `bridge/FOR-DEV.md` — cited suite count re-derived (529 → 535) and the
      Windows-flake item corrected to say what this bug actually was.
- [x] Commits follow Conventional Commits.
- [x] No `shared` contract changed; no `architecture/` change owed (no contract,
      behavior-visible-to-the-phone, or phase-state change — this restores the
      documented persistence behavior rather than altering it).