### PR TITLE
fix(pairing): Tailscale manual pairing, honest failure messages, and same-day update check

### DIFF
--- a/architecture/02a-system-architecture.md
+++ b/architecture/02a-system-architecture.md
@@ -1576,7 +1576,7 @@ bridge/
 │   ├── daemon-config.ts            # ~/.uxnan/daemon-config.json
 │   ├── handler-router.ts           # ruteo + validacion Ajv de metodos JSON-RPC
 │   ├── bridge-status.ts            # snapshots de estado / relayConnected / update (latestVersion)
-│   ├── update-check.ts             # chequeo de version en npm (dist-tag latest, cache 24h)
+│   ├── update-check.ts             # chequeo de version en npm (dist-tag latest, cache 24h; `start` la ignora y re-chequea)
 │   ├── qr.ts                       # QR + pairing code
 │   ├── account-status.ts           # snapshot sanitizado de auth (nunca tokens)
 │   ├── version.ts                  # BRIDGE_VERSION + BRIDGE_PACKAGE_NAME desde package.json

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Changed — `start` always re-checks for a new bridge version
+- `uxnan-bridge start` now bypasses the 24h update-check cache (`ttlMs: 0`).
+  Reported after 0.0.9 shipped: a bridge that had checked while 0.0.8 was newest
+  stayed silent for up to a day, so the operator never learned an update existed
+  and kept pairing a version-incompatible pair. Short-lived commands
+  (`status`/`qr`/`code`) keep using the cache so they stay fast.
+
+### Added — `/pair/resolve` now logs its outcome
+- The manual-pairing endpoint logs accepted / rejected / rate-limited per client
+  IP (**never the code — it is a shared secret**). Without it, a request that
+  never arrived and a request that was rejected looked identical in the bridge
+  log, which is exactly how a Tailscale connect-timeout was misdiagnosed as a
+  bad pairing code.
+
 ### Fixed — a refused atomic write could hang a turn forever (Windows)
 - **`DaemonState.writeJson` now retries the `rename`.** Renaming over an existing
   file is intermittently refused on Windows with `EPERM` (also `EBUSY`/`EACCES`)

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -137,8 +137,10 @@ platform scripts under `scripts/`.
 The bridge is the ecosystem's core engine, so `start`/`status`/`qr`/`code` also
 print a one-line **"a newer bridge is available"** notice to stderr when the
 running version is behind the latest published to npm (`latest` dist-tag). The
-check is best-effort and cached in `~/.uxnan/update-check.json` (24h TTL), and
-the result is also exposed to the phone via `bridge/status`
+check is best-effort and cached in `~/.uxnan/update-check.json` (24h TTL);
+**`start` always re-checks** (it bypasses the cache), so a release published
+inside that window is announced the next time you start the bridge rather than
+up to a day later. The result is also exposed to the phone via `bridge/status`
 (`latestVersion`/`updateAvailable`).
 
 The Ed25519 identity is stored in the OS keychain (Windows Credential Manager /

--- a/bridge/docs/connectivity.md
+++ b/bridge/docs/connectivity.md
@@ -45,6 +45,12 @@ same tailnet reaches the bridge directly from anywhere, **with no hosted relay**
    (confirm it's listed in the "Direct addresses" line).
 3. Off-LAN, the phone connects over Tailscale exactly like it would on the LAN.
 
+> **"Browse nearby bridges" does not work over Tailscale — type the address.**
+> Discovery is mDNS (`_uxnan._tcp`), which is link-local multicast and does not
+> traverse a tailnet by design. Over Tailscale, enter the PC's `100.x` address
+> (it is printed as a "Direct address" when the bridge starts). This is inherent
+> to mDNS, not a bug — and once paired, reconnecting needs no discovery at all.
+
 No extra config needed: the relay is **off by default**, so this mode is pure
 direct (the QR carries only `hosts`).
 

--- a/bridge/docs/installation.md
+++ b/bridge/docs/installation.md
@@ -81,7 +81,11 @@ Update with: npm install -g uxnan-bridge@latest
 
 The check is best-effort (silent when offline / up to date), cached in
 `~/.uxnan/update-check.json` with a 24h TTL, and the running daemon refreshes it
-in the background. The paired phone learns the same thing via `bridge/status`
+in the background. **`start` always re-checks** (it ignores the cache), so a
+release published inside the 24h window is announced the next time you start the
+bridge instead of up to a day later; the short-lived `status`/`qr`/`code`
+commands keep using the cache so they stay fast. The paired phone learns the
+same thing via `bridge/status`
 (`latestVersion`/`updateAvailable`) and shows an informational hint — see the
 mobile app. Update with `npm install -g uxnan-bridge@latest` (or `git pull` +
 `npm install` for a source checkout).

--- a/bridge/src/bridge.ts
+++ b/bridge/src/bridge.ts
@@ -640,11 +640,20 @@ export async function startBridge(options: StartBridgeOptions = {}): Promise<Bri
         },
         // Manual-code pairing: trade a code shown on the PC for the pairing payload.
         onPairResolve: (code, ip) => {
+          // Log the OUTCOME (never the code — it is a shared secret). Without
+          // this a failed manual pairing is indistinguishable from a request
+          // that never arrived, which is exactly how a Tailscale-only failure
+          // was misread as a rejected code.
           if (pairingCodeService.rateLimited(ip)) {
+            logger.warn(`pair/resolve from ${ip}: rate limited (429)`);
             return { status: 429, json: { error: 'rate_limited' } };
           }
           const payload = pairingCodeService.resolve(code);
-          if (!payload) return { status: 403, json: { error: 'invalid_or_expired_code' } };
+          if (!payload) {
+            logger.warn(`pair/resolve from ${ip}: code did not match or expired (403)`);
+            return { status: 403, json: { error: 'invalid_or_expired_code' } };
+          }
+          logger.info(`pair/resolve from ${ip}: accepted (200); pairing window armed`);
           return { status: 200, json: payload };
         },
         // Claude PreToolUse approval hook: ask the user (on the phone) whether a

--- a/bridge/src/cli.ts
+++ b/bridge/src/cli.ts
@@ -49,9 +49,13 @@ Commands:
  * on-disk cache, bounded by a short fetch timeout, and silent when up to date,
  * offline, or the latest version is unknown.
  */
-async function printUpdateNotice(): Promise<void> {
+async function printUpdateNotice(options: { force?: boolean } = {}): Promise<void> {
   try {
-    const status = await ensureUpdateStatus(new DaemonState());
+    // `start` always re-checks: it is the one command a user runs deliberately,
+    // and the 24h cache meant a release published inside that window went
+    // unannounced for up to a day (reported after 0.0.9 shipped). Short-lived
+    // commands keep the cache so they stay fast.
+    const status = await ensureUpdateStatus(new DaemonState(), options.force ? { ttlMs: 0 } : {});
     const message = updateNoticeMessage(status);
     if (message) process.stderr.write(`\n${message}\n`);
   } catch {
@@ -147,7 +151,7 @@ async function cmdStart(): Promise<void> {
     process.stdout.write('Relay disabled; using the direct LAN/Tailscale path only.\n');
   }
 
-  await printUpdateNotice();
+  await printUpdateNotice({ force: true });
   process.stdout.write('Press Ctrl+C to stop.\n');
   await new Promise<void>((resolve) => {
     const shutdown = (): void => {

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,15 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed — manual pairing failed over Tailscale
+- The manual-pairing HTTP client used a 5s `connectTimeout`. Over Tailscale the
+  first request to a peer must bring the tunnel up (DERP relay, then an attempted
+  direct upgrade), which routinely takes longer — so the request was abandoned
+  before it ever reached the bridge, and pairing "always failed on Tailscale but
+  worked on the same Wi-Fi" even with the `100.x` address typed correctly.
+  `connectTimeout` is now 20s (read/write stay at 10s: once connected the bridge
+  answers immediately).
+
 ### Fixed — a version-mismatched bridge said "invalid QR/code" instead of "update the bridge"
 - Pairing against a bridge older than `SECURE_PROTOCOL_VERSION` 2 correctly
   fails at the handshake, but both pairing screens funnelled every handshake

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,20 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed — a version-mismatched bridge said "invalid QR/code" instead of "update the bridge"
+- Pairing against a bridge older than `SECURE_PROTOCOL_VERSION` 2 correctly
+  fails at the handshake, but both pairing screens funnelled every handshake
+  exception into a generic message — the QR screen showed *"this is not a valid
+  Uxnan pairing code"* and the manual screen *"the bridge could not complete
+  pairing"*. Both blame the code, so the user regenerates it forever while the
+  real problem (an out-of-date bridge) is never mentioned. Reported from a real
+  device after the 0.0.10 release.
+- `TransportErrorKind.incompatibleVersion` is now a distinct kind (not
+  `handshake`), so both screens can recognise it by type rather than by string,
+  and show: *"The bridge on this PC is a different version than the app. Update
+  the bridge on your PC (npm install -g uxnan-bridge) and the app, then pair
+  again."*
+
 ## [0.0.10-alpha.20260720+20260720] - 2026-07-20
 
 ### Changed

--- a/uxnanmobile/l10n/app_en.arb
+++ b/uxnanmobile/l10n/app_en.arb
@@ -76,6 +76,10 @@
   "actionOpenSettings": "Open settings",
   "qrHint": "Point the camera at the QR code in your bridge terminal.",
   "qrErrorExpired": "This QR code has expired. Generate a new one on your PC.",
+  "pairingErrorIncompatibleVersion": "This PC's bridge is a different version than the app. Update the bridge on your PC (npm install -g uxnan-bridge) and the app, then pair again.",
+  "@pairingErrorIncompatibleVersion": {
+    "description": "Shown when pairing fails because the bridge and the app speak different secure-protocol versions."
+  },
   "qrErrorMalformed": "This isn't a valid Uxnan pairing code.",
   "qrCameraErrorTitle": "Camera unavailable",
   "qrCameraErrorBody": "Couldn't start the camera to scan. You can pair with a code instead, or try again.",

--- a/uxnanmobile/l10n/app_es.arb
+++ b/uxnanmobile/l10n/app_es.arb
@@ -46,6 +46,7 @@
   "actionOpenSettings": "Abrir ajustes",
   "qrHint": "Apunta la cámara al código QR en la terminal de tu bridge.",
   "qrErrorExpired": "Este código QR expiró. Genera uno nuevo en tu PC.",
+  "pairingErrorIncompatibleVersion": "El bridge de esta PC es de una versión distinta a la de la app. Actualiza el bridge en tu PC (npm install -g uxnan-bridge) y la app, y vuelve a emparejar.",
   "qrErrorMalformed": "Este no es un código de vinculación de Uxnan válido.",
   "qrCameraErrorTitle": "Cámara no disponible",
   "qrCameraErrorBody": "No se pudo iniciar la cámara para escanear. Puedes emparejar con un código o intentar de nuevo.",

--- a/uxnanmobile/lib/core/errors/transport_exception.dart
+++ b/uxnanmobile/lib/core/errors/transport_exception.dart
@@ -28,6 +28,12 @@ enum TransportErrorKind {
   /// The E2EE handshake did not complete successfully.
   handshake,
 
+  /// The bridge speaks a different `SECURE_PROTOCOL_VERSION` than this app, so
+  /// the two cannot exchange encrypted frames at all. Distinct from
+  /// [handshake] because it is not a failure the user can retry — both sides
+  /// must be updated — and blaming the QR/code instead sends them in circles.
+  incompatibleVersion,
+
   /// An envelope failed authenticated decryption (AES-256-GCM tag mismatch).
   decryption,
 

--- a/uxnanmobile/lib/infrastructure/transport/secure_transport_layer.dart
+++ b/uxnanmobile/lib/infrastructure/transport/secure_transport_layer.dart
@@ -230,7 +230,7 @@ class SecureTransportLayer {
     // AAD, so a mismatch would look like "connected, but nothing ever works".
     if (hello.protocolVersion != ProtocolConstants.secureProtocolVersion) {
       throw TransportException(
-        TransportErrorKind.handshake,
+        TransportErrorKind.incompatibleVersion,
         'Incompatible bridge: it speaks secure protocol '
         'v${hello.protocolVersion}, this app speaks '
         'v${ProtocolConstants.secureProtocolVersion}. Update the '

--- a/uxnanmobile/lib/l10n/app_localizations.dart
+++ b/uxnanmobile/lib/l10n/app_localizations.dart
@@ -362,6 +362,12 @@ abstract class AppLocalizations {
   /// **'This QR code has expired. Generate a new one on your PC.'**
   String get qrErrorExpired;
 
+  /// Shown when pairing fails because the bridge and the app speak different secure-protocol versions.
+  ///
+  /// In en, this message translates to:
+  /// **'This PC\'s bridge is a different version than the app. Update the bridge on your PC (npm install -g uxnan-bridge) and the app, then pair again.'**
+  String get pairingErrorIncompatibleVersion;
+
   /// No description provided for @qrErrorMalformed.
   ///
   /// In en, this message translates to:

--- a/uxnanmobile/lib/l10n/app_localizations_en.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_en.dart
@@ -153,6 +153,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'This QR code has expired. Generate a new one on your PC.';
 
   @override
+  String get pairingErrorIncompatibleVersion =>
+      'This PC\'s bridge is a different version than the app. Update the bridge on your PC (npm install -g uxnan-bridge) and the app, then pair again.';
+
+  @override
   String get qrErrorMalformed => 'This isn\'t a valid Uxnan pairing code.';
 
   @override

--- a/uxnanmobile/lib/l10n/app_localizations_es.dart
+++ b/uxnanmobile/lib/l10n/app_localizations_es.dart
@@ -153,6 +153,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Este código QR expiró. Genera uno nuevo en tu PC.';
 
   @override
+  String get pairingErrorIncompatibleVersion =>
+      'El bridge de esta PC es de una versión distinta a la de la app. Actualiza el bridge en tu PC (npm install -g uxnan-bridge) y la app, y vuelve a emparejar.';
+
+  @override
   String get qrErrorMalformed =>
       'Este no es un código de vinculación de Uxnan válido.';
 

--- a/uxnanmobile/lib/presentation/providers/infrastructure_providers.dart
+++ b/uxnanmobile/lib/presentation/providers/infrastructure_providers.dart
@@ -204,15 +204,22 @@ final bridgeDiscoveryProvider =
 });
 
 /// Manual-code pairing service (resolves a typed host + code against the
-/// bridge's `GET /pair/resolve` endpoint). Short timeouts so an unreachable
-/// host fails fast instead of hanging the screen.
+/// bridge's `GET /pair/resolve` endpoint).
+///
+/// `connectTimeout` is deliberately generous: over Tailscale the FIRST request
+/// to a peer has to bring the tunnel up (DERP relay, then an attempted direct
+/// upgrade), which routinely takes longer than a LAN connect. The previous 5s
+/// budget expired during that setup, so manual pairing "always failed on
+/// Tailscale but worked on the same Wi-Fi" — and, because the request never
+/// arrived, the bridge logged nothing to contradict it. Once connected, the
+/// bridge answers immediately, so the read/write budgets stay short.
 final manualPairingServiceProvider = Provider<ManualPairingService>(
   (ref) => ManualPairingService(
     Dio(
       BaseOptions(
-        connectTimeout: const Duration(seconds: 5),
-        receiveTimeout: const Duration(seconds: 5),
-        sendTimeout: const Duration(seconds: 5),
+        connectTimeout: const Duration(seconds: 20),
+        receiveTimeout: const Duration(seconds: 10),
+        sendTimeout: const Duration(seconds: 10),
       ),
     ),
   ),

--- a/uxnanmobile/lib/presentation/screens/pairing/manual_code_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/pairing/manual_code_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:uxnan/core/errors/transport_exception.dart';
 import 'package:uxnan/core/utils/logger.dart';
 import 'package:uxnan/infrastructure/pairing/manual_pairing_service.dart';
 import 'package:uxnan/l10n/app_localizations.dart';
@@ -107,7 +108,12 @@ class _ManualCodeScreenState extends ConsumerState<ManualCodeScreen> {
       if (!mounted) return;
       setState(() {
         _connecting = false;
-        _error = l10n.manualCodeErrorServer;
+        // A version mismatch is not something retrying can fix — say so, rather
+        // than implying the bridge hiccuped.
+        _error = error is TransportException &&
+                error.kind == TransportErrorKind.incompatibleVersion
+            ? l10n.pairingErrorIncompatibleVersion
+            : l10n.manualCodeErrorServer;
       });
     }
   }

--- a/uxnanmobile/lib/presentation/screens/pairing/qr_scanner_screen.dart
+++ b/uxnanmobile/lib/presentation/screens/pairing/qr_scanner_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:uxnan/core/errors/transport_exception.dart';
 import 'package:uxnan/core/utils/logger.dart';
 import 'package:uxnan/domain/entities/pairing_payload.dart';
 import 'package:uxnan/domain/services/pairing_validator.dart';
@@ -147,7 +148,15 @@ class _QrScannerScreenState extends ConsumerState<QrScannerScreen> {
       AppLogger.warn('Pairing failed', error, stackTrace);
       if (!mounted) return;
       setState(() => _connecting = false);
-      _showError(AppLocalizations.of(context).qrErrorMalformed);
+      final l10n = AppLocalizations.of(context);
+      // A protocol-version mismatch is NOT a bad QR — blaming the code
+      // sends the user to regenerate it forever. Name the real problem.
+      _showError(
+        (error is TransportException &&
+                error.kind == TransportErrorKind.incompatibleVersion)
+            ? l10n.pairingErrorIncompatibleVersion
+            : l10n.qrErrorMalformed,
+      );
       await _resumeScanning();
     }
   }

--- a/uxnanmobile/test/unit/infrastructure/secure_transport_layer_test.dart
+++ b/uxnanmobile/test/unit/infrastructure/secure_transport_layer_test.dart
@@ -222,7 +222,13 @@ void main() {
         ),
         throwsA(
           isA<TransportException>()
-              .having((e) => e.kind, 'kind', TransportErrorKind.handshake)
+              .having(
+                (e) => e.kind,
+                'kind',
+                // A dedicated kind, so the UI can say "update both" instead of
+                // blaming the QR/code (which sends the user in circles).
+                TransportErrorKind.incompatibleVersion,
+              )
               .having(
                 (e) => e.message,
                 'message',


### PR DESCRIPTION
Post-`0.0.10` pairing reliability + diagnosis pass, all traced from a real
on-device report (and, for the manual-code failure, from the bridge logs the
user supplied). Three distinct fixes plus their docs; each is its own commit.

## Affected component(s)

- [ ] `shared` · [x] `bridge` · [ ] `relay` · [ ] `uxnandesktop` · [x] `uxnanmobile`

## Type of change

- [x] `fix` — bug fix  ·  [x] `docs`

---

## 1. Manual pairing failed over Tailscale — the request never arrived

The manual-pairing HTTP client used a **5s `connectTimeout`**. Over Tailscale the
first request to a peer must bring the tunnel up (DERP relay, then an attempted
direct upgrade), which routinely exceeds 5s — so the phone abandoned the request
**before it reached the bridge**, and pairing "always failed on Tailscale but
worked on the same Wi-Fi" even with the `100.x` address typed correctly.

Confirmed from the user's bridge logs: on the failed attempts the bridge logged
**nothing** between startup and shutdown — the tell that the request never
landed, not that a code was rejected.

- `connectTimeout` → **20s** (`receiveTimeout`/`sendTimeout` stay at 10s: once
  connected the bridge answers immediately).
- `uxnanmobile/lib/presentation/providers/infrastructure_providers.dart`.

## 2. The bridge hid *why* manual pairing failed

`/pair/resolve` logged nothing, so "never arrived" and "arrived and was
rejected" were indistinguishable — which is exactly how a Tailscale
connect-timeout got misread as a bad code. It now logs the **outcome**
(accepted / rejected / rate-limited) per client IP, **never the code** (it is a
shared secret). `bridge/src/bridge.ts`.

## 3. A version-mismatched bridge said "invalid QR/code" instead of "update the bridge"

Pairing against a bridge older than `SECURE_PROTOCOL_VERSION` 2 correctly fails
at the handshake, but both pairing screens funnelled every handshake exception
into a generic message — QR: *"this is not a valid Uxnan pairing code"*; manual:
*"the bridge could not complete pairing"*. Both blame the code, so the user
regenerates it forever while the real cause (an out-of-date bridge) is never
named.

- `TransportErrorKind.incompatibleVersion` is now a **distinct kind** (not
  `handshake`), so both screens match on type, not on a message string.
- Both screens show: *"The bridge on this PC is a different version than the app.
  Update the bridge on your PC (`npm install -g uxnan-bridge`) and the app, then
  pair again."* (EN + ES.)

## 4. `start` never announced a same-day release  *(the reporter's request)*

`UPDATE_CHECK_TTL_MS` caches for 24h, so a bridge that checked while the previous
version was newest stayed silent for up to a day — the operator never learned an
update existed and kept pairing an incompatible pair. `uxnan-bridge start` now
**bypasses the cache and re-checks every start**; short-lived `status`/`qr`/`code`
keep the cache so they stay fast. `bridge/src/cli.ts`.

---

## Not a bug (documented, not "fixed")

**"Browse nearby bridges" cannot find the PC over Tailscale.** Discovery is mDNS
(`_uxnan._tcp`) — link-local multicast that does not traverse a tailnet by
design. Over Tailscale, type the PC's `100.x` address (printed as a "Direct
address" at start). Documented in `bridge/docs/connectivity.md`; once paired,
reconnecting needs no discovery at all.

## How was it tested?

- **535 bridge tests + 702 mobile tests pass**; `flutter analyze`,
  `dart format`, `flutter gen-l10n` (no drift) and `prettier --check` all clean.
- The version-mismatch transport test now pins the new `incompatibleVersion`
  kind.
- The Tailscale timeout and the `/pair/resolve` logging are config/observability
  changes with no unit seam; verified by re-reading against the user's logs
  (which is what pinpointed all four).

## Docs kept in sync (no drift)

- `bridge/docs/connectivity.md` — the mDNS-over-Tailscale caveat + type-the-address.
- `bridge/README.md` + `bridge/docs/installation.md` — `start` re-checks; the 24h
  TTL still applies to the short-lived commands.
- `architecture/02a` §5.8 file map — `update-check.ts` note.
- `bridge/CHANGELOG.md` + `uxnanmobile/CHANGELOG.md` — one entry per fix under
  `[Unreleased]`.
- No cited counts changed (no tests added: item 3 updates an existing test;
  items 1/2/4 have no unit seam). No `shared` contract or wire change.

## Follow-up (not in this PR)

None owed. The one remaining unknown from the original report — manual pairing
returning "incorrect or expired code" against an *updated* bridge — is now
explained by item 1 (a connect timeout over Tailscale), and the item 2 logging
will confirm it directly the next time it happens.
