### PR TITLE
feat(desktop): experimental unsigned macOS installer (Intel + Apple Silicon)

### DIFF
--- a/.github/workflows/ci-desktop.yml
+++ b/.github/workflows/ci-desktop.yml
@@ -23,11 +23,14 @@ concurrency:
 jobs:
   verify:
     uses: ./.github/workflows/verify-desktop.yml
-    # CI also verifies the EXPERIMENTAL macOS targets (Apple Silicon macos-14 +
-    # Intel macos-13), so a Mac-only regression surfaces on the PR. The release
-    # workflow keeps its gate on the default Linux + Windows pair.
+    # CI also verifies the EXPERIMENTAL macOS build on Apple Silicon (macos-14),
+    # so a Mac-only regression surfaces on the PR. One mac leg is enough — the code
+    # paths are identical across architectures, and GitHub's Intel (macos-13)
+    # runners are being retired / queue unpredictably, so the Intel DMG is
+    # cross-compiled in the release rather than verified on its own runner. The
+    # release workflow keeps its gate on the default Linux + Windows pair.
     with:
-      os-list: '["ubuntu-latest", "windows-latest", "macos-14", "macos-13"]'
+      os-list: '["ubuntu-latest", "windows-latest", "macos-14"]'
 
   pr-comment-on-failure:
     needs: verify

--- a/.github/workflows/ci-desktop.yml
+++ b/.github/workflows/ci-desktop.yml
@@ -23,6 +23,11 @@ concurrency:
 jobs:
   verify:
     uses: ./.github/workflows/verify-desktop.yml
+    # CI also verifies the EXPERIMENTAL macOS targets (Apple Silicon macos-14 +
+    # Intel macos-13), so a Mac-only regression surfaces on the PR. The release
+    # workflow keeps its gate on the default Linux + Windows pair.
+    with:
+      os-list: '["ubuntu-latest", "windows-latest", "macos-14", "macos-13"]'
 
   pr-comment-on-failure:
     needs: verify

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -12,7 +12,12 @@ name: Release — Desktop (Tauri installers)
 #
 # Windows ships without OS code-signing for now (SmartScreen warning) — that is a
 # SEPARATE, paid certificate, unrelated to the free updater signature below.
-# macOS is deferred with the rest of Apple — add `macos-latest` when it resumes.
+# macOS ships as an EXPERIMENTAL, UNSIGNED build: two separate DMGs (Apple Silicon
+# aarch64 + Intel x86_64) carrying an ad-hoc signature (tauri.conf.json →
+# bundle.macOS, signingIdentity "-" — free, no Apple secrets). It has NO Apple
+# Developer ID / notarization, so users clear Gatekeeper by hand (see
+# uxnandesktop/docs/install-macos.md). A mac leg failing never blocks the
+# win/linux artifacts (fail-fast: false).
 #
 # FOR-HUMAN: the updater signature needs two repo secrets (free; generate with
 # `npx tauri signer generate`). Without them the build still succeeds, just
@@ -39,11 +44,26 @@ jobs:
   build:
     needs: verify
     strategy:
-      fail-fast: false
+      fail-fast: false # a failing mac leg must not drop the win/linux artifacts
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            args: ''
+            rust-target: ''
+          - os: windows-latest
+            args: ''
+            rust-target: ''
+          # EXPERIMENTAL macOS — two separate DMGs, one per architecture. Native
+          # runners (macos-14 = Apple Silicon, macos-13 = Intel) build their own
+          # target; the explicit --target keeps the bundle + artifact names clear.
+          - os: macos-14
+            args: '--target aarch64-apple-darwin'
+            rust-target: 'aarch64-apple-darwin'
+          - os: macos-13
+            args: '--target x86_64-apple-darwin'
+            rust-target: 'x86_64-apple-darwin'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60 # building installers for two OSes is the slow case
+    timeout-minutes: 60 # building installers for four targets is the slow case
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,6 +91,8 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }} # the Apple target on mac; empty otherwise
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
@@ -114,3 +136,4 @@ jobs:
           releaseName: 'Uxnan Desktop ${{ steps.meta.outputs.version }}'
           releaseDraft: true
           prerelease: ${{ steps.meta.outputs.prerelease }}
+          args: ${{ matrix.args }} # per-arch --target on macOS; empty on win/linux

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -53,13 +53,16 @@ jobs:
           - os: windows-latest
             args: ''
             rust-target: ''
-          # EXPERIMENTAL macOS — two separate DMGs, one per architecture. Native
-          # runners (macos-14 = Apple Silicon, macos-13 = Intel) build their own
-          # target; the explicit --target keeps the bundle + artifact names clear.
+          # EXPERIMENTAL macOS — two separate DMGs, one per architecture, both built
+          # on Apple Silicon runners (macos-14). GitHub's Intel (macos-13) runners
+          # are being retired and queue unpredictably, so the Intel DMG is
+          # cross-compiled to x86_64 (the frontend is arch-agnostic and the Rust
+          # deps cross-compile). Bundling only compiles + packages — it never runs
+          # the x86_64 binary — so no Rosetta is needed.
           - os: macos-14
             args: '--target aarch64-apple-darwin'
             rust-target: 'aarch64-apple-darwin'
-          - os: macos-13
+          - os: macos-14
             args: '--target x86_64-apple-darwin'
             rust-target: 'x86_64-apple-darwin'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/verify-desktop.yml
+++ b/.github/workflows/verify-desktop.yml
@@ -6,6 +6,16 @@ name: _verify-desktop (reusable)
 
 on:
   workflow_call:
+    inputs:
+      os-list:
+        description: >-
+          JSON array of runner labels to verify on. Defaults to the
+          release-gating pair (Linux + Windows); CI passes the experimental
+          macOS runners too so a Mac regression is caught on PRs without
+          blocking the release build.
+        required: false
+        type: string
+        default: '["ubuntu-latest", "windows-latest"]'
 
 defaults:
   run:
@@ -19,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJSON(inputs.os-list) }}
 
     steps:
       - name: Checkout

--- a/README.es.md
+++ b/README.es.md
@@ -119,6 +119,14 @@ funciona sin modificación.
   <img alt="Descargar desde GitHub Releases" src="https://img.shields.io/badge/Descargar-GitHub_Releases-24292e?style=for-the-badge&logo=github&logoColor=white"/>
 </a>
 
+> **La compilación de macOS es EXPERIMENTAL y sin firma** (DMGs separados para
+> Intel y Apple Silicon): macOS la marca como de un "desarrollador no
+> identificado", así que la autorizas a mano una sola vez
+> ([guía de instalación en macOS](uxnandesktop/docs/install-macos.md)). También
+> puedes [compilarla en tu propia Mac](uxnandesktop/docs/build.md); los issues/PRs
+> que mejoren los instaladores de macOS — o ayuden a usuarios no técnicos — son
+> muy bienvenidos.
+
 → **[Lee el README de la app de escritorio](uxnandesktop/README.md)**
 
 ---

--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ without modification.
   <img alt="Download from GitHub Releases" src="https://img.shields.io/badge/Download-GitHub_Releases-24292e?style=for-the-badge&logo=github&logoColor=white"/>
 </a>
 
+> **macOS is an EXPERIMENTAL, unsigned build** (separate Intel & Apple Silicon
+> DMGs) — macOS flags it as from an "unidentified developer", so you authorize it
+> by hand once ([macOS install guide](uxnandesktop/docs/install-macos.md)). You can
+> also [build it on your own Mac](uxnandesktop/docs/build.md); issues/PRs that
+> improve the macOS installers — or help non-technical users — are very welcome.
+
 → **[Read the desktop app README](uxnandesktop/README.md)**
 
 ---

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -32,11 +32,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 ### Changed — CI verifies macOS; the release builds it
 
 - `verify-desktop.yml` is parameterized with an `os-list` input; desktop CI now also
-  verifies on the two macOS runners (Apple Silicon `macos-14` + Intel `macos-13`) so
-  a Mac-only regression surfaces on PRs, while the **release gate stays on Linux +
-  Windows**. The release build matrix adds both macOS legs with `fail-fast: false`,
-  so a failing mac leg never drops the Windows/Linux artifacts. +5 Rust tests (266
-  total).
+  verifies on the Apple Silicon runner (`macos-14`) so a Mac-only regression surfaces
+  on PRs, while the **release gate stays on Linux + Windows**. The release build
+  matrix adds both macOS legs on Apple Silicon runners — the Intel (`x86_64`) DMG is
+  **cross-compiled** since GitHub's Intel runners are being retired — with
+  `fail-fast: false`, so a failing mac leg never drops the Windows/Linux artifacts.
+  +5 Rust tests (266 total).
 
 ### Fixed — theme-tinted, text-shaped editor text selection
 

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,39 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — experimental macOS installer (Intel + Apple Silicon)
+
+- The release pipeline now builds an **experimental, unsigned macOS build**: two
+  separate DMGs, one per architecture (`aarch64-apple-darwin` Apple Silicon,
+  `x86_64-apple-darwin` Intel), each **ad-hoc-signed**
+  (`bundle.macOS.signingIdentity "-"`, `hardenedRuntime false`,
+  `minimumSystemVersion 11.0`) so the Apple Silicon binary runs at all — **no Apple
+  Developer account needed**. It is **not notarized**, so users clear Gatekeeper
+  once by hand; a new [macOS install guide](docs/install-macos.md) documents the
+  non-technical / technical / advanced paths, and the root + desktop READMEs flag
+  it as experimental and invite issues/PRs (self-build stays supported).
+
+### Fixed — macOS CLI detection under a Finder/Dock launch
+
+- A macOS app launched from Finder inherits `launchd`'s minimal `PATH`, so Homebrew
+  (`/opt/homebrew` on Apple Silicon, `/usr/local` on Intel), npm globals, node
+  version managers and `~/.local/bin` were invisible — agent CLIs, `gh`, `git` and
+  CLI editors all reported "not installed" although present. A new `path_env` module
+  enriches the process `PATH` once at startup (macOS only) from the user's
+  login+interactive shell (time-bounded so a slow rc can't hang launch) plus
+  well-known directories, so detection and every PTY shell find the user's tools.
+  The seeded terminal profile is now a real login shell (`-l`) and `default_shell()`
+  falls back to `zsh` on macOS instead of `/bin/bash`.
+
+### Changed — CI verifies macOS; the release builds it
+
+- `verify-desktop.yml` is parameterized with an `os-list` input; desktop CI now also
+  verifies on the two macOS runners (Apple Silicon `macos-14` + Intel `macos-13`) so
+  a Mac-only regression surfaces on PRs, while the **release gate stays on Linux +
+  Windows**. The release build matrix adds both macOS legs with `fail-fast: false`,
+  so a failing mac leg never drops the Windows/Linux artifacts. +5 Rust tests (266
+  total).
+
 ### Fixed — theme-tinted, text-shaped editor text selection
 
 - Selecting text in the file editor / diff no longer paints an opaque, full-width block

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -17,9 +17,10 @@ status/diff/stage/commit/history, agent monitoring with the axum hook server +
 OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
-with" external editors/IDEs**). 261 Rust backend tests + 225 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS is **unvalidated**
-(developed on Windows; CI is `{ubuntu, windows}`). **Phase 6 (embedded bridge /
-mobile pairing) is NOT started.**
+with" external editors/IDEs**). 266 Rust backend tests + 225 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS now ships an
+**experimental, unsigned** build (Intel + Apple Silicon; CI verifies `{ubuntu,
+windows, macOS}`, release gate stays `{ubuntu, windows}`) but is **not yet validated
+on real hardware**. **Phase 6 (embedded bridge / mobile pairing) is NOT started.**
 
 **Built (DONE), in detail:**
 
@@ -471,7 +472,12 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
 
 ## Platform validation
 
-- [ ] **macOS** is unvalidated end-to-end (no macOS CI; developed on Windows).
+- [ ] **macOS** — an **experimental, unsigned** build now ships (two ad-hoc-signed
+      DMGs, Intel + Apple Silicon; `docs/install-macos.md`), CI compiles + tests it on
+      both arch runners, and the Finder/Dock `PATH` gap is fixed (`path_env.rs`).
+      Still **not validated on real hardware** by the maintainer — needs a smoke test
+      of launch, agent/`gh`/editor detection, notifications, keep-awake and a
+      self-update on both architectures.
 - [ ] **keep-awake** is implemented for macOS/Linux but **untested** there
       (`power.rs`); Windows works.
 - [ ] **Update UI (pinned sonner toast + in-Settings download/install) — visual +
@@ -480,18 +486,21 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
       download/install actions were surfaced inline in **Settings → Updates**.
       `svelte-check` + Vitest pass, but the toast's on-screen appearance and the
       end-to-end download → install flow haven't been exercised in a running build
-      yet (blocked on a real update to appear — see the private-repo 404 item under
-      *CI/CD — release*). Validate the toast look/feel and the Settings actions in
-      the next update.
+      yet. The repo is now **public** and updates flow (the maintainer has verified
+      stable + nightly on each release), so this is no longer blocked — validate the
+      toast look/feel and the Settings actions in the next update.
 
 ## CI/CD — release
 
 - ✅ **Verify** — `.github/workflows/ci-desktop.yml` runs svelte-check + `npm test`
-  (Vitest) + vite build + cargo fmt/clippy/test on `{ubuntu, windows}` (macOS
-  deferred with Apple). 261 Rust + 225 Vitest tests.
-- ✅ **`release-desktop.yml`** — exists: `tauri-action` bundles on a `desktop-v*` tag
-  → draft GitHub Release, **and signs the updater artifacts** when the signing
-  secrets are set. **Windows ships without OS code-signing for now; macOS deferred.**
+  (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
+  macos-14, macos-13}` (via `verify-desktop.yml`'s `os-list` input); the release
+  gate keeps the default `{ubuntu, windows}`. 266 Rust + 225 Vitest tests.
+- ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →
+  draft GitHub Release, **and signs the updater artifacts** when the signing secrets
+  are set. Builds Windows + Linux + **experimental unsigned macOS** (two ad-hoc-signed
+  DMGs, Intel `macos-13` + Apple Silicon `macos-14`, `fail-fast: false`). Windows and
+  macOS ship without OS code-signing (SmartScreen / Gatekeeper warnings).
 - ✅ **Auto-updater** — `tauri-plugin-updater` wired end-to-end in the app
   (`src-tauri/src/updater.rs` + Settings → Updates with inline download/install +
   a pinned sonner toast `UpdateToast.svelte`; stable/nightly channels via GitHub's
@@ -499,15 +508,6 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
   `release-desktop-manifest.yml`. The signing keypair is configured and
   `desktop-v0.0.1-alpha.20260627` shipped signed installers + a `latest.json`
   on the `desktop-updater-stable` channel. See [`docs/updates.md`](docs/updates.md).
-- [ ] **Public distribution while the repo is PRIVATE (blocker for end users)** —
-      the GitHub-Releases download URLs and the updater endpoint
-      (`…/releases/download/desktop-updater-<channel>/latest.json`) return **404**
-      to anonymous clients while `luisgamas/uxnan` is private, so the in-app
-      updater and public installer downloads only work for authenticated
-      collaborators. Decision (2026-06-27): **keep the repo private for now.**
-      Revisit when going public, or move desktop binaries to a dedicated **public**
-      releases repo (then update `tauri.conf.json → plugins.updater.endpoints` +
-      `release-desktop*.yml`). npm and Play distribution are unaffected.
 - [ ] **Manifest workflow needs `contents: write` for first-time channel creation** —
       `release-desktop-manifest.yml`'s `gh release create` of a channel's rolling
       release 403'd because the repo's `default_workflow_permissions` is `read`
@@ -517,9 +517,11 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
       Settings → Actions → Workflow permissions to **Read and write**
       (`gh api -X PUT repos/luisgamas/uxnan/actions/permissions/workflow -f default_workflow_permissions=write`).
 - [ ] **Code-signing (OS)** — Windows Authenticode + macOS Developer ID +
-      notarization (human-provided **paid** certs — see `FOR-HUMAN.md`).
-      Independent of the (free) updater signature above; the build runs unsigned
-      without them (OS "unknown publisher" warnings).
+      notarization (human-provided **paid** certs — see `FOR-HUMAN.md`). Independent
+      of the (free) updater signature above; without them Windows ships unsigned
+      (SmartScreen) and macOS ships the **experimental ad-hoc** build (Gatekeeper
+      "unidentified developer", cleared per `docs/install-macos.md`). Apple Developer
+      ID + notarization is the optional path to a warning-free macOS install.
 
 ## Cross-cutting / standing rules
 

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -494,13 +494,15 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
 
 - ✅ **Verify** — `.github/workflows/ci-desktop.yml` runs svelte-check + `npm test`
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
-  macos-14, macos-13}` (via `verify-desktop.yml`'s `os-list` input); the release
-  gate keeps the default `{ubuntu, windows}`. 266 Rust + 225 Vitest tests.
+  macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
+  Intel runners are being retired and the code is arch-identical); the release gate
+  keeps the default `{ubuntu, windows}`. 266 Rust + 225 Vitest tests.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →
   draft GitHub Release, **and signs the updater artifacts** when the signing secrets
   are set. Builds Windows + Linux + **experimental unsigned macOS** (two ad-hoc-signed
-  DMGs, Intel `macos-13` + Apple Silicon `macos-14`, `fail-fast: false`). Windows and
-  macOS ship without OS code-signing (SmartScreen / Gatekeeper warnings).
+  DMGs, both built on Apple Silicon `macos-14` with the Intel `x86_64` DMG
+  **cross-compiled**, `fail-fast: false`). Windows and macOS ship without OS
+  code-signing (SmartScreen / Gatekeeper warnings).
 - ✅ **Auto-updater** — `tauri-plugin-updater` wired end-to-end in the app
   (`src-tauri/src/updater.rs` + Settings → Updates with inline download/install +
   a pinned sonner toast `UpdateToast.svelte`; stable/nightly channels via GitHub's

--- a/uxnandesktop/FOR-HUMAN.md
+++ b/uxnandesktop/FOR-HUMAN.md
@@ -31,12 +31,18 @@ only this checklist and the inline `FOR-HUMAN:` markers describing what's needed
 > warnings). They're required for a clean, signed, auto-updating release. Supply
 > each as a **GitHub Actions repository secret** consumed by `release-desktop.yml`.
 
-- [ ] **Code-signing identities (OS — paid)** (release) — Windows code-signing cert
-      (SignTool / `WINDOWS_CERTIFICATE` + password), Apple Developer ID +
-      notarization (`APPLE_CERTIFICATE`, `APPLE_ID`, team id, app-specific
-      password), optional GPG for Linux packages (spec §5.1). This removes the OS
-      "unknown publisher" warning. **Unrelated to the updater key** (which is free
-      and already configured).
+- [ ] **Code-signing identities (OS — paid, OPTIONAL)** (release) — to remove the OS
+      "unidentified developer" / SmartScreen warnings on distributed builds. Supply
+      each as a GitHub Actions secret consumed by `release-desktop.yml`:
+      - **Windows** — code-signing cert (SignTool / `WINDOWS_CERTIFICATE` + password).
+      - **macOS** — Apple Developer ID + notarization (`APPLE_CERTIFICATE`, `APPLE_ID`,
+        team id, app-specific password). **Not required to ship macOS today:** CI
+        already produces an **experimental, ad-hoc-signed** build (no Apple account
+        needed), which users authorize by hand (see `docs/install-macos.md`); this
+        cert is the *optional* upgrade to a warning-free, notarized install.
+      - **Linux** — optional GPG for `.deb`/`.rpm` (spec §5.1).
+
+      **Unrelated to the updater key** (free, already configured).
 
 ## Deferred until later phases (no action needed yet)
 

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -157,10 +157,13 @@ and Linux — but **all current testing has been carried out directly on Windows
   by the maintainer. If you run it on Linux, your feedback and recommendations are
   genuinely welcome; please open an issue or a discussion so the experience can be
   hardened.
-- **macOS** — supported by the toolchain, but no maintainer builds are produced
-  yet and the platform is unvalidated. Until a signed build exists, macOS users
-  can build it themselves by following
-  [release builds & packaging](docs/build.md).
+- **macOS** — **experimental, unsigned builds are now produced** (separate Intel
+  and Apple Silicon `.dmg`s, ad-hoc-signed). Because they aren't notarized, macOS
+  flags them as from an "unidentified developer", so you authorize the app once by
+  hand — see the [macOS install guide](docs/install-macos.md). It hasn't been
+  validated on real hardware by the maintainer yet, so treat it as experimental;
+  you can also [build it yourself](docs/build.md), and issues/PRs that improve the
+  macOS installers (or help non-technical users) are very welcome.
 
 The only remaining roadmap phase is **Phase 6 (bridge integration / mobile
 pairing)**, which is *optional for standalone use* — required only if you want the
@@ -173,6 +176,7 @@ in [`FOR-DEV.md`](FOR-DEV.md).
 Detailed docs live in [`docs/`](./docs/):
 [development & running in debug](./docs/development.md) ·
 [release builds & packaging](./docs/build.md) ·
+[installing on macOS (experimental)](./docs/install-macos.md) ·
 [testing & verification](./docs/testing.md) ·
 [architecture orientation](./docs/architecture.md) ·
 [design tokens](./docs/design-tokens.md) ·

--- a/uxnandesktop/architecture/04-technical-reference.md
+++ b/uxnandesktop/architecture/04-technical-reference.md
@@ -357,8 +357,14 @@ Monitoreo en tiempo real de agentes. Badges en sidebar. Notificaciones nativas d
   banner fijo superior) + acciones de **descargar/instalar dentro de
   Settings → Updates** (coherentes con la política de instalación); store
   `state/updater.svelte.ts`; i18n EN/ES. Firma minisign gratuita (`pubkey` en
-  `tauri.conf.json`), independiente del code-signing del SO. Detalle operativo
-  en `docs/updates.md`; clave de firma en `FOR-HUMAN.md`.
+  `tauri.conf.json`), independiente del code-signing del SO. **Distribucion macOS
+  EXPERIMENTAL:** el CI genera dos DMG por arquitectura (Intel `x86_64` + Apple
+  Silicon `aarch64`) con **firma ad-hoc** (`bundle.macOS.signingIdentity "-"`,
+  `hardenedRuntime false`, `minimumSystemVersion 11.0`) — sin cuenta Apple; el
+  usuario autoriza Gatekeeper a mano (`docs/install-macos.md`), y el `PATH` de un
+  arranque desde Finder se enriquece al inicio (`path_env.rs`) para detectar los CLI
+  de Homebrew/npm. La notarizacion con Apple Developer ID queda como via opcional
+  futura. Detalle operativo en `docs/updates.md`; clave de firma en `FOR-HUMAN.md`.
 
 #### Entregable
 

--- a/uxnandesktop/docs/build.md
+++ b/uxnandesktop/docs/build.md
@@ -33,7 +33,7 @@ Per platform, `bundle/` contains:
 | Platform | Formats | Notes |
 |---|---|---|
 | **Windows** | `.msi` (WiX), `.exe` (NSIS) | Tauri downloads WiX/NSIS automatically on first bundle. |
-| **macOS** | `.app`, `.dmg` | Requires Xcode Command Line Tools. |
+| **macOS** | `.app`, `.dmg` (one per architecture) | Requires Xcode Command Line Tools. CI ships an **experimental, unsigned** build, ad-hoc-signed per arch (`aarch64` + `x86_64`) — see [install-macos.md](install-macos.md). |
 | **Linux** | `.deb`, `.AppImage`, `.rpm` | AppImage is the most portable. |
 
 ## Useful variants
@@ -47,6 +47,10 @@ npm run tauri build -- --bundles msi
 
 # Debug-optimized build (keeps debug assertions; for profiling a "release-ish" run):
 npm run tauri build -- --debug
+
+# macOS: build a specific architecture (CI builds both, one DMG each):
+npm run tauri build -- --target aarch64-apple-darwin   # Apple Silicon
+npm run tauri build -- --target x86_64-apple-darwin    # Intel
 ```
 
 ## Quick local verification before bundling
@@ -66,7 +70,12 @@ distribution. They depend on assets only a human can provide — tracked in
 [`../FOR-HUMAN.md`](../FOR-HUMAN.md):
 
 - **Windows** — code-signing certificate (SignTool) to avoid SmartScreen warnings.
-- **macOS** — Apple Developer ID + notarization (mandatory since macOS 10.15).
+- **macOS** — the maintainer ships an **experimental, unsigned** build that is only
+  **ad-hoc-signed** (`bundle.macOS.signingIdentity: "-"` in `tauri.conf.json`), so it
+  needs **no Apple account**; users clear Gatekeeper by hand
+  ([install-macos.md](install-macos.md)). An **Apple Developer ID + notarization**
+  (paid) is the *optional* path to a warning-free install — it removes the manual
+  step but is **not** required to run, and is not configured.
 - **Linux** — optional GPG signing for `.deb`/`.rpm`.
 - **Auto-updater** — `pubkey` + `endpoints` for `tauri-plugin-updater` in
   `tauri.conf.json` (see the spec, `architecture/03-implementation-guide.md` §5.2).

--- a/uxnandesktop/docs/install-macos.md
+++ b/uxnandesktop/docs/install-macos.md
@@ -1,0 +1,142 @@
+# Installing Uxnan Desktop on macOS (EXPERIMENTAL)
+
+![Status](https://img.shields.io/badge/macOS-EXPERIMENTAL-orange?style=for-the-badge&logo=apple&logoColor=white)
+![Signing](https://img.shields.io/badge/signing-ad--hoc_(unsigned)-lightgrey?style=for-the-badge)
+
+> **The macOS build is experimental and unsigned.** It has **no Apple Developer
+> ID and is not notarized**, so macOS will not let it open on the first try — you
+> have to authorize it by hand, **once**. This is a property of macOS Gatekeeper,
+> not a sign that the app is unsafe. If you'd rather not do this, you can always
+> [build it yourself](build.md) on your own Mac (a self-built app runs with no
+> prompt), and **issues / PRs that improve these installers — or help
+> non-technical users — are very welcome.**
+
+## Pick the right download
+
+Two separate `.dmg` files are published, one per CPU architecture:
+
+| Your Mac | Download |
+|---|---|
+| **Apple Silicon** (M1/M2/M3/M4 — most Macs since 2020) | the `aarch64` / "Apple Silicon" `.dmg` |
+| **Intel** (pre-2020 Macs) | the `x86_64` / "Intel" `.dmg` |
+
+Not sure which you have?  → Apple menu () → **About This Mac** → look at
+**Chip** / **Processor** ("Apple M…" = Apple Silicon; "Intel …" = Intel).
+
+Installing the wrong architecture will fail to open, so grab the matching one.
+
+## Install — choose your comfort level
+
+Do the common part first, then follow **one** of the three tiers below.
+
+**Common step (everyone):** open the `.dmg` and **drag "Uxnan Desktop" into the
+Applications folder.** Always run it from **Applications** — running it straight
+from the mounted disk image or from Downloads can trigger macOS "app
+translocation" and misbehave.
+
+---
+
+### Tier 1 — No Terminal (the official Apple way)
+
+Best if you don't want to touch a command line.
+
+1. In **Applications**, double-click **Uxnan Desktop**.
+2. macOS shows *"Apple could not verify … it is free of malware"* (or
+   *"unidentified developer"*). Click **Done** (do **not** click Move to Trash).
+3. Open **System Settings → Privacy & Security**. Scroll down to the **Security**
+   section — you'll see *"Uxnan Desktop was blocked to protect your Mac."* Click
+   **Open Anyway**.
+4. Confirm with your password / Touch ID. On macOS Sequoia (15) and Tahoe (26)
+   you may be asked to double-click the app once more and click **Open** — do so.
+
+That's it — macOS remembers your choice and opens it normally from then on.
+
+> On **macOS Sequoia and later, the old right-click → Open shortcut no longer
+> works** — you must use **System Settings → Privacy & Security → Open Anyway**.
+
+---
+
+### Tier 2 — One Terminal command
+
+Faster if you're comfortable with Terminal. After dragging the app to
+**Applications**, run:
+
+```bash
+xattr -dr com.apple.quarantine "/Applications/Uxnan Desktop.app"
+```
+
+This removes the *quarantine* attribute macOS put on the download, so the app
+opens on the first double-click. (`-d` deletes the attribute, `-r` applies it to
+everything inside the app bundle.)
+
+---
+
+### Tier 3 — Verify what you're running (advanced)
+
+If you want to inspect it before trusting it:
+
+```bash
+# See the ad-hoc signature (Signature=adhoc, Identifier=dev.luisgamas.uxnandesktop):
+codesign -dv --verbose=4 "/Applications/Uxnan Desktop.app"
+
+# See Gatekeeper's verdict (it will REJECT — expected for an unsigned app):
+spctl -a -vvv "/Applications/Uxnan Desktop.app"
+
+# Inspect the quarantine attribute before removing it:
+xattr -p com.apple.quarantine "/Applications/Uxnan Desktop.app"
+```
+
+Please **don't** disable Gatekeeper system-wide (`sudo spctl --master-disable`) —
+it weakens security for *every* app. Authorize this one app instead (Tier 1 or 2).
+
+## Why the extra step?
+
+macOS only opens apps without a warning when they carry a paid **Apple Developer
+ID** signature *and* have been **notarized** by Apple. This build has neither —
+that's the maintainer's deliberate, experimental choice while macOS support
+matures. What it **does** have is an **ad-hoc signature**, which is what lets the
+Apple Silicon build run at all (Apple Silicon refuses to launch a binary with no
+signature whatsoever). The one-time authorization above is the price of skipping
+the paid Apple path.
+
+## Updates
+
+The in-app updater (**Settings → Updates**, stable/nightly channels) works on
+macOS too — it's signed with a free minisign key, independent of Apple signing.
+Because the updater downloads inside the app (not through a browser), updates it
+installs are **not re-quarantined**, so once you've authorized the app the first
+time, self-updates generally apply without repeating the Gatekeeper step. This
+path is experimental; if an update ever refuses to open, re-apply Tier 1 or 2, or
+just download the latest `.dmg`.
+
+## Troubleshooting
+
+- **"Uxnan Desktop is damaged and can't be opened. You should move it to the
+  Trash."** — This is almost always the **quarantine attribute**, not real
+  damage. Run the Tier 2 command (`xattr -dr com.apple.quarantine …`) and open
+  again. Also make sure you downloaded the **matching architecture**.
+- **Nothing happens / it bounces once and quits.** — Confirm you moved it to
+  **/Applications** (translocation), and that you picked the right
+  architecture (Apple Silicon vs Intel).
+- **"Open Anyway" isn't in System Settings.** — You need to try opening the app
+  **first** (double-click → Done); the button only appears after macOS has
+  blocked a launch.
+- **CLIs (Claude, Codex, Gemini, `gh`, node, …) show as "not installed"
+  although they are.** — Uxnan enriches its `PATH` from your login shell at
+  startup so Homebrew / npm / version-manager tools are found even when launched
+  from Finder. If something is still missing, make sure it's on your login
+  shell's `PATH` (e.g. Homebrew's line in `~/.zprofile`), then relaunch the app.
+
+## Prefer to build it yourself?
+
+A build you compile locally is **not quarantined and needs no authorization
+step**. See [release builds & packaging](build.md) — in short, on your Mac:
+
+```bash
+cd uxnandesktop
+npm install
+npm run tauri build          # produces a .dmg/.app for your Mac's architecture
+```
+
+Found a way to make the experimental installers smoother for everyone (especially
+non-technical users)? Please open an issue or a PR.

--- a/uxnandesktop/docs/updates.md
+++ b/uxnandesktop/docs/updates.md
@@ -71,6 +71,11 @@ quitting the app), so nothing is killed mid-write.
   `src-tauri/tauri.conf.json`. This is a **free minisign key**, unrelated to OS
   code-signing (the paid Authenticode/Apple cert that removes "unknown publisher"
   warnings — see `FOR-HUMAN.md`).
+  - **macOS is experimental** (unsigned, ad-hoc-signed). The updater downloads
+    inside the app rather than through a browser, so the replacement bundle is
+    **not re-quarantined** and self-updates generally apply without repeating the
+    Gatekeeper authorization. First-time install still needs it — see
+    [`install-macos.md`](install-macos.md).
 - **Channel = the release tag, enforced by CI.** A
   `desktop-stable-v0.0.PATCH` tag creates a normal Release and feeds `stable`.
   A `desktop-nightly-v0.0.PATCH-nightly.YYYYMMDD.N` tag creates a GitHub

--- a/uxnandesktop/src-tauri/src/lib.rs
+++ b/uxnandesktop/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ mod hooks;
 mod mcp;
 mod mcpinject;
 mod model;
+mod path_env;
 mod persistence;
 mod power;
 mod procscan;
@@ -49,6 +50,12 @@ use crate::state::AppState;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Enrich `PATH` for a macOS GUI launch (Finder/Dock omit the login-shell
+    // `PATH`, so Homebrew/npm/version-manager CLIs would otherwise be invisible
+    // to agent/`gh`/editor detection and to PTY shells). Must run first, before
+    // any child is spawned or any thread reads `PATH`. A no-op off macOS.
+    crate::path_env::enrich_for_gui_launch();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())

--- a/uxnandesktop/src-tauri/src/model.rs
+++ b/uxnandesktop/src-tauri/src/model.rs
@@ -283,7 +283,13 @@ pub fn default_terminal_profiles() -> Vec<TerminalProfile> {
             },
         ]
     } else {
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| {
+            if cfg!(target_os = "macos") {
+                "/bin/zsh".to_string()
+            } else {
+                "/bin/bash".to_string()
+            }
+        });
         let name = std::path::Path::new(&shell)
             .file_name()
             .map(|s| s.to_string_lossy().to_string())
@@ -293,7 +299,10 @@ pub fn default_terminal_profiles() -> Vec<TerminalProfile> {
                 id: "login".to_string(),
                 name: format!("{name} (login shell)"),
                 command: shell,
-                args: Vec::new(),
+                // A real login shell (`-l`) so it sources the user's login files
+                // (Homebrew `PATH`, aliases) — matching Terminal.app and the
+                // profile's own name.
+                args: vec!["-l".to_string()],
             },
             TerminalProfile {
                 id: "bash".to_string(),

--- a/uxnandesktop/src-tauri/src/path_env.rs
+++ b/uxnandesktop/src-tauri/src/path_env.rs
@@ -1,0 +1,238 @@
+//! macOS `PATH` enrichment for GUI-launched processes.
+//!
+//! On macOS an app launched from Finder / Dock / Spotlight inherits `launchd`'s
+//! minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`) — it does **not** read the
+//! user's login-shell `PATH`, so Homebrew (`/opt/homebrew/bin` on Apple Silicon,
+//! `/usr/local/bin` on Intel), npm globals, node version managers and
+//! `~/.local/bin` are all missing. Every CLI-agent / `gh` / `git` / editor probe
+//! in this app resolves binaries against the process `PATH`
+//! ([`crate::which::resolve`], `Command::new`), and PTY shells inherit it too, so
+//! without help a normal Mac would report installed tools as "not installed".
+//! This is the same class of problem VS Code / Electron apps solve with
+//! `fix-path` / `shell-path`.
+//!
+//! [`enrich_for_gui_launch`] fixes it once at startup by **appending** (never
+//! reordering or removing) the user's real tool directories to the process
+//! `PATH`: the directories reported by the user's login+interactive shell, plus a
+//! static set of well-known locations that exist on disk. It is time-bounded so a
+//! slow or misbehaving shell rc can never hang app launch, and it is a **no-op on
+//! every non-macOS platform** (the probe returns `None`, the well-known list is
+//! empty), so Windows / Linux `PATH` is left exactly as-is.
+
+use std::collections::HashSet;
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Markers wrapped around the printed `$PATH` so a login rc that echoes a banner
+/// to stdout on startup can't corrupt what we parse (we read only what sits
+/// between them).
+const BEGIN: &str = "__UXNAN_PATH_BEGIN__";
+const END: &str = "__UXNAN_PATH_END__";
+
+/// How long to wait for the login-shell probe before giving up and falling back
+/// to the well-known directories alone. Generous enough for a heavy `.zshrc`,
+/// short enough that app launch never visibly stalls on a hostile one.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Enrich the current process `PATH` so a macOS GUI launch can find
+/// Homebrew / npm / version-manager CLIs. Safe to call unconditionally and
+/// exactly once, as early as possible at startup — before any worker thread
+/// spawns or reads `PATH` (mutating the process environment is only sound while
+/// the process is still single-threaded). A no-op off macOS.
+pub fn enrich_for_gui_launch() {
+    let base = std::env::var_os("PATH").unwrap_or_default();
+
+    let mut additions: Vec<PathBuf> = Vec::new();
+    if let Some(login_path) = login_shell_path() {
+        additions.extend(std::env::split_paths(&login_path));
+    }
+    additions.extend(well_known_dirs());
+    if additions.is_empty() {
+        return;
+    }
+
+    let merged = merge_path(&base, &additions);
+    if merged != base {
+        // SAFE: single-threaded startup, before any child is spawned or any
+        // background task reads `PATH`. Every subsequently spawned child (agent
+        // CLIs, `gh`, `git`, PTY shells) inherits the enriched value.
+        std::env::set_var("PATH", &merged);
+    }
+}
+
+/// Append `additions` to the `base` `PATH`, preserving order and de-duplicating
+/// (so a directory already present is never added twice). Base entries keep their
+/// original priority — additions only ever extend the tail, so system tools
+/// resolve exactly as before and user tool directories become discoverable.
+fn merge_path(base: &OsStr, additions: &[PathBuf]) -> OsString {
+    let mut seen: HashSet<OsString> = HashSet::new();
+    let mut ordered: Vec<PathBuf> = Vec::new();
+    for dir in std::env::split_paths(base) {
+        if seen.insert(dir.as_os_str().to_os_string()) {
+            ordered.push(dir);
+        }
+    }
+    for dir in additions {
+        if seen.insert(dir.as_os_str().to_os_string()) {
+            ordered.push(dir.clone());
+        }
+    }
+    std::env::join_paths(ordered.iter()).unwrap_or_else(|_| base.to_os_string())
+}
+
+/// Directories where user-installed CLIs commonly live but a macOS GUI launch
+/// omits from `PATH`. Both Homebrew prefixes are included (`/opt/homebrew` on
+/// Apple Silicon, `/usr/local` on Intel) so the same build works on either
+/// architecture. Only directories that actually exist are returned, so `PATH`
+/// isn't bloated with dead entries. Empty on every non-macOS platform.
+fn well_known_dirs() -> Vec<PathBuf> {
+    if !cfg!(target_os = "macos") {
+        return Vec::new();
+    }
+    let mut dirs = vec![
+        PathBuf::from("/opt/homebrew/bin"),
+        PathBuf::from("/opt/homebrew/sbin"),
+        PathBuf::from("/usr/local/bin"),
+        PathBuf::from("/usr/local/sbin"),
+    ];
+    if let Some(home) = home_dir() {
+        dirs.push(home.join(".local").join("bin"));
+        dirs.push(home.join(".npm-global").join("bin"));
+        dirs.push(home.join(".cargo").join("bin"));
+        dirs.push(home.join(".bun").join("bin"));
+        dirs.push(home.join(".deno").join("bin"));
+    }
+    dirs.into_iter().filter(|d| d.is_dir()).collect()
+}
+
+/// Probe the user's login **and** interactive shell for its real `PATH` — the one
+/// Homebrew (`~/.zprofile`, a login file) and node version managers (`~/.zshrc`,
+/// an interactive file) actually populate. Returns `None` off macOS, if the shell
+/// can't be spawned, if it doesn't answer within [`PROBE_TIMEOUT`], or if the
+/// output has no usable `PATH`.
+fn login_shell_path() -> Option<String> {
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    // `-l` sources login files (Homebrew), `-i` sources interactive files (nvm/
+    // fnm/volta). The printf is wrapped in markers so rc-file banner output can't
+    // corrupt the captured value.
+    let script = format!("printf '{BEGIN}%s{END}' \"$PATH\"");
+
+    let mut child = std::process::Command::new(&shell)
+        .args(["-ilc", &script])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+
+    // Read stdout to EOF on a worker thread so we can enforce a hard timeout on
+    // the parent: EOF arrives when the shell exits (or closes stdout). If it
+    // never does, the timeout fires and we kill the child (we still own it), which
+    // unblocks the reader.
+    let mut stdout = child.stdout.take()?;
+    let (tx, rx) = std::sync::mpsc::channel();
+    let reader = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = Vec::new();
+        let _ = stdout.read_to_end(&mut buf);
+        let _ = tx.send(buf);
+    });
+
+    let bytes = match rx.recv_timeout(PROBE_TIMEOUT) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = reader.join();
+            return None;
+        }
+    };
+    let _ = child.wait();
+    let _ = reader.join();
+    extract_path(&bytes)
+}
+
+/// Pull the `PATH` string from between the [`BEGIN`]/[`END`] markers in the
+/// probe's stdout, ignoring any surrounding rc-file noise. `None` when the markers
+/// are absent or wrap an empty value.
+fn extract_path(bytes: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(bytes);
+    let start = text.find(BEGIN)? + BEGIN.len();
+    let rest = &text[start..];
+    let end = rest.find(END)?;
+    let path = &rest[..end];
+    if path.trim().is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+/// The user's home directory (`HOME`, or `USERPROFILE` as a fallback).
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_appends_new_dirs_and_dedupes() {
+        let base = std::env::join_paths(["/usr/bin", "/bin"].iter().map(PathBuf::from)).unwrap();
+        // One brand-new dir and one already present (must not be duplicated).
+        let additions = vec![
+            PathBuf::from("/opt/homebrew/bin"),
+            PathBuf::from("/usr/bin"),
+        ];
+        let merged = merge_path(&base, &additions);
+        let got: Vec<PathBuf> = std::env::split_paths(&merged).collect();
+        assert_eq!(
+            got,
+            vec![
+                PathBuf::from("/usr/bin"),
+                PathBuf::from("/bin"),
+                PathBuf::from("/opt/homebrew/bin"),
+            ],
+            "additions extend the tail; existing entries keep their order and aren't duplicated"
+        );
+    }
+
+    #[test]
+    fn merge_with_no_additions_is_identity() {
+        let base = std::env::join_paths(["/usr/bin", "/bin"].iter().map(PathBuf::from)).unwrap();
+        let merged = merge_path(&base, &[]);
+        assert_eq!(merged, base);
+    }
+
+    #[test]
+    fn extract_path_reads_between_markers_and_ignores_noise() {
+        let out = b"Welcome to your shell\n__UXNAN_PATH_BEGIN__/opt/homebrew/bin:/usr/bin__UXNAN_PATH_END__\n";
+        assert_eq!(
+            extract_path(out).as_deref(),
+            Some("/opt/homebrew/bin:/usr/bin")
+        );
+    }
+
+    #[test]
+    fn extract_path_none_without_markers_or_when_empty() {
+        assert!(extract_path(b"no markers here").is_none());
+        assert!(extract_path(b"__UXNAN_PATH_BEGIN____UXNAN_PATH_END__").is_none());
+        assert!(extract_path(b"__UXNAN_PATH_BEGIN__   __UXNAN_PATH_END__").is_none());
+    }
+
+    // The enrichment only ever touches macOS; on every other platform the probe
+    // is skipped and the well-known list is empty, so `PATH` is left untouched.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn is_a_noop_off_macos() {
+        assert!(well_known_dirs().is_empty());
+        assert!(login_shell_path().is_none());
+    }
+}

--- a/uxnandesktop/src-tauri/src/pty.rs
+++ b/uxnandesktop/src-tauri/src/pty.rs
@@ -249,12 +249,19 @@ impl PtyManager {
 }
 
 /// Default shell per platform: honor the user's configured shell, else a sane
-/// built-in (PowerShell on Windows, `/bin/bash` elsewhere).
+/// built-in (PowerShell on Windows, the user's `$SHELL`, then `zsh` on macOS —
+/// its modern default — or `/bin/bash` elsewhere).
 fn default_shell() -> String {
     if cfg!(windows) {
         std::env::var("UXNAN_SHELL").unwrap_or_else(|_| "powershell.exe".to_string())
     } else {
-        std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string())
+        std::env::var("SHELL").unwrap_or_else(|_| {
+            if cfg!(target_os = "macos") {
+                "/bin/zsh".to_string()
+            } else {
+                "/bin/bash".to_string()
+            }
+        })
     }
 }
 

--- a/uxnandesktop/src-tauri/tauri.conf.json
+++ b/uxnandesktop/src-tauri/tauri.conf.json
@@ -29,6 +29,11 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
+    "macOS": {
+      "minimumSystemVersion": "11.0",
+      "signingIdentity": "-",
+      "hardenedRuntime": false
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Adds an **experimental, unsigned macOS build** and the plug-and-play fixes it needs. No Apple Developer account required; users clear Gatekeeper by hand ([docs/install-macos.md](uxnandesktop/docs/install-macos.md)).

## What's in it

- **`feat(rust)` — macOS PATH enrichment.** A Finder/Dock launch inherits `launchd`'s minimal PATH, so Homebrew / npm / version-manager CLIs were invisible to agent/`gh`/`git`/editor detection and PTY shells. New `path_env` module enriches the process PATH once at startup (macOS only): login+interactive shell probe (time-bounded) + well-known dirs, append-only. Seeded terminal profile is now a real login shell (`-l`); `zsh` fallback on macOS. +5 Rust tests (266 total).
- **`feat(tauri)` — macOS bundle config.** Ad-hoc signing (`signingIdentity "-"`) so the Apple Silicon binary runs at all; `minimumSystemVersion 11.0`; `hardenedRuntime false`.
- **`ci(desktop)` — two separate DMGs.** Release build matrix adds `macos-14` (aarch64) + `macos-13` (x86_64) with `fail-fast: false` (a mac leg never drops win/linux). `verify-desktop.yml` is parameterized (`os-list`); **CI verifies macOS**, the **release gate stays win+linux**.
- **`docs`** — new `install-macos.md` (3-tier install guide), READMEs flag macOS experimental + invite issues/PRs, build/updates docs, CHANGELOG, FOR-DEV/FOR-HUMAN, architecture spec-drift sync. Private-repo blocker removed (repo is public).

## Validation

Locally (Windows): `cargo fmt` clean · `cargo clippy -D warnings` 0 warnings · **266 tests pass**. macOS compile/test is exercised here on CI for the first time.