### PR TITLE
chore(mobile): prepare 0.0.13 alpha release

### DIFF
--- a/.github/whatsnew/whatsnew-en-US
+++ b/.github/whatsnew/whatsnew-en-US
@@ -1,4 +1,5 @@
 What's new in this update:
 
-• More private by design: your phone's pairing identity is no longer copied into device backups or phone-to-phone transfers. A restored phone simply pairs again — it can't clone a trusted device.
-• Your activity stats now start loading the moment you connect, so your Profile is ready without the wait.
+• Conversation lists now get useful automatic titles while keeping your manual renames.
+• The response indicator shimmers while waiting, then follows streamed text like a live cursor.
+• The Devices screen keeps its navigation visible when empty and now features the Uxnan logo.

--- a/.github/whatsnew/whatsnew-es-ES
+++ b/.github/whatsnew/whatsnew-es-ES
@@ -1,4 +1,5 @@
 Novedades de esta actualización:
 
-• Más privado por diseño: la identidad de emparejamiento de tu teléfono ya no se copia en las copias de seguridad ni en las transferencias entre teléfonos. Un teléfono restaurado simplemente se vuelve a emparejar — no puede clonar un dispositivo de confianza.
-• Tus estadísticas de actividad empiezan a cargarse en cuanto conectas, así tu Perfil está listo sin esperas.
+• Las conversaciones reciben títulos automáticos útiles sin reemplazar tus nombres manuales.
+• El indicador de respuesta brilla mientras espera y después sigue el texto como un cursor en vivo.
+• La pantalla Dispositivos conserva su navegación cuando está vacía y ahora muestra el logo de Uxnan.

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.13-alpha.20260722+20260723] - 2026-07-22
+
 ### Changed
 
 - The no-devices state now lives inside the standard Devices screen instead of

--- a/uxnanmobile/pubspec.yaml
+++ b/uxnanmobile/pubspec.yaml
@@ -4,10 +4,9 @@ description: "Uxnan - remote control for AI coding agents (E2EE mobile client)"
 publish_to: 'none'
 
 # version: <build-name>+<build-number>
-# The build-number is Play's versionCode and must strictly increase. 0.0.6 (cut
-# earlier today) already took 20260716, so this same-day release borrows the next
-# day — the same thing 0.0.2-alpha.20260628+20260629 did.
-version: 0.0.12-alpha.20260721+20260722
+# The build-number is Play's versionCode and must strictly increase. The previous
+# release used 20260722, so this same-day release borrows the next calendar day.
+version: 0.0.13-alpha.20260722+20260723
 
 environment:
   sdk: '>=3.4.0 <4.0.0'


### PR DESCRIPTION
## Summary
- bump uxnanmobile to 0.0.13-alpha.20260722+20260723
- close the mobile changelog entries for the 2026-07-22 release
- refresh the English and Spanish Google Play release notes

## Release contract
- target tag: mobile-v0.0.13-alpha.20260722+20260723
- en-US notes: 306 characters
- es-ES notes: 329 characters
- no other component version is changed