### PR TITLE
ci(web): inject Search Console token from a repo variable

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -64,10 +64,16 @@ jobs:
         run: npm ci
 
       - name: Build the static export
-        # Baked into the export at build time, so the OG/canonical URLs are
-        # absolute. Falls back to the Pages subdomain until a domain is set.
+        # Baked into the export at build time.
+        #   SITE_URL — makes the OG/canonical URLs absolute; falls back to the
+        #     Pages subdomain until a custom domain is set.
+        #   GOOGLE_SITE_VERIFICATION — optional Search Console token, kept as a
+        #     repo *variable* (Settings → Secrets and variables → Actions →
+        #     Variables) so it never lives in this public repo's source; it is
+        #     only emitted into the built HTML, where it is public by design.
         env:
           NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL || 'https://uxnan.pages.dev' }}
+          NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: ${{ vars.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION }}
         run: npm run build
 
       - name: Deploy to Cloudflare Pages

--- a/web/docs/deploy.md
+++ b/web/docs/deploy.md
@@ -118,10 +118,19 @@ it exists.
   and `/robots.txt` (allows everything, points at the sitemap) are generated at
   build time. Submit `https://uxnan.pages.dev/sitemap.xml` in **Google Search
   Console → Sitemaps** once the property is verified.
-- **Verifying the property.** The simplest method on Cloudflare is **DNS** (add
-  the TXT record Search Console gives you), which needs no code. If you prefer the
-  HTML-tag method, set a repository **variable** `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`
-  to the token and it is emitted as a `<meta>` tag on the next deploy.
+- **Verifying the property.** The site lives on a `*.pages.dev` subdomain, which
+  you do not own the DNS zone for — so the **DNS / Domain-property method is not
+  available**. Add a **URL-prefix property** for `https://uxnan.pages.dev/` and
+  use the **HTML-tag** method: copy the token from the `content="…"` value Search
+  Console shows, then add it as a repository **variable**
+  `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` (Settings → Secrets and variables →
+  Actions → **Variables**). The deploy build injects it as a
+  `<meta name="google-site-verification">` tag — so the token stays out of this
+  public repo's source and only appears in the built HTML, which is public by
+  design. Trigger a deploy (push to `web/**` or *Run workflow*), then click
+  **Verify**. Do **not** commit Google's HTML verification *file* — the variable
+  keeps the repo clean and achieves the same thing. (The token is not a secret:
+  it cannot be used to claim your property from any other domain.)
 - **Canonicals & structured data.** Each route is a server component that exports
   its own canonical URL; the home page also carries schema.org JSON-LD describing
   Uxnan and both apps, so a result can be built without scraping prose.


### PR DESCRIPTION
Passes `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` (a repository **variable**, not a committed file) into the deploy build, so it is emitted as a `<meta name="google-site-verification">` tag.

This keeps the Google Search Console token **out of this public repo's source** — it only lands in the built HTML, which is public by design anyway. DNS/domain verification isn't available on a `*.pages.dev` subdomain, so this is the verification path for the site. Docs (`web/docs/deploy.md`) updated.