### PR TITLE
fix(svelte): open the picked terminals/agents in a new worktree

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — the project "+" launcher now really opens what you picked in a brand-new worktree
+
+- Creating a worktree from the project card's **"+" → New worktree** with a terminal,
+  a profile, one or more agents (or the browser) selected created the worktree and the
+  branch **but opened nothing**. The launcher's reset effect (which picks a default
+  target and clears the "what to open" selection each time the dialog opens) also read
+  `projects.worktreesByRepo` and `projects.activeWorktreePath` as tracked dependencies.
+  Creating a worktree changes both — so the effect re-ran **mid-submit**, across the
+  `await`, and wiped `selected` before `runActions` could launch it: the loop then
+  iterated over an empty list. Verified against Svelte 5.56's scheduler (the effect
+  re-ran twice per create).
+- `LauncherDialog.svelte` now (a) wraps the reset body in `untrack` so it depends
+  **only** on `open`, and (b) **snapshots the selection before the first `await`** and
+  launches that snapshot — so nothing that runs during creation can change what opens.
+  Selecting an existing worktree as the target was never affected (no `await` in that
+  path), and "create only" (nothing selected) is unchanged.
+
 ### Changed — GitHub: a per-project inline view replaces the full-screen section
 
 - The full-screen GitHub overlay is gone. GitHub now opens **per project** from each

--- a/uxnandesktop/docs/agent-launch.md
+++ b/uxnandesktop/docs/agent-launch.md
@@ -113,6 +113,11 @@ You don't have to launch an agent by hand for every new branch:
   you create a worktree**. Leave it on **None** to never start one automatically.
 - The **New worktree** dialog pre-selects that default but lets you **override it
   per worktree** — choose a different agent, or **None** for that one worktree.
+- The project card's **"+" launcher** takes a different route: when its target is
+  **New worktree**, the **"What to open" selection is the only source of truth** —
+  the default agent is deliberately *not* auto-launched, so you get exactly the
+  terminals / profiles / agents (one or several) you ticked, and nothing if you
+  ticked nothing.
 
 When the worktree is created, the chosen agent starts in its own terminal in that
 worktree, using the launch shell and env vars from its profile.

--- a/uxnandesktop/src/lib/components/LauncherDialog.svelte
+++ b/uxnandesktop/src/lib/components/LauncherDialog.svelte
@@ -6,6 +6,7 @@
   // to open there (a terminal / profile, one or several agents, the browser).
   // Everything runs against the chosen target so the workspace linkage
   // (terminals ↔ agents ↔ worktree) is preserved.
+  import { untrack } from "svelte";
   import * as Dialog from "$lib/components/ui/dialog";
   import { Button } from "$lib/components/ui/button";
   import { Spinner } from "$lib/components/ui/spinner";
@@ -140,20 +141,26 @@
   // Reset + pick a sensible default target every time the dialog opens. The
   // worktree-creation fields reset themselves (WorktreeCreateFields, keyed off
   // `active={isNew}`), so nothing branch-related is touched here.
+  // `untrack` so this depends ONLY on `open`: creating a worktree refreshes the
+  // repo's list and moves the active worktree, and a tracked read of either would
+  // re-run this reset mid-submit — wiping the user's "what to open" picks before
+  // they were launched.
   $effect(() => {
     if (!open) return;
-    const active = projects.activeWorktreePath;
-    const belongs = active && worktrees.some((w) => w.path === active);
-    target = belongs ? active! : (worktrees[0]?.path ?? repo.path);
-    selected = [];
-    projects.error = null;
+    untrack(() => {
+      const active = projects.activeWorktreePath;
+      const belongs = active && worktrees.some((w) => w.path === active);
+      target = belongs ? active! : (worktrees[0]?.path ?? repo.path);
+      selected = [];
+      projects.error = null;
+    });
   });
 
-  function runActions(path: string) {
+  function runActions(path: string, actions: string[]) {
     // Switch to (and link) the target first, so even a browser-only launch
     // leaves the app focused on the chosen worktree.
     projects.setActiveWorktree(path);
-    for (const id of selected) {
+    for (const id of actions) {
       if (id === "term:default") projects.openTerminalAt(path);
       else if (id.startsWith("term:")) projects.openTerminalAt(path, id.slice(5));
       else if (id.startsWith("agent:")) {
@@ -167,8 +174,13 @@
     if (!canSubmit || busy) return;
     busy = true;
     try {
+      // Snapshot what the user picked BEFORE any await: creating the worktree
+      // yields, and whatever runs in between must not be able to change what we
+      // launch. The snapshot is what `runActions` opens.
+      const actions = [...selected];
+      const creating = isNew;
       let path = target;
-      if (isNew) {
+      if (creating) {
         // `null` = don't auto-launch the default agent; the "what to open"
         // selection is the single source of truth for what starts here.
         const ok = await projects.createWorktree(repo.id, wtEffectiveBranch, {
@@ -180,7 +192,7 @@
         if (!ok) return;
         path = projects.activeWorktreePath ?? path;
       }
-      runActions(path);
+      runActions(path, actions);
       open = false;
     } finally {
       busy = false;


### PR DESCRIPTION
## Problem

From a project card's **"+" launcher**, choosing target **New worktree** and ticking
terminals / profiles / agents created the worktree **and** the branch, but **opened
nothing**.

## Root cause

`LauncherDialog.svelte`'s reset effect — the one that picks a default target and clears
the "what to open" selection each time the dialog opens — also read
`projects.worktreesByRepo` and `projects.activeWorktreePath` as **tracked dependencies**.

Creating a worktree changes both (`adoptWorktree` reloads the repo's list and activates
the new worktree). Because `submit()` is async, the effect re-ran **mid-submit, across
the `await`**, and executed its `selected = []` *before* `runActions()` iterated the
selection — so the loop ran over an empty list.

Reproduced against Svelte 5.56's scheduler with a compiled minimal case: the effect
re-ran **twice per create**, and the selection arrived empty.

## Fix

Two layers, so it holds regardless of scheduling:

1. Wrap the reset body in **`untrack`** → the effect depends **only** on `open`, so
   creating a worktree can't re-trigger it.
2. **Snapshot the selection before the first `await`** and launch that snapshot
   (`runActions(path, actions)`) → nothing running during creation can change what opens.

Unaffected paths: an **existing-worktree** target (no `await` there) and **create-only**
(nothing ticked).

## Verification

- `npm run check` (rune guard + version sync + `svelte-check`): **0 errors, 0 warnings**
  (1353 files).
- `npm test`: **225 tests / 23 files, all green**.
- Real render probe: Vite dev server + headless browser DOM dump — the app mounts, no
  `ReferenceError`.
- Sibling dialogs audited — `NewWorktreeDialog`, `GithubWorktreeDialog` and
  `RemoveWorktreeDialog` read their selections **before** the `await` and their effects
  don't depend on the state that changes, so they don't have this bug.

**Not covered:** no automated regression test — the desktop Vitest harness is pure-logic
only (no Svelte plugin), and component tests are already tracked as pending in
`FOR-DEV.md`. The in-app click-through is left to manual review.

## Docs (same change set)

- `uxnandesktop/CHANGELOG.md` — `[Unreleased]` → `Fixed`.
- `uxnandesktop/docs/agent-launch.md` — "Auto-launch on worktree create" now documents
  that the "+" launcher's selection is the only source of truth there, so the default
  agent is deliberately **not** auto-launched by that route (a real, previously
  undocumented difference).

No contract, architecture or status change is owed: this restores documented behavior.
