### PR TITLE
fix(svelte): show the agent logos the CSP was blocking, and re-detect installed agents

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,38 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — most agent logos never rendered, and the catalog didn't notice an uninstall
+
+- **Every logo that came from a favicon was blocked.** Only 7 of the 32 catalog
+  agents ship a bundled SVG; the rest fall back to their product's favicon, and
+  that URL went straight into an `<img>` — which the app's CSP (`img-src 'self'
+  data: blob: asset:`) has always refused. So the fallback chain silently ended at
+  the generic Bot glyph for 25 agents, **`opencode` and `grok` among them**.
+  Widening the CSP wouldn't have been enough on its own either: the favicon
+  service answers `301` to a different host, so the allowance would have had to
+  cover the redirect target too. Logos are now fetched by the backend — the same
+  `image_fetch_data_url` command project and branch icons already use — and
+  rendered as `data:` URLs, which the existing CSP allows. Results (including
+  failures) are memoized for the session, and concurrent asks for the same logo
+  collapse into one fetch.
+- **Settings → Agents kept showing agents you had uninstalled.** Detection ran
+  once per app run, so a CLI removed while uxnan was open stayed listed as
+  installed — and one just installed stayed missing — until a restart. The pane
+  now re-checks every time it is opened, and a **refresh button** in the agents
+  header re-runs it on demand (which also retries any logo that failed while the
+  machine was offline). Detection was always a live filesystem walk; it was only
+  the asking that was stale.
+
+### Changed
+
+- **Scripts from an older build are swept from the hooks dir by rule, not by
+  list.** Anything named `uxnan-*` that the current build didn't just write is a
+  leftover and is deleted on startup, so a reporter renamed in some future version
+  cleans itself up instead of lingering until someone remembers to add it to a
+  list. What can't be derived — the old names matched inside each agent's *config*,
+  one of which is what silently disabled Codex resume — stays hand-kept and says
+  so. Files we don't own, including the hook server's `endpoint.*`, are untouched.
+
 ### Fixed — agent sessions came back for one tab, and never for Codex
 
 - **A reporter from an older build was mislabelling every Codex session.** Its

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -17,7 +17,7 @@ status/diff/stage/commit/history, agent monitoring with the axum hook server +
 OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
-with" external editors/IDEs**, **automations**, **pets**). 372 Rust backend tests + 380 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS now ships an
+with" external editors/IDEs**, **automations**, **pets**). 372 Rust backend tests + 386 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS now ships an
 **experimental, unsigned** build (Intel + Apple Silicon; CI verifies `{ubuntu,
 windows, macOS}`, release gate stays `{ubuntu, windows}`) but is **not yet validated
 on real hardware**. **Phase 6 (embedded bridge / mobile pairing) is NOT started.**
@@ -826,7 +826,7 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 372 Rust + 380 Vitest tests.
+  keeps the default `{ubuntu, windows}`. 372 Rust + 386 Vitest tests.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →
   draft GitHub Release, **and signs the updater artifacts** when the signing secrets
   are set. Builds Windows + Linux + **experimental unsigned macOS** (two ad-hoc-signed

--- a/uxnandesktop/FOR-HUMAN.md
+++ b/uxnandesktop/FOR-HUMAN.md
@@ -12,15 +12,20 @@ only this checklist and the inline `FOR-HUMAN:` markers describing what's needed
 - [ ] **(Optional) Crisper brand SVGs for catalog agents** — every catalog agent
       already shows a logo automatically: `AgentLogo.svelte` resolves a bundled SVG
       first, then the agent's favicon (`favicon` field in `src/lib/agentCatalog.ts`,
-      fetched via Google's favicon service), then the generic Bot glyph. So this is
-      **not blocking** — it only sharpens agents that currently fall back to a
-      low-res favicon.
+      fetched by the backend and inlined as a `data:` URL — see
+      `src/lib/agentLogoCache.ts`), then the generic Bot glyph. So this is **not
+      blocking** — it only sharpens agents that currently fall back to a low-res
+      favicon, and removes their dependency on being online.
       - **What/Where:** drop a vector logo at `static/agents/<logo>.svg`, where
         `<logo>` is the catalog entry's `logo` field; it takes priority over the
-        favicon. Agents without a bundled SVG today: `cursor`, `aider`, `amp`,
-        `cline`, `droid`, `copilot`, `continue`, `kiro`, `auggie`, `crush`,
-        `codebuff`, `commandcode`, `mimo`, `devin`, `hermes`, `mistralvibe`, `rovo`,
-        `autohand`, `openclaude`, `openclaw`, `omp`, `ante`.
+        favicon. **7 of 32** catalog agents have one today (`antigravity`,
+        `claudecode`, `codex`, `gemini`, `openclaude`, `pi`, `zero`). The 25
+        without: `opencode`, `goose`, `grok`, `kilocode`, `kimi`, `qwen`, `cursor`,
+        `aider`, `amp`, `cline`, `droid`, `copilot`, `continue`, `kiro`, `auggie`,
+        `crush`, `codebuff`, `commandcode`, `mimo`, `devin`, `mistralvibe`, `rovo`,
+        `autohand`, `omp`, `ante`. Worth doing first for the ones uxnan drives as
+        real agents — **`opencode` and `grok`** — since those show up in the
+        sidebar and tab strip, not just in the Settings catalog.
       - **Config:** none — `AgentLogo` picks up `/agents/<logo>.svg` automatically
         once the file exists (viewBox-normalized, monochrome-friendly like the
         existing ones).

--- a/uxnandesktop/architecture/02d-agent-monitoring.md
+++ b/uxnandesktop/architecture/02d-agent-monitoring.md
@@ -136,8 +136,13 @@ El ADE levanta un **servidor HTTP en localhost** que los agentes pueden usar par
   emitía un reporter pre-relay ya retirado; un informe **sin** tipo nunca borra
   la identidad ya establecida del tab (misma regla que la sesión), porque
   perderla se lleva por delante el comando de resume. Los reporters de builds
-  anteriores se barren del directorio de hooks y de la config de cada agente al
-  arrancar, y una sesión **ya persistida** con ese placeholder se repara al
+  anteriores se barren al arrancar por dos vías distintas: del **directorio de
+  hooks** por regla — se borra todo `uxnan-*` que esta build no acabe de escribir,
+  así que un renombrado futuro se limpia solo (los ficheros que no son nuestros,
+  como `endpoint.*`, quedan intactos) — y de la **config de cada agente** por una
+  lista de nombres retirados mantenida a mano, que es lo único que no se puede
+  deducir: renombrar un reporter obliga a añadir su nombre viejo ahí. Una sesión
+  **ya persistida** con ese placeholder se repara al
   volver el tab deduciendo el CLI de la ruta de transcript que venía en el mismo
   informe (`~/.codex/sessions/…`, `~/.claude/projects/…`, …); si no se puede
   ubicar se deja como está — lanzar la línea de otro CLI a ciegas es peor que no

--- a/uxnandesktop/docs/agent-hooks.md
+++ b/uxnandesktop/docs/agent-hooks.md
@@ -449,14 +449,20 @@ alongside it names the CLI it belongs to (`~/.codex/sessions/…`,
 both the agent and its resume command. One that can't be placed is left alone —
 running another CLI's command line on a guess is worse than offering nothing.
 
-**Reporters from older builds are swept.** Scripts a previous version installed
-and the ADE no longer ships (`uxnan-agent-status-hook.cjs`,
-`uxnan-claude-hook.cjs`, `uxnan-opencode-hook.cjs`,
-`uxnan-opencode-status-plugin.js`) are deleted from the hooks dir on startup and
-matched as managed entries so they are stripped from every agent config the ADE
-touches. The pre-relay bridge in that list did real damage while it lingered: it
-read its agent type from a `UXNAN_AGENT_TYPE` env var the ADE no longer injects
-and so reported the literal `"agent"`, which the server now rejects outright.
+**Reporters from older builds are swept.** On startup the ADE deletes every
+`uxnan-*` file in its hooks dir that the current build did not just write: the dir
+is app-data it owns, so anything else in it is a leftover — which means a reporter
+renamed in some future version cleans itself up, with no list to remember to
+update. Files it doesn't own, including the `endpoint.*` coordinates file and
+anything you put there yourself, are untouched.
+
+The *config* side can't be derived that way, so the retired reporter names
+(`uxnan-agent-status-hook`, `uxnan-claude-hook`, `uxnan-opencode-hook`) are
+matched by a hand-kept list and stripped from every agent config the ADE writes —
+**renaming a reporter means adding its old name to that list**. The pre-relay
+bridge that made this necessary did real damage while it lingered: it read its
+agent type from a `UXNAN_AGENT_TYPE` env var the ADE no longer injects and so
+reported the literal `"agent"`, which the server now rejects outright.
 
 ---
 

--- a/uxnandesktop/docs/agent-launch.md
+++ b/uxnandesktop/docs/agent-launch.md
@@ -29,8 +29,19 @@ In **Settings → Agents**:
 - **Available agents** lists the known catalog (Claude Code, Codex, Gemini CLI,
   OpenCode, …). The ADE detects which are **installed** on your `PATH`; click the
   **+** to add an installed one. **Add all installed** adds them in one click.
+  Detection re-runs each time you open the pane, and the **refresh** button in the
+  agents header re-runs it on demand — so an agent installed (or uninstalled)
+  while uxnan is open appears (or disappears) without restarting the app.
 - **Add custom agent** registers anything else by hand (a command on your `PATH`,
   or an absolute path to a script — e.g. a [hook wrapper](./agent-hooks.md)).
+
+Each agent's logo resolves in a chain: a custom image you set → a bundled SVG
+(`static/agents/`) → the product's favicon → a generic glyph. The favicon step is
+fetched by the **backend** and inlined as a `data:` URL, because the app's CSP
+allows no remote image host — a URL rendered directly by the webview is simply
+blocked (`src/lib/agentLogoCache.ts`). That step needs network the first time per
+app run; a bundled SVG never does, which is why adding more of them is tracked in
+[`FOR-HUMAN.md`](../FOR-HUMAN.md).
 
 Each agent profile has:
 

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -54,7 +54,10 @@ register / unregister + `Promise.allSettled` fan-out), `utils/pointerLock.ts`
 (the orphaned-body-pointer-lock guard: orphan detection + deferred modal open),
 `pathid.ts` (workspace path identity + the boot reconcile plan) and
 `agentResume.ts` (the per-CLI session-resume command registry + hostile-input
-rejection), `terminal/scrollback.ts` (the scrollback clamp) and
+rejection), `agentSessionId.ts` (which CLIs take a caller-chosen session id, and
+never pinning on top of args that already choose one), `agentLogoCache.ts` (the
+backend-fetched logo memo: one fetch per URL, failures remembered, concurrent
+asks collapsed), `terminal/scrollback.ts` (the scrollback clamp) and
 `terminal/windowsJunctionDetector.ts` (the Windows Redirection-Guard failure
 signature detector, incl. chunk-split matching) and `pets/` (the Codex-compatible
 manifest parser, frame timing, and the agent-state → animation mapping +
@@ -63,7 +66,7 @@ schedule + next-runs preview, the run/step display projections, the seeded
 example automations, and the prompt-variable insertion) and
 `state/statusSweepRegistry.ts` (the all-worktree status sweep's pacing +
 its request registry) and `usageCatalog.ts` (which providers are still offered
-vs merely still readable) — 380 tests in
+vs merely still readable) — 386 tests in
 `src/lib/**/*.test.ts`, config in
 `vitest.config.ts`. **Component tests** (Vitest + jsdom) and **E2E**
 (Playwright/WebdriverIO + tauri-driver) are still to come — see

--- a/uxnandesktop/src-tauri/src/agent_hooks.rs
+++ b/uxnandesktop/src-tauri/src/agent_hooks.rs
@@ -31,6 +31,7 @@
 //! (idempotent) and, when auto-install is on, merges the managed reporter into
 //! each agent's config — preserving every other user setting.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
@@ -78,23 +79,26 @@ const PI_EXTENSION_SRC_FILENAME: &str = "uxnan-pi-status.js";
 const EVENT_HOOK_SH_FILENAME: &str = "uxnan-event-hook.sh";
 const EVENT_HOOK_CMD_FILENAME: &str = "uxnan-event-hook.cmd";
 
-/// Reporter scripts earlier builds wrote into the hooks dir and no longer ship.
-/// They are swept from the dir (and from every agent config — see
-/// [`is_legacy_reporter`]) because a stale one is not merely dead weight: the
-/// pre-relay `uxnan-agent-status-hook.cjs` read its agent type from a
-/// `UXNAN_AGENT_TYPE` env var we stopped injecting, so it reported the literal
-/// `"agent"` — mislabelling the tab's captured session (which then has no resume
-/// entry) and dropping the state (no `normalize_event` arm matches).
-const LEGACY_SCRIPT_FILENAMES: &[&str] = &[
-    "uxnan-agent-status-hook.cjs",
-    "uxnan-claude-hook.cjs",
-    "uxnan-opencode-hook.cjs",
-    "uxnan-opencode-status-plugin.js",
-];
+/// Prefix every script we write into the hooks dir carries. The dir is ours, so
+/// a `uxnan-*` file we did NOT just write is by definition from an older build:
+/// [`sweep_foreign_scripts`] deletes those without needing a list to maintain.
+/// (Non-prefixed files we own — the `endpoint.*` coordinates file — are left
+/// alone by the same rule.)
+const SCRIPT_PREFIX: &str = "uxnan-";
 
-/// Filename stems of the legacy reporters, matched inside a config's hook entry.
-/// Kept apart from [`LEGACY_SCRIPT_FILENAMES`] so the match survives a renamed
-/// extension, and stem-only so an absolute path in any spelling still hits.
+/// Filename stems of reporters earlier builds installed, matched inside an agent
+/// **config** entry. Deleting the script is not enough: the entry that invokes it
+/// lives in the agent's own config, which we can only match by name — so unlike
+/// the dir sweep this list has to be maintained, and **renaming a reporter means
+/// adding its old stem here**. Stem-only so any path spelling or extension hits.
+///
+/// This is not hygiene for its own sake. The pre-relay `uxnan-agent-status-hook`
+/// read its agent type from a `UXNAN_AGENT_TYPE` env var we stopped injecting, so
+/// it reported the literal `"agent"` — mislabelling the tab's captured session
+/// (which then has no resume entry) and dropping the state (no `normalize_event`
+/// arm matches). It stayed registered in `~/.codex/hooks.json` long after the
+/// script stopped shipping, and being a Node program it outran the current curl
+/// hook, so its report usually won.
 const LEGACY_REPORTER_STEMS: &[&str] = &[
     "uxnan-agent-status-hook",
     "uxnan-claude-hook",
@@ -385,10 +389,6 @@ pub(crate) fn write_text_atomic(path: &Path, text: &str) -> Result<(), AppError>
 /// Settings UI needs. `+x` is set on the POSIX scripts a shell runs directly.
 pub fn install_scripts_to(dir: &Path) -> Result<HookInstall, AppError> {
     std::fs::create_dir_all(dir)?;
-    // Drop reporters earlier builds wrote here before writing the current set, so
-    // a config entry that still points at one becomes a no-op even if that config
-    // is never rewritten (an agent we don't auto-install for, say).
-    sweep_legacy_scripts(dir);
     let dir = dir.to_path_buf();
     let write = |name: &str, content: &str| -> Result<PathBuf, AppError> {
         let path = dir.join(name);
@@ -415,6 +415,29 @@ pub fn install_scripts_to(dir: &Path) -> Result<HookInstall, AppError> {
             let _ = std::fs::set_permissions(f, std::fs::Permissions::from_mode(0o755));
         }
     }
+    // Everything this build ships is now on disk, so anything else of ours in
+    // here came from an older one — drop it. Done AFTER the writes so the keep
+    // list is derived from what we actually wrote rather than restated (a
+    // restated list is what drifts), which makes a future rename self-cleaning:
+    // the old name simply stops being written and is swept on the next launch.
+    sweep_foreign_scripts(
+        &dir,
+        &[
+            &relay,
+            &codex_sh,
+            &codex_cmd,
+            &opencode,
+            &pi,
+            &bash,
+            &ps,
+            &cmd,
+            &fish,
+            &browser_bash,
+            &browser_cmd,
+            &event_sh,
+            &event_cmd,
+        ],
+    );
     let path_str = |p: &Path| p.to_string_lossy().into_owned();
     let opt = |p: Option<PathBuf>| p.map(|p| path_str(&p)).unwrap_or_default();
     Ok(HookInstall {
@@ -665,15 +688,32 @@ fn is_legacy_reporter(text: &str) -> bool {
     LEGACY_REPORTER_STEMS.iter().any(|s| lower.contains(s))
 }
 
-/// Delete the reporter scripts earlier builds left in our hooks dir. Exact
-/// filenames only (never a glob), and only inside the dir we own, so a file the
-/// user put there is never touched. Missing files are not an error — this runs
-/// on every startup.
-fn sweep_legacy_scripts(dir: &Path) {
-    for name in LEGACY_SCRIPT_FILENAMES {
-        let path = dir.join(name);
-        if path.is_file() {
-            let _ = std::fs::remove_file(&path);
+/// Delete every `uxnan-*` script in our hooks dir that this build did not just
+/// write — by definition a leftover from an older one. `keep` is the set of files
+/// [`install_scripts_to`] produced this run.
+///
+/// Scoped three ways so it can only ever remove our own leavings: the dir is
+/// app-data we own, only files carrying [`SCRIPT_PREFIX`] are considered (so the
+/// `endpoint.*` coordinates file and anything a user dropped in survive), and
+/// only regular files are touched. Best-effort throughout — this runs on every
+/// startup and must never be able to fail a launch.
+fn sweep_foreign_scripts(dir: &Path, keep: &[&Path]) {
+    // Windows paths are case-insensitive; compare on the lowercased file name.
+    let keep: HashSet<String> = keep
+        .iter()
+        .filter_map(|p| p.file_name())
+        .map(|n| n.to_string_lossy().to_ascii_lowercase())
+        .collect();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
+        if !name.starts_with(SCRIPT_PREFIX) || keep.contains(&name) {
+            continue;
+        }
+        if entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            let _ = std::fs::remove_file(entry.path());
         }
     }
 }
@@ -1613,22 +1653,35 @@ mod tests {
     }
 
     #[test]
-    fn legacy_scripts_are_swept_from_our_hooks_dir_only_by_exact_name() {
+    fn scripts_from_an_older_build_are_swept_without_a_list_to_maintain() {
         let dir = std::env::temp_dir().join(format!("uxnan-sweep-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
-        let legacy = dir.join("uxnan-agent-status-hook.cjs");
         let current = dir.join(STATUS_RELAY_FILENAME);
-        // A same-prefix file we never wrote: exact names only, never a glob.
-        let foreign = dir.join("uxnan-agent-status-hook.cjs.bak");
-        for f in [&legacy, &current, &foreign] {
+        // A reporter we shipped once and don't any more…
+        let legacy = dir.join("uxnan-agent-status-hook.cjs");
+        // …and one under a name nobody has thought of yet: the whole point is that
+        // a future rename cleans itself up, with no list to remember to update.
+        let renamed_someday = dir.join("uxnan-whatever-we-rename-it-to.cjs");
+        // Ours by prefix, but NOT ours by ownership: the endpoint file the hook
+        // server writes, and a file the user dropped in.
+        let endpoint = dir.join("endpoint.cmd");
+        let user_file = dir.join("my-notes.txt");
+        for f in [&current, &legacy, &renamed_someday, &endpoint, &user_file] {
             std::fs::write(f, "x").unwrap();
         }
-        sweep_legacy_scripts(&dir);
-        assert!(!legacy.exists(), "legacy script removed");
-        assert!(current.exists(), "current script kept");
-        assert!(foreign.exists(), "unknown file untouched");
+        sweep_foreign_scripts(&dir, &[&current]);
+        assert!(current.exists(), "the script we just wrote is kept");
+        assert!(!legacy.exists(), "a retired reporter is swept");
+        assert!(
+            !renamed_someday.exists(),
+            "an unknown uxnan- script is swept"
+        );
+        assert!(endpoint.exists(), "the endpoint file is not ours to sweep");
+        assert!(user_file.exists(), "a user's own file is never touched");
         // Idempotent: a second pass over a clean dir is a no-op, not an error.
-        sweep_legacy_scripts(&dir);
+        sweep_foreign_scripts(&dir, &[&current]);
+        assert!(current.exists());
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/uxnandesktop/src/lib/agentLogoCache.test.ts
+++ b/uxnandesktop/src/lib/agentLogoCache.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearRemoteLogoCache,
+  isRemoteLogo,
+  peekRemoteLogo,
+  resolveRemoteLogo,
+} from "./agentLogoCache";
+
+const URL_A = "https://www.google.com/s2/favicons?domain=opencode.ai&sz=64";
+const DATA = "data:image/png;base64,iVBORw0KGgo=";
+
+beforeEach(() => clearRemoteLogoCache());
+
+describe("isRemoteLogo", () => {
+  it("separates what the webview can load from what the backend must fetch", () => {
+    expect(isRemoteLogo(URL_A)).toBe(true);
+    expect(isRemoteLogo("http://example.test/i.png")).toBe(true);
+    // Bundled assets and inline data are rendered directly — the CSP allows both.
+    expect(isRemoteLogo("/agents/codex.svg")).toBe(false);
+    expect(isRemoteLogo(DATA)).toBe(false);
+  });
+});
+
+describe("resolveRemoteLogo", () => {
+  it("fetches once and serves the rest from memory", async () => {
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return DATA;
+    };
+    expect(await resolveRemoteLogo(URL_A, fetcher)).toBe(DATA);
+    expect(await resolveRemoteLogo(URL_A, fetcher)).toBe(DATA);
+    expect(calls).toBe(1);
+    expect(peekRemoteLogo(URL_A)).toBe(DATA);
+  });
+
+  it("collapses concurrent asks for the same logo into one fetch", async () => {
+    // Every catalog row renders its own <AgentLogo>, so the same favicon is asked
+    // for many times in the same frame.
+    let calls = 0;
+    const fetcher = async () => {
+      calls += 1;
+      return DATA;
+    };
+    const all = await Promise.all([
+      resolveRemoteLogo(URL_A, fetcher),
+      resolveRemoteLogo(URL_A, fetcher),
+      resolveRemoteLogo(URL_A, fetcher),
+    ]);
+    expect(all).toEqual([DATA, DATA, DATA]);
+    expect(calls).toBe(1);
+  });
+
+  it("remembers a failure so a dead URL isn't retried on every render", async () => {
+    let calls = 0;
+    const failing = async () => {
+      calls += 1;
+      throw new Error("offline");
+    };
+    expect(await resolveRemoteLogo(URL_A, failing)).toBeNull();
+    expect(await resolveRemoteLogo(URL_A, failing)).toBeNull();
+    expect(calls).toBe(1);
+    // `null` is a resolved answer, not "unknown" — the caller shows its glyph.
+    expect(peekRemoteLogo(URL_A)).toBeNull();
+  });
+
+  it("rejects a response that isn't inline data", async () => {
+    // The backend contract is a `data:` URL; anything else would be put straight
+    // into <img src> and blocked by the CSP all over again.
+    expect(await resolveRemoteLogo(URL_A, async () => "https://elsewhere.test/i.png")).toBeNull();
+  });
+
+  it("forgets everything on clear, so a refresh can retry", async () => {
+    await resolveRemoteLogo(URL_A, async () => {
+      throw new Error("offline");
+    });
+    expect(peekRemoteLogo(URL_A)).toBeNull();
+    clearRemoteLogoCache();
+    expect(peekRemoteLogo(URL_A)).toBeUndefined();
+    expect(await resolveRemoteLogo(URL_A, async () => DATA)).toBe(DATA);
+  });
+});

--- a/uxnandesktop/src/lib/agentLogoCache.ts
+++ b/uxnandesktop/src/lib/agentLogoCache.ts
@@ -1,0 +1,75 @@
+// Remote agent logos are fetched by the backend, never by the webview.
+//
+// Most catalog agents have no bundled SVG and fall back to their product's
+// favicon (`agentCatalog.faviconUrl`). Putting that URL straight into an `<img>`
+// could never work: the app ships a deliberately tight CSP whose `img-src` allows
+// only `'self' data: blob: asset:`, so every one of those requests was blocked —
+// which is why the favicon half of the fallback chain rendered nothing and most
+// agents showed the generic Bot glyph. (Widening the CSP wouldn't be enough on
+// its own either: the favicon service answers 301 to another host, so the
+// allowance would have to cover the redirect target too.)
+//
+// Fetching through `image_fetch_data_url` — the same Rust command project and
+// branch icons already use — sidesteps both: reqwest follows the redirect, and
+// what comes back is a `data:` URL, which the existing CSP already allows.
+//
+// Results are memoized for the session, including failures (a null), so a
+// missing logo is attempted once rather than on every render. They are NOT
+// persisted: the whole set is a few KB of tiny PNGs, fetched only while a view
+// that shows catalog agents is open.
+
+import { invoke } from "@tauri-apps/api/core";
+
+/** Resolved logos: URL → `data:` URL, or `null` when it could not be fetched. */
+const cache = new Map<string, string | null>();
+/** In-flight fetches, so N components asking for the same logo make one call. */
+const inflight = new Map<string, Promise<string | null>>();
+
+/** Whether this candidate has to go through the backend (vs. a bundled asset). */
+export function isRemoteLogo(src: string): boolean {
+  return /^https?:/i.test(src);
+}
+
+/** The already-resolved logo for `url`: a `data:` URL, `null` if it failed, or
+ *  `undefined` if it hasn't been fetched yet. Synchronous — for a render that
+ *  shouldn't wait. */
+export function peekRemoteLogo(url: string): string | null | undefined {
+  return cache.get(url);
+}
+
+/** Fetch `url` through the backend and memoize it. Never throws: a failure is
+ *  cached as `null` so the caller can fall back to its glyph and we don't retry
+ *  a dead URL on every render. `fetcher` is injectable for tests only. */
+export function resolveRemoteLogo(
+  url: string,
+  fetcher: (url: string) => Promise<string> = (u) =>
+    invoke<string>("image_fetch_data_url", { url: u }),
+): Promise<string | null> {
+  const hit = cache.get(url);
+  if (hit !== undefined) return Promise.resolve(hit);
+  const pending = inflight.get(url);
+  if (pending) return pending;
+  const task = fetcher(url)
+    .then((dataUrl) => {
+      const value = dataUrl?.startsWith("data:") ? dataUrl : null;
+      cache.set(url, value);
+      return value;
+    })
+    .catch(() => {
+      // Offline, blocked, no backend (web preview) — all the same to the caller.
+      cache.set(url, null);
+      return null;
+    })
+    .finally(() => {
+      inflight.delete(url);
+    });
+  inflight.set(url, task);
+  return task;
+}
+
+/** Forget every resolved logo, so the next render re-fetches. Used by the manual
+ *  refresh in Settings → Agents: re-checking what's installed is also the moment
+ *  to retry a logo that failed while the machine was offline. */
+export function clearRemoteLogoCache(): void {
+  cache.clear();
+}

--- a/uxnandesktop/src/lib/components/AgentLogo.svelte
+++ b/uxnandesktop/src/lib/components/AgentLogo.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
   // An agent's brand logo, resolved through a fallback chain: a user's custom
   // logo → the bundled SVG (static/agents/) → the product's favicon → a generic
-  // Bot glyph. Each candidate that fails to load advances to the next; when all
-  // are exhausted the Bot shows, so a broken <img> never appears. Sized via tokens.
+  // Bot glyph. A bundled candidate that fails to load advances the chain via
+  // `onerror`; a remote one (the favicon) can't be loaded by the webview at all
+  // under the app's CSP, so it is fetched by the backend and rendered as a
+  // `data:` URL (see `$lib/agentLogoCache`). When everything is exhausted the Bot
+  // shows, so a broken <img> never appears. Sized via tokens.
   import { agentIconSources } from "$lib/agentCatalog";
+  import { isRemoteLogo, peekRemoteLogo, resolveRemoteLogo } from "$lib/agentLogoCache";
   import { cn } from "$lib/utils";
   import { icon } from "$lib/design";
   import BotIcon from "@lucide/svelte/icons/bot";
@@ -20,7 +24,34 @@
     void sources;
     idx = 0;
   });
-  const src = $derived(sources[idx]);
+  const candidate = $derived(sources[idx]);
+  /** Backend-fetched bytes for a remote candidate (null = unavailable). */
+  let fetched = $state<string | null>(null);
+
+  $effect(() => {
+    const url = candidate;
+    if (!url || !isRemoteLogo(url)) {
+      fetched = null;
+      return;
+    }
+    const known = peekRemoteLogo(url);
+    if (known !== undefined) {
+      fetched = known;
+      return;
+    }
+    // Guard the async result against a logo that changed while it was in flight.
+    let current = true;
+    void resolveRemoteLogo(url).then((data) => {
+      if (current) fetched = data;
+    });
+    return () => {
+      current = false;
+    };
+  });
+
+  // A remote candidate renders only once the backend has handed us the bytes;
+  // while it's in flight (and if it fails) the Bot glyph stands in.
+  const src = $derived(candidate && isRemoteLogo(candidate) ? fetched : candidate);
 </script>
 
 {#if src}

--- a/uxnandesktop/src/lib/components/Settings.svelte
+++ b/uxnandesktop/src/lib/components/Settings.svelte
@@ -28,6 +28,7 @@
   import { activatableUsageProviders, usageProvider, defaultStatusBarPick } from "$lib/usageCatalog";
   import { statusMeta } from "$lib/usageFormat";
   import { detectAgents, usageDetect } from "$lib/api";
+  import { clearRemoteLogoCache } from "$lib/agentLogoCache";
   import { usage } from "$lib/state/usage.svelte";
   import type { UsageProvider } from "$lib/types";
   import * as Tabs from "$lib/components/ui/tabs";
@@ -80,6 +81,7 @@
   import WebhookIcon from "@lucide/svelte/icons/webhook";
   import DownloadIcon from "@lucide/svelte/icons/download";
   import PlusIcon from "@lucide/svelte/icons/plus";
+  import RefreshCwIcon from "@lucide/svelte/icons/refresh-cw";
   import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
   import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
   import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
@@ -221,19 +223,34 @@
   // --- Agents ---------------------------------------------------------------
   // Which catalog commands are installed (null = not checked yet).
   let installed = $state<Set<string> | null>(null);
+  let detectingAgents = $state(false);
   async function detectInstalled() {
+    detectingAgents = true;
     try {
       const found = await detectAgents(AGENT_CATALOG.map((c) => c.command));
       installed = new Set(found);
     } catch {
       installed = new Set(); // backend unreachable (e.g. web preview)
+    } finally {
+      detectingAgents = false;
     }
   }
-  // Check installation the first time the Agents pane is opened.
+  /** Re-check what's on PATH now. Detection is a live filesystem walk, so this is
+   *  all it takes for an agent installed (or uninstalled) since the app started to
+   *  appear or disappear. Also drops the fetched-logo cache, since a machine that
+   *  was offline earlier is exactly when a logo failed to load. */
+  function refreshAgents() {
+    clearRemoteLogoCache();
+    void detectInstalled();
+  }
+  // Re-check every time the Agents pane is opened — not just once per app run, or
+  // an agent uninstalled meanwhile keeps showing as available until a restart.
+  // Plain `let` (not `$state`) so tracking the edge can't re-trigger the effect.
+  let agentsPaneWasOpen = false;
   $effect(() => {
-    if (app.settingsOpen && app.settingsSection === "agents" && installed === null) {
-      void detectInstalled();
-    }
+    const open = app.settingsOpen && app.settingsSection === "agents";
+    if (open && !agentsPaneWasOpen) void detectInstalled();
+    agentsPaneWasOpen = open;
   });
 
   const isInstalled = (c: CatalogAgent) => installed?.has(c.command) ?? false;
@@ -1088,6 +1105,20 @@
               <div class="flex flex-wrap items-center justify-between gap-2 px-1">
                 <span class={text.section}>{i18n.t("settings.yourAgents")}</span>
                 <div class="flex items-center gap-1.5">
+                  <TooltipSimple title={i18n.t("settings.refreshAgents")}>
+                    {#snippet children(tp)}
+                      <Button
+                        {...tp}
+                        variant="ghost"
+                        size="icon-sm"
+                        disabled={detectingAgents}
+                        aria-label={i18n.t("settings.refreshAgents")}
+                        onclick={refreshAgents}
+                      >
+                        <RefreshCwIcon class={cn(icon.button, detectingAgents && "animate-spin")} />
+                      </Button>
+                    {/snippet}
+                  </TooltipSimple>
                   {#if addableCount > 0}
                     <Button variant="outline" size="sm" onclick={addAllInstalled}>
                       <PlusIcon data-icon="inline-start" />

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -1041,6 +1041,7 @@ export const en = {
   "settings.agentNotFound": "not found",
   "settings.agentDeprecated": "discontinued — pick another",
   "settings.detecting": "Checking which agents are installed…",
+  "settings.refreshAgents": "Check again which agents are installed",
   "settings.yourAgents": "Your agents",
   "settings.addCustomAgent": "Add custom agent",
   "settings.noAgents": "No agents yet. Add one above to launch it into any worktree.",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -1042,6 +1042,7 @@ export const es: Record<MessageKey, string> = {
   "settings.agentNotFound": "no encontrado",
   "settings.agentDeprecated": "descontinuado — elige otro",
   "settings.detecting": "Verificando qué agentes están instalados…",
+  "settings.refreshAgents": "Volver a verificar qué agentes están instalados",
   "settings.yourAgents": "Tus agentes",
   "settings.addCustomAgent": "Agregar agente personalizado",
   "settings.noAgents":


### PR DESCRIPTION
Two quiet faults in **Settings → Agents**, plus the generalized version of the stale-file sweep from #128.

## Most agent logos could never render

Only **7 of the 32** catalog agents ship a bundled SVG. The rest fall back to their product's favicon — and that URL went straight into an `<img>`, which the app's CSP has always refused:

```
img-src 'self' data: blob: asset: http://asset.localhost
```

So the fallback chain silently ended at the generic Bot glyph for 25 agents, **`opencode` and `grok` among them** (agents uxnan drives for real, visible in the sidebar and tab strip — not just catalog rows).

Widening the CSP wouldn't have been enough on its own either: the favicon service answers **301 to another host** (`gstatic.com`), so the allowance would have had to cover the redirect target too.

Logos now resolve through **`image_fetch_data_url`** — the same backend command project and branch icons already use — and render as `data:` URLs, which the existing CSP allows. reqwest follows the redirect; nothing about the CSP changes. Results are memoized per session (failures included, so a dead URL isn't retried every render) and concurrent asks for the same logo collapse into one fetch.

## The catalog didn't notice an install or an uninstall

Detection ran **once per app run**, so a CLI removed while uxnan was open stayed listed as installed — and one just installed stayed missing — until a restart. It now re-runs each time the pane is opened, plus a **refresh button** in the agents header for on demand, which also drops the logo cache (a machine that was offline earlier is exactly when a logo failed). Detection in Rust was always a live filesystem walk; only the asking was stale.

## Sweeping old files by rule instead of by list

#128 removed reporters from older builds using a hard-coded list of filenames. That only works while someone remembers to extend it. Now: anything named `uxnan-*` in our hooks dir that the current build didn't just write is a leftover and is deleted — so a reporter renamed in a future version cleans itself up. Files we don't own, including the hook server's `endpoint.*`, are untouched.

What genuinely can't be derived — the old names matched inside each *agent's own config* — stays a hand-kept list, and the code, `docs/agent-hooks.md` and `architecture/02d` now all say so, since that is the list that must be extended on a rename. (It was one of those entries that silently disabled Codex resume.)

## Also

`FOR-HUMAN.md`'s missing-logo list was recomputed from the source — it named agents that *do* have an SVG and omitted several that don't — and now points at `opencode` and `grok` as the ones worth drawing first.

## Gates

`svelte-check` 0 errors · 386 Vitest (6 new) · 372 Rust · `cargo fmt` + `clippy` clean · `vite build` OK.

Verified on the maintainer's machine: the refresh button and the logos behave as described, and the two agents that kept appearing after an "uninstall" turned out to be genuine leftovers (orphaned npm shims for Gemini CLI, a `go install` binary for Zero) — detection was right, which is the behavior this PR preserves.