### PR TITLE
feat(desktop): measure the resource footprint instead of asserting it

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,6 +47,18 @@ screenshot/video for UI changes. "It builds" is not enough._
 > 3. Built `flutter build apk --release` and confirmed the QR scanner opens and
 >    scans without crashing (screenshot below).
 
+## Resource impact (`uxnandesktop` only)
+
+_Does this change spawn a process, open a webview, start a watcher, poll, cache,
+hold a socket, or run at startup? If so, name the
+[resource scenario](../uxnandesktop/docs/resource-benchmarks.md) that covers it
+and paste the measured numbers. If it costs nothing, say how you know. Delete
+this section for non-desktop PRs._
+
+> **Example:** Adds a 30 s poll. Covered by R01; measured on Windows over 5
+> repetitions: `ownRssP50Mb` 214 → 215, `cpuP95` 1.4 % → 1.6 %. The feature is
+> opt-in, so R09-style variants prove it costs nothing while disabled.
+
 ## Checklist
 
 - [ ] Lint/format pass for the touched component(s) (see `CONTRIBUTING.md`).
@@ -56,3 +68,4 @@ screenshot/video for UI changes. "It builds" is not enough._
 - [ ] Commits follow Conventional Commits — `type(scope): message`.
 - [ ] **If this is a `uxnanmobile` release:** `.github/whatsnew/whatsnew-{en-US,es-ES}` updated with short, non-technical notes (≤ 500 chars each).
 - [ ] If a `shared` contract changed, all consumers (bridge/relay/mobile) were updated in the same change.
+- [ ] If this adds a desktop process/watcher/poll/webview/cache, the resource scenario that covers it was run and the numbers are above.

--- a/.github/workflows/resource-benchmarks.yml
+++ b/.github/workflows/resource-benchmarks.yml
@@ -1,0 +1,142 @@
+name: Resource benchmarks (uxnandesktop)
+
+# Measures uxnan's own footprint against the canonical scenarios
+# (`uxnandesktop/scripts/resources/`, documented in
+# `uxnandesktop/docs/resource-benchmarks.md`).
+#
+# On demand and nightly — never on a PR. A GitHub runner is a noisy, shared VM
+# with no GPU and an unpredictable neighbour, so its absolute numbers cannot gate
+# anything; what it gives is a cheap trend signal and proof that the harness
+# still runs. **This workflow never fails the build.** The gate that matters runs
+# on the reference hardware, against an approved baseline.
+#
+# Windows only for now: it is the only platform whose collector has been verified
+# on real hardware, and publishing a macOS or Linux figure nobody has looked at
+# would be exactly the unfounded claim this harness exists to prevent.
+#
+# R08 (GitHub panel) is never included: it needs a real `gh` login, and CI is
+# never handed one.
+
+on:
+  workflow_dispatch:
+    inputs:
+      scenarios:
+        description: "Space-separated scenario ids, or 'all' for every unattended one"
+        required: false
+        default: "all"
+      repeats:
+        description: "Repetitions per scenario"
+        required: false
+        default: "3"
+      duration:
+        description: "Seconds of measurement per repetition (CI uses a short window)"
+        required: false
+        default: "60"
+  schedule:
+    # 04:20 UTC — off the hour, so it does not queue behind everyone else's cron.
+    - cron: "20 4 * * *"
+
+concurrency:
+  group: resource-benchmarks
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: uxnandesktop
+
+jobs:
+  benchmark:
+    name: benchmark (windows)
+    runs-on: windows-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: uxnandesktop/package-lock.json
+
+      - name: Set up Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: uxnandesktop/src-tauri
+
+      - name: Install frontend deps
+        run: npm ci
+
+      # `tauri build --no-bundle`, not a bare `cargo build --release`: without
+      # Tauri's `custom-protocol` feature the binary stays in dev mode and loads
+      # `http://localhost:1420`, so the app would run with no UI at all and the
+      # numbers would be meaningless. The harness checks the binary for embedded
+      # frontend assets and refuses such a build, but doing it right here means
+      # the check never has to fire.
+      - name: Build a measurable release binary
+        run: npm run bench:build
+
+      - name: Harness unit tests
+        run: npx vitest run scripts/
+
+      - name: Run the scenarios
+        shell: bash
+        run: |
+          set -u
+          scenarios="${{ github.event.inputs.scenarios || 'all' }}"
+          repeats="${{ github.event.inputs.repeats || '3' }}"
+          duration="${{ github.event.inputs.duration || '60' }}"
+          # A shared runner cannot honour a two-hour soak inside a job budget, and
+          # a truncated soak is not a soak — it is excluded rather than faked.
+          if [ "$scenarios" = "all" ]; then
+            list="R00 R01 R02 R03 R04 R05 R06 R09 R11"
+          else
+            list="$scenarios"
+          fi
+          echo "scenarios: $list (x$repeats, ${duration}s each)"
+          for id in $list; do
+            node scripts/resources/run.mjs \
+              --scenario "$id" \
+              --repeats "$repeats" \
+              --duration "$duration" \
+              --stabilize 15 \
+              --no-samples || echo "::warning::scenario $id did not complete cleanly"
+          done
+
+      - name: Render the report
+        if: always()
+        run: node scripts/resources/report.mjs || echo "::warning::no aggregates to report"
+
+      - name: Compare against the approved baseline
+        if: always()
+        run: |
+          node scripts/resources/compare.mjs --baseline scripts/resources/baselines/windows --file .resource-results/comparison.md || true
+
+      - name: Summarise on the run page
+        if: always()
+        shell: bash
+        run: |
+          {
+            if [ -f .resource-results/report.md ]; then cat .resource-results/report.md; fi
+            if [ -f .resource-results/comparison.md ]; then echo; cat .resource-results/comparison.md; fi
+            echo
+            echo "> Numbers from a shared GitHub runner. Trend signal only — the gate runs on reference hardware."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: resource-benchmarks-windows
+          path: |
+            uxnandesktop/.resource-results/runs/
+            uxnandesktop/.resource-results/aggregates/
+            uxnandesktop/.resource-results/report.md
+            uxnandesktop/.resource-results/comparison.md
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.es.md
+++ b/README.es.md
@@ -102,9 +102,12 @@ cifrado y bridge-first.
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=white)
 
 Un **Agent Development Environment** ligero construido con Tauri 2, Rust y Svelte
-5. A diferencia de las alternativas basadas en Electron que consumen 200-500 MB
-de RAM solo por existir, este ADE usa el webview nativo del OS y apunta a 30-100
-MB de RAM.
+5. Renderiza con el webview nativo del sistema operativo en vez de empaquetar un
+segundo navegador, y de ahí sale la diferencia frente a las alternativas basadas
+en Electron: su propio núcleo ocupa ~40 MB, y una sesión típica ronda los
+**250 MB** — medidos, no estimados (Windows 11, WebView2 150, build release;
+método y cifras completas en
+[`uxnandesktop/docs/resource-benchmarks.md`](uxnandesktop/docs/resource-benchmarks.md)).
 
 La idea central: cada tarea vive en su propio git worktree con su propio agente
 corriendo en un pseudoterminal independiente. Puedo tener 5 agentes trabajando en

--- a/README.md
+++ b/README.md
@@ -100,8 +100,12 @@ channel.
 ![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=white)
 
 A lightweight **Agent Development Environment** built with Tauri 2, Rust and
-Svelte 5. Unlike Electron-based alternatives that consume 200-500 MB of RAM just
-by existing, this ADE uses the OS's native webview and targets 30-100 MB of RAM.
+Svelte 5. It renders through the operating system's native webview instead of
+bundling a second browser, which is where the difference against Electron-based
+alternatives comes from: its own core is ~40 MB, and a typical session sits
+around **250 MB** — measured, not estimated (Windows 11, WebView2 150, release
+build; method and full numbers in
+[`uxnandesktop/docs/resource-benchmarks.md`](uxnandesktop/docs/resource-benchmarks.md)).
 
 The core idea: each task lives in its own git worktree with its own agent running
 in an independent pseudoterminal. I can have 5 agents working in parallel without

--- a/uxnandesktop/.gitignore
+++ b/uxnandesktop/.gitignore
@@ -16,3 +16,8 @@ src-tauri/gen/schemas
 
 # pnpm
 pnpm-debug.log*
+
+# Resource benchmarks — raw results, generated fixtures and disposable app
+# profiles. Only approved summaries under scripts/resources/baselines/ are
+# committed (see docs/resource-benchmarks.md).
+/.resource-results

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,125 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — a reproducible resource benchmark, so "it stays small" is a measurement
+
+- **The efficiency claim now has a harness behind it** (`scripts/resources/`,
+  documented in [`docs/resource-benchmarks.md`](docs/resource-benchmarks.md)):
+  twelve canonical scenarios (cold start, idle, 1 / 4 terminals, a sleeping
+  workspace, an agent working, a 10 000-file repo, browser, GitHub, pet off /
+  layer / overlay, a 2-hour soak, restart-and-restore), a versioned result
+  schema, per-platform budgets and a baseline comparator. `npm run bench`,
+  `npm run bench:report`, `npm run bench:compare`.
+- **Three buckets that are never summed.** `own` is the app plus its webview
+  helpers, `managed` adds the shells and sidecars uxnan spawned, `external` is
+  the agent CLI or program the user ran inside them. Attribution is structural —
+  parent/child descent from a PID the harness spawned itself — so a same-named
+  process that was already running can never be counted, and a renamed one can
+  never escape. `null` means "not measurable on this platform", never zero.
+- **Scenarios reach their state by seeding the app's own persisted profile**, so
+  they are reproducible without driving the UI: a `state.json` is written into a
+  throwaway directory and the app is pointed at it. The seeded profile also turns
+  off the updater check, provider polling, the pet and hook auto-install, so a
+  resting measurement measures resting.
+- **Fixtures are local, offline and deterministic**: a generated git repository
+  whose commit hash is a function of its arguments (pinned author, committer and
+  timestamps, seeded PRNG), a stand-in agent that reproduces an agent's *shape*
+  of load without a model, a network or credentials, and a fixed loopback page
+  for the browser.
+- **A result carries its conditions or it is not a result.** OS, webview version,
+  CPU, core count, power plan, build profile and commit are required by the
+  schema; a debug build is refused outright, because debug numbers are not
+  comparable with anything.
+- **Working set and private bytes are both published.** A webview tree is many
+  processes sharing one large code region, and a working-set sum counts those
+  pages once per process — so `*RssMb` over-states the machine's real burden even
+  though it stays the better like-for-like signal between runs. `*PrivateMb` sums
+  private committed bytes and double-counts nothing. Reporting only one of them
+  would be a quiet accounting choice; reporting both makes the gap visible.
+- **A memory slope is only reported over a window long enough to mean it**
+  (ten minutes). Fitted over a 45-second run, warm-up alone extrapolates to
+  thousands of MB/h — a fabricated leak is worse than a missing number.
+- **Three ways a run can look excellent and mean nothing are now refused.** The
+  binary is scanned for embedded frontend assets, because `cargo build --release`
+  alone leaves Tauri in dev mode: the window opens, the Rust backend runs, real
+  WebView2 processes spawn — and the UI is a connection-refused page pointing at
+  `localhost:1420`. Measured that way a one-terminal scenario reports ~27 MB and
+  no shell. Each scenario also asserts that the terminals its profile seeded
+  actually came back, which catches a broken restore path on its own and is the
+  second net under "the UI never booted".
+- **Nothing personal leaves the machine.** The collectors never read a command
+  line, an environment block or a window title; every document is scrubbed before
+  it is written (user, host, and the folder names *under* the home directory —
+  which are the project names) and the write is refused if anything personal
+  survives. No telemetry, no network.
+- **The gate starts in warn mode.** Absolute budgets live per platform, and the
+  regression comparison only fails when a metric moves by both a relative and an
+  absolute margin (>15 % *and* >10 MB / 2 pp CPU), so noise cannot trip it.
+  macOS and Linux budgets ship empty on purpose and report `unknown` rather than
+  borrowing a number measured on another platform.
+- **A first Windows baseline is approved and committed**
+  (`scripts/resources/baselines/windows/`, eleven scenarios × 5 repetitions,
+  release build, Windows 11 / WebView2 150 / i7-13620H), and `budgets/windows.json`
+  is derived from it with explicit margins. R07 and R08 need an operator and R10
+  (the two-hour soak) has never been run, so those three carry no budget entry and
+  report `unknown` — the distinction between "not judged" and "passed" is the
+  whole point. What the baseline shows:
+  - **sleeping a workspace really does give memory back** — 48 MB and 8 processes
+    between four live terminals and the same four asleep;
+  - **restart-and-restore comes back whole** — the restored session lands on the
+    same 15 managed processes and within 3 % of the memory of the session it
+    replaced;
+  - **the pet costs nothing while off**, 28 MB as a layer, and **88 MB plus double
+    the CPU as a desktop overlay**, where it is a second webview window (visible
+    as an eighth `own` process);
+  - **the agent's cost stays out of uxnan's figure** — the fixture agent is
+    reported in `external` at 48 MB working set / 27 MB private;
+  - **the published memory figure described the wrong thing.** "30–100 MB" is the
+    Rust process alone (~40 MB — the row Task Manager shows); the app also runs
+    six OS-webview processes that Windows lists under their own name, and the
+    honest total is **236 MB private cold, 252 MB with one terminal** (~500 MB if
+    you sum working sets, which counts the pages those six share once each).
+
+### Changed — the published memory figure now says what it measures
+
+- **"30–100 MB" became "~250 MB", everywhere at once**: both root READMEs, this
+  component's README (badge + a breakdown of why Task Manager shows ~40 MB), and
+  `web/src/lib/site.ts`, where `RAM_TARGET` is replaced by a measured
+  `RAM_FOOTPRINT` + `RAM_CORE` pair carrying the platform, build and method in a
+  doc comment. The site's hero, OG description, feature card and comparison copy
+  follow from those constants, and `web/docs/content.md` records where the number
+  comes from and how to re-derive it. The old figure was not wrong so much as
+  about a different thing — the core, not the app — and it was checkable in
+  thirty seconds by anyone with Task Manager, which is the worst property a public
+  number can have.
+- **A nightly / on-demand CI workflow** (`resource-benchmarks.yml`) runs the
+  unattended scenarios on a Windows runner and uploads the results. It never
+  fails the build: a shared VM gives a trend signal, not a gate.
+- The PR template now asks for the resource impact of any change that spawns a
+  process, opens a webview, starts a watcher, polls, caches, or runs at startup.
+
+### Added — `UXNAN_DATA_DIR`, for running the app against a disposable profile
+
+- The application data directory can be relocated for one process with
+  `UXNAN_DATA_DIR` (`src-tauri/src/datadir.rs`), honoured by the app, by every
+  command that reads `<app-data>`, and by the headless automation runner. It
+  exists so the benchmarks (and, later, an E2E driver) can start from a known
+  state *and* can never write into the real profile. A relative path is refused —
+  it would resolve against whatever the working directory happened to be, so the
+  same command could mean two different profiles — and the platform location is
+  used instead.
+
+### Known limitation — one uxnan at a time while benchmarking
+
+- **WebView2 keeps one browser process per user-data folder**, and uxnan's is
+  `%LOCALAPPDATA%\dev.luisgamas.uxnandesktop\EBWebView`. A second instance
+  attaches to the first one's browser process, so its renderers are spawned
+  outside the tree being sampled: the run would report the Rust process alone
+  (~27 MB) and silently omit the entire webview. The harness therefore refuses to
+  start while another instance is running, and marks any run that never grew a
+  webview inside its own tree as invalid. A benchmarking constraint only — it
+  does not affect normal use.
+
 ### Fixed — most agent logos never rendered, and the catalog didn't notice an uninstall
 
 - **Every logo that came from a favicon was blocked.** Only 7 of the 32 catalog

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -17,7 +17,10 @@ status/diff/stage/commit/history, agent monitoring with the axum hook server +
 OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
-with" external editors/IDEs**, **automations**, **pets**). 372 Rust backend tests + 386 frontend Vitest unit tests (pure logic); **no Svelte component or E2E tests yet**. macOS now ships an
+with" external editors/IDEs**, **automations**, **pets**, **a reproducible
+resource benchmark**). 377 Rust backend tests + 517 frontend Vitest unit tests
+(pure logic, the benchmark harness included); **no Svelte component or E2E tests
+yet**. macOS now ships an
 **experimental, unsigned** build (Intel + Apple Silicon; CI verifies `{ubuntu,
 windows, macOS}`, release gate stays `{ubuntu, windows}`) but is **not yet validated
 on real hardware**. **Phase 6 (embedded bridge / mobile pairing) is NOT started.**
@@ -224,6 +227,55 @@ on real hardware**. **Phase 6 (embedded bridge / mobile pairing) is NOT started.
   **Caveat: the write side is implemented but not yet exercised against real GitHub
   data** (this repo has no PRs/issues/collaborators) — see *Validation status* under
   "GitHub integration — follow-ups" before trusting any of it in anger.
+- **Resource benchmark** (`scripts/resources/`) — twelve canonical scenarios, a
+  versioned result schema, structural own/managed/external process attribution,
+  deterministic offline fixtures (generated git repo, stand-in agent, loopback
+  page), per-platform budgets in warn mode, a baseline comparator, a redaction
+  gate that refuses to write anything personal, and a nightly/on-demand CI
+  workflow. Scenarios reach their state by seeding a disposable app profile
+  (`UXNAN_DATA_DIR`, `src-tauri/src/datadir.rs`), never by driving the UI.
+  See [`docs/resource-benchmarks.md`](docs/resource-benchmarks.md).
+  **Caveats: only Windows has been run on real hardware; R07/R08 still need an
+  operator; the gate is warn-only.** See "Resource benchmarks — follow-ups".
+
+## Resource benchmarks — follow-ups ☐
+
+**The harness is complete and runs.** What is left is coverage and confidence,
+not missing machinery.
+
+- [ ] **Re-measure the published figure on a modest machine.** The ~250 MB now
+      quoted everywhere comes from a 16 GB box, and WebView2 is more generous with
+      memory when there is memory to spare — so the number a low-RAM user actually
+      sees is probably lower, and is currently unknown. That is the machine the
+      claim is aimed at, so it is the machine it should be measured on.
+- [ ] **Leave the gate in warn mode for two weeks of real runs, then flip
+      `"mode": "enforce"`** in `budgets/windows.json`. The limits are derived
+      from the 2026-07-30 baseline with explicit margins (the rule is written
+      into the file), but flipping before the noise floor is known on a second
+      machine is how a gate earns a reputation for false positives and gets
+      switched off.
+- [ ] **Capture R07 and R08 with an operator, and run R10 once.** The Windows
+      baseline covers eleven scenarios; those three have no entry and correctly
+      report `unknown`. R10 in particular means there is currently **no evidence
+      either way** about long-run memory growth — the slope metrics exist and
+      have never been exercised on a real two-hour run.
+- [ ] **Run the Unix collector on real macOS and Linux hardware.** It is
+      implemented and shares the schema, but has never executed anywhere: until
+      it has, `budgets/{macos,linux}.json` stay empty and no figure for those
+      platforms may be published. macOS additionally needs its own definition of
+      the `own` bucket — WebKit's content process lives outside the app's tree,
+      so the Windows framing does not transfer.
+- [ ] **Automate R07 (browser) and R08 (GitHub) once an E2E driver exists.** Both
+      need a person to click today. The metric names will not change when they
+      flip to `auto`; R08 stays out of CI regardless, because it needs a real
+      `gh` login. Same for R04's *wake* half — the asleep cost is automatic, the
+      wake latency and scrollback fidelity are still on the checklist.
+- [ ] **Per-run WebView2 profile, if a way appears.** Tauri forces the webview
+      user-data folder to `LocalData/<identifier>` when a window config does not
+      set one, which is why two instances share a browser process and why the
+      harness has to refuse to run alongside another uxnan. Isolating it per run
+      would remove that precondition; it needs either a config-level
+      `dataDirectory` uxnan controls per launch or an upstream hook.
 
 ## Automations — follow-ups ☐
 
@@ -826,7 +878,7 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 372 Rust + 386 Vitest tests.
+  keeps the default `{ubuntu, windows}`. 377 Rust + 517 Vitest tests.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →
   draft GitHub Release, **and signs the updater artifacts** when the signing secrets
   are set. Builds Windows + Linux + **experimental unsigned macOS** (two ad-hoc-signed

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -12,7 +12,7 @@ CodeMirror 6.
 ![Tauri](https://img.shields.io/badge/Tauri_2-FFC131?style=for-the-badge&logo=tauri&logoColor=000000)
 ![Svelte](https://img.shields.io/badge/Svelte_5-FF3E00?style=for-the-badge&logo=svelte&logoColor=white)
 ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS_v4-06B6D4?style=for-the-badge&logo=tailwindcss&logoColor=white)
-![RAM](https://img.shields.io/badge/RAM-~30%E2%80%93100_MB-2ea44f?style=for-the-badge)
+![RAM](https://img.shields.io/badge/RAM-~250_MB_measured-2ea44f?style=for-the-badge)
 ![i18n](https://img.shields.io/badge/i18n-EN_%7C_ES-blue?style=for-the-badge)
 ![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white)
 ![macOS](https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white)
@@ -28,11 +28,32 @@ CodeMirror 6.
 Uxnan Desktop is for developers who want a clear, multi-agent workflow without
 paying the resource cost of a full IDE or an Electron shell. Because it renders
 through the operating system's native webview instead of bundling its own browser,
-it targets **30–100 MB of RAM** where comparable Electron applications routinely
-sit at **200–500 MB**. That difference is the point: it is meant to be a practical
-choice on low-to-moderate-resource machines, not only on high-end workstations,
-while still offering an intuitive interface for running and reviewing several
-agents at once.
+it costs **about 250 MB of RAM** in a normal session, against the **200–500 MB**
+an Electron shell routinely idles at. That difference is the point: it is meant to
+be a practical choice on low-to-moderate-resource machines, not only on high-end
+workstations, while still offering an intuitive interface for running and
+reviewing several agents at once.
+
+That figure is measured, not asserted — and it is worth knowing how it breaks
+down, because the number Task Manager shows you is a different one:
+
+| | |
+|---|---|
+| `uxnan-desktop.exe`, the Rust core | **~40 MB** — this is the row you see in Task Manager |
+| the OS webview the interface renders in | six more processes, listed separately by Windows |
+| **the whole thing, private memory** | **~250 MB** (236 MB with nothing open) |
+
+Windows lists those webview processes under their own name, so uxnan looks far
+smaller than it is; summing the rows the way Task Manager displays them gives
+~500 MB, which over-counts, because the six share large parts of their memory.
+**~250 MB is the honest figure**: private memory across the whole tree, nothing
+counted twice.
+
+Measured on Windows 11 (x64), WebView2 150.0.4078.105, release build, five
+repetitions — a
+[reproducible benchmark](./docs/resource-benchmarks.md) with a scenario matrix,
+per-platform budgets and a regression gate is what keeps it that way. No figure is
+published here without the platform, build and method behind it.
 
 It is deliberately **not an IDE**. It is an orchestration, monitoring, and
 change-review layer, and any CLI agent works inside it without modification.
@@ -197,6 +218,7 @@ Detailed docs live in [`docs/`](./docs/):
 [release builds & packaging](./docs/build.md) ·
 [installing on macOS (experimental)](./docs/install-macos.md) ·
 [testing & verification](./docs/testing.md) ·
+[resource benchmarks](./docs/resource-benchmarks.md) ·
 [architecture orientation](./docs/architecture.md) ·
 [design tokens](./docs/design-tokens.md) ·
 [theming & appearance](./docs/theming.md) ·

--- a/uxnandesktop/architecture/01-product-vision.md
+++ b/uxnandesktop/architecture/01-product-vision.md
@@ -267,7 +267,7 @@ El **Uxnan Relay** es un servidor Node.js que facilita la comunicación entre la
 | Tecnología | Qué es | Para qué la usamos | Ventajas clave |
 |---|---|---|---|
 | **Rust** | Lenguaje de programación de sistemas | Todo el backend pesado: gestión de git worktrees, procesos de terminales (PTY), servidor HTTP de hooks, monitoreo de agentes, filesystem, operaciones git, lógica de orquestación, persistencia. | Extrema ligereza y bajo uso de RAM/CPU. Seguridad de memoria (sin crashes por null/dangling pointers). Concurrencia segura con Tokio (runtime async). Excelente para crecer (SSH, Docker, etc.) sin perder rendimiento. FFI nativo para integrar con APIs del sistema operativo. |
-| **Tauri 2** | Framework para apps de escritorio | Une el frontend con el backend Rust y genera la app nativa multiplataforma. Provee el sistema de commands/events para comunicación backend-frontend. | Usa el webview nativo del sistema operativo (no bundlea Chromium). Instaladores de 5-15 MB vs 150-300 MB de Electron. Bajo consumo de RAM (30-100 MB típico). Seguridad fuerte con permisos explícitos por capability. Fácil de empaquetar y distribuir. |
+| **Tauri 2** | Framework para apps de escritorio | Une el frontend con el backend Rust y genera la app nativa multiplataforma. Provee el sistema de commands/events para comunicación backend-frontend. | Usa el webview nativo del sistema operativo (no bundlea Chromium). Instaladores de 5-15 MB vs 150-300 MB de Electron. Bajo consumo de RAM (~250 MB medidos, de los cuales ~40 MB son el proceso propio). Seguridad fuerte con permisos explícitos por capability. Fácil de empaquetar y distribuir. |
 | **Svelte 5** | Framework frontend | Construir toda la interfaz: sidebars, layout de tres paneles, tabs, splits, estado en tiempo real, command palette, etc. | `$state` y `$derived` (Runes) eliminan la necesidad de librerías de estado externas como Zustand o Redux. Menor runtime overhead que React o Vue. Excelente rendimiento en actualizaciones en tiempo real. Código simple y mantenible. |
 | **shadcn-svelte** | Colección de componentes UI | Botones, sidebars, tabs, modales, tablas, tooltips, command palette, dark mode, y más. | Componentes modernos, accesibles y personalizables. Ligero porque solo copias lo que usas (no hay dependencia de un paquete monolítico). Basado en Bits UI (equivalente de Radix para Svelte). Look profesional sin esfuerzo. |
 | **Tailwind CSS** | Framework de CSS utilitario | Estilos rápidos y consistentes de toda la aplicación. | Muy ligero gracias al purge automático de clases no usadas en producción. Alta velocidad de desarrollo. Fácil de mantener y escalar. Integración nativa con shadcn-svelte. |
@@ -307,7 +307,7 @@ Tauri 2 elimina el overhead de bundlear Chromium + Node.js (que es lo que hace E
 
 | Métrica | Electron (referencia) | Tauri 2 + Rust |
 |---|---|---|
-| **RAM en reposo** | 200-500 MB | 30-100 MB |
+| **RAM en reposo** | 200-500 MB | **~240 MB medidos** (nucleo Rust ~40 MB + webview del OS) |
 | **Tamaño del instalador** | 150-300 MB | 5-15 MB |
 | **Tiempo de arranque** | 2-5 segundos | < 1 segundo |
 | **Bundled runtime** | Chromium + Node.js completos | Webview del OS (ya instalado) |
@@ -315,7 +315,18 @@ Tauri 2 elimina el overhead de bundlear Chromium + Node.js (que es lo que hace E
 | **Overhead de IPC** | JSON serialization sobre IPC channel | Tauri commands con serialización Serde (más rápido) |
 | **Procesos de sistema** | 3+ procesos (main, renderer, GPU) | 1 proceso nativo + webview del OS |
 
-La diferencia de 200-500 MB a 30-100 MB de RAM es especialmente relevante para un ADE que gestiona N agentes en paralelo — cada agente ya consume memoria propia. Si el ADE base consume 400 MB antes de que los agentes empiecen a trabajar, el sistema se satura más rápido.
+Esa diferencia es especialmente relevante para un ADE que gestiona N agentes en paralelo — cada agente ya consume memoria propia. Si el ADE base consume 400 MB antes de que los agentes empiecen a trabajar, el sistema se satura más rápido.
+
+**Estas cifras son un objetivo verificable, no una impresión.** La promesa de bajo
+consumo se mide con un banco de pruebas reproducible (`scripts/resources/`,
+documentado en `docs/resource-benchmarks.md`): matriz de escenarios canónicos,
+esquema de resultado versionado, presupuestos por plataforma y comparador contra una
+línea base aprobada. El banco separa siempre tres costos que **nunca se suman** —
+**propio** (la app y los procesos auxiliares de su runtime), **gestionado** (más las
+shells y sidecars que Uxnan lanza) y **externo** (el CLI del agente que el usuario
+ejecutó dentro de una shell) — porque presentar la suma como "lo que cuesta Uxnan"
+sería exactamente la cifra engañosa que este documento no debe publicar. Todo número
+publicado va acompañado de plataforma, versión del webview, perfil de build y método.
 
 ### Justificación de Svelte 5 con Runes
 
@@ -457,6 +468,6 @@ Uxnan Desktop corre en **Windows, macOS y Linux** con el mismo codebase. Gracias
 | Terminal-céntrico | Cualquier agente CLI funciona sin integración |
 | Conectividad móvil | Bridge embebido opcional para Uxnan Mobile |
 | Cross-platform | Windows, macOS, Linux con instalador de 5-15 MB |
-| Ligero | 30-100 MB RAM vs 200-500 MB de alternativas Electron |
+| Ligero | ~250 MB de RAM medidos vs 200-500 MB de alternativas Electron |
 
 > **Referencia:** Para la arquitectura detallada de cada pilar, consultar: [02a — Arquitectura del Sistema](02a-system-architecture.md) (estructura de módulos, comunicación backend-frontend, persistencia), [02b — Motor de Terminales y PTY](02b-terminal-engine.md) (motor de terminales, xterm.js, PTY lifecycle), [02c — Git, Worktrees y Diffs](02c-git-worktrees.md) (worktree lifecycle, capa de ejecución git, polling, staging), [02d — Monitoreo y Orquestación de Agentes](02d-agent-monitoring.md) (hooks, notificaciones, multi-agente), [04 — Referencia Técnica](04-technical-reference.md) (fases, MVP, estimaciones).

--- a/uxnandesktop/architecture/03-implementation-guide.md
+++ b/uxnandesktop/architecture/03-implementation-guide.md
@@ -24,7 +24,7 @@
 | Tecnologia | Que es | Para que la usamos | Ventajas clave |
 |------------|--------|---------------------|----------------|
 | **Rust** | Lenguaje de programacion de sistemas | Todo el nucleo pesado: gestion de git worktrees, procesos de terminales (PTY), servidor HTTP de hooks, monitoreo de agentes, filesystem, operaciones git, logica de orquestacion, persistencia. | Extrema ligereza y bajo uso de RAM/CPU. Seguridad de memoria (sin crashes por null/dangling pointers). Concurrencia segura con Tokio. Excelente para crecer (SSH, Docker, etc.) sin perder rendimiento. |
-| **Tauri 2** | Framework para apps de escritorio | Une el frontend con el backend Rust y genera la app nativa para Windows, macOS y Linux. Provee el sistema de commands/events para comunicacion backend-frontend. | Mucho mas ligero que Electron (usa webview del sistema, no Chromium). Bajo consumo de RAM (30-100MB tipico vs 200-500MB de Electron). Seguridad fuerte (permisos explicitos por capability). Facil de empaquetar y distribuir. |
+| **Tauri 2** | Framework para apps de escritorio | Une el frontend con el backend Rust y genera la app nativa para Windows, macOS y Linux. Provee el sistema de commands/events para comunicacion backend-frontend. | Mucho mas ligero que Electron (usa webview del sistema, no Chromium). Bajo consumo de RAM (~250MB medidos vs 200-500MB de Electron; el proceso propio son ~40MB). Seguridad fuerte (permisos explicitos por capability). Facil de empaquetar y distribuir. |
 | **Svelte 5** | Framework frontend | Construir la interfaz: sidebars, layout de tres paneles, tabs, splits, estado en tiempo real, command palette, etc. | Muy ligero (menos runtime overhead que React/Vue). `$state` y `$derived` (Runes) eliminan la necesidad de librerias de estado externas como Zustand. Excelente rendimiento en actualizaciones en tiempo real. Codigo simple y mantenible. |
 | **shadcn-svelte** | Coleccion de componentes UI para Svelte | Botones, sidebars, tabs, modales, tablas, tooltips, command palette, dark mode, etc. | Componentes modernos, accesibles y personalizables. Ligero (solo copias lo que usas). Basado en Bits UI (equivalente de Radix para Svelte). Look profesional sin esfuerzo. |
 | **Tailwind CSS** | Framework de CSS utilitario | Estilos rapidos y consistentes de toda la aplicacion. | Muy ligero (purge automatico de clases no usadas). Alta velocidad de desarrollo. Facil de mantener y escalar. |
@@ -1272,7 +1272,7 @@ La eleccion de Tauri 2 + Rust sobre Electron se justifica por diferencias signif
 
 | Metrica | Electron (referencia) | Tauri 2 + Rust |
 |---------|----------------------|----------------|
-| **RAM en reposo** | 200-500 MB | 30-100 MB |
+| **RAM en reposo** | 200-500 MB | **~240 MB medidos** (nucleo Rust ~40 MB + webview del OS) |
 | **Tamano del instalador** | 150-300 MB | 5-15 MB |
 | **Tiempo de arranque** | 2-5 segundos | <1 segundo |
 | **Bundled runtime** | Chromium + Node.js completos | Webview del OS (ya instalado) |

--- a/uxnandesktop/architecture/04-technical-reference.md
+++ b/uxnandesktop/architecture/04-technical-reference.md
@@ -404,6 +404,62 @@ Monitoreo en tiempo real de agentes. Badges en sidebar. Notificaciones nativas d
   de Homebrew/npm. La notarizacion con Apple Developer ID queda como via opcional
   futura. Detalle operativo en `docs/updates.md`; clave de firma en `FOR-HUMAN.md`.
 
+#### Banco de pruebas de recursos — ✅ Hecho (adición post-plan)
+
+La promesa de bajo consumo (`01-product-vision.md` §"Justificación de Tauri 2 sobre
+Electron") pasa de objetivo declarado a contrato medible. Vive en
+`scripts/resources/` y se documenta en `docs/resource-benchmarks.md`.
+
+- **Doce escenarios canónicos** (R00–R11): proceso frío, reposo, 1 y 4 terminales,
+  workspace dormido, agente trabajando, repositorio Git grande (10 000 archivos),
+  browser, GitHub, pet apagado/capa/overlay, soak de 2 h, y reinicio con
+  restauración. Cada uno declara pregunta, preparación determinista, ventana de
+  estabilización descartada y ventana de medición.
+- **Tres cubetas que nunca se suman**: `own` (la app + los auxiliares que crea su
+  runtime), `managed` (más shells, ConPTY, `git`/`gh`, sidecars) y `external` (lo
+  que el usuario ejecutó dentro de una shell). La atribución es **estructural** —
+  descenso padre/hijo desde un PID que el propio harness lanzó — nunca por nombre:
+  un proceso homónimo anterior no puede contarse, y uno renombrado no puede
+  escaparse. El nombre solo decide *en qué* cubeta cae un descendiente (¿es shell?,
+  ¿es auxiliar del webview?), replicando la lista de shells por las que desciende
+  `procscan.rs`.
+- **Los escenarios alcanzan su estado sembrando el perfil persistido de la app**
+  (`AppData` + `SavedTerminalLayout`) en un directorio desechable, no conduciendo
+  la UI. Eso los hace reproducibles hoy, sin esperar al driver E2E, y garantiza que
+  el banco jamás lea ni escriba el perfil real.
+- **`UXNAN_DATA_DIR`** (`src-tauri/src/datadir.rs`) es la única pieza de producción
+  que el banco necesita: reubica el directorio de datos para un proceso — app,
+  comandos que leen `<app-data>`, y runner headless de automatizaciones. Rechaza
+  rutas relativas (dependerían del directorio de trabajo, así que el mismo comando
+  podría apuntar a dos perfiles distintos). Un `env::var_os` al arranque; no altera
+  nada de lo medido.
+- **Fixtures locales, offline y deterministas**: repositorio Git generado cuyo hash
+  de commit es función de sus argumentos (autor, committer y ambas fechas fijados,
+  PRNG con semilla), agente sustituto que reproduce la *forma* de la carga de un
+  agente sin modelo, red ni credenciales, y una página fija servida en loopback.
+- **Presupuestos por plataforma** (absolutos; no comparables entre sistemas) más un
+  **comparador contra línea base** que solo falla si una métrica empeora en términos
+  relativos **y** absolutos a la vez. Arranca en `mode: "warn"`: recoge datos sin
+  bloquear hasta conocer el ruido del hardware de referencia.
+- **Privacidad**: los colectores no leen líneas de comando, entornos ni títulos de
+  ventana; cada documento se depura antes de escribirse (usuario, host y los
+  nombres de carpeta *bajo* el home, que son los nombres de proyecto) y la escritura
+  se **rechaza** si algo personal sobrevive. Sin telemetría ni red.
+- **Restricción conocida**: WebView2 mantiene un proceso navegador por carpeta de
+  datos de usuario, así que una segunda instancia de Uxnan adjunta sus renderers al
+  navegador de la primera y quedan fuera del árbol medido (el resultado reportaría
+  solo el proceso Rust, ~27 MB, omitiendo el webview entero). El harness se niega a
+  arrancar con otra instancia viva y marca inválida cualquier ejecución que nunca
+  vio un webview dentro de su propio árbol.
+- **CI** (`.github/workflows/resource-benchmarks.yml`): nocturno y bajo demanda en
+  un runner Windows; sube resultados y reporte, y **nunca falla el build** — una VM
+  compartida da señal de tendencia, no un gate.
+
+Pendientes en `FOR-DEV.md` → *Resource benchmarks — follow-ups*: promover la línea
+base de Windows y rellenar su presupuesto, pasar a `enforce` tras dos semanas de
+ejecuciones reales, ejecutar el colector Unix en hardware real, y automatizar
+R07/R08 cuando exista el driver E2E.
+
 #### Entregable
 
 ADE MVP completo, pulido y listo para uso diario.

--- a/uxnandesktop/docs/agent-hooks.md
+++ b/uxnandesktop/docs/agent-hooks.md
@@ -94,6 +94,12 @@ exact path is shown in **Settings → Agents → Hooks** ("Installed at …"):
 | macOS | `~/Library/Application Support/dev.luisgamas.uxnandesktop/hooks/` |
 | Linux | `~/.local/share/dev.luisgamas.uxnandesktop/hooks/` |
 
+Setting **`UXNAN_DATA_DIR`** to an absolute path moves `<app-data>` — and with it
+everything below it — for that one process. It exists so a launch can be given a
+disposable profile: the [resource benchmarks](resource-benchmarks.md) use it, and
+an E2E driver will. A relative path is ignored, since it would resolve against
+whatever the working directory happened to be.
+
 The reporters (one per agent, plus the generic wrapper) — full table in
 [`static/hooks/README.md`](../static/hooks/README.md):
 

--- a/uxnandesktop/docs/resource-benchmarks.md
+++ b/uxnandesktop/docs/resource-benchmarks.md
@@ -1,0 +1,436 @@
+# Desktop — resource benchmarks
+
+![Harness](https://img.shields.io/badge/harness-node_%2B_per--OS_collectors-339933?style=for-the-badge&logo=node.js&logoColor=white)
+![Gate](https://img.shields.io/badge/gate-warn_only-f59e0b?style=for-the-badge)
+![Baseline](https://img.shields.io/badge/baseline-windows_only-2563eb?style=for-the-badge)
+
+uxnan claims to stay small enough to leave the machine to the agents. This is how
+that claim is measured, repeated and defended — a scenario matrix, a versioned
+result schema, per-platform budgets and a comparator, all runnable from a clean
+checkout with no credentials and no network.
+
+**A number without its conditions is not a measurement.** Every result records the
+OS, webview version, CPU, core count, power plan, build profile and commit, and
+the report prints them before anything else.
+
+---
+
+## Quick start
+
+```bash
+cd uxnandesktop
+
+# 1. build what you are going to measure (release, frontend embedded — see below)
+npm run bench:build
+
+# 2. close every other uxnan window (the harness refuses to run otherwise)
+
+# 3. measure
+npm run bench -- --scenario R01 --repeats 5
+
+# 4. read it
+npm run bench:report
+```
+
+Results land in `.resource-results/` (git-ignored). Nothing is written anywhere
+else: each repetition gets a disposable app profile inside that directory and the
+app is pointed at it with `UXNAN_DATA_DIR`, so your real profile is never read or
+modified.
+
+| Command | What it does |
+|---|---|
+| `npm run bench:build` | build a measurable release binary (`tauri build --no-bundle`) |
+| `npm run bench -- --scenario <id>` | run one scenario |
+| `npm run bench -- --all` | every unattended scenario |
+| `npm run bench:report` | render `report.md` from the aggregates |
+| `npm run bench:compare` | compare the results against an approved baseline |
+
+`npm run bench -- --help` lists every flag.
+
+---
+
+## Preconditions
+
+Each of these is *enforced*, and each exists because breaking it produces a
+believable number rather than an error. That is the failure mode this harness is
+built to refuse.
+
+**A release binary with its frontend embedded.** Debug numbers are not comparable
+with anything, and the schema refuses a document that does not say which profile
+it measured. More subtly: **`cargo build --release` on its own is not enough.** It
+does not enable Tauri's `custom-protocol` feature, so the build stays in *dev*
+mode and the window loads `http://localhost:1420` — which nothing is serving. The
+app then opens a real window, starts its Rust backend, spawns real WebView2
+processes, and shows a connection-refused page. Every signal the harness would
+normally trust is present; only the product is missing. Measured that way, a
+one-terminal scenario reports ~27 MB and no shell at all. So the harness scans the
+binary for embedded frontend assets and refuses to start without them — use
+`npm run bench:build`.
+
+**No other uxnan may be running** — and that includes one your own interrupted
+run left behind: a benchmark stopped mid-scenario never gets to close its app, and
+the next run will refuse to start until that window is closed. The refusal names
+the PID. This is enforced, not advisory, and the reason
+is specific: on Windows, WebView2 keeps **one browser process per user-data
+folder**, and uxnan's folder is `%LOCALAPPDATA%\dev.luisgamas.uxnandesktop\EBWebView`.
+A second instance attaches to the first instance's browser process, so its
+renderers are spawned *outside* the process tree being sampled. The run then
+reports the Rust process alone — around 27 MB — and silently omits the entire
+webview. That is a plausible, excellent-looking, completely wrong number, which is
+worse than an error, so the harness refuses to start and any run that somehow
+still shows a single `own` process is marked invalid.
+
+**The seeded session has to come back.** Each scenario knows how many live
+terminals its profile seeds, and the run fails if that many managed processes
+never appear. That catches a broken restore path on its own, and it is the second
+net under everything above: a UI that never booted cannot spawn a shell.
+
+**A quiet machine.** Not enforceable, but a build or a video call running
+alongside shows up in the CPU percentiles. The report prints the power plan for
+the same reason.
+
+---
+
+## What is measured
+
+### The three buckets
+
+The single most misleading thing a desktop benchmark can publish is "the app used
+N MB" when N includes a shell and whatever agent CLI happened to be running. So
+every process is placed in exactly one bucket, and **the buckets are never
+summed**:
+
+| Bucket | What it holds | Why it is separate |
+|---|---|---|
+| **own** | the app process + its webview/crash-handler helpers | uxnan's own footprint — the number that must stay small |
+| **managed** | own + PTY shells, ConPTY hosts, `git`/`gh`, sidecars | what uxnan costs you in practice; uxnan is responsible for these existing |
+| **external** | the agent CLI or program running inside a shell, and its children | someone else's cost, reported for context, never folded in |
+
+Attribution is **structural**: the harness spawns the app itself, so it knows the
+root PID, and walks parent/child edges from there. A process is never claimed
+because of its name — a `node.exe` that was already running cannot be counted, and
+a renamed one cannot escape. Names are consulted only to decide *which* bucket a
+descendant belongs to (is it a shell? a webview helper?), mirroring the shell list
+`procscan.rs` descends through, and once — in `preflight.mjs` — to answer "is
+another instance already running".
+
+The boundary between `managed` and `external` is the shell: uxnan spawns the
+shell, the user runs the program. Nested shells stay managed, because agent CLIs
+are routinely launched through a `.cmd`/`.ps1` shim.
+
+### Metrics
+
+Metric names encode their bucket, statistic and unit, so `ownRssP50Mb` needs no
+legend. The ones a budget can gate:
+
+| Metric | Meaning |
+|---|---|
+| `ownRssP50Mb` / `ownRssP95Mb` | working-set sum of the app and its runtime helpers |
+| `managedRssP50Mb` / `managedRssP95Mb` | the same, including shells and sidecars |
+| `externalRssP50Mb` | what the user's own program cost (context only) |
+| `ownPrivateP50Mb` / `ownPrivateP95Mb` | private committed bytes of the app and its helpers |
+| `managedPrivateP50Mb` / `externalPrivateP50Mb` | the same, per bucket |
+| `cpuP50` / `cpuP95` | managed CPU, **percent of one core** — divide by the core count for percent-of-machine |
+| `ownCpuP95` | the app alone |
+| `ownProcsP50` / `managedProcsP50` | process counts |
+| `threadsP95` / `handlesP95` | thread and handle counts (Windows; `null` elsewhere) |
+| `ownRssSlopeMbPerHour` | memory trend — the soak scenario's whole point |
+| `launchToWindowMs` | launch until the app owns a visible window (Windows) |
+| `launchToBackendMs` | launch until the hook server is listening |
+| `launchToShellMs` | launch until a restored terminal's shell is live |
+| `closeMs` | how long a graceful close took |
+| `orphanCount` | managed processes still alive after a bounded wait |
+
+**`Rss` and `Private` answer different questions, and neither alone is honest
+about a webview.** A WebView2/WebKit tree is many processes sharing a large read-
+only code region, and a *working set* counts those shared pages once per process
+— so `ownRssP50Mb` materially over-states what the machine is actually carrying.
+`ownPrivateP50Mb` sums private committed bytes: nothing double-counted, and the
+defensible answer to "how much memory does this cost me". Both are published,
+because `Rss` remains the better like-for-like signal between two runs on the same
+platform, and hiding the gap between them would be the sort of quiet accounting
+choice this harness exists to prevent. On Unix there is no cheap private figure,
+so those metrics are `null` there.
+
+**Slopes need a long window.** A memory trend fitted over a 45-second run is
+dominated by warm-up and extrapolates to thousands of MB/h — a fabricated leak.
+Slope metrics are therefore `null` unless the stable window is at least ten
+minutes, which in practice means the soak scenario.
+
+**`null` always means "not measurable on this platform" — never zero.** That is
+what lets a Linux run sit next to a Windows one without inventing handle counts
+that do not exist there.
+
+A resting statistic ignores the **stabilisation window** (`stabilizeS`): a
+just-launched app is still paging in its webview, and folding that into a "cost at
+rest" figure publishes a number no user experiences. Those early samples stay in
+the document — they *are* the launch measurement.
+
+---
+
+## The first measured baseline
+
+Windows 11 Pro 10.0.26200 (x64) · WebView2 150.0.4078.105 · i7-13620H, 16 logical
+cores · 16 GB · release build of `54d935e8` · five repetitions per scenario ·
+medians. Full documents in
+[`scripts/resources/baselines/windows/`](../scripts/resources/baselines/windows/).
+
+| Scenario | own private | own working set | managed private | CPU P95 | procs (own/managed) |
+|---|---:|---:|---:|---:|---:|
+| R00 cold | 236 MB | 479 MB | 236 MB | 1.6 % | 7 / 7 |
+| R01 idle, one project | 239 MB | 479 MB | 296 MB | 10.9 % | 7 / 9 |
+| R02 one terminal | 252 MB | 506 MB | 257 MB | 6.4 % | 7 / 9 |
+| R03 four terminals | 274 MB | 574 MB | 293 MB | 7.2 % | 7 / 15 |
+| R04 workspace asleep | 226 MB | 470 MB | 226 MB | 4.6 % | 7 / 7 |
+| R05 agent working | 271 MB | 526 MB | 276 MB | 35.1 % | 7 / 9 |
+| R06 10 000-file repo | 246 MB | 492 MB | 251 MB | 12.8 % | 7 / 9 |
+| R09 pet off | 242 MB | 495 MB | 247 MB | 11.1 % | 7 / 9 |
+| R09 pet as a layer | 270 MB | 526 MB | 275 MB | 10.9 % | 7 / 9 |
+| R09 pet as an overlay window | 330 MB | 637 MB | 335 MB | 24.2 % | 8 / 10 |
+| R11 restart + restore | 266 MB | 568 MB | 289 MB | 8.7 % | 7 / 15 |
+
+What it says, beyond the raw figures:
+
+- **Sleep is real.** R03 → R04 gives back **48 MB and 8 processes**.
+- **Restore comes back whole.** R11 lands on the same 15 managed processes as R03
+  and within 3 % of its memory — the session is genuinely restored, not
+  approximated.
+- **A terminal is cheap; a webview is not.** Four terminals add 22 MB over one;
+  the seven-process webview is most of the footprint in every scenario.
+- **The pet is free when off** (R09-off ≈ R02) and **costs 88 MB and doubles CPU
+  as a desktop overlay** — a second webview window, visible as the 8th `own`
+  process. As a layer inside the main window it costs 28 MB.
+- **The agent's cost is separated.** R05's fixture agent shows up in `external`
+  (48 MB working set / 27 MB private) and never in uxnan's own figure; the 35 %
+  CPU is the app rendering a terminal streaming 20 lines a second.
+
+These numbers replaced the previously published "30–100 MB", which described the
+Rust process alone (~40 MB) rather than what the app costs a machine. The claim
+now reads **~250 MB** everywhere it appears — the two root READMEs, this
+component's README, and `web/src/lib/site.ts` (`RAM_FOOTPRINT` / `RAM_CORE`).
+Re-measure before changing it, and keep the platform and build beside it.
+
+R07, R08 and R10 have no baseline: two need an operator, and the soak has never
+been run. They report `unknown`, which is the honest distinction between "not
+judged" and "passed".
+
+---
+
+## Scenarios
+
+| ID | Scenario | Mode | Question |
+|---|---|---|---|
+| R00 | Cold process | auto | launch time and cost before anything is opened |
+| R01 | Idle, default configuration | auto | cost at rest with one small project |
+| R02 | One terminal | auto | what a single live shell adds |
+| R03 | Four terminals in splits | auto | cost per additional terminal |
+| R04 | Sleeping workspace | auto | what sleep actually gives back |
+| R05 | Agent working | auto | cost while an agent streams, separated from the agent's own |
+| R06 | Large git repository | auto | watcher and status-sweep cost on 10 000 files |
+| R07 | Integrated browser | assisted | cost while closed, and what opening it adds |
+| R08 | GitHub panel | assisted | polling, cache and open-panel cost |
+| R09 | Pet companion | auto | off / layer / overlay — "off" must cost nothing |
+| R10 | Soak (2 h) | auto | does anything grow: memory, handles, processes |
+| R11 | Restart and restore | auto | restore time and fidelity |
+
+**auto** scenarios prepare a profile and let the app restore itself into the state
+under test — no UI driving, fully unattended, and what `--all` and CI run.
+
+**assisted** scenarios need a person at the keyboard (or an account the benchmark
+must never hold, in R08's case) and only run with `--assisted`. The harness still
+samples and records; the report labels the result as operator-driven. They become
+`auto` when the E2E driver lands, and the metric names will not change.
+
+R04's *asleep* cost is automatic; **wake latency and fidelity are still on the
+operator checklist**, because waking is a click.
+
+### How a scenario reaches its state
+
+By seeding the app's own persisted state. `lib/profile.mjs` writes a `state.json`
+matching `AppData` (`src-tauri/src/model.rs`) and `SavedTerminalLayout`
+(`src/lib/types.ts`), the app restores it at boot, and only the active workspace
+spawns shells — so "four terminals" is four *regions*, not four tabs.
+
+Every seeded profile also turns off what a resting measurement must not include:
+the updater's auto-check, provider usage polling, the pet, notifications, and
+hook auto-install (which would write into `~/.claude` and friends — outside the
+scenario's own directory, which the harness never does).
+
+### Fixtures
+
+All local, all offline, all deterministic:
+
+- **`fixtures/make-repo.mjs`** — a generated git repository. Author, committer and
+  both timestamps are pinned and content comes from a seeded PRNG, so the commit
+  hash is a function of the arguments; `--print-hash` prints it. Generation beats
+  committing 10 000 files, and a drifted generator is caught by the hash.
+- **`fixtures/agent-fixture.mjs`** — a stand-in agent. A real CLI would make the
+  run depend on a model, a network and an account, and CI must never hold
+  credentials. What the benchmark needs is the *shape* of the load: output at a
+  fixed rate, a wait, more output, done — optionally reporting each transition to
+  the hook server exactly as a real reporter does.
+- **`fixtures/http-server.mjs`** — a fixed loopback page for the browser scenario.
+
+---
+
+## Budgets, baselines and the gate
+
+Two independent questions, deliberately kept apart:
+
+**Is it within budget?** An absolute per-scenario ceiling in
+`scripts/resources/budgets/<os>.json`. Absolute limits cannot be shared across
+platforms — a WebView2 tree and a WebKitGTK one differ by more than any regression
+worth gating on — so each OS carries its own file, and a scenario with no entry is
+reported `unknown`, not `pass`.
+
+**Did it get worse?** `compare.mjs` against an approved baseline. It fires only
+when a metric moves by **both** a relative and an absolute margin (default: more
+than 15 % *and* more than 10 MB / 2 pp CPU / 200 handles). A 20 % jump on a 4 MB
+number is a `warn`, not a `fail` — a gate that fires on noise gets switched off,
+and then nothing is measured at all.
+
+### The warn phase
+
+Every budget ships with `"mode": "warn"`, which downgrades a `fail` to a `warn` so
+CI reports without blocking. That is the deliberate first phase:
+
+1. collect data without failing anything;
+2. set a per-scenario ceiling with an explicit margin over the measured median;
+3. leave it in warn mode for two weeks of real runs;
+4. flip to `"mode": "enforce"` — a one-line, reviewable change;
+5. from then on, raising a limit needs the run that justifies it in the diff.
+
+### Promoting a baseline
+
+1. Run the scenarios five times on a quiet machine with a release build.
+2. Read `report.md` and sanity-check the conditions block.
+3. Copy the aggregates into `scripts/resources/baselines/<os>/`.
+4. Commit them **on their own**, separately from any code change, so review can
+   tell measurements from behaviour.
+5. Update the budget file in the same series if a limit moves, citing the run.
+
+Raw results, samples, generated fixtures and disposable profiles stay in
+`.resource-results/` and are never committed. Only approved aggregates, budgets,
+fixtures and the schema are.
+
+---
+
+## Privacy
+
+A result is meant to be attachable to a PR, so it must say nothing about the
+person who ran it.
+
+- The collectors never read a command line, an environment block or a window
+  title, so a sample cannot carry a prompt, a token or a file path.
+- Every document is scrubbed before it is written: user name, host name and
+  temp/home directories are replaced, and paths under them collapse to a stable
+  tag — `<home>/<path:1a2b3c4d5e6f>` — so the same folder stays recognisable
+  across runs without the project's name being readable.
+- The write is *refused* if anything personal survives the scrub.
+- The machine is identified by a hash of hostname + user, so two runs on the same
+  box compare without naming it.
+- Nothing is transmitted anywhere. There is no telemetry.
+
+---
+
+## Adding a scenario when you add a feature
+
+Anything that spawns a process, opens a webview, starts a watcher, polls, caches
+or holds a socket changes the answer this document gives, so it comes with a
+scenario change in the same series:
+
+1. Add or extend the entry in `lib/scenarios.mjs` — a question, a deterministic
+   preparation, a measurement window.
+2. Prefer `auto`: reach the state by seeding the profile rather than by asking an
+   operator to click.
+3. If the feature is opt-in, add a variant proving it costs **nothing** while off
+   (R09 is the model).
+4. Run it, and put the measured numbers in the PR body.
+5. Add a budget entry once a baseline exists for the platform.
+
+---
+
+## Platform support
+
+| Platform | Collector | Status |
+|---|---|---|
+| Windows | `collectors/windows.ps1` (Windows PowerShell 5.1, CIM) | verified on real hardware |
+| macOS | `collectors/unix.sh` (`ps`) | implemented, **never run on real hardware** |
+| Linux | `collectors/unix.sh` (`ps`) | implemented, **never run on real hardware** |
+
+Semantic differences that matter, surfaced rather than hidden:
+
+- Windows reports a **working set**; `ps` reports **RSS**, which counts shared
+  pages in every process that maps them, so a multi-process tree reads higher on
+  Unix. The two are not directly comparable, which is exactly why budgets are
+  per-platform.
+- There is no cheap per-process private-memory or handle figure on Unix, and no
+  window-handle probe outside Windows: those metrics are `null`.
+- macOS runs the WebKit content process outside the app's process tree entirely,
+  so the `own` bucket means something different there and needs its own measured
+  ceilings.
+
+Neither Unix collector has been run on real hardware. Until it has, do not publish
+numbers for those platforms — the harness will happily produce them, and they will
+be wrong in ways nobody has looked for yet.
+
+---
+
+## CI
+
+`.github/workflows/resource-benchmarks.yml` runs on demand (`workflow_dispatch`)
+and nightly. It builds a release binary on a Windows runner, runs the unattended
+scenarios with short windows, and uploads the results and report as artifacts. It
+never fails the build: a GitHub runner is a noisy, shared VM, so its numbers are a
+trend signal, not a gate. The gate that matters runs on the reference hardware.
+
+R08 never runs in CI at all — it needs a real `gh` login, and CI is never handed
+one.
+
+---
+
+## Where things live
+
+```
+uxnandesktop/scripts/resources/
+├── run.mjs                 # run scenarios → result documents
+├── report.mjs              # aggregates → Markdown report
+├── compare.mjs             # baseline vs candidate → verdict
+├── lib/
+│   ├── scenarios.mjs       # the scenario table (R00–R11)
+│   ├── profile.mjs         # disposable app-data profiles
+│   ├── app.mjs             # launch / readiness / graceful teardown
+│   ├── sampler.mjs         # collector process → schema samples
+│   ├── tree.mjs            # process-tree attribution (own/managed/external)
+│   ├── stats.mjs           # percentiles, rates, slopes
+│   ├── schema.mjs          # the result contract + validation
+│   ├── budgets.mjs         # absolute budgets + regression policy
+│   ├── preflight.mjs       # the checks that make a result believable
+│   ├── redact.mjs          # what may leave the machine
+│   ├── platform.mjs        # collector selection + machine facts
+│   └── markdown.mjs        # the report
+├── collectors/             # windows.ps1, unix.sh (+ unix.test.mjs)
+├── fixtures/               # git repo, agent, http server (+ make-repo.test.mjs)
+├── budgets/                # windows.json, macos.json, linux.json
+└── baselines/              # approved aggregates, per platform
+```
+
+The pure logic (`schema`, `tree`, `stats`, `budgets`, `redact`, `scenarios`,
+`preflight`) is covered by Vitest and runs in the normal `npm test` — it decides
+what every published number means, so it is tested like product code.
+
+Two of those suites are worth calling out because they cover code that otherwise
+has none:
+
+- **`collectors/unix.test.mjs`** lifts the awk program out of `unix.sh` (rather
+  than duplicating it) and runs it against a synthetic `ps` snapshot: subtree
+  descent, the same-named-but-unrelated process, CPU-time parsing, and the
+  `null`-not-zero rule. It skips where `awk` is unavailable, so the Linux and
+  macOS CI legs are what actually exercise it — which is where the script is
+  destined to run.
+- **`fixtures/make-repo.test.mjs`** pins the generated repository's commit hash,
+  so a drifted generator is caught immediately instead of quietly changing what
+  every git scenario measures. It also covers a path with spaces and non-ASCII
+  characters.
+
+See [`testing.md`](testing.md).

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -18,7 +18,7 @@ cargo fmt --check              # formatting — must be clean (run `cargo fmt` t
 
 Unit tests live in-file under `#[cfg(test)]` (e.g. `model.rs`, `persistence.rs`,
 `git.rs`, `gitfast.rs`, `pty.rs`, `hooks.rs`, `agent_hooks.rs`, `procscan.rs`,
-`updater.rs`, `which.rs`, `pets.rs`); integration tests go in `src-tauri/tests/`. ~275
+`updater.rs`, `which.rs`, `pets.rs`); integration tests go in `src-tauri/tests/`. 377
 backend tests cover the Serde model shape, persistence round-trip / atomicity /
 migration / backups, git + worktree ops (including creation, opt-in branch
 cleanup on removal — local/remote/force — checking out an existing branch,
@@ -66,11 +66,34 @@ schedule + next-runs preview, the run/step display projections, the seeded
 example automations, and the prompt-variable insertion) and
 `state/statusSweepRegistry.ts` (the all-worktree status sweep's pacing +
 its request registry) and `usageCatalog.ts` (which providers are still offered
-vs merely still readable) — 386 tests in
-`src/lib/**/*.test.ts`, config in
+vs merely still readable) — plus the **resource-benchmark harness** under
+`scripts/resources/lib/` (process-tree attribution own/managed/external, the
+result schema and its validation messages, percentile / CPU-rate / soak-slope
+maths, absolute budgets and the regression policy, the redaction gate, the
+scenario table, the pre-flight checks that mark a run invalid, the Unix collector's awk parser and the git fixture's determinism) — **517 tests**
+in `src/lib/**/*.test.ts` and `scripts/**/*.test.mjs`, config in
 `vitest.config.ts`. **Component tests** (Vitest + jsdom) and **E2E**
 (Playwright/WebdriverIO + tauri-driver) are still to come — see
 [`../FOR-DEV.md`](../FOR-DEV.md).
+
+## Resource benchmarks
+
+Type-checks and tests say the code is correct; they say nothing about what it
+costs. The scenario matrix that measures uxnan's own footprint — and the budgets
+and regression comparison built on it — is documented in
+[`resource-benchmarks.md`](resource-benchmarks.md):
+
+```bash
+cd uxnandesktop
+npm run bench:build                          # release, frontend embedded
+npm run bench -- --scenario R01 --repeats 5  # measure
+npm run bench:report                         # read it
+```
+
+Run it for any change that spawns a process, opens a webview, starts a watcher,
+polls, caches or runs at startup, and put the numbers in the PR (the template
+asks for them). Close every other uxnan window first — the harness refuses to
+measure otherwise, and the doc explains why.
 
 ## UI / behavior verification
 

--- a/uxnandesktop/package.json
+++ b/uxnandesktop/package.json
@@ -16,6 +16,10 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test": "vitest run",
     "test:watch": "vitest",
+    "bench:build": "tauri build --no-bundle",
+    "bench": "node scripts/resources/run.mjs",
+    "bench:report": "node scripts/resources/report.mjs",
+    "bench:compare": "node scripts/resources/compare.mjs",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/uxnandesktop/scripts/resources/baselines/README.md
+++ b/uxnandesktop/scripts/resources/baselines/README.md
@@ -1,0 +1,49 @@
+# Approved baselines
+
+One directory per platform, holding the **aggregate** documents (not the raw
+samples) that `compare.mjs` measures a candidate against.
+
+```
+baselines/
+└── windows/
+    ├── R00.json
+    ├── R01.json
+    └── …
+```
+
+A file here is a claim about the product, so getting one in has rules:
+
+1. Measured with a **release** build on a quiet machine, five repetitions.
+2. Every other uxnan instance closed — see the WebView2 note in
+   [`../../../docs/resource-benchmarks.md`](../../../docs/resource-benchmarks.md).
+   A run that never grew a webview inside its own tree is invalid and must not be
+   promoted.
+3. Copied straight from `.resource-results/aggregates/` — never hand-edited.
+4. Committed **on their own**, separate from any code change, so a reviewer can
+   tell measurements from behaviour.
+5. The commit body records the machine (the `hostId` in the document), the
+   webview version and anything unusual about the conditions.
+
+Replacing a baseline means the numbers moved for a reason you can state. Say the
+reason in the commit; "re-baselined" on its own is how a budget quietly becomes
+meaningless.
+
+A baseline's own `verdict` field reads `unknown`, and that is correct: a baseline
+*is* the line, so judging it against the budget derived from it would be
+circular. Verdicts belong to candidate runs.
+
+Platforms with no directory here have **no approved baseline**: `compare.mjs`
+reports `unknown` for them, which is the honest answer, and nothing about those
+platforms should be published.
+
+## What is in `windows/` today
+
+Captured 2026-07-30 on Windows 11 Pro 10.0.26200 (x64), WebView2 150.0.4078.105,
+i7-13620H / 16 logical cores, 16 GB, "Equilibrado" power plan, release build of
+`54d935e8`. Five repetitions per scenario, measurement windows shortened from the
+scenario defaults (each result records its own `durationS` / `stabilizeS`).
+
+Eleven scenarios: R00–R06, R09 in all three variants, and R11. **Missing: R07 and
+R08** (operator-driven) and **R10** (the two-hour soak, never run). Those three
+therefore have no budget entry and report `unknown` — which is the point of
+distinguishing "not judged" from "passed".

--- a/uxnandesktop/scripts/resources/baselines/windows/R00.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R00.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R00",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": null,
+    "durationS": 45,
+    "stabilizeS": 15,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 478.76,
+      "min": 471.66,
+      "max": 481.18,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 480.06,
+      "min": 473.03,
+      "max": 482.48,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 478.76,
+      "min": 471.66,
+      "max": 481.18,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 480.06,
+      "min": 473.03,
+      "max": 482.48,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 236.25,
+      "min": 230.59,
+      "max": 238.12,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 239.3,
+      "min": 234.29,
+      "max": 241.2,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 236.25,
+      "min": 230.59,
+      "max": 238.12,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 1.56,
+      "min": 1.5,
+      "max": 3.99,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 1.56,
+      "min": 1.5,
+      "max": 3.99,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 174,
+      "min": 173,
+      "max": 176,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 3501,
+      "min": 3492,
+      "max": 3511,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 46394,
+      "min": 46351,
+      "max": 46439,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 50,
+      "min": 47,
+      "max": 58,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 394,
+      "min": 385,
+      "max": 443,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 172,
+      "min": 167,
+      "max": 264,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "empty profile: no projects, no terminals, no optional features"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R01.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R01.json
@@ -1,0 +1,155 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R01",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": null,
+    "durationS": 120,
+    "stabilizeS": 40,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 478.55,
+      "min": 474.68,
+      "max": 481.82,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 497.45,
+      "min": 494.16,
+      "max": 525.7,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 558.49,
+      "min": 554.5,
+      "max": 561.87,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 577.36,
+      "min": 574.11,
+      "max": 605.82,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 238.9,
+      "min": 237.32,
+      "max": 240.83,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 240.93,
+      "min": 239.09,
+      "max": 268.17,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 296.1,
+      "min": 294.33,
+      "max": 298.02,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 3.06,
+      "min": 0,
+      "max": 3.09,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 10.88,
+      "min": 4.86,
+      "max": 13.99,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 10.88,
+      "min": 4.78,
+      "max": 13.99,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 9,
+      "min": 9,
+      "max": 9,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 222,
+      "min": 221,
+      "max": 224,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 4442,
+      "min": 4438,
+      "max": 4449,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 121417,
+      "min": 121394,
+      "max": 121495,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 52,
+      "min": 39,
+      "max": 57,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 425,
+      "min": 343,
+      "max": 441,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 177,
+      "min": 167,
+      "max": 251,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "fixture repo at commit 7bc71b46fc8bf283e2277a9eb16ed3a7f4469358 (200 files)"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R02.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R02.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R02",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": null,
+    "durationS": 75,
+    "stabilizeS": 25,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 505.59,
+      "min": 492.7,
+      "max": 509.19,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 510.14,
+      "min": 496.71,
+      "max": 515.73,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 521.3,
+      "min": 508.43,
+      "max": 524.87,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 525.87,
+      "min": 517.35,
+      "max": 531.5,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 252.01,
+      "min": 239.93,
+      "max": 257.12,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 264.92,
+      "min": 253.02,
+      "max": 273.23,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 256.86,
+      "min": 244.84,
+      "max": 261.93,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 6.39,
+      "min": 4.7,
+      "max": 9.54,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 6.39,
+      "min": 4.7,
+      "max": 9.54,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 9,
+      "min": 9,
+      "max": 9,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 214,
+      "min": 198,
+      "max": 217,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 3921,
+      "min": 3802,
+      "max": 3934,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 76425,
+      "min": 76389,
+      "max": 76487,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 54,
+      "min": 50,
+      "max": 66,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 431,
+      "min": 410,
+      "max": 450,
+      "n": 5
+    },
+    "launchToShellMs": {
+      "median": 1310,
+      "min": 1281,
+      "max": 1347,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 171,
+      "min": 164,
+      "max": 175,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "one region, one shell"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R03.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R03.json
@@ -1,0 +1,161 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R03",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": null,
+    "durationS": 75,
+    "stabilizeS": 25,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 574.42,
+      "min": 522.25,
+      "max": 578.98,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 586.82,
+      "min": 535.88,
+      "max": 592.43,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 636.97,
+      "min": 584.85,
+      "max": 641.68,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 649.67,
+      "min": 598.8,
+      "max": 655.44,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 274.17,
+      "min": 269.65,
+      "max": 276.72,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 296.82,
+      "min": 292.47,
+      "max": 299.7,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 293.38,
+      "min": 288.93,
+      "max": 296.06,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 7.2,
+      "min": 6.33,
+      "max": 14.98,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 7.2,
+      "min": 6.33,
+      "max": 14.98,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 15,
+      "min": 15,
+      "max": 15,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 254,
+      "min": 237,
+      "max": 255,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 4566,
+      "min": 4460,
+      "max": 4583,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 76516,
+      "min": 76396,
+      "max": 76568,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 63,
+      "min": 45,
+      "max": 65,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 472,
+      "min": 414,
+      "max": 487,
+      "n": 5
+    },
+    "launchToShellMs": {
+      "median": 1334,
+      "min": 1319,
+      "max": 1365,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 173,
+      "min": 167,
+      "max": 196,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "2×2 split: four regions, four live shells"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R04.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R04.json
@@ -1,0 +1,156 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R04",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": null,
+    "durationS": 75,
+    "stabilizeS": 25,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 469.82,
+      "min": 459.18,
+      "max": 477.88,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 470.7,
+      "min": 463.54,
+      "max": 482.6,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 469.82,
+      "min": 459.18,
+      "max": 477.88,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 470.75,
+      "min": 463.54,
+      "max": 482.65,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 226.22,
+      "min": 213.3,
+      "max": 237.24,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 234.45,
+      "min": 228.54,
+      "max": 244.56,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 226.22,
+      "min": 213.3,
+      "max": 237.24,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 4.64,
+      "min": 4.14,
+      "max": 6.34,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 4.64,
+      "min": 4.14,
+      "max": 6.34,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 185,
+      "min": 185,
+      "max": 186,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 3524,
+      "min": 3515,
+      "max": 3530,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 76382,
+      "min": 76369,
+      "max": 76418,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 53,
+      "min": 50,
+      "max": 55,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 417,
+      "min": 402,
+      "max": 417,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 171,
+      "min": 165,
+      "max": 172,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "the same four regions as R03, restored asleep — compare against R03 for what sleep gives back",
+    "waking is a UI action: wake latency and fidelity are measured in the assisted checklist"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R05.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R05.json
@@ -1,0 +1,167 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R05",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": null,
+    "durationS": 75,
+    "stabilizeS": 20,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 526.42,
+      "min": 508.2,
+      "max": 531.62,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 540.89,
+      "min": 524.21,
+      "max": 546.53,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 542.2,
+      "min": 524.24,
+      "max": 547.41,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 556.72,
+      "min": 540.04,
+      "max": 562.23,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 50.94,
+      "min": 48.11,
+      "max": 51.56,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 270.61,
+      "min": 253.73,
+      "max": 275.7,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 283.95,
+      "min": 277.41,
+      "max": 291.11,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 275.73,
+      "min": 259.84,
+      "max": 280.68,
+      "n": 5
+    },
+    "externalPrivateP50Mb": {
+      "median": 26.94,
+      "min": 26.66,
+      "max": 27.2,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 12.65,
+      "min": 7.82,
+      "max": 16.76,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 35.06,
+      "min": 34.41,
+      "max": 40.54,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 35.06,
+      "min": 33.62,
+      "max": 40.44,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 9,
+      "min": 9,
+      "max": 9,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 215,
+      "min": 213,
+      "max": 218,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 3958,
+      "min": 3930,
+      "max": 3977,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 76422,
+      "min": 76386,
+      "max": 76482,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 54,
+      "min": 46,
+      "max": 62,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 426,
+      "min": 419,
+      "max": 437,
+      "n": 5
+    },
+    "launchToShellMs": {
+      "median": 1292,
+      "min": 1258,
+      "max": 1333,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 175,
+      "min": 172,
+      "max": 238,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "the fixture <user> is offline and deterministic; it runs inside a shell, so its cost lands in the `external` bucket and is never folded into uxnan's"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R06.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R06.json
@@ -1,0 +1,162 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R06",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": null,
+    "durationS": 90,
+    "stabilizeS": 30,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 491.74,
+      "min": 488.19,
+      "max": 503.3,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 502.41,
+      "min": 499.66,
+      "max": 526.65,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 507.44,
+      "min": 503.89,
+      "max": 518.98,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 518.13,
+      "min": 515.35,
+      "max": 542.33,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 246.41,
+      "min": 245.16,
+      "max": 255.92,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 248.48,
+      "min": 248.24,
+      "max": 271.44,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 251.24,
+      "min": 250.01,
+      "max": 260.74,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 2.3,
+      "min": 0,
+      "max": 4.63,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 12.82,
+      "min": 12.71,
+      "max": 15.52,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 12.82,
+      "min": 12.71,
+      "max": 15.52,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 9,
+      "min": 9,
+      "max": 9,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 210,
+      "min": 207,
+      "max": 211,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 3931,
+      "min": 3921,
+      "max": 3950,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 91423,
+      "min": 91388,
+      "max": 91569,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 47,
+      "min": 44,
+      "max": 56,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 436,
+      "min": 426,
+      "max": 484,
+      "n": 5
+    },
+    "launchToShellMs": {
+      "median": 1303,
+      "min": 1287,
+      "max": 1312,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 186,
+      "min": 173,
+      "max": 273,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "fixture repo at commit e6d20ce3ceaf3e67de7c09d6bbfe07cda12e174a (10000 files, 250 modified)",
+    "covers the 3 s active-worktree watcher and the 15 s all-worktree sweep"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R09-layer.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R09-layer.json
@@ -1,0 +1,162 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R09",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": "layer",
+    "durationS": 60,
+    "stabilizeS": 20,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 526.16,
+      "min": 520.79,
+      "max": 562.67,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 533.16,
+      "min": 526.43,
+      "max": 569.04,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 541.86,
+      "min": 536.48,
+      "max": 578.38,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 549.44,
+      "min": 542.2,
+      "max": 585.24,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 269.98,
+      "min": 267.9,
+      "max": 273.78,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 284.36,
+      "min": 283.04,
+      "max": 290.98,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 274.88,
+      "min": 272.75,
+      "max": 278.63,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 3.22,
+      "min": 2.37,
+      "max": 4.72,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 10.88,
+      "min": 9.65,
+      "max": 15.86,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 10.88,
+      "min": 9.65,
+      "max": 15.86,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 9,
+      "min": 9,
+      "max": 9,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 215,
+      "min": 213,
+      "max": 216,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 3930,
+      "min": 3925,
+      "max": 3936,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 61549,
+      "min": 61451,
+      "max": 61959,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 46,
+      "min": 41,
+      "max": 122,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 424,
+      "min": 374,
+      "max": 460,
+      "n": 5
+    },
+    "launchToShellMs": {
+      "median": 1399,
+      "min": 1253,
+      "max": 1796,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 250,
+      "min": 172,
+      "max": 279,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "pet variant: layer",
+    "compare the three variants: 'off' must cost nothing at all"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R09-off.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R09-off.json
@@ -1,0 +1,162 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R09",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": "off",
+    "durationS": 60,
+    "stabilizeS": 20,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 495.32,
+      "min": 492.49,
+      "max": 497.13,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 499.55,
+      "min": 498.65,
+      "max": 503.19,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 511.17,
+      "min": 508.49,
+      "max": 512.89,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 515.83,
+      "min": 514.71,
+      "max": 519.56,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 241.65,
+      "min": 240.26,
+      "max": 243.12,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 255.41,
+      "min": 254.46,
+      "max": 258.35,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 246.83,
+      "min": 245.34,
+      "max": 247.99,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 3.1,
+      "min": 3.07,
+      "max": 3.13,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 11.11,
+      "min": 9.25,
+      "max": 15.7,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 11.11,
+      "min": 9.25,
+      "max": 15.7,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 9,
+      "min": 9,
+      "max": 9,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 213,
+      "min": 213,
+      "max": 217,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 3923,
+      "min": 3908,
+      "max": 3941,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 61386,
+      "min": 61358,
+      "max": 61411,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 55,
+      "min": 44,
+      "max": 59,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 416,
+      "min": 402,
+      "max": 438,
+      "n": 5
+    },
+    "launchToShellMs": {
+      "median": 1277,
+      "min": 1273,
+      "max": 1331,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 173,
+      "min": 165,
+      "max": 175,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "pet variant: off",
+    "compare the three variants: 'off' must cost nothing at all"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R09-overlay.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R09-overlay.json
@@ -1,0 +1,163 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R09",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": "overlay",
+    "durationS": 60,
+    "stabilizeS": 20,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 637.04,
+      "min": 635.33,
+      "max": 671.81,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 649.2,
+      "min": 648.11,
+      "max": 684.5,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 652.71,
+      "min": 651.21,
+      "max": 687.48,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 665.17,
+      "min": 663.84,
+      "max": 700.52,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 329.91,
+      "min": 328.26,
+      "max": 336.07,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 352.25,
+      "min": 349.85,
+      "max": 355.96,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 334.75,
+      "min": 333.1,
+      "max": 340.91,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 11.2,
+      "min": 9.36,
+      "max": 12.64,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 24.19,
+      "min": 22,
+      "max": 28.25,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 24.19,
+      "min": 22,
+      "max": 28.25,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 8,
+      "min": 8,
+      "max": 8,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 10,
+      "min": 10,
+      "max": 10,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 221,
+      "min": 221,
+      "max": 224,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 4206,
+      "min": 4183,
+      "max": 4213,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 76485,
+      "min": 76468,
+      "max": 76564,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 50,
+      "min": 36,
+      "max": 53,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 431,
+      "min": 362,
+      "max": 451,
+      "n": 5
+    },
+    "launchToShellMs": {
+      "median": 1316,
+      "min": 1308,
+      "max": 1441,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 15232,
+      "min": 15195,
+      "max": 15300,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "pet variant: overlay",
+    "compare the three variants: 'off' must cost nothing at all",
+    "the app had to be force-killed: it did not close on request"
+  ]
+}

--- a/uxnandesktop/scripts/resources/baselines/windows/R11.json
+++ b/uxnandesktop/scripts/resources/baselines/windows/R11.json
@@ -1,0 +1,162 @@
+{
+  "schemaVersion": 1,
+  "scenario": "R11",
+  "commit": "54d935e8",
+  "platform": {
+    "os": "windows",
+    "arch": "x64",
+    "osName": "Microsoft Windows 11 Pro",
+    "osVersion": "10.0.26200",
+    "webview": "150.0.4078.105",
+    "cpuModel": "13th Gen Intel(R) Core(TM) i7-13620H",
+    "cpuCores": 16,
+    "totalMemMb": 16076,
+    "powerPlan": "Equilibrado",
+    "nodeVersion": "v24.18.0",
+    "hostId": "2b9d89e1cf9f",
+    "infoError": null
+  },
+  "configuration": {
+    "buildProfile": "release",
+    "variant": null,
+    "durationS": 75,
+    "stabilizeS": 25,
+    "intervalMs": 1000,
+    "repetition": 1,
+    "mode": "auto"
+  },
+  "repeats": 5,
+  "metrics": {
+    "ownRssP50Mb": {
+      "median": 567.86,
+      "min": 557.34,
+      "max": 574.9,
+      "n": 5
+    },
+    "ownRssP95Mb": {
+      "median": 582.29,
+      "min": 562.71,
+      "max": 588.35,
+      "n": 5
+    },
+    "managedRssP50Mb": {
+      "median": 630.8,
+      "min": 620.21,
+      "max": 3875.42,
+      "n": 5
+    },
+    "managedRssP95Mb": {
+      "median": 647.21,
+      "min": 625.86,
+      "max": 3893.19,
+      "n": 5
+    },
+    "externalRssP50Mb": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "ownPrivateP50Mb": {
+      "median": 266.14,
+      "min": 259.52,
+      "max": 275.52,
+      "n": 5
+    },
+    "ownPrivateP95Mb": {
+      "median": 288.03,
+      "min": 273.89,
+      "max": 295.01,
+      "n": 5
+    },
+    "managedPrivateP50Mb": {
+      "median": 288.69,
+      "min": 278.86,
+      "max": 4038.94,
+      "n": 5
+    },
+    "cpuP50": {
+      "median": 0,
+      "min": 0,
+      "max": 1.61,
+      "n": 5
+    },
+    "cpuP95": {
+      "median": 8.71,
+      "min": 7.11,
+      "max": 18.74,
+      "n": 5
+    },
+    "ownCpuP95": {
+      "median": 8.64,
+      "min": 4.93,
+      "max": 10.35,
+      "n": 5
+    },
+    "ownProcsP50": {
+      "median": 7,
+      "min": 7,
+      "max": 7,
+      "n": 5
+    },
+    "managedProcsP50": {
+      "median": 15,
+      "min": 15,
+      "max": 37,
+      "n": 5
+    },
+    "threadsP95": {
+      "median": 252,
+      "min": 251,
+      "max": 810,
+      "n": 5
+    },
+    "handlesP95": {
+      "median": 4593,
+      "min": 4574,
+      "max": 14139,
+      "n": 5
+    },
+    "orphanCount": {
+      "median": 0,
+      "min": 0,
+      "max": 22,
+      "n": 5
+    },
+    "durationMs": {
+      "median": 76294,
+      "min": 76257,
+      "max": 96423,
+      "n": 5
+    },
+    "launchToWindowMs": {
+      "median": 53,
+      "min": 32,
+      "max": 62,
+      "n": 5
+    },
+    "launchToBackendMs": {
+      "median": 0,
+      "min": 0,
+      "max": 0,
+      "n": 5
+    },
+    "launchToShellMs": {
+      "median": 1305,
+      "min": 567,
+      "max": 1337,
+      "n": 5
+    },
+    "closeMs": {
+      "median": 187,
+      "min": 172,
+      "max": 201,
+      "n": 5
+    }
+  },
+  "verdict": "unknown",
+  "notes": [
+    "measured launch is the second one, against a profile the first launch already used",
+    "a warm-up launch wrote the session this run restores"
+  ]
+}

--- a/uxnandesktop/scripts/resources/budgets/linux.json
+++ b/uxnandesktop/scripts/resources/budgets/linux.json
@@ -1,0 +1,13 @@
+{
+  "budgetVersion": 1,
+  "os": "linux",
+  "mode": "warn",
+  "_comment": [
+    "Empty on purpose: no baseline has been captured on Linux hardware. WebKitGTK's",
+    "footprint differs from WebView2's by more than any regression worth gating on,",
+    "and the collector reports RSS (shared pages counted per process) rather than a",
+    "working set — so these ceilings must be measured here, not copied from Windows.",
+    "Fill this in from a real run before claiming Linux support."
+  ],
+  "scenarios": {}
+}

--- a/uxnandesktop/scripts/resources/budgets/macos.json
+++ b/uxnandesktop/scripts/resources/budgets/macos.json
@@ -1,0 +1,15 @@
+{
+  "budgetVersion": 1,
+  "os": "macos",
+  "mode": "warn",
+  "_comment": [
+    "Empty on purpose: no baseline has been captured on macOS hardware, so every",
+    "scenario is reported as `unknown` rather than judged against a number invented",
+    "on another platform. A WebKit process tree and a WebView2 one are not",
+    "comparable, and macOS keeps the web content process outside the app's tree",
+    "entirely — the `own` bucket therefore means something different here and needs",
+    "its own measured ceilings.",
+    "Fill this in from a real run before claiming macOS support."
+  ],
+  "scenarios": {}
+}

--- a/uxnandesktop/scripts/resources/budgets/windows.json
+++ b/uxnandesktop/scripts/resources/budgets/windows.json
@@ -1,0 +1,307 @@
+{
+  "budgetVersion": 1,
+  "os": "windows",
+  "mode": "warn",
+  "_comment": [
+    "Absolute ceilings for Windows, derived from the approved baseline in",
+    "scripts/resources/baselines/windows/ (5 repetitions per scenario, release",
+    "build, quiet machine). Each limit is the measured median plus an explicit",
+    "margin: +15% warn / +35% fail for memory, +20/+40% for the managed bucket,",
+    "+25/+50% for handles. CPU P95 and launch latency get much wider bands (x2.5",
+    "/ x4 and x6 / x12, with floors) because they are the noisy metrics on a",
+    "desktop — a gate that fires on noise gets switched off, and then nothing is",
+    "measured at all.",
+    "",
+    "mode: 'warn' downgrades every `fail` to a warning, so CI reports without",
+    "blocking. Flip to 'enforce' after two weeks of real runs establish the noise",
+    "floor. Raising a limit afterwards needs the run that justifies it in the diff."
+  ],
+  "scenarios": {
+    "R00": {
+      "ownPrivateP50Mb": {
+        "warn": 272,
+        "fail": 319
+      },
+      "ownRssP50Mb": {
+        "warn": 551,
+        "fail": 647
+      },
+      "managedPrivateP50Mb": {
+        "warn": 284,
+        "fail": 331
+      },
+      "handlesP95": {
+        "warn": 4377,
+        "fail": 5252
+      },
+      "cpuP95": {
+        "warn": 8,
+        "fail": 15
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R01": {
+      "ownPrivateP50Mb": {
+        "warn": 275,
+        "fail": 323
+      },
+      "ownRssP50Mb": {
+        "warn": 551,
+        "fail": 647
+      },
+      "managedPrivateP50Mb": {
+        "warn": 356,
+        "fail": 415
+      },
+      "handlesP95": {
+        "warn": 5553,
+        "fail": 6663
+      },
+      "cpuP95": {
+        "warn": 28,
+        "fail": 44
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R02": {
+      "ownPrivateP50Mb": {
+        "warn": 290,
+        "fail": 341
+      },
+      "ownRssP50Mb": {
+        "warn": 582,
+        "fail": 683
+      },
+      "managedPrivateP50Mb": {
+        "warn": 309,
+        "fail": 360
+      },
+      "handlesP95": {
+        "warn": 4902,
+        "fail": 5882
+      },
+      "cpuP95": {
+        "warn": 16,
+        "fail": 26
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R03": {
+      "ownPrivateP50Mb": {
+        "warn": 316,
+        "fail": 371
+      },
+      "ownRssP50Mb": {
+        "warn": 661,
+        "fail": 776
+      },
+      "managedPrivateP50Mb": {
+        "warn": 353,
+        "fail": 411
+      },
+      "handlesP95": {
+        "warn": 5708,
+        "fail": 6849
+      },
+      "cpuP95": {
+        "warn": 18,
+        "fail": 29
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R04": {
+      "ownPrivateP50Mb": {
+        "warn": 261,
+        "fail": 306
+      },
+      "ownRssP50Mb": {
+        "warn": 541,
+        "fail": 635
+      },
+      "managedPrivateP50Mb": {
+        "warn": 272,
+        "fail": 317
+      },
+      "handlesP95": {
+        "warn": 4405,
+        "fail": 5286
+      },
+      "cpuP95": {
+        "warn": 12,
+        "fail": 19
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R05": {
+      "ownPrivateP50Mb": {
+        "warn": 312,
+        "fail": 366
+      },
+      "ownRssP50Mb": {
+        "warn": 606,
+        "fail": 711
+      },
+      "managedPrivateP50Mb": {
+        "warn": 331,
+        "fail": 387
+      },
+      "handlesP95": {
+        "warn": 4948,
+        "fail": 5937
+      },
+      "cpuP95": {
+        "warn": 88,
+        "fail": 141
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R06": {
+      "ownPrivateP50Mb": {
+        "warn": 284,
+        "fail": 333
+      },
+      "ownRssP50Mb": {
+        "warn": 566,
+        "fail": 664
+      },
+      "managedPrivateP50Mb": {
+        "warn": 302,
+        "fail": 352
+      },
+      "handlesP95": {
+        "warn": 4914,
+        "fail": 5897
+      },
+      "cpuP95": {
+        "warn": 33,
+        "fail": 52
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R09-layer": {
+      "ownPrivateP50Mb": {
+        "warn": 311,
+        "fail": 365
+      },
+      "ownRssP50Mb": {
+        "warn": 606,
+        "fail": 711
+      },
+      "managedPrivateP50Mb": {
+        "warn": 330,
+        "fail": 385
+      },
+      "handlesP95": {
+        "warn": 4913,
+        "fail": 5895
+      },
+      "cpuP95": {
+        "warn": 28,
+        "fail": 44
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R09-off": {
+      "ownPrivateP50Mb": {
+        "warn": 278,
+        "fail": 327
+      },
+      "ownRssP50Mb": {
+        "warn": 570,
+        "fail": 669
+      },
+      "managedPrivateP50Mb": {
+        "warn": 297,
+        "fail": 346
+      },
+      "handlesP95": {
+        "warn": 4904,
+        "fail": 5885
+      },
+      "cpuP95": {
+        "warn": 28,
+        "fail": 45
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R09-overlay": {
+      "ownPrivateP50Mb": {
+        "warn": 380,
+        "fail": 446
+      },
+      "ownRssP50Mb": {
+        "warn": 733,
+        "fail": 861
+      },
+      "managedPrivateP50Mb": {
+        "warn": 402,
+        "fail": 469
+      },
+      "handlesP95": {
+        "warn": 5258,
+        "fail": 6309
+      },
+      "cpuP95": {
+        "warn": 61,
+        "fail": 97
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R11": {
+      "ownPrivateP50Mb": {
+        "warn": 307,
+        "fail": 360
+      },
+      "ownRssP50Mb": {
+        "warn": 654,
+        "fail": 767
+      },
+      "managedPrivateP50Mb": {
+        "warn": 347,
+        "fail": 405
+      },
+      "handlesP95": {
+        "warn": 5742,
+        "fail": 6890
+      },
+      "cpuP95": {
+        "warn": 22,
+        "fail": 35
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    }
+  }
+}

--- a/uxnandesktop/scripts/resources/collectors/unix.sh
+++ b/uxnandesktop/scripts/resources/collectors/unix.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env sh
+# macOS / Linux resource collector — the POSIX counterpart of `windows.ps1`.
+#
+# Same contract: prune to the subtree of --root-pid, print one compact JSON line
+# per sample, never read a command line or an environment block. Attribution
+# stays in `lib/tree.mjs`; this script only walks parent/child edges.
+#
+# Semantic differences from Windows, which the report surfaces rather than hides:
+#   - `rssKb` is resident set size. Shared pages (a webview's) are counted in
+#     every process that maps them, so a multi-process tree reads higher here
+#     than the Windows working-set figure. Never compare the two directly.
+#   - There is no cheap per-process private-memory figure, and no handle count
+#     without an `lsof` sweep whose own cost would dwarf what it measures. Both
+#     are emitted as `null`, which the schema reads as "unsupported", not zero.
+#
+# Modes:
+#   --root-pid N [--interval-ms N]   stream the subtree
+#   --pids 1,2,3 --once              one snapshot of exactly those PIDs
+#   --name app --once                one snapshot of every process with that name
+#   --info                           one line of static machine facts
+#
+# `--name` exists only for the pre-flight guard ("is another instance already
+# running?"), never for attribution — see the note in `lib/tree.mjs`.
+
+set -eu
+
+ROOT_PID=0
+INTERVAL_MS=1000
+PIDS=""
+NAME=""
+ONCE=0
+INFO=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root-pid) ROOT_PID="$2"; shift 2 ;;
+    --interval-ms) INTERVAL_MS="$2"; shift 2 ;;
+    --pids) PIDS="$2"; shift 2 ;;
+    --name) NAME="$2"; shift 2 ;;
+    --once) ONCE=1; shift ;;
+    --info) INFO=1; shift ;;
+    *) echo "unix.sh: unknown argument $1" >&2; exit 2 ;;
+  esac
+done
+
+now_ms() {
+  # `date +%s%3N` is a GNU extension; BSD/macOS `date` has no sub-second format,
+  # so fall back to whole seconds rather than emitting a wrong number.
+  ms=$(date +%s%3N 2>/dev/null || true)
+  case "$ms" in
+    *N*|"") echo "$(date +%s)000" ;;
+    *) echo "$ms" ;;
+  esac
+}
+
+if [ "$INFO" -eq 1 ]; then
+  os_name=$(uname -s)
+  os_version=$(uname -r)
+  if [ "$os_name" = "Darwin" ]; then
+    cores=$(sysctl -n hw.logicalcpu 2>/dev/null || echo 0)
+    total_mb=$(( $(sysctl -n hw.memsize 2>/dev/null || echo 0) / 1048576 ))
+    cpu_model=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "unknown")
+    # WebKit ships with the OS; its version is the system version.
+    webview="\"WebKit (system $(sw_vers -productVersion 2>/dev/null || echo unknown))\""
+  else
+    cores=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 0)
+    total_mb=$(( $(awk '/MemTotal/ {print $2}' /proc/meminfo 2>/dev/null || echo 0) / 1024 ))
+    cpu_model=$(awk -F': ' '/model name/ {print $2; exit}' /proc/cpuinfo 2>/dev/null || echo "unknown")
+    wk=$(pkg-config --modversion webkit2gtk-4.1 2>/dev/null || true)
+    if [ -n "$wk" ]; then webview="\"WebKitGTK $wk\""; else webview="null"; fi
+  fi
+  printf '{"webview":%s,"osName":"%s","osVersion":"%s","cpuModel":"%s","cpuCores":%s,"totalMemMb":%s,"powerPlan":null}\n' \
+    "$webview" "$os_name" "$os_version" "$cpu_model" "$cores" "$total_mb"
+  exit 0
+fi
+
+# One `ps` call gives pid, ppid, rss (KiB), cumulative CPU time and the command
+# name. `-o comm=` is the executable basename on both platforms.
+snapshot() {
+  ps -e -o pid=,ppid=,rss=,etime=,time=,comm= 2>/dev/null
+}
+
+emit_rows() {
+  # stdin: the ps snapshot. $1: comma-separated PID filter, $2: subtree root
+  # (used when $1 is empty), $3: executable-name filter for the pre-flight guard.
+  filter="$1"
+  root="$2"
+  namefilter="${3:-}"
+  awk -v filter="$filter" -v root="$root" -v namefilter="$namefilter" '
+    function cputime_ms(t,   n, parts, ms, secs, mins, hours, days, frac) {
+      ms = 0
+      if (index(t, ".") > 0) { frac = substr(t, index(t, ".") + 1); ms = (frac + 0) * 10; t = substr(t, 1, index(t, ".") - 1) }
+      n = split(t, parts, ":")
+      secs = parts[n] + 0
+      mins = (n >= 2) ? parts[n-1] + 0 : 0
+      hours = (n >= 3) ? parts[n-2] + 0 : 0
+      days = 0
+      if (n >= 3 && index(parts[n-2], "-") > 0) { split(parts[n-2], d, "-"); days = d[1] + 0; hours = d[2] + 0 }
+      return ((days * 86400) + (hours * 3600) + (mins * 60) + secs) * 1000 + ms
+    }
+    function esc(s) { gsub(/\\/, "\\\\", s); gsub(/"/, "\\\"", s); return s }
+    {
+      pid[NR] = $1; ppid[NR] = $2; rss[NR] = $3; et[NR] = $4; cpu[NR] = $5; name[NR] = $6
+      idx[$1] = NR
+      kids[$2] = kids[$2] " " $1
+      total = NR
+    }
+    END {
+      want_count = 0
+      if (namefilter != "") {
+        for (r = 1; r <= total; r++) if (name[r] == namefilter) { want[pid[r] + 0] = 1; want_count++ }
+      } else if (filter != "") {
+        split(filter, f, ",")
+        for (i in f) { want[f[i] + 0] = 1; want_count++ }
+      } else {
+        # Breadth-first descent from the root; the seen[] guard cuts a cycle a
+        # recycled parent PID could forge.
+        queue[1] = root + 0; head = 1; tail = 1; seen[root + 0] = 1
+        while (head <= tail) {
+          cur = queue[head]; head++
+          if (idx[cur] == "") continue
+          want[cur] = 1; want_count++
+          n = split(kids[cur], ks, " ")
+          for (i = 1; i <= n; i++) {
+            c = ks[i] + 0
+            if (c > 0 && !(c in seen)) { seen[c] = 1; tail++; queue[tail] = c }
+          }
+        }
+      }
+      out = ""; first = 1
+      for (r = 1; r <= total; r++) {
+        if (!(pid[r] + 0 in want)) continue
+        if (!first) out = out ","
+        first = 0
+        out = out "{\"pid\":" pid[r] ",\"ppid\":" ppid[r] ",\"name\":\"" esc(name[r]) "\"" \
+              ",\"rssKb\":" rss[r] ",\"privateKb\":null,\"cpuMs\":" cputime_ms(cpu[r]) \
+              ",\"threads\":null,\"handles\":null,\"startedAt\":null}"
+      }
+      print out
+    }
+  '
+}
+
+if [ -n "$PIDS" ] || [ -n "$NAME" ]; then
+  rows=$(snapshot | emit_rows "$PIDS" 0 "$NAME")
+  printf '{"t":%s,"rows":[%s]}\n' "$(now_ms)" "$rows"
+  exit 0
+fi
+
+if [ "$ROOT_PID" -le 0 ]; then
+  echo "unix.sh: --root-pid is required unless --pids, --name or --info is used" >&2
+  exit 2
+fi
+
+sleep_s=$(awk -v ms="$INTERVAL_MS" 'BEGIN { printf "%.3f", ms / 1000 }')
+while :; do
+  rows=$(snapshot | emit_rows "" "$ROOT_PID" "")
+  printf '{"t":%s,"rows":[%s]}\n' "$(now_ms)" "$rows"
+  [ "$ONCE" -eq 1 ] && break
+  sleep "$sleep_s"
+done

--- a/uxnandesktop/scripts/resources/collectors/unix.test.mjs
+++ b/uxnandesktop/scripts/resources/collectors/unix.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * Coverage for the Unix collector's parser.
+ *
+ * `unix.sh` has never been run on real macOS or Linux hardware, so its awk
+ * program — the part that turns `ps` output into schema rows — is the piece most
+ * likely to be quietly wrong when someone finally does. It is pure text
+ * transformation, so it can be exercised anywhere `awk` exists: the test lifts
+ * the program out of the script (rather than duplicating it, which would test a
+ * copy) and feeds it a synthetic snapshot.
+ *
+ * Skipped where `awk` is unavailable — Windows runners, mainly. Linux and macOS
+ * CI legs run it, which is precisely where the script is destined to live.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(HERE, "unix.sh");
+
+const hasAwk = spawnSync("awk", ["--version"], { encoding: "utf8" }).error === undefined;
+const describeAwk = hasAwk ? describe : describe.skip;
+
+/** Lift the awk program out of `emit_rows`, so the test runs the real thing. */
+function awkProgram() {
+  const src = fs.readFileSync(SCRIPT, "utf8");
+  const start = src.indexOf("awk -v filter=");
+  const open = src.indexOf("'", start);
+  const close = src.indexOf("\n  '", open);
+  if (start === -1 || open === -1 || close === -1) {
+    throw new Error("could not find the awk program in unix.sh — did emit_rows change shape?");
+  }
+  return src.slice(open + 1, close);
+}
+
+/**
+ * A tree matching what `ps -e -o pid=,ppid=,rss=,etime=,time=,comm=` prints:
+ *
+ *   100 uxnan-desktop        the app we launched
+ *   ├─ 101 WebKitWebProcess  its webview helper
+ *   ├─ 103 bash              a shell it spawned
+ *   │   └─ 104 node          the agent the user ran
+ *   900 uxnan-desktop        an unrelated instance — must never be counted
+ */
+const PS = [
+  "100 1 27000 05:00 00:01:30 uxnan-desktop",
+  "101 100 90000 05:00 00:00:45.50 WebKitWebProcess",
+  "103 100 4000 04:59 00:00:01 bash",
+  "104 103 120000 04:58 00:02:00 node",
+  "900 1 999000 06:00 01:10:00 uxnan-desktop",
+].join("\n");
+
+// The program goes to a file rather than an argument: it is dense with quotes
+// and backslashes, and Windows argument escaping would corrupt it on the way in.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "uxnan-awk-test-"));
+afterAll(() => fs.rmSync(TMP, { recursive: true, force: true }));
+
+function run({ filter = "", root = 0, name = "" }) {
+  const file = path.join(TMP, "rows.awk");
+  fs.writeFileSync(file, awkProgram(), "utf8");
+  const out = execFileSync(
+    "awk",
+    ["-v", `filter=${filter}`, "-v", `root=${root}`, "-v", `namefilter=${name}`, "-f", file],
+    { input: PS, encoding: "utf8" },
+  );
+  return JSON.parse(`[${out.trim()}]`);
+}
+
+describeAwk("the unix collector's row parser", () => {
+  it("walks the subtree of the root and nothing else", () => {
+    const rows = run({ root: 100 });
+    expect(rows.map((r) => r.pid)).toEqual([100, 101, 103, 104]);
+    // The same-named process 900 is not a descendant, so it is invisible —
+    // the whole point of structural attribution.
+    expect(rows.some((r) => r.pid === 900)).toBe(false);
+  });
+
+  it("parses cumulative CPU time into milliseconds", () => {
+    const rows = run({ root: 100 });
+    const cpu = Object.fromEntries(rows.map((r) => [r.pid, r.cpuMs]));
+    expect(cpu[100]).toBe(90_000); // 00:01:30
+    expect(cpu[101]).toBe(45_500); // 00:00:45.50 — hundredths kept
+    expect(cpu[104]).toBe(120_000); // 00:02:00
+  });
+
+  it("handles an hours component", () => {
+    const [row] = run({ filter: "900" });
+    expect(row.cpuMs).toBe(4_200_000); // 01:10:00
+  });
+
+  it("reports the metrics Unix cannot cheaply provide as null, not zero", () => {
+    const [row] = run({ filter: "100" });
+    expect(row.privateKb).toBeNull();
+    expect(row.threads).toBeNull();
+    expect(row.handles).toBeNull();
+    expect(row.rssKb).toBe(27_000);
+  });
+
+  it("selects an explicit pid list, ignoring the tree", () => {
+    expect(run({ filter: "103,104" }).map((r) => r.pid)).toEqual([103, 104]);
+  });
+
+  it("selects by executable name for the pre-flight guard only", () => {
+    // This is the one place a name is matched — "is another instance running?".
+    expect(run({ name: "uxnan-desktop" }).map((r) => r.pid)).toEqual([100, 900]);
+  });
+
+  it("emits nothing when the root is not in the snapshot", () => {
+    expect(run({ root: 555 })).toEqual([]);
+  });
+});

--- a/uxnandesktop/scripts/resources/collectors/windows.ps1
+++ b/uxnandesktop/scripts/resources/collectors/windows.ps1
@@ -1,0 +1,217 @@
+# Windows resource collector for the desktop benchmarks.
+#
+# Deliberately dumb: it samples the process subtree rooted at -RootPid and prints
+# one compact JSON line per sample. It makes no judgement about which process is
+# "uxnan" beyond parent/child descent from a PID the harness spawned itself —
+# all attribution lives in `lib/tree.mjs`, where it can be unit-tested.
+#
+# It never reads a command line, an environment block or a window title, so a
+# sample cannot carry a prompt, a token or a path.
+#
+# Modes:
+#   -RootPid <int>            stream the subtree every -IntervalMs (default 1000)
+#   -Pids "12,34" -Once       one snapshot of exactly those PIDs (orphan check)
+#   -Name "app.exe" -Once     one snapshot of every process with that name
+#   -WindowWatch <int>        block until that PID owns a main window, then exit
+#   -Info                     one line of static machine facts, then exit
+#
+# `-Name` exists only for the pre-flight guard ("is another instance already
+# running?"), never for attribution — see the note in `lib/tree.mjs`.
+#
+# Output (one JSON object per line, stdout):
+#   {"t":<unix ms>,"rows":[{"pid":..,"ppid":..,"name":"..","rssKb":..,
+#     "privateKb":..,"cpuMs":..,"threads":..,"handles":..,"startedAt":<unix ms>}]}
+#
+# Uses Windows PowerShell 5.1 cmdlets only (present on every supported Windows),
+# so the harness never depends on pwsh being installed.
+
+[CmdletBinding()]
+param(
+  [int] $RootPid = 0,
+  [int] $IntervalMs = 1000,
+  [string] $Pids = "",
+  [string] $Name = "",
+  [int] $WindowWatch = 0,
+  [int] $TimeoutMs = 120000,
+  [switch] $Once,
+  [switch] $Info
+)
+
+$ErrorActionPreference = "Stop"
+$out = [Console]::Out
+
+function Write-Line([string] $text) {
+  $out.WriteLine($text)
+  $out.Flush()
+}
+
+function Escape-Json([string] $value) {
+  if ($null -eq $value) { return "" }
+  return $value.Replace('\', '\\').Replace('"', '\"').Replace("`r", "").Replace("`n", "")
+}
+
+if ($Info) {
+  # The WebView2 runtime version decides a large share of the memory figure, so a
+  # result is not comparable without it. Read from the registry (per-machine
+  # first, then per-user); null when absent rather than guessed.
+  $webview = $null
+  foreach ($key in @(
+      "HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
+      "HKLM:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
+      "HKCU:\SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}")) {
+    try {
+      $v = (Get-ItemProperty -Path $key -Name pv -ErrorAction Stop).pv
+      if ($v) { $webview = $v; break }
+    } catch { }
+  }
+  $os = Get-CimInstance -ClassName Win32_OperatingSystem -Property Caption, Version, TotalVisibleMemorySize
+  $cpu = @(Get-CimInstance -ClassName Win32_Processor -Property Name, NumberOfLogicalProcessors)[0]
+  $power = $null
+  try { $power = (powercfg /getactivescheme) -replace '.*\(([^)]*)\).*', '$1' } catch { }
+  # Each element is parenthesised on purpose: PowerShell's comma binds tighter
+  # than `+`, so `'a:' + $x, 'b:' + $y` would build one concatenation of an
+  # array rather than two array elements — and the join would silently produce
+  # space-separated garbage instead of JSON.
+  $parts = @(
+    ('"webview":' + $(if ($webview) { '"' + (Escape-Json $webview) + '"' } else { 'null' })),
+    ('"osName":"' + (Escape-Json $os.Caption) + '"'),
+    ('"osVersion":"' + (Escape-Json $os.Version) + '"'),
+    ('"cpuModel":"' + (Escape-Json $cpu.Name) + '"'),
+    ('"cpuCores":' + [int] $cpu.NumberOfLogicalProcessors),
+    ('"totalMemMb":' + [int] ($os.TotalVisibleMemorySize / 1024)),
+    ('"powerPlan":' + $(if ($power) { '"' + (Escape-Json $power) + '"' } else { 'null' }))
+  )
+  Write-Line ('{' + ($parts -join ',') + '}')
+  exit 0
+}
+
+if ($WindowWatch -gt 0) {
+  # "Launch to a window the user can see", measured from outside the app: poll
+  # until the process owns a main window handle. Nothing is injected into the
+  # app to report this, so the measurement can't change what it measures.
+  $sw = [System.Diagnostics.Stopwatch]::StartNew()
+  while ($sw.ElapsedMilliseconds -lt $TimeoutMs) {
+    try {
+      $p = Get-Process -Id $WindowWatch -ErrorAction Stop
+      if ($p.MainWindowHandle -ne 0) {
+        Write-Line ('{"event":"window","elapsedMs":' + [long] $sw.ElapsedMilliseconds + '}')
+        exit 0
+      }
+    } catch {
+      Write-Line '{"event":"exited"}'
+      exit 1
+    }
+    Start-Sleep -Milliseconds 50
+  }
+  Write-Line '{"event":"timeout"}'
+  exit 3
+}
+
+# Fields kept to the minimum the schema needs — a narrower CIM projection is a
+# measurably cheaper query, and the collector's own cost is overhead on the very
+# thing being measured.
+$fields = @(
+  "ProcessId", "ParentProcessId", "Name", "WorkingSetSize", "PrivatePageCount",
+  "KernelModeTime", "UserModeTime", "ThreadCount", "HandleCount", "CreationDate"
+)
+
+$epoch = [datetime]::new(1970, 1, 1, 0, 0, 0, [System.DateTimeKind]::Utc)
+
+function Get-Snapshot {
+  $all = Get-CimInstance -ClassName Win32_Process -Property $fields
+  $map = @{}
+  foreach ($p in $all) { $map[[int] $p.ProcessId] = $p }
+  return $map
+}
+
+function Format-Row($p) {
+  $started = "null"
+  if ($p.CreationDate) {
+    $started = [string] [long] ($p.CreationDate.ToUniversalTime() - $epoch).TotalMilliseconds
+  }
+  # KernelModeTime/UserModeTime are 100-nanosecond units.
+  $cpuMs = [long] (([double] $p.KernelModeTime + [double] $p.UserModeTime) / 10000.0)
+  return '{"pid":' + [int] $p.ProcessId +
+  ',"ppid":' + [int] $p.ParentProcessId +
+  ',"name":"' + (Escape-Json $p.Name) + '"' +
+  ',"rssKb":' + [long] ([double] $p.WorkingSetSize / 1024.0) +
+  ',"privateKb":' + [long] ([double] $p.PrivatePageCount / 1024.0) +
+  ',"cpuMs":' + $cpuMs +
+  ',"threads":' + [int] $p.ThreadCount +
+  ',"handles":' + [int] $p.HandleCount +
+  ',"startedAt":' + $started + '}'
+}
+
+function Write-Sample([array] $rows) {
+  $now = [long] ([datetime]::UtcNow - $epoch).TotalMilliseconds
+  Write-Line ('{"t":' + $now + ',"rows":[' + ($rows -join ',') + ']}')
+}
+
+if ($Pids) {
+  # Snapshot of specific PIDs — used after teardown, when the tree no longer
+  # exists and only "is this PID still alive" matters.
+  $wanted = @($Pids.Split(",") | ForEach-Object { [int] $_.Trim() } | Where-Object { $_ -gt 0 })
+  $map = Get-Snapshot
+  $rows = @()
+  foreach ($id in $wanted) { if ($map.ContainsKey($id)) { $rows += (Format-Row $map[$id]) } }
+  Write-Sample $rows
+  exit 0
+}
+
+if ($Name) {
+  $map = Get-Snapshot
+  $rows = @()
+  foreach ($p in $map.Values) { if ($p.Name -ieq $Name) { $rows += (Format-Row $p) } }
+  Write-Sample $rows
+  exit 0
+}
+
+if ($RootPid -le 0) {
+  [Console]::Error.WriteLine("windows.ps1: -RootPid is required unless -Pids, -Name or -Info is used")
+  exit 2
+}
+
+$sw = [System.Diagnostics.Stopwatch]::StartNew()
+$next = 0
+
+while ($true) {
+  $map = Get-Snapshot
+
+  # Prune to the subtree of $RootPid. Structural only: children of children, no
+  # name matching, so a same-named process started elsewhere can never be
+  # counted as ours. The visited set also stops a recycled parent PID from
+  # forming a cycle.
+  $children = @{}
+  foreach ($p in $map.Values) {
+    $parent = [int] $p.ParentProcessId
+    if (-not $children.ContainsKey($parent)) { $children[$parent] = New-Object System.Collections.ArrayList }
+    [void] $children[$parent].Add([int] $p.ProcessId)
+  }
+
+  $rows = New-Object System.Collections.ArrayList
+  if ($map.ContainsKey($RootPid)) {
+    $seen = New-Object 'System.Collections.Generic.HashSet[int]'
+    $queue = New-Object System.Collections.Queue
+    [void] $queue.Enqueue($RootPid)
+    [void] $seen.Add($RootPid)
+    while ($queue.Count -gt 0) {
+      $id = [int] $queue.Dequeue()
+      [void] $rows.Add((Format-Row $map[$id]))
+      if ($children.ContainsKey($id)) {
+        foreach ($child in $children[$id]) {
+          if ($seen.Add($child) -and $map.ContainsKey($child)) { [void] $queue.Enqueue($child) }
+        }
+      }
+    }
+  }
+
+  Write-Sample $rows.ToArray()
+  if ($Once) { break }
+
+  # Absolute cadence: sleeping a fixed interval after a variable-cost query
+  # would let the sample spacing drift, and the CPU rate is a per-interval
+  # division — drift there is a wrong number, not just a late one.
+  $next += $IntervalMs
+  $wait = $next - $sw.ElapsedMilliseconds
+  if ($wait -gt 0) { Start-Sleep -Milliseconds $wait } else { $next = $sw.ElapsedMilliseconds }
+}

--- a/uxnandesktop/scripts/resources/compare.mjs
+++ b/uxnandesktop/scripts/resources/compare.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Compare a candidate run against an approved baseline.
+ *
+ *   node scripts/resources/compare.mjs --baseline baselines/windows --candidate .resource-results
+ *
+ * This is the check that actually catches drift: absolute budgets say "still
+ * under the ceiling", a comparison says "this change made it worse". It is
+ * deliberately hard to trip — a metric has to move by both a relative and an
+ * absolute margin — because a gate that fires on noise gets switched off, and
+ * then nothing is measured at all.
+ *
+ * Exit code: 0 for pass/warn/unknown, 1 for fail. Failing only happens once the
+ * platform's budget file leaves `mode: "warn"`.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { DEFAULT_REGRESSION_POLICY, evaluateRegression } from "./lib/budgets.mjs";
+import { verdictTable } from "./lib/markdown.mjs";
+import { worstOf } from "./lib/schema.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DESKTOP_ROOT = path.resolve(HERE, "..", "..");
+
+function parseArgs(argv) {
+  const args = {
+    baseline: path.join(HERE, "baselines"),
+    candidate: path.join(DESKTOP_ROOT, ".resource-results"),
+    file: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--baseline") args.baseline = path.resolve(argv[++i]);
+    else if (argv[i] === "--candidate") args.candidate = path.resolve(argv[++i]);
+    else if (argv[i] === "--file") args.file = path.resolve(argv[++i]);
+    else if (argv[i] === "--help" || argv[i] === "-h") args.help = true;
+    else throw new Error(`unknown argument ${argv[i]}`);
+  }
+  return args;
+}
+
+/** Load `{ scenarioName: aggregate }` from a directory of aggregate files. */
+function loadAggregates(dir) {
+  const root = fs.existsSync(path.join(dir, "aggregates")) ? path.join(dir, "aggregates") : dir;
+  if (!fs.existsSync(root)) return {};
+  const out = {};
+  for (const f of fs.readdirSync(root)) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const doc = JSON.parse(fs.readFileSync(path.join(root, f), "utf8"));
+      if (doc?.scenario) out[path.basename(f, ".json")] = doc;
+    } catch {
+      /* a malformed file is reported by its absence below */
+    }
+  }
+  return out;
+}
+
+function loadBudget(osKey, baselineDir) {
+  for (const c of [
+    path.join(baselineDir, `budget-${osKey}.json`),
+    path.join(HERE, "budgets", `${osKey}.json`),
+  ]) {
+    if (fs.existsSync(c)) {
+      try {
+        return JSON.parse(fs.readFileSync(c, "utf8"));
+      } catch {
+        /* fall through */
+      }
+    }
+  }
+  return null;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(
+      "node scripts/resources/compare.mjs --baseline <dir> --candidate <dir> [--file <out.md>]\n",
+    );
+    return 0;
+  }
+
+  const baseline = loadAggregates(args.baseline);
+  const candidate = loadAggregates(args.candidate);
+  const names = Object.keys(candidate).sort();
+
+  if (names.length === 0) {
+    process.stderr.write(`no candidate aggregates found in ${args.candidate}\n`);
+    return 1;
+  }
+
+  const lines = ["# Resource comparison", ""];
+  const statuses = [];
+
+  for (const name of names) {
+    const cand = candidate[name];
+    const base = baseline[name] ?? null;
+    const budget = loadBudget(cand.platform?.os, args.baseline);
+    const verdict = evaluateRegression(base, cand, DEFAULT_REGRESSION_POLICY, budget?.mode);
+    statuses.push(verdict.status);
+
+    lines.push(`## ${name} — ${verdict.status}`, "");
+    if (verdict.notes.length > 0) lines.push(...verdict.notes.map((n) => `> ${n}`), "");
+    const table = verdictTable(verdict);
+    if (table) lines.push(table, "");
+  }
+
+  const overall = worstOf(statuses);
+  lines.splice(2, 0, `**Overall: ${overall}**`, "");
+  const markdown = lines.join("\n");
+
+  if (args.file) {
+    fs.mkdirSync(path.dirname(args.file), { recursive: true });
+    fs.writeFileSync(args.file, markdown, "utf8");
+  }
+  process.stdout.write(markdown);
+  process.stdout.write("\n");
+  return overall === "fail" ? 1 : 0;
+}
+
+process.exit(main());

--- a/uxnandesktop/scripts/resources/fixtures/agent-fixture.mjs
+++ b/uxnandesktop/scripts/resources/fixtures/agent-fixture.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * A stand-in for a coding agent, so the "agent working" scenario is measurable.
+ *
+ * Running a real CLI here would be wrong twice over: its cost varies with a
+ * model, a network and an account (so the run would not be reproducible), and CI
+ * must never be handed credentials to make that happen. What the benchmark
+ * actually needs from an agent is the *shape* of the load it puts on the app —
+ * a stream of terminal output, periods of silence, a state change — and that is
+ * exactly what this produces, at a fixed rate, offline.
+ *
+ * The phases mirror what the agent monitor infers from a real session:
+ *
+ *   working → output at `--rate` lines/second
+ *   waiting → silence (a prompt the user has to answer)
+ *   working → output again
+ *   done    → a final line, then exit 0
+ *
+ * With `--hooks` it also reports each transition to the local hook server the
+ * way a real reporter does, using only the `UXNAN_*` variables the app injected
+ * into this terminal, so the Layer 1 path is exercised too. Without them it
+ * simply skips reporting — never an error, never a hang.
+ *
+ * Usage:
+ *   node agent-fixture.mjs [--rate 20] [--work 20] [--wait 10] [--hooks]
+ */
+
+import process from "node:process";
+
+const argv = process.argv.slice(2);
+const num = (name, fallback) => {
+  const i = argv.indexOf(`--${name}`);
+  const v = i === -1 ? NaN : Number(argv[i + 1]);
+  return Number.isFinite(v) ? v : fallback;
+};
+
+const RATE = num("rate", 20); // lines per second
+const WORK_S = num("work", 20); // seconds per working phase
+const WAIT_S = num("wait", 10); // seconds of the waiting phase
+const HOOKS = argv.includes("--hooks");
+
+const LINE =
+  "· reading src/lib/state/terminals.svelte.ts … 1284 lines, 42 symbols, 3 references resolved";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Report a state to the app's hook server, if this terminal has one. */
+async function report(state, extra = {}) {
+  if (!HOOKS) return;
+  const url = process.env.UXNAN_HOOK_URL;
+  const token = process.env.UXNAN_HOOK_TOKEN;
+  const agentId = process.env.UXNAN_AGENT_ID;
+  if (!url || !token || !agentId) return;
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", "X-Uxnan-Token": token },
+      body: JSON.stringify({ agentId, agent: "fixture", state, ...extra }),
+      signal: AbortSignal.timeout(2000),
+    });
+  } catch {
+    // A benchmark fixture never fails the run because reporting failed.
+  }
+}
+
+async function emit(seconds, rate) {
+  const intervalMs = Math.max(1, Math.round(1000 / rate));
+  const until = Date.now() + seconds * 1000;
+  let n = 0;
+  while (Date.now() < until) {
+    process.stdout.write(`${String(n).padStart(6, "0")} ${LINE}\n`);
+    n += 1;
+    await sleep(intervalMs);
+  }
+  return n;
+}
+
+async function main() {
+  process.stdout.write("uxnan resource fixture agent — deterministic load, no network\n");
+
+  await report("working", { prompt: "benchmark fixture", tool: "read" });
+  const first = await emit(WORK_S, RATE);
+
+  await report("waiting", { summary: "waiting for input" });
+  process.stdout.write("\n? Continue with the plan? (this fixture answers itself)\n");
+  await sleep(WAIT_S * 1000);
+
+  await report("working", { tool: "edit" });
+  const second = await emit(WORK_S, RATE);
+
+  await report("done", { summary: "fixture run complete" });
+  process.stdout.write(`\nfixture complete — ${first + second} lines emitted\n`);
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    process.stderr.write(`fixture failed: ${err?.message ?? err}\n`);
+    process.exit(1);
+  },
+);

--- a/uxnandesktop/scripts/resources/fixtures/http-server.mjs
+++ b/uxnandesktop/scripts/resources/fixtures/http-server.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * A local page for the browser scenario.
+ *
+ * The integrated browser's cost depends on what it loads, so pointing it at a
+ * real site would make the measurement depend on that site's ads, fonts and
+ * A/B test of the day — and would put the benchmark on the network, which it is
+ * not allowed to be. This serves a fixed page from loopback instead: known
+ * weight, known DOM, no requests leaving the machine.
+ *
+ * Prints `{"url":"http://127.0.0.1:<port>/"}` on stdout once listening, so the
+ * harness can wait for a line rather than guess a port.
+ *
+ * Usage: node http-server.mjs [--port 0] [--weight light|heavy]
+ */
+
+import http from "node:http";
+
+const argv = process.argv.slice(2);
+const portArg = argv.indexOf("--port");
+const port = portArg === -1 ? 0 : Number(argv[portArg + 1]);
+const weightArg = argv.indexOf("--weight");
+const weight = weightArg === -1 ? "light" : argv[weightArg + 1];
+
+/** A deterministic page: N rows of static markup, no scripts, no requests. */
+function page(rows) {
+  const items = Array.from(
+    { length: rows },
+    (_, i) =>
+      `<li><code>src/mod${String(i % 20).padStart(3, "0")}/file${String(i).padStart(5, "0")}.ts</code> — ${
+        (i * 37) % 400
+      } lines</li>`,
+  ).join("\n");
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>uxnan browser fixture</title>
+<style>body{font:14px/1.5 system-ui;margin:2rem;max-width:60rem}li{margin:.15rem 0}</style>
+</head><body>
+<h1>uxnan browser fixture</h1>
+<p>Static page served from loopback for the resource benchmarks. ${rows} rows.</p>
+<ul>
+${items}
+</ul>
+</body></html>`;
+}
+
+const body = page(weight === "heavy" ? 5000 : 200);
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  res.end(body);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  const address = server.address();
+  console.log(JSON.stringify({ url: `http://127.0.0.1:${address.port}/` }));
+});
+
+for (const sig of ["SIGINT", "SIGTERM"]) {
+  process.on(sig, () => server.close(() => process.exit(0)));
+}

--- a/uxnandesktop/scripts/resources/fixtures/make-repo.mjs
+++ b/uxnandesktop/scripts/resources/fixtures/make-repo.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Deterministic git fixtures.
+ *
+ * The Git scenarios need a repository whose size and shape are the same on every
+ * machine and every run — otherwise "status took 180 ms" says as much about the
+ * checkout as about the app. Generating it beats committing it: 10 000 files
+ * would be a miserable thing to carry in the repo, and generation is verifiable
+ * (the commit hash is fixed, so a drifted generator is caught immediately).
+ *
+ * Determinism comes from pinning everything git would otherwise take from the
+ * environment: author, committer, both timestamps, and the file content (derived
+ * from a seeded PRNG, never `Math.random`). The same arguments therefore always
+ * produce the same commit hash, which `--print-hash` prints so a test can assert
+ * it.
+ *
+ * Usage:
+ *   node make-repo.mjs --dir <path> [--files 200] [--dirs 20] [--dirty 0]
+ *   node make-repo.mjs --dir <path> --print-hash
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+/** Deterministic 32-bit PRNG (mulberry32) — same seed, same repository. */
+function rng(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const WORDS = [
+  "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta",
+  "iota", "kappa", "lambda", "mu", "nu", "xi", "omicron", "pi",
+];
+
+function fileBody(rand, lines) {
+  const out = [];
+  for (let i = 0; i < lines; i += 1) {
+    const a = WORDS[Math.floor(rand() * WORDS.length)];
+    const b = WORDS[Math.floor(rand() * WORDS.length)];
+    out.push(`export const ${a}_${i} = "${b}-${Math.floor(rand() * 1000)}";`);
+  }
+  return `${out.join("\n")}\n`;
+}
+
+/** Fixed identity + timestamps, so the commit hash is a function of the tree. */
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: "Uxnan Benchmark",
+  GIT_AUTHOR_EMAIL: "benchmark@uxnan.invalid",
+  GIT_COMMITTER_NAME: "Uxnan Benchmark",
+  GIT_COMMITTER_EMAIL: "benchmark@uxnan.invalid",
+  GIT_AUTHOR_DATE: "2020-01-01T00:00:00+0000",
+  GIT_COMMITTER_DATE: "2020-01-01T00:00:00+0000",
+  // Ignore the operator's own git config: an `init.defaultBranch`, a
+  // `commit.gpgsign` or a template dir would change the result.
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+};
+
+function git(dir, args) {
+  return execFileSync("git", args, {
+    cwd: dir,
+    env: { ...process.env, ...GIT_ENV },
+    encoding: "utf8",
+    windowsHide: true,
+  }).trim();
+}
+
+/**
+ * Create (or reuse) the fixture repository at `dir` and return
+ * `{ dir, head, files, reused }`.
+ *
+ * An existing directory with the expected commit is reused as-is — generating
+ * 10 000 files takes seconds and every repetition of a scenario would otherwise
+ * pay for it again.
+ */
+export function makeRepo({ dir, files = 200, dirs = 20, dirty = 0, lines = 40, seed = 42 }) {
+  const marker = path.join(dir, ".uxnan-fixture.json");
+  const want = { files, dirs, lines, seed, version: 1 };
+  if (fs.existsSync(marker)) {
+    try {
+      const have = JSON.parse(fs.readFileSync(marker, "utf8"));
+      if (JSON.stringify(have.spec) === JSON.stringify(want)) {
+        applyDirty(dir, dirty, seed);
+        return { dir, head: have.head, files, reused: true };
+      }
+    } catch {
+      /* regenerate below */
+    }
+  }
+
+  fs.rmSync(dir, { recursive: true, force: true });
+  fs.mkdirSync(dir, { recursive: true });
+  git(dir, ["init", "--quiet", "--initial-branch=main"]);
+  git(dir, ["config", "user.name", GIT_ENV.GIT_AUTHOR_NAME]);
+  git(dir, ["config", "user.email", GIT_ENV.GIT_AUTHOR_EMAIL]);
+  git(dir, ["config", "commit.gpgsign", "false"]);
+  git(dir, ["config", "core.autocrlf", "false"]);
+
+  const rand = rng(seed);
+  for (let i = 0; i < files; i += 1) {
+    const bucket = dirs > 0 ? `src/mod${String(i % dirs).padStart(3, "0")}` : "src";
+    const full = path.join(dir, bucket);
+    fs.mkdirSync(full, { recursive: true });
+    fs.writeFileSync(path.join(full, `file${String(i).padStart(5, "0")}.ts`), fileBody(rand, lines));
+  }
+  fs.writeFileSync(
+    path.join(dir, "README.md"),
+    `# uxnan resource fixture\n\nGenerated repository: ${files} files in ${dirs} directories.\n`,
+  );
+  git(dir, ["add", "-A"]);
+  git(dir, ["commit", "--quiet", "-m", "chore: generated resource fixture"]);
+  const head = git(dir, ["rev-parse", "HEAD"]);
+  fs.writeFileSync(marker, JSON.stringify({ spec: want, head }, null, 2));
+  applyDirty(dir, dirty, seed);
+  return { dir, head, files, reused: false };
+}
+
+/** Leave `count` files modified, so a status scan has real work to do. */
+function applyDirty(dir, count, seed) {
+  if (!count) return;
+  const rand = rng(seed + 7);
+  const all = listTracked(dir);
+  for (let i = 0; i < Math.min(count, all.length); i += 1) {
+    const target = path.join(dir, all[Math.floor(rand() * all.length)]);
+    try {
+      fs.appendFileSync(target, `// touched ${i}\n`);
+    } catch {
+      /* skip */
+    }
+  }
+}
+
+function listTracked(dir) {
+  return git(dir, ["ls-files"])
+    .split(/\r?\n/)
+    .filter((l) => l.endsWith(".ts"));
+}
+
+// --- CLI -------------------------------------------------------------------
+
+function isMain() {
+  return process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]));
+}
+
+if (isMain()) {
+  const argv = process.argv.slice(2);
+  const arg = (name, fallback) => {
+    const i = argv.indexOf(`--${name}`);
+    return i === -1 ? fallback : argv[i + 1];
+  };
+  const dir = arg("dir");
+  if (!dir) {
+    console.error("make-repo.mjs: --dir <path> is required");
+    process.exit(2);
+  }
+  const result = makeRepo({
+    dir: path.resolve(dir),
+    files: Number(arg("files", 200)),
+    dirs: Number(arg("dirs", 20)),
+    dirty: Number(arg("dirty", 0)),
+    lines: Number(arg("lines", 40)),
+    seed: Number(arg("seed", 42)),
+  });
+  if (argv.includes("--print-hash")) console.log(result.head);
+  else console.log(JSON.stringify(result));
+}

--- a/uxnandesktop/scripts/resources/fixtures/make-repo.test.mjs
+++ b/uxnandesktop/scripts/resources/fixtures/make-repo.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * The git fixture has to be *identical* every time, or the scenarios built on it
+ * measure the fixture instead of the app. These tests pin that: same arguments →
+ * same commit hash, different arguments → different repository, and a path with
+ * spaces or non-ASCII characters is handled rather than mangled (the case that
+ * breaks tooling built on shell strings — here every git call goes through
+ * `execFileSync` with an argument array, so there is no shell to confuse).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { makeRepo } from "./make-repo.mjs";
+
+const hasGit = spawnSync("git", ["--version"], { encoding: "utf8" }).status === 0;
+const describeGit = hasGit ? describe : describe.skip;
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "uxnan-fixture-test-"));
+afterAll(() => fs.rmSync(TMP, { recursive: true, force: true }));
+
+const SMALL = { files: 6, dirs: 2, lines: 4 };
+
+describeGit("the generated git fixture", () => {
+  it("produces the same commit hash for the same arguments", () => {
+    const a = makeRepo({ ...SMALL, dir: path.join(TMP, "a") });
+    const b = makeRepo({ ...SMALL, dir: path.join(TMP, "b") });
+    expect(a.head).toMatch(/^[0-9a-f]{40}$/);
+    expect(b.head).toBe(a.head);
+  });
+
+  it("produces a different repository for different arguments", () => {
+    const a = makeRepo({ ...SMALL, dir: path.join(TMP, "c") });
+    const more = makeRepo({ ...SMALL, files: 7, dir: path.join(TMP, "d") });
+    expect(more.head).not.toBe(a.head);
+  });
+
+  it("reuses an existing fixture instead of regenerating it", () => {
+    const dir = path.join(TMP, "reuse");
+    const first = makeRepo({ ...SMALL, dir });
+    const second = makeRepo({ ...SMALL, dir });
+    expect(first.reused).toBe(false);
+    expect(second.reused).toBe(true);
+    expect(second.head).toBe(first.head);
+  });
+
+  it("regenerates when the requested shape changes", () => {
+    const dir = path.join(TMP, "reshape");
+    makeRepo({ ...SMALL, dir });
+    const changed = makeRepo({ ...SMALL, files: 8, dir });
+    expect(changed.reused).toBe(false);
+  });
+
+  it("survives a path with spaces and non-ASCII characters", () => {
+    const dir = path.join(TMP, "ruta con espacios y ácentos");
+    const repo = makeRepo({ ...SMALL, dir });
+    expect(repo.head).toMatch(/^[0-9a-f]{40}$/);
+    expect(fs.existsSync(path.join(dir, "README.md"))).toBe(true);
+  });
+
+  it("leaves the requested number of files modified when asked", () => {
+    const dir = path.join(TMP, "dirty");
+    makeRepo({ ...SMALL, dir, dirty: 2 });
+    const status = spawnSync("git", ["status", "--porcelain"], { cwd: dir, encoding: "utf8" });
+    expect(status.stdout.trim().split("\n").filter(Boolean).length).toBeGreaterThan(0);
+  });
+
+  it("writes nothing outside its own directory", () => {
+    const dir = path.join(TMP, "scoped");
+    makeRepo({ ...SMALL, dir });
+    const stray = fs
+      .readdirSync(TMP)
+      .filter((e) => !["a", "b", "c", "d", "reuse", "reshape", "dirty", "scoped"].includes(e));
+    expect(stray).toEqual(["ruta con espacios y ácentos"]);
+  });
+});

--- a/uxnandesktop/scripts/resources/lib/app.mjs
+++ b/uxnandesktop/scripts/resources/lib/app.mjs
@@ -1,0 +1,195 @@
+/**
+ * Launching, observing and tearing down the app under measurement.
+ *
+ * Three readiness signals, because "ready" means different things and only one
+ * of them exists everywhere:
+ *
+ * - **backendReady** — the hook server's endpoint file appears inside the
+ *   scenario's own profile directory. Cross-platform, and observed by watching a
+ *   file the app already writes: nothing is added to the app to report it.
+ * - **windowReady** — the process owns a main window (Windows only, via the
+ *   collector's `-WindowWatch`). This is the number a user would call "startup
+ *   time"; on other platforms it is recorded as `null`, not approximated.
+ * - **shellReady** — the first managed shell shows up in the process tree, i.e.
+ *   the restored terminal is live. Only meaningful for scenarios that seed one.
+ *
+ * Teardown asks the window to close and only escalates if it doesn't. That
+ * ordering matters: a killed app never runs its flush-on-close path, so the
+ * "closing uxnan leaves zero managed processes" check would be measuring the
+ * wrong thing.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawn, execFileSync } from "node:child_process";
+
+import { collectorCommand } from "./platform.mjs";
+import { sleep } from "./sampler.mjs";
+
+/**
+ * Locate the release binary. Release only, and by default: a debug build's
+ * numbers are not comparable with anything, and quietly falling back to one
+ * would silently invalidate a whole run.
+ */
+export function findBinary({ root, profile = "release", explicit = null } = {}) {
+  if (explicit) {
+    if (!fs.existsSync(explicit)) throw new Error(`binary not found: ${explicit}`);
+    return explicit;
+  }
+  const exe = process.platform === "win32" ? "uxnan-desktop.exe" : "uxnan-desktop";
+  const candidates = [
+    path.join(root, "src-tauri", "target", profile, exe),
+    // A shared CARGO_TARGET_DIR is common on machines that keep several
+    // worktrees of this repo.
+    process.env.CARGO_TARGET_DIR ? path.join(process.env.CARGO_TARGET_DIR, profile, exe) : null,
+  ].filter(Boolean);
+  for (const c of candidates) if (fs.existsSync(c)) return c;
+  throw new Error(
+    `no ${profile} binary found. Build it first:\n` +
+      `  cd uxnandesktop && npm run bench:build\n` +
+      `(a bare \`cargo build --release\` leaves Tauri in dev mode and produces a binary that\n` +
+      ` loads http://localhost:1420 instead of the app — see docs/resource-benchmarks.md)\n` +
+      `looked in:\n  ${candidates.join("\n  ")}`,
+  );
+}
+
+/** A launched app instance. */
+export class AppRun {
+  constructor(child, { dataDir }) {
+    this.child = child;
+    this.pid = child.pid;
+    this.dataDir = dataDir;
+    this.exited = false;
+    this.exitCode = null;
+    child.on("exit", (code) => {
+      this.exited = true;
+      this.exitCode = code;
+    });
+  }
+
+  /** Resolve once the hook server has written its endpoint file, or `null` on
+   *  timeout (recorded as such — a slow boot is a result, not a crash). */
+  async waitForBackend(timeoutMs = 120_000) {
+    const dir = path.join(this.dataDir, "hooks");
+    const names = ["endpoint.cmd", "endpoint.env"];
+    const started = Date.now();
+    while (Date.now() - started < timeoutMs) {
+      if (this.exited) return null;
+      for (const n of names) {
+        if (fs.existsSync(path.join(dir, n))) return Date.now() - started;
+      }
+      await sleep(50);
+    }
+    return null;
+  }
+
+  /** Resolve with the ms to a visible main window, or `null` where the platform
+   *  can't answer (everything but Windows today). */
+  async waitForWindow(timeoutMs = 120_000) {
+    if (process.platform !== "win32") return null;
+    const { command, baseArgs } = collectorCommand("windows");
+    const started = Date.now();
+    return await new Promise((resolve) => {
+      const child = spawn(
+        command,
+        [...baseArgs, "-WindowWatch", String(this.pid), "-TimeoutMs", String(timeoutMs)],
+        { stdio: ["ignore", "pipe", "ignore"], windowsHide: true },
+      );
+      let buf = "";
+      child.stdout.on("data", (d) => {
+        buf += String(d);
+      });
+      child.on("exit", () => {
+        const line = buf.trim().split(/\r?\n/).pop() ?? "";
+        try {
+          const parsed = JSON.parse(line);
+          resolve(parsed.event === "window" ? (parsed.elapsedMs ?? Date.now() - started) : null);
+        } catch {
+          resolve(null);
+        }
+      });
+      child.on("error", () => resolve(null));
+    });
+  }
+
+  /**
+   * Ask the app to close, then make sure it did.
+   *
+   * A graceful close first (WM_CLOSE on Windows, SIGTERM elsewhere) so the app
+   * runs its own shutdown — flushing scrollback, stopping watchers, reaping
+   * PTYs. Only a process still alive after `graceMs` is killed, and the run
+   * records that it had to be, because an app that needs killing is itself a
+   * finding.
+   */
+  async quit({ graceMs = 15_000 } = {}) {
+    if (this.exited) return { forced: false, exitCode: this.exitCode };
+    const started = Date.now();
+    let forced = false;
+
+    if (process.platform === "win32") {
+      // `taskkill` without /F posts WM_CLOSE to the window — the same thing
+      // clicking the X does.
+      try {
+        execFileSync("taskkill.exe", ["/PID", String(this.pid)], {
+          stdio: "ignore",
+          windowsHide: true,
+        });
+      } catch {
+        /* the window may already be gone */
+      }
+    } else {
+      try {
+        process.kill(this.pid, "SIGTERM");
+      } catch {
+        /* already gone */
+      }
+    }
+
+    while (!this.exited && Date.now() - started < graceMs) await sleep(100);
+
+    if (!this.exited) {
+      forced = true;
+      try {
+        if (process.platform === "win32") {
+          execFileSync("taskkill.exe", ["/PID", String(this.pid), "/T", "/F"], {
+            stdio: "ignore",
+            windowsHide: true,
+          });
+        } else {
+          process.kill(this.pid, "SIGKILL");
+        }
+      } catch {
+        /* nothing left to kill */
+      }
+      while (!this.exited && Date.now() - started < graceMs + 10_000) await sleep(100);
+    }
+
+    return { forced, exitCode: this.exitCode, closeMs: Date.now() - started };
+  }
+}
+
+/**
+ * Start the app against a disposable profile.
+ *
+ * The environment is trimmed to what a launch needs plus the overrides: the goal
+ * is that two runs on the same machine differ only by the scenario. `UXNAN_*`
+ * hook variables from the operator's own shell are dropped, so a benchmark run
+ * can never report into the operator's live uxnan.
+ */
+export function launchApp(binary, { dataDir, env = {}, cwd = undefined } = {}) {
+  const clean = { ...process.env };
+  for (const key of Object.keys(clean)) {
+    if (key.startsWith("UXNAN_")) delete clean[key];
+  }
+  const child = spawn(binary, [], {
+    cwd,
+    env: { ...clean, UXNAN_DATA_DIR: dataDir, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: false,
+    detached: false,
+  });
+  // Drain the pipes; a full stdio buffer would block the app being measured.
+  child.stdout?.resume();
+  child.stderr?.resume();
+  return new AppRun(child, { dataDir });
+}

--- a/uxnandesktop/scripts/resources/lib/budgets.mjs
+++ b/uxnandesktop/scripts/resources/lib/budgets.mjs
@@ -1,0 +1,193 @@
+/**
+ * Turning measurements into a verdict.
+ *
+ * Two independent questions, deliberately kept apart:
+ *
+ * 1. **Is this within budget?** An absolute per-scenario, per-platform ceiling.
+ *    Absolute limits cannot be shared across platforms — a WebView2 process tree
+ *    and a WebKitGTK one differ by more than any regression we would ever care
+ *    about — so each OS carries its own file.
+ * 2. **Did it get worse?** A relative comparison against an approved baseline
+ *    artifact. This is the one that actually catches gradual drift, and it only
+ *    fires when a change is **both** relatively large and absolutely large, so
+ *    a 20 % jump on a 4 MB number stays quiet.
+ *
+ * Until a baseline exists on real hardware, budgets ship in `mode: "warn"`: every
+ * `fail` is reported as a `warn` and CI stays green. Flipping the mode is a
+ * reviewable one-line change with the evidence attached — which is the point.
+ */
+
+import { relativeDelta, round } from "./stats.mjs";
+import { worstOf } from "./schema.mjs";
+
+/** Metrics compared against a baseline when a budget doesn't name its own.
+ *  Both memory families are here on purpose: a change that moves shared webview
+ *  pages around shows up in one and not the other. */
+export const DEFAULT_REGRESSION_METRICS = [
+  "ownPrivateP50Mb",
+  "ownRssP50Mb",
+  "ownRssP95Mb",
+  "managedPrivateP50Mb",
+  "managedRssP50Mb",
+  "cpuP95",
+  "handlesP95",
+  "threadsP95",
+];
+
+/** Default regression policy — the plan's "clear relative regression" rule. */
+export const DEFAULT_REGRESSION_POLICY = {
+  /** Fraction, e.g. 0.15 = +15 %. */
+  relative: 0.15,
+  /** Absolute change that must *also* be exceeded, in the metric's own unit
+   *  (MB for `*Mb`, percent-of-core for `cpu*`, count otherwise). */
+  absolute: { mb: 10, cpuPct: 2, count: 200, ms: 500 },
+};
+
+/** Which unit family a metric name belongs to (encoded in the name by design). */
+export function unitOf(metric) {
+  if (/Mb$/i.test(metric)) return "mb";
+  if (/^cpu|Cpu/.test(metric)) return "cpuPct";
+  if (/Ms$/i.test(metric)) return "ms";
+  return "count";
+}
+
+/**
+ * Check one scenario aggregate against its absolute budget.
+ *
+ * A metric with no entry in the budget is reported as `skipped`, not as a pass:
+ * "we never looked" and "we looked and it was fine" must not read the same.
+ */
+export function evaluateBudget(aggregate, budget) {
+  const checks = [];
+  const scenarioBudget = budget?.scenarios?.[aggregate?.scenario];
+
+  if (!budget) {
+    return {
+      status: "unknown",
+      budgetVersion: null,
+      checks,
+      notes: ["no budget file for this platform — the run was recorded but not judged"],
+    };
+  }
+  if (!scenarioBudget) {
+    return {
+      status: "unknown",
+      budgetVersion: budget.budgetVersion ?? null,
+      checks,
+      notes: [`budget ${budget.budgetVersion ?? "?"} has no entry for ${aggregate?.scenario}`],
+    };
+  }
+
+  for (const [metric, limits] of Object.entries(scenarioBudget)) {
+    const measured = aggregate?.metrics?.[metric]?.median;
+    if (typeof measured !== "number") {
+      checks.push({
+        metric,
+        status: "skipped",
+        measured: null,
+        limit: limits,
+        reason: "not measured on this platform",
+      });
+      continue;
+    }
+    let status = "pass";
+    let limit = null;
+    if (typeof limits.fail === "number" && measured > limits.fail) {
+      status = "fail";
+      limit = limits.fail;
+    } else if (typeof limits.warn === "number" && measured > limits.warn) {
+      status = "warn";
+      limit = limits.warn;
+    }
+    checks.push({ metric, status, measured, limit, budget: limits });
+  }
+
+  const status = applyMode(
+    worstOf(checks.filter((c) => c.status !== "skipped").map((c) => c.status)),
+    budget.mode,
+  );
+  return { status, budgetVersion: budget.budgetVersion ?? null, checks, notes: [] };
+}
+
+/**
+ * Compare a candidate against an approved baseline for the same scenario.
+ *
+ * Both thresholds must be crossed for a `fail`; crossing only the relative one
+ * is a `warn`, because that is exactly the shape of both real early drift and of
+ * ordinary noise, and the reader — not the gate — should decide which it is.
+ */
+export function evaluateRegression(baseline, candidate, policy = DEFAULT_REGRESSION_POLICY, mode) {
+  const checks = [];
+  if (!baseline) {
+    return {
+      status: "unknown",
+      checks,
+      notes: ["no approved baseline for this scenario/platform — nothing to compare against"],
+    };
+  }
+  if (baseline.scenario !== candidate.scenario) {
+    return {
+      status: "unknown",
+      checks,
+      notes: [
+        `baseline is ${baseline.scenario} but the candidate is ${candidate.scenario} — refusing to compare`,
+      ],
+    };
+  }
+  if (baseline.platform?.os !== candidate.platform?.os) {
+    return {
+      status: "unknown",
+      checks,
+      notes: [
+        `baseline ran on ${baseline.platform?.os} and the candidate on ${candidate.platform?.os} — refusing to compare`,
+      ],
+    };
+  }
+
+  const metrics = policy.metrics ?? DEFAULT_REGRESSION_METRICS;
+  for (const metric of metrics) {
+    const before = baseline.metrics?.[metric]?.median;
+    const after = candidate.metrics?.[metric]?.median;
+    if (typeof before !== "number" || typeof after !== "number") {
+      checks.push({ metric, status: "skipped", before: before ?? null, after: after ?? null });
+      continue;
+    }
+    const absolute = after - before;
+    const relative = relativeDelta(before, after);
+    const absLimit = policy.absolute?.[unitOf(metric)] ?? Infinity;
+    const relOver = relative !== null && relative > policy.relative;
+    const absOver = absolute > absLimit;
+    const status = relOver && absOver ? "fail" : relOver || absOver ? "warn" : "pass";
+    checks.push({
+      metric,
+      status,
+      before,
+      after,
+      absolute: round(absolute),
+      relative: round(relative, 4),
+      relativeLimit: policy.relative,
+      absoluteLimit: Number.isFinite(absLimit) ? absLimit : null,
+    });
+  }
+
+  const status = applyMode(
+    worstOf(checks.filter((c) => c.status !== "skipped").map((c) => c.status)),
+    mode,
+  );
+  return { status, checks, notes: [] };
+}
+
+/** In `warn` mode a `fail` is downgraded — the gate reports, it doesn't block. */
+function applyMode(status, mode) {
+  if (mode === "warn" && status === "fail") return "warn";
+  return status;
+}
+
+/** Combine an absolute-budget verdict and a regression verdict. */
+export function combineVerdicts(...verdicts) {
+  return {
+    status: worstOf(verdicts.map((v) => v?.status ?? "unknown")),
+    checks: verdicts.flatMap((v) => v?.checks ?? []),
+    notes: verdicts.flatMap((v) => v?.notes ?? []),
+  };
+}

--- a/uxnandesktop/scripts/resources/lib/budgets.test.mjs
+++ b/uxnandesktop/scripts/resources/lib/budgets.test.mjs
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  combineVerdicts,
+  DEFAULT_REGRESSION_POLICY,
+  evaluateBudget,
+  evaluateRegression,
+  unitOf,
+} from "./budgets.mjs";
+
+function agg(metrics, overrides = {}) {
+  return {
+    scenario: "R01",
+    platform: { os: "windows" },
+    metrics: Object.fromEntries(
+      Object.entries(metrics).map(([k, v]) => [k, { median: v, min: v, max: v, n: 5 }]),
+    ),
+    ...overrides,
+  };
+}
+
+const BUDGET = {
+  budgetVersion: 1,
+  os: "windows",
+  mode: "enforce",
+  scenarios: { R01: { ownRssP50Mb: { warn: 250, fail: 300 }, cpuP95: { warn: 3, fail: 6 } } },
+};
+
+describe("unitOf", () => {
+  it("reads the unit out of the metric name", () => {
+    expect(unitOf("ownRssP50Mb")).toBe("mb");
+    expect(unitOf("cpuP95")).toBe("cpuPct");
+    expect(unitOf("launchToWindowMs")).toBe("ms");
+    expect(unitOf("handlesP95")).toBe("count");
+  });
+});
+
+describe("evaluateBudget", () => {
+  it("passes under the warn line", () => {
+    const v = evaluateBudget(agg({ ownRssP50Mb: 200, cpuP95: 1 }), BUDGET);
+    expect(v.status).toBe("pass");
+    expect(v.budgetVersion).toBe(1);
+  });
+
+  it("warns between the lines and fails above the fail line", () => {
+    expect(evaluateBudget(agg({ ownRssP50Mb: 270 }), BUDGET).status).toBe("warn");
+    expect(evaluateBudget(agg({ ownRssP50Mb: 340 }), BUDGET).status).toBe("fail");
+  });
+
+  it("downgrades a failure to a warning while the budget is in warn mode", () => {
+    const warnMode = { ...BUDGET, mode: "warn" };
+    expect(evaluateBudget(agg({ ownRssP50Mb: 340 }), warnMode).status).toBe("warn");
+  });
+
+  it("marks an unmeasured metric skipped rather than passed", () => {
+    const v = evaluateBudget(agg({ ownRssP50Mb: 200 }), BUDGET);
+    const cpu = v.checks.find((c) => c.metric === "cpuP95");
+    expect(cpu.status).toBe("skipped");
+    expect(v.status).toBe("pass"); // a skip does not turn the scenario red…
+    expect(cpu.reason).toMatch(/not measured/);
+  });
+
+  it("is unknown when there is no budget at all", () => {
+    const v = evaluateBudget(agg({ ownRssP50Mb: 200 }), null);
+    expect(v.status).toBe("unknown");
+    expect(v.notes.join(" ")).toMatch(/not judged/);
+  });
+
+  it("is unknown when the budget has no entry for this scenario", () => {
+    const v = evaluateBudget(agg({ ownRssP50Mb: 200 }, { scenario: "R07" }), BUDGET);
+    expect(v.status).toBe("unknown");
+    expect(v.notes.join(" ")).toMatch(/no entry for R07/);
+  });
+});
+
+describe("evaluateRegression", () => {
+  const base = agg({ ownRssP50Mb: 200, cpuP95: 2, handlesP95: 1200 });
+
+  it("passes when nothing moved", () => {
+    expect(evaluateRegression(base, agg({ ownRssP50Mb: 201, cpuP95: 2 })).status).toBe("pass");
+  });
+
+  it("stays quiet for noise below both thresholds", () => {
+    // +4 % and +8 MB: neither limit crossed.
+    expect(evaluateRegression(base, agg({ ownRssP50Mb: 208 })).status).toBe("pass");
+  });
+
+  it("only warns when the relative jump is big but the absolute one is small", () => {
+    // A 4 MB metric growing 50 % is 2 MB — real, but not worth blocking on.
+    const small = agg({ ownRssP50Mb: 4 });
+    expect(evaluateRegression(small, agg({ ownRssP50Mb: 6 })).status).toBe("warn");
+  });
+
+  it("fails when a change is both relatively and absolutely large", () => {
+    // 200 → 260 MB: +30 % and +60 MB.
+    const v = evaluateRegression(base, agg({ ownRssP50Mb: 260 }));
+    expect(v.status).toBe("fail");
+    const check = v.checks.find((c) => c.metric === "ownRssP50Mb");
+    expect(check.absolute).toBe(60);
+    expect(check.relative).toBeCloseTo(0.3, 4);
+  });
+
+  it("never fails an improvement", () => {
+    expect(evaluateRegression(base, agg({ ownRssP50Mb: 120 })).status).toBe("pass");
+  });
+
+  it("is unknown with no baseline, and says so", () => {
+    const v = evaluateRegression(null, agg({ ownRssP50Mb: 200 }));
+    expect(v.status).toBe("unknown");
+    expect(v.notes.join(" ")).toMatch(/no approved baseline/);
+  });
+
+  it("refuses to compare different scenarios or different platforms", () => {
+    expect(evaluateRegression(base, agg({ ownRssP50Mb: 200 }, { scenario: "R02" })).status).toBe(
+      "unknown",
+    );
+    const otherOs = agg({ ownRssP50Mb: 200 }, { platform: { os: "linux" } });
+    expect(evaluateRegression(base, otherOs).notes.join(" ")).toMatch(/refusing to compare/);
+  });
+
+  it("skips a metric the candidate did not measure", () => {
+    const v = evaluateRegression(base, agg({ ownRssP50Mb: 200 }));
+    expect(v.checks.find((c) => c.metric === "handlesP95").status).toBe("skipped");
+  });
+
+  it("downgrades a failure in warn mode", () => {
+    const v = evaluateRegression(base, agg({ ownRssP50Mb: 260 }), DEFAULT_REGRESSION_POLICY, "warn");
+    expect(v.status).toBe("warn");
+  });
+});
+
+describe("combineVerdicts", () => {
+  it("keeps the worst status and concatenates the evidence", () => {
+    const a = { status: "pass", checks: [{ metric: "x" }], notes: ["a"] };
+    const b = { status: "warn", checks: [{ metric: "y" }], notes: ["b"] };
+    const combined = combineVerdicts(a, b);
+    expect(combined.status).toBe("warn");
+    expect(combined.checks).toHaveLength(2);
+    expect(combined.notes).toEqual(["a", "b"]);
+  });
+});

--- a/uxnandesktop/scripts/resources/lib/markdown.mjs
+++ b/uxnandesktop/scripts/resources/lib/markdown.mjs
@@ -1,0 +1,132 @@
+/**
+ * The human-readable half of a result.
+ *
+ * A JSON document is what CI compares; a Markdown report is what a person reads
+ * before deciding whether a number is believable. It therefore leads with the
+ * conditions (OS, webview, cores, build profile, repetitions) rather than the
+ * headline figure — a memory number without them is not a claim anybody can
+ * defend.
+ */
+
+const STATUS_ICON = { pass: "✅", warn: "⚠️", fail: "❌", unknown: "•", skipped: "–" };
+
+function fmt(value, unit = "") {
+  if (value === null || value === undefined) return "—";
+  if (typeof value !== "number") return String(value);
+  const rounded = Math.abs(value) >= 100 ? Math.round(value) : Math.round(value * 100) / 100;
+  return `${rounded}${unit}`;
+}
+
+function unitFor(metric) {
+  if (/Mb$/i.test(metric)) return " MB";
+  if (/MbPerHour$/i.test(metric)) return " MB/h";
+  if (/Ms$/i.test(metric)) return " ms";
+  if (/^cpu|Cpu/.test(metric)) return " %";
+  return "";
+}
+
+/** The conditions block every report opens with. */
+export function platformTable(platform, configuration) {
+  const rows = [
+    ["OS", `${platform.osName ?? platform.os} ${platform.osVersion ?? ""}`.trim()],
+    ["Architecture", platform.arch],
+    ["Webview", platform.webview ?? "unknown"],
+    ["CPU", `${platform.cpuModel ?? "unknown"} (${platform.cpuCores} logical cores)`],
+    ["Memory", `${platform.totalMemMb} MB`],
+    ["Power plan", platform.powerPlan ?? "—"],
+    ["Build profile", configuration?.buildProfile ?? "unknown"],
+    ["Machine", `\`${platform.hostId}\``],
+  ];
+  return ["| | |", "|---|---|", ...rows.map(([k, v]) => `| ${k} | ${v} |`)].join("\n");
+}
+
+/** One scenario aggregate as a table of metrics. */
+export function scenarioTable(aggregate) {
+  const names = Object.keys(aggregate.metrics ?? {}).sort();
+  if (names.length === 0) return "_no metrics recorded_";
+  const head = ["| Metric | Median | Min | Max | Runs |", "|---|---:|---:|---:|---:|"];
+  const rows = names.map((name) => {
+    const m = aggregate.metrics[name];
+    const u = unitFor(name);
+    return `| \`${name}\` | ${fmt(m.median, u)} | ${fmt(m.min, u)} | ${fmt(m.max, u)} | ${m.n} |`;
+  });
+  return [...head, ...rows].join("\n");
+}
+
+/** The verdict's checks, so a warn or fail says which limit it crossed. */
+export function verdictTable(verdict) {
+  const checks = verdict?.checks ?? [];
+  if (checks.length === 0) return "";
+  const head = ["| | Check | Measured | Limit |", "|---|---|---:|---:|"];
+  const rows = checks.map((c) => {
+    const icon = STATUS_ICON[c.status] ?? "•";
+    if ("before" in c) {
+      const rel = c.relative === null || c.relative === undefined ? "—" : `${fmt(c.relative * 100)} %`;
+      return `| ${icon} | \`${c.metric}\` vs baseline | ${fmt(c.before)} → ${fmt(c.after)} (${rel}) | ${fmt(c.relativeLimit * 100)} % + ${fmt(c.absoluteLimit)} |`;
+    }
+    return `| ${icon} | \`${c.metric}\` | ${fmt(c.measured, unitFor(c.metric))} | ${fmt(c.limit, unitFor(c.metric))} |`;
+  });
+  return [...head, ...rows].join("\n");
+}
+
+/**
+ * Full report for a set of scenario aggregates.
+ *
+ * `scenarios` is the ordered list of `{ aggregate, scenario, verdict }`.
+ */
+export function renderReport({ scenarios, platform, configuration, commit, generatedAt }) {
+  const out = [];
+  out.push("# Resource benchmark report", "");
+  out.push(
+    `Commit \`${commit}\` · generated ${generatedAt} · ${scenarios.length} scenario${scenarios.length === 1 ? "" : "s"}`,
+    "",
+  );
+  out.push("## Conditions", "", platformTable(platform, configuration), "");
+  out.push(
+    "> Buckets are never summed. **own** is the app and its webview helpers, **managed** adds the shells and sidecars uxnan spawned, **external** is what the user ran inside them (an agent CLI, a build) and is reported for context only.",
+    "",
+    "> CPU figures are percent of **one** core. Divide by the core count above for a percent-of-machine reading.",
+    "",
+  );
+
+  out.push("## Summary", "");
+  out.push(
+    "| Scenario | Verdict | own private | own working set | managed private | CPU P95 |",
+    "|---|---|---:|---:|---:|---:|",
+  );
+  for (const s of scenarios) {
+    const m = s.aggregate.metrics ?? {};
+    out.push(
+      `| **${s.aggregate.scenario}** ${s.scenario?.title ?? ""} | ${STATUS_ICON[s.verdict?.status] ?? "•"} ${s.verdict?.status ?? "unknown"} | ${fmt(m.ownPrivateP50Mb?.median, " MB")} | ${fmt(m.ownRssP50Mb?.median, " MB")} | ${fmt(m.managedPrivateP50Mb?.median, " MB")} | ${fmt(m.cpuP95?.median, " %")} |`,
+    );
+  }
+  out.push(
+    "",
+    "> **private** sums private committed bytes (nothing double-counted) — the honest \"what does this cost me\". **working set** sums per-process working sets, which counts the pages the webview processes share once each, so it reads higher; it stays useful as a like-for-like signal between runs.",
+    "",
+  );
+
+  for (const s of scenarios) {
+    const a = s.aggregate;
+    out.push(`## ${a.scenario} — ${s.scenario?.title ?? ""}`, "");
+    if (s.scenario?.question) out.push(`*${s.scenario.question}*`, "");
+    out.push(
+      `Mode: **${s.scenario?.mode ?? "auto"}** · repetitions: **${a.repeats}** · verdict: **${s.verdict?.status ?? "unknown"}**`,
+      "",
+    );
+    out.push(scenarioTable(a), "");
+    const vt = verdictTable(s.verdict);
+    if (vt) out.push("### Checks", "", vt, "");
+    const notes = [...(a.notes ?? []), ...(s.verdict?.notes ?? [])];
+    if (notes.length > 0) {
+      out.push("### Notes", "", ...notes.map((n) => `- ${n}`), "");
+    }
+  }
+
+  out.push("---", "");
+  out.push(
+    "Methodology, scenario definitions and the rules for promoting a baseline: [`docs/resource-benchmarks.md`](../docs/resource-benchmarks.md).",
+    "",
+  );
+  return out.join("\n");
+}

--- a/uxnandesktop/scripts/resources/lib/platform.mjs
+++ b/uxnandesktop/scripts/resources/lib/platform.mjs
@@ -1,0 +1,104 @@
+/**
+ * Which collector to run, and the machine facts a result is meaningless
+ * without.
+ *
+ * A memory figure with no OS, no webview version and no core count is not a
+ * measurement, it is an anecdote — so the platform block is required by the
+ * schema and filled here, once, from the collector's `--info` mode.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { tag } from "./redact.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const COLLECTORS = path.join(HERE, "..", "collectors");
+
+/** `windows` | `macos` | `linux`; anything else is unsupported. */
+export function osKey(platform = process.platform) {
+  if (platform === "win32") return "windows";
+  if (platform === "darwin") return "macos";
+  if (platform === "linux") return "linux";
+  return platform;
+}
+
+/** How to invoke the collector for this OS: `{ command, baseArgs, flag }`. */
+export function collectorCommand(key = osKey()) {
+  if (key === "windows") {
+    return {
+      command: "powershell.exe",
+      baseArgs: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        path.join(COLLECTORS, "windows.ps1"),
+      ],
+      style: "powershell",
+    };
+  }
+  if (key === "macos" || key === "linux") {
+    return {
+      command: "/bin/sh",
+      baseArgs: [path.join(COLLECTORS, "unix.sh")],
+      style: "posix",
+    };
+  }
+  throw new Error(`no resource collector for platform ${key} (supported: windows, macos, linux)`);
+}
+
+/** Collector arguments for a streaming run. */
+export function streamArgs(style, rootPid, intervalMs) {
+  return style === "powershell"
+    ? ["-RootPid", String(rootPid), "-IntervalMs", String(intervalMs)]
+    : ["--root-pid", String(rootPid), "--interval-ms", String(intervalMs)];
+}
+
+/** Collector arguments for a one-shot snapshot of specific PIDs. */
+export function pidsArgs(style, pids) {
+  return style === "powershell"
+    ? ["-Pids", pids.join(","), "-Once"]
+    : ["--pids", pids.join(","), "--once"];
+}
+
+/**
+ * Read the static machine facts. Failure is not fatal: a run on a box whose
+ * collector can't answer still records what it does know, with the rest `null`
+ * so nobody mistakes it for a measured zero.
+ */
+export function readPlatform() {
+  const key = osKey();
+  const { command, baseArgs, style } = collectorCommand(key);
+  let info = {};
+  try {
+    const raw = execFileSync(command, [...baseArgs, style === "powershell" ? "-Info" : "--info"], {
+      encoding: "utf8",
+      timeout: 30_000,
+      windowsHide: true,
+    });
+    info = JSON.parse(raw.trim().split(/\r?\n/).pop() ?? "{}");
+  } catch (err) {
+    info = { infoError: String(err?.message ?? err) };
+  }
+
+  return {
+    os: key,
+    arch: process.arch,
+    osName: info.osName ?? null,
+    osVersion: info.osVersion ?? null,
+    webview: info.webview ?? null,
+    cpuModel: info.cpuModel ?? null,
+    cpuCores: Number.isFinite(info.cpuCores) && info.cpuCores > 0 ? info.cpuCores : os.cpus().length,
+    totalMemMb: info.totalMemMb ?? Math.round(os.totalmem() / 1024 / 1024),
+    powerPlan: info.powerPlan ?? null,
+    nodeVersion: process.version,
+    // Lets two runs on the same machine be recognised as such without the
+    // hostname ever appearing in the document.
+    hostId: tag(`${os.hostname()}|${os.userInfo().username}`),
+    infoError: info.infoError ?? null,
+  };
+}

--- a/uxnandesktop/scripts/resources/lib/preflight.mjs
+++ b/uxnandesktop/scripts/resources/lib/preflight.mjs
@@ -1,0 +1,191 @@
+/**
+ * The checks that decide whether a measurement is worth believing.
+ *
+ * Two of these come from a real failure found while building the harness, and
+ * both would otherwise produce a *plausible but wrong* number rather than an
+ * error — the worst possible outcome for a benchmark:
+ *
+ * **1. A shared WebView2 browser process.** On Windows, WebView2 keeps one
+ * browser process per user-data folder and every client using that folder
+ * attaches to it. uxnan's folder is `%LOCALAPPDATA%\<identifier>\EBWebView`, so
+ * when a second uxnan starts, its renderers are spawned by the *first*
+ * instance's browser process — outside the tree we are sampling. The run then
+ * reports the Rust process alone (~27 MB) and silently omits ~90 MB of webview.
+ * A launch that never grows a runtime helper inside its own tree is therefore
+ * treated as an invalid run, not as a very good result.
+ *
+ * **2. A browser process outliving the client.** The same sharing means a
+ * lingering browser process from repetition *n* can be adopted by repetition
+ * *n+1*. So each repetition waits for its own tree to actually be gone before
+ * the next one starts — which doubles as the honest way to count orphans:
+ * a process still alive after a bounded wait really is orphaned, whereas one
+ * sampled a moment after teardown is just being reaped.
+ *
+ * **3. A binary with no frontend in it.** `cargo build --release` on its own does
+ * not enable Tauri's `custom-protocol` feature, so the build stays in *dev* mode:
+ * the window opens, the Rust backend runs, the hook server answers — and the
+ * webview navigates to `http://localhost:1420`, which nothing is serving. The app
+ * shows a browser error page, no terminal is ever restored, and the run reports
+ * the cost of an app that did nothing. Every observable the harness would
+ * normally trust (a window, a backend, webview processes) is present, so the only
+ * honest defence is to check the binary itself for embedded frontend assets.
+ *
+ * Name matching appears here and **only** here. It answers "is another instance
+ * running?", never "is this process ours" — attribution stays structural
+ * (`tree.mjs`).
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+import { collectorCommand } from "./platform.mjs";
+import { sleep, snapshotPids } from "./sampler.mjs";
+
+/** Every process on the machine with this executable name. */
+export function processesNamed(name) {
+  const { command, baseArgs, style } = collectorCommand();
+  const args =
+    style === "powershell" ? ["-Name", name, "-Once"] : ["--name", name, "--once"];
+  try {
+    const raw = execFileSync(command, [...baseArgs, ...args], {
+      encoding: "utf8",
+      timeout: 30_000,
+      windowsHide: true,
+    });
+    const line = raw.trim().split(/\r?\n/).pop() ?? "{}";
+    return JSON.parse(line).rows ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Refuse to start while another copy of the app under test is running.
+ *
+ * Returns `null` when the field is clear, or an actionable message. The caller
+ * decides whether that is fatal; `run.mjs` treats it as fatal, because every
+ * number produced alongside a second instance would be wrong in a way no
+ * reader could detect afterwards.
+ */
+export function checkNoForeignInstance(binary) {
+  const name = path.basename(binary);
+  const running = processesNamed(name);
+  if (running.length === 0) return null;
+  return (
+    `${running.length} other ${name} process(es) are already running (pid ${running.map((r) => r.pid).join(", ")}).\n` +
+    `Close every uxnan window — including a dev build — before measuring: a second instance shares ` +
+    `the WebView2 browser process, so this run's webview would be spawned outside the tree being ` +
+    `sampled and the result would under-report memory by roughly the whole webview.\n` +
+    `If you did not open one, it is probably a benchmark run of your own that was interrupted ` +
+    `before it could close its app; that window is safe to close.`
+  );
+}
+
+/**
+ * SvelteKit writes every built asset under this directory, and Tauri embeds the
+ * asset *keys* as plain strings even though the payloads are compressed — so
+ * their presence in the executable is a reliable "the frontend is in here".
+ */
+const EMBEDDED_ASSET_MARKER = "_app/immutable";
+
+/**
+ * Refuse a binary that was built without its frontend.
+ *
+ * Returns `null` when the assets are there, or an actionable message naming the
+ * build command that produces a measurable binary. Scans in chunks with an
+ * overlap, so a marker straddling a boundary is still found and a 30 MB
+ * executable never lands in memory whole.
+ */
+export function checkBinaryEmbedsFrontend(binary) {
+  const marker = Buffer.from(EMBEDDED_ASSET_MARKER, "utf8");
+  const chunkSize = 1 << 20;
+  const overlap = marker.length - 1;
+  const buf = Buffer.alloc(chunkSize + overlap);
+  let fd;
+  try {
+    fd = fs.openSync(binary, "r");
+  } catch {
+    return `cannot read ${binary}`;
+  }
+  try {
+    let carried = 0;
+    for (;;) {
+      const read = fs.readSync(fd, buf, carried, chunkSize, null);
+      if (read <= 0) break;
+      if (buf.subarray(0, carried + read).includes(marker)) return null;
+      buf.copy(buf, 0, carried + read - overlap, carried + read);
+      carried = overlap;
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+  return (
+    `${path.basename(binary)} contains no embedded frontend, so it would launch in Tauri's dev ` +
+    `mode and try to load http://localhost:1420 — the window opens, the backend runs, and the UI ` +
+    `is a connection-refused page, which is exactly the kind of run that produces a small, ` +
+    `meaningless number. Build it with:\n` +
+    `  cd uxnandesktop && npm run bench:build\n` +
+    `(equivalently: npm run build && cargo build --release --features tauri/custom-protocol)`
+  );
+}
+
+/**
+ * Wait for a set of PIDs to disappear. Returns the ones still alive at the
+ * deadline — the genuine orphans.
+ */
+export async function waitForExit(pids, { timeoutMs = 15_000, pollMs = 500 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  let alive = pids;
+  while (alive.length > 0 && Date.now() < deadline) {
+    await sleep(pollMs);
+    alive = snapshotPids(alive).map((r) => r.pid);
+  }
+  return alive;
+}
+
+/**
+ * Did the app's own webview actually land inside the measured tree?
+ *
+ * `samples` are the folded samples; a healthy Windows/Linux run grows past one
+ * `own` process within seconds of the window appearing. Returns `null` when the
+ * run looks sound, or the reason it does not.
+ */
+export function checkWebviewInTree(samples, { os = process.platform } = {}) {
+  if (samples.length === 0) return "no samples were collected at all";
+  const maxOwnProcs = Math.max(...samples.map((s) => s.own?.procs ?? 0));
+  if (maxOwnProcs > 1) return null;
+  // macOS runs the WebKit content process outside the app's process tree by
+  // design (it is spawned by the system), so one `own` process is expected
+  // there and this check cannot say anything.
+  if (os === "darwin") return null;
+  return (
+    "the webview never appeared inside the measured process tree: the run recorded only the " +
+    "main process. On Windows this means another WebView2 client is sharing uxnan's browser " +
+    "process — close every other uxnan instance and re-run."
+  );
+}
+
+/**
+ * Did the shells the scenario seeded actually come back?
+ *
+ * A scenario that seeds four terminals and measures three is not measuring that
+ * scenario. This also catches the whole class of "the UI never booted" failures
+ * from the outside — a dev-mode binary, a frontend that threw during restore, a
+ * broken restore path — none of which announce themselves in a memory figure.
+ *
+ * `null` when the count was met (or none was expected), else the reason.
+ */
+export function checkExpectedShells(samples, expected) {
+  if (!expected) return null;
+  const seen = Math.max(
+    0,
+    ...samples.map((s) => (s.managed?.procs ?? 0) - (s.own?.procs ?? 0)),
+  );
+  if (seen >= expected) return null;
+  return (
+    `the scenario seeded ${expected} live terminal(s) but at most ${seen} managed process(es) ` +
+    `ever appeared beside the app. Either the session did not restore, or the frontend never ` +
+    `ran — check that the binary embeds its frontend and that the profile seeds a valid layout.`
+  );
+}

--- a/uxnandesktop/scripts/resources/lib/preflight.test.mjs
+++ b/uxnandesktop/scripts/resources/lib/preflight.test.mjs
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { checkBinaryEmbedsFrontend, checkExpectedShells, checkWebviewInTree } from "./preflight.mjs";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "uxnan-preflight-test-"));
+afterAll(() => fs.rmSync(TMP, { recursive: true, force: true }));
+
+function sample(ownProcs, managedProcs = ownProcs) {
+  const bucket = { procs: ownProcs, rssMb: 27, privateMb: 5, threads: 27, handles: 330, cpuPct: 0 };
+  return {
+    t: 0,
+    own: bucket,
+    managed: { ...bucket, procs: managedProcs },
+    external: { ...bucket, procs: 0, rssMb: 0 },
+  };
+}
+
+describe("checkWebviewInTree", () => {
+  it("accepts a run whose webview is inside the tree", () => {
+    expect(checkWebviewInTree([sample(1), sample(7)], { os: "win32" })).toBeNull();
+  });
+
+  it("rejects a run that only ever saw the main process", () => {
+    // The exact failure the harness hit: 27 MB and no webview, because another
+    // instance owned the shared WebView2 browser process.
+    const reason = checkWebviewInTree([sample(1), sample(1)], { os: "win32" });
+    expect(reason).toMatch(/never appeared inside the measured process tree/);
+    expect(reason).toMatch(/close every other uxnan instance/i);
+  });
+
+  it("says so when there are no samples at all", () => {
+    expect(checkWebviewInTree([], { os: "win32" })).toMatch(/no samples/);
+  });
+
+  it("stays quiet on macOS, where the content process is outside the tree by design", () => {
+    expect(checkWebviewInTree([sample(1)], { os: "darwin" })).toBeNull();
+  });
+});
+
+describe("checkExpectedShells", () => {
+  it("accepts a run where the seeded shells came back", () => {
+    expect(checkExpectedShells([sample(7, 7), sample(7, 11)], 4)).toBeNull();
+  });
+
+  it("rejects a run that restored fewer terminals than it seeded", () => {
+    const reason = checkExpectedShells([sample(7, 9)], 4);
+    expect(reason).toMatch(/seeded 4 live terminal\(s\) but at most 2/);
+  });
+
+  it("catches the session not restoring at all", () => {
+    // The exact shape of the dev-mode-binary failure: webview up, no shells.
+    expect(checkExpectedShells([sample(7, 7)], 1)).toMatch(/did not restore/);
+  });
+
+  it("has nothing to say when a scenario seeds no terminals", () => {
+    expect(checkExpectedShells([sample(7, 7)], 0)).toBeNull();
+  });
+});
+
+describe("checkBinaryEmbedsFrontend", () => {
+  const write = (name, contents) => {
+    const file = path.join(TMP, name);
+    fs.writeFileSync(file, contents);
+    return file;
+  };
+
+  it("accepts a binary containing the built asset keys", () => {
+    const blob = Buffer.concat([
+      Buffer.alloc(3_000_000, 0x41),
+      Buffer.from("/_app/immutable/entry/start.abc123.js"),
+      Buffer.alloc(1000, 0x42),
+    ]);
+    expect(checkBinaryEmbedsFrontend(write("good.exe", blob))).toBeNull();
+  });
+
+  it("finds a marker straddling a read-chunk boundary", () => {
+    // 1 MiB chunks: place the marker so it spans the first boundary.
+    const marker = "_app/immutable";
+    const head = Buffer.alloc((1 << 20) - 5, 0x41);
+    const blob = Buffer.concat([head, Buffer.from(marker), Buffer.alloc(100, 0x42)]);
+    expect(checkBinaryEmbedsFrontend(write("split.exe", blob))).toBeNull();
+  });
+
+  it("rejects a dev-mode binary and names the build command", () => {
+    const reason = checkBinaryEmbedsFrontend(write("dev.exe", Buffer.alloc(2_000_000, 0x41)));
+    expect(reason).toMatch(/no embedded frontend/);
+    expect(reason).toMatch(/localhost:1420/);
+    expect(reason).toMatch(/npm run bench:build/);
+  });
+
+  it("reports a binary it cannot read", () => {
+    expect(checkBinaryEmbedsFrontend(path.join(TMP, "missing.exe"))).toMatch(/cannot read/);
+  });
+});

--- a/uxnandesktop/scripts/resources/lib/profile.mjs
+++ b/uxnandesktop/scripts/resources/lib/profile.mjs
@@ -1,0 +1,200 @@
+/**
+ * Disposable app-data profiles: how a scenario becomes reproducible.
+ *
+ * A benchmark that starts from whatever the developer's real profile happens to
+ * contain measures the developer, not the app. So every scenario is handed a
+ * freshly-built `state.json` in a throwaway directory and the app is launched
+ * with `UXNAN_DATA_DIR` pointing at it (see `src-tauri/src/datadir.rs`). Two
+ * consequences, both intended:
+ *
+ * - the same scenario measures the same thing on any machine, and
+ * - the harness never reads or writes the real profile, so nothing it does can
+ *   cost the operator their session.
+ *
+ * The seeded document is the app's own persisted shape (`AppData` in
+ * `src-tauri/src/model.rs`, `SavedTerminalLayout` in `src/lib/types.ts`). Only
+ * the fields those types require are written; everything else is left to the
+ * app's defaults, which is what keeps this file from drifting every time a
+ * setting is added.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Mirrors `SCHEMA_VERSION` in `src-tauri/src/model.rs`. */
+export const STATE_SCHEMA_VERSION = 1;
+
+/** The workspace key the app uses for terminals not bound to a worktree. */
+export const GLOBAL_WORKSPACE = "";
+
+/** A cheap, always-present shell, so the *shell* is not what varies between
+ *  platforms in a terminal scenario. */
+export function defaultShell() {
+  if (process.platform === "win32") {
+    return { shell: process.env.COMSPEC || "C:\\Windows\\System32\\cmd.exe", args: [] };
+  }
+  return { shell: "/bin/sh", args: [] };
+}
+
+/**
+ * A terminal that starts a shell and runs `command` inside it, the way the app
+ * itself launches an agent: the user's terminal profile is the shell, and the
+ * CLI is what runs *in* it.
+ *
+ * That nesting is not cosmetic — it is what makes the cost attributable. The
+ * benchmark calls anything under a shell `external`, so a program launched *as*
+ * the shell would be counted as uxnan's own doing (see `tree.mjs`). Running the
+ * fixture agent the realistic way is therefore also the only way the scenario
+ * can separate the agent's cost from the app's.
+ *
+ * The shell stays alive after the command exits (`/k`, `exec sh`), so the tab
+ * still holds a terminal for the rest of the measurement window.
+ */
+export function shellRunning(argv) {
+  if (process.platform === "win32") {
+    return {
+      shell: process.env.COMSPEC || "C:\\Windows\\System32\\cmd.exe",
+      args: ["/k", ...argv],
+    };
+  }
+  const quoted = argv.map((a) => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
+  return { shell: "/bin/sh", args: ["-c", `${quoted}; exec /bin/sh`] };
+}
+
+/** The five settings the Rust `AppSettings` requires, plus any overrides. */
+export function settings(overrides = {}) {
+  return {
+    theme: "system",
+    leftSidebarWidth: 280,
+    rightSidebarWidth: 350,
+    leftSidebarOpen: true,
+    rightSidebarOpen: true,
+    // Off by default in every scenario that isn't explicitly measuring them, so
+    // "the app at rest" means the app, not the app plus an updater check and a
+    // provider poll over the network.
+    updater: { autoCheck: false, channel: "stable", autoDownload: false, installPolicy: "ask" },
+    usageProviders: [],
+    usageStatusBarEnabled: false,
+    pets: { enabled: false },
+    // Installing hook configs would write into the operator's real `~/.claude`
+    // and friends — outside the scenario's temp dir, which the harness never
+    // does.
+    autoInstallHooks: false,
+    agentNotifications: false,
+    ...overrides,
+  };
+}
+
+/** One terminal tab descriptor (`SavedTab`, kind `terminal`). */
+export function terminalTab({ title = "shell", cwd, asleep = false, shell, args, sid } = {}) {
+  const d = defaultShell();
+  return {
+    kind: "terminal",
+    title,
+    ...(cwd ? { cwd } : {}),
+    shell: shell ?? d.shell,
+    args: args ?? d.args,
+    ...(sid ? { sid } : {}),
+    ...(asleep ? { asleep: true } : {}),
+  };
+}
+
+/** A region holding one or more tabs (only the active one hosts a live PTY). */
+export function group(tabs, activeTab = 0) {
+  return { type: "group", tabs, activeTab };
+}
+
+/** A split of two regions. Every region in the tree hosts its own live PTY,
+ *  which is why "four terminals" is four regions and not four tabs. */
+export function split(dir, a, b, ratio = 0.5) {
+  return { type: "split", dir, ratio, a, b };
+}
+
+/**
+ * Build a balanced tree of `count` single-tab regions — the shape "N terminals"
+ * means in the app: alternating row/column splits, so four regions form a 2×2
+ * grid rather than four thin columns.
+ */
+export function terminalGrid(count, tabFactory, dir = "row") {
+  if (count <= 1) return group([tabFactory(0)]);
+  const half = Math.ceil(count / 2);
+  const next = dir === "row" ? "col" : "row";
+  const left = terminalGrid(half, tabFactory, next);
+  const right = terminalGrid(count - half, (i) => tabFactory(half + i), next);
+  return split(dir, left, right);
+}
+
+/** A project entry (`RepoData`), plus the single worktree the app shows for a
+ *  plain checkout. */
+export function project({ id, name, dir, isGit = true }) {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    id,
+    name,
+    path: dir,
+    isGit,
+    worktrees: [
+      {
+        id: `${id}-main`,
+        repoId: id,
+        name,
+        branch: "main",
+        path: dir,
+        createdByAde: false,
+        createdAt: now,
+        lastActivity: now,
+      },
+    ],
+  };
+}
+
+/**
+ * Write a profile directory and return its path.
+ *
+ * `dir` must already be inside the run's temp root — this function creates it
+ * but never removes anything, so a mistyped path can't delete a real profile.
+ */
+export function writeProfile(dir, { repos = [], settingsOverrides = {}, layout = null } = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+  const state = {
+    version: STATE_SCHEMA_VERSION,
+    repos,
+    settings: settings(settingsOverrides),
+    agentCache: [],
+    terminalLayout: layout,
+    quickCommands: [],
+    orchestrationRuns: null,
+  };
+  fs.writeFileSync(path.join(dir, "state.json"), JSON.stringify(state, null, 2), "utf8");
+  return dir;
+}
+
+/** A layout document: which workspace is active, and each workspace's tree. */
+export function layout(active, workspaces) {
+  return { active, workspaces };
+}
+
+/**
+ * How many live shells a layout should produce at boot.
+ *
+ * Only the **active** workspace mounts at boot, and within a region only the
+ * **active tab** hosts a PTY — so this is one per region whose active tab is an
+ * awake terminal. The harness asserts against this number, which is what turns
+ * "the session silently failed to restore" from an unexplained small memory
+ * figure into a failed run.
+ */
+export function liveTerminalCount(doc) {
+  const tree = doc?.workspaces?.[doc.active];
+  if (!tree) return 0;
+  const walk = (node) => {
+    if (!node) return 0;
+    if (node.type === "group") {
+      const tab = node.tabs?.[node.activeTab ?? 0];
+      if (!tab) return 0;
+      const isTerminal = tab.kind === undefined || tab.kind === "terminal";
+      return isTerminal && !tab.asleep ? 1 : 0;
+    }
+    return walk(node.a) + walk(node.b);
+  };
+  return walk(tree);
+}

--- a/uxnandesktop/scripts/resources/lib/redact.mjs
+++ b/uxnandesktop/scripts/resources/lib/redact.mjs
@@ -1,0 +1,141 @@
+/**
+ * What may leave the machine.
+ *
+ * A benchmark result is meant to be attached to a PR and eventually published,
+ * so it must not carry anything about the person who ran it. The collectors
+ * already refuse to read command lines or environments; this module is the
+ * second gate, applied to the whole document right before it is written, and the
+ * thing the "no personal data" test asserts against.
+ *
+ * Removed: absolute paths (replaced by a stable, non-reversible tag), the user
+ * name, the host name. Kept: executable basenames, counts, timings, sizes — the
+ * measurement itself.
+ */
+
+import os from "node:os";
+import crypto from "node:crypto";
+
+/** Short, stable, non-reversible tag for a string (so two runs on the same box
+ *  compare, without the string itself being recoverable). */
+export function tag(value, salt = "uxnan-resource-benchmark") {
+  return crypto
+    .createHash("sha256")
+    .update(`${salt}:${value}`)
+    .digest("hex")
+    .slice(0, 12);
+}
+
+/** The identifiers we scrub, longest first so a home directory is replaced
+ *  before the user name inside it. */
+function secrets() {
+  const home = os.homedir();
+  const user = os.userInfo().username;
+  const host = os.hostname();
+  const tmp = os.tmpdir();
+  return [
+    { value: tmp, replacement: "<tmp>" },
+    { value: home, replacement: "<home>" },
+    { value: user, replacement: "<user>" },
+    { value: host, replacement: "<host>" },
+  ]
+    .filter((s) => typeof s.value === "string" && s.value.length >= 3)
+    .sort((a, b) => b.value.length - a.value.length);
+}
+
+/**
+ * Scrub one string: known identifiers first, then any surviving path.
+ *
+ * Substituting the home directory is not enough on its own — what follows it is
+ * the folder names, and those are exactly the client and project names that must
+ * not be published. So a path *under* a substituted root collapses too, keeping
+ * only the root as context: `C:\Users\me\work\acme` becomes
+ * `<home>/<path:1a2b3c4d5e6f>`. A bare absolute path (`D:\build\out`, `/srv/x`)
+ * collapses whole.
+ *
+ * The tag is keyed by the path itself, so the same folder stays recognisable
+ * across samples and runs without ever being readable.
+ */
+export function redactString(input, subs = secrets()) {
+  if (typeof input !== "string") return input;
+  let out = input;
+  for (const { value, replacement } of subs) {
+    if (!value) continue;
+    out = splitReplace(out, value, replacement);
+    // Windows paths arrive with either separator depending on who wrote them.
+    if (value.includes("\\")) out = splitReplace(out, value.replace(/\\/g, "/"), replacement);
+  }
+  // Segments hanging off a substituted root. `[^\s"'<>|]` excludes `<`, so an
+  // already-replaced `<path:…>` can never be matched a second time.
+  out = out.replace(
+    /(<home>|<tmp>)((?:[\\/][^\s"'<>|]+)+)/g,
+    (_, root, rest) => `${root}/<path:${tag(rest)}>`,
+  );
+  out = out.replace(/(?:[A-Za-z]:[\\/]|\\\\|\/)[^\s"'<>|]{2,}/g, (m) => `<path:${tag(m)}>`);
+  return out;
+}
+
+/** Case-insensitive literal replace (paths on Windows differ only in case). */
+function splitReplace(haystack, needle, replacement) {
+  if (!needle) return haystack;
+  const lowerHay = haystack.toLowerCase();
+  const lowerNeedle = needle.toLowerCase();
+  let out = "";
+  let i = 0;
+  for (;;) {
+    const at = lowerHay.indexOf(lowerNeedle, i);
+    if (at === -1) {
+      out += haystack.slice(i);
+      return out;
+    }
+    out += haystack.slice(i, at) + replacement;
+    i = at + needle.length;
+  }
+}
+
+/**
+ * Deep-scrub a result document. Objects and arrays are rebuilt; strings go
+ * through [`redactString`]; numbers, booleans and `null` pass through.
+ *
+ * Keys are scrubbed too, because a map keyed by workspace path would otherwise
+ * leak the path it was keyed by.
+ */
+export function redact(value, subs = secrets()) {
+  if (typeof value === "string") return redactString(value, subs);
+  if (Array.isArray(value)) return value.map((v) => redact(v, subs));
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) out[redactString(k, subs)] = redact(v, subs);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Assert a document is clean — used by the harness before writing and by the
+ * tests. Returns the offending strings (empty array = clean) rather than
+ * throwing, so a caller can report all of them at once.
+ */
+export function findLeaks(value, subs = secrets()) {
+  const found = [];
+  const needles = subs.map((s) => s.value.toLowerCase()).filter(Boolean);
+  const walk = (v) => {
+    if (typeof v === "string") {
+      const lower = v.toLowerCase();
+      for (const n of needles) if (lower.includes(n)) found.push(v);
+      if (/(?:[A-Za-z]:[\\/])/.test(v)) found.push(v);
+      return;
+    }
+    if (Array.isArray(v)) {
+      v.forEach(walk);
+      return;
+    }
+    if (v && typeof v === "object") {
+      for (const [k, sub] of Object.entries(v)) {
+        walk(k);
+        walk(sub);
+      }
+    }
+  };
+  walk(value);
+  return [...new Set(found)];
+}

--- a/uxnandesktop/scripts/resources/lib/redact.test.mjs
+++ b/uxnandesktop/scripts/resources/lib/redact.test.mjs
@@ -1,0 +1,104 @@
+import os from "node:os";
+import { describe, expect, it } from "vitest";
+
+import { findLeaks, redact, redactString, tag } from "./redact.mjs";
+
+const SUBS = [
+  { value: "C:\\Users\\someone", replacement: "<home>" },
+  { value: "someone", replacement: "<user>" },
+  { value: "DESKTOP-ABC123", replacement: "<host>" },
+];
+
+describe("redactString", () => {
+  it("replaces the home directory before the user name inside it", () => {
+    expect(redactString("C:\\Users\\someone\\Documents\\repo", SUBS)).toMatch(
+      /^<home>\/<path:[0-9a-f]{12}>$/,
+    );
+  });
+
+  it("hides the folder names under the home directory, not just the home itself", () => {
+    // These are the client and project names; substituting only `<home>` would
+    // publish them.
+    const a = redactString("C:\\Users\\someone\\work\\acme", SUBS);
+    const b = redactString("C:\\Users\\someone\\work\\other-client", SUBS);
+    expect(a).not.toContain("acme");
+    expect(b).not.toContain("other-client");
+    expect(a).not.toBe(b);
+  });
+
+  it("is case-insensitive, as Windows paths are", () => {
+    expect(redactString("c:\\users\\SOMEONE\\x", SUBS)).toMatch(/^<home>\/<path:[0-9a-f]{12}>$/);
+  });
+
+  it("leaves a bare substituted root as the root", () => {
+    expect(redactString("C:\\Users\\someone", SUBS)).toBe("<home>");
+  });
+
+  it("collapses any surviving absolute path to a stable tag", () => {
+    const out = redactString("D:\\work\\secret-client\\src", SUBS);
+    expect(out).toMatch(/^<path:[0-9a-f]{12}>$/);
+    // Stable across calls, so two samples of the same folder still line up.
+    expect(out).toBe(redactString("D:\\work\\secret-client\\src", SUBS));
+  });
+
+  it("leaves an executable basename alone — that is the measurement", () => {
+    expect(redactString("msedgewebview2.exe", SUBS)).toBe("msedgewebview2.exe");
+  });
+
+  it("passes non-strings through", () => {
+    expect(redactString(42, SUBS)).toBe(42);
+  });
+});
+
+describe("redact", () => {
+  it("walks objects, arrays and keys", () => {
+    const doc = {
+      notes: ["ran in C:\\Users\\someone\\proj"],
+      workspaces: { "C:\\Users\\someone\\proj": { rssMb: 12 } },
+      nested: [{ host: "DESKTOP-ABC123" }],
+    };
+    const clean = redact(doc, SUBS);
+    const key = Object.keys(clean.workspaces)[0];
+    expect(clean.notes[0]).toMatch(/^ran in <home>\/<path:[0-9a-f]{12}>$/);
+    expect(key).toMatch(/^<home>\/<path:[0-9a-f]{12}>$/);
+    expect(clean.nested[0].host).toBe("<host>");
+    // The value survives the key being rewritten.
+    expect(clean.workspaces[key].rssMb).toBe(12);
+  });
+
+  it("leaves numbers, booleans and null untouched", () => {
+    expect(redact({ a: 1, b: true, c: null }, SUBS)).toEqual({ a: 1, b: true, c: null });
+  });
+});
+
+describe("findLeaks", () => {
+  it("finds an identifier that survived", () => {
+    expect(findLeaks({ note: "hello someone" }, SUBS)).toContain("hello someone");
+  });
+
+  it("finds a raw drive-letter path even when no identifier matches", () => {
+    expect(findLeaks({ note: "E:\\build\\out" }, SUBS)).toContain("E:\\build\\out");
+  });
+
+  it("reports nothing for a scrubbed document", () => {
+    const doc = redact({ note: "C:\\Users\\someone\\x", host: "DESKTOP-ABC123" }, SUBS);
+    expect(findLeaks(doc, SUBS)).toEqual([]);
+  });
+
+  it("catches this machine's own identifiers with the real substitution list", () => {
+    // The guard that actually runs before a result file is written.
+    const doc = { note: `ran as ${os.userInfo().username} on ${os.hostname()}` };
+    expect(findLeaks(doc).length).toBeGreaterThan(0);
+    expect(findLeaks(redact(doc))).toEqual([]);
+  });
+});
+
+describe("tag", () => {
+  it("is stable, short and not reversible by inspection", () => {
+    const a = tag("DESKTOP-ABC123");
+    expect(a).toHaveLength(12);
+    expect(a).toBe(tag("DESKTOP-ABC123"));
+    expect(a).not.toBe(tag("DESKTOP-ABC124"));
+    expect(a).not.toContain("DESKTOP");
+  });
+});

--- a/uxnandesktop/scripts/resources/lib/sampler.mjs
+++ b/uxnandesktop/scripts/resources/lib/sampler.mjs
@@ -1,0 +1,149 @@
+/**
+ * The sampling loop: run a collector, turn its lines into schema samples.
+ *
+ * Everything here is I/O plumbing around the pure functions in `tree.mjs` and
+ * `stats.mjs` — parse a line, fold it into buckets, keep the previous CPU
+ * reading so the next fold can produce a rate. A dropped or malformed line is
+ * counted and skipped rather than fatal: losing one sample of a five-minute run
+ * is noise, aborting the run over it is not.
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import readline from "node:readline";
+
+import { aggregate } from "./tree.mjs";
+import { collectorCommand, pidsArgs, streamArgs } from "./platform.mjs";
+
+export class Sampler {
+  /**
+   * @param {number} rootPid PID of the app process the harness spawned.
+   * @param {object} opts `intervalMs` (default 1000), `onSample(sample)`.
+   */
+  constructor(rootPid, { intervalMs = 1000, onSample = null } = {}) {
+    this.rootPid = rootPid;
+    this.intervalMs = intervalMs;
+    this.onSample = onSample;
+    /** @type {object[]} schema samples, oldest first. */
+    this.samples = [];
+    /** Raw rows of the most recent snapshot — the orphan check's "before". */
+    this.lastRows = [];
+    this.droppedLines = 0;
+    this.startedAtMs = null;
+    this.child = null;
+    this.prevCpuMs = null;
+    this.prevT = null;
+  }
+
+  /** Spawn the collector and start folding its output. */
+  start() {
+    const { command, baseArgs, style } = collectorCommand();
+    this.child = spawn(command, [...baseArgs, ...streamArgs(style, this.rootPid, this.intervalMs)], {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    this.stderr = "";
+    this.child.stderr.on("data", (d) => {
+      this.stderr += String(d);
+    });
+    const rl = readline.createInterface({ input: this.child.stdout, crlfDelay: Infinity });
+    rl.on("line", (line) => this.#ingest(line));
+    return this;
+  }
+
+  #ingest(line) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) return;
+    let parsed;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      this.droppedLines += 1;
+      return;
+    }
+    if (!Number.isFinite(parsed.t) || !Array.isArray(parsed.rows)) {
+      this.droppedLines += 1;
+      return;
+    }
+    if (this.startedAtMs === null) this.startedAtMs = parsed.t;
+
+    const elapsedMs = this.prevT === null ? null : parsed.t - this.prevT;
+    const folded = aggregate(parsed.rows, this.rootPid, {
+      prevCpuMs: this.prevCpuMs,
+      elapsedMs,
+    });
+    const sample = {
+      t: parsed.t - this.startedAtMs,
+      own: strip(folded.own),
+      managed: strip(folded.managed),
+      external: strip(folded.external),
+    };
+    this.samples.push(sample);
+    this.lastRows = parsed.rows;
+    this.prevCpuMs = folded.cpuMsByPid;
+    this.prevT = parsed.t;
+    this.onSample?.(sample, parsed.rows);
+  }
+
+  /** Stop the collector. Safe to call twice. */
+  stop() {
+    if (!this.child) return;
+    try {
+      this.child.kill();
+    } catch {
+      /* already gone */
+    }
+    this.child = null;
+  }
+
+  /** Wait until at least `n` samples have been folded, or `timeoutMs` elapses.
+   *  Resolves `true` when the count was reached. */
+  async waitForSamples(n, timeoutMs = 60_000) {
+    const deadline = Date.now() + timeoutMs;
+    while (this.samples.length < n) {
+      if (Date.now() > deadline) return false;
+      await sleep(50);
+    }
+    return true;
+  }
+}
+
+/** Drop the fields that only exist to feed the next fold. */
+function strip(bucket) {
+  return {
+    procs: bucket.procs,
+    rssMb: round2(bucket.rssMb),
+    privateMb: round2(bucket.privateMb),
+    threads: bucket.threads,
+    handles: bucket.handles,
+    cpuPct: round2(bucket.cpuPct),
+  };
+}
+
+function round2(v) {
+  return typeof v === "number" && Number.isFinite(v) ? Math.round(v * 100) / 100 : null;
+}
+
+/**
+ * One-shot snapshot of specific PIDs — used after the app is gone, when there is
+ * no tree left to walk and the only question is which of the processes we were
+ * responsible for are still running.
+ */
+export function snapshotPids(pids) {
+  if (pids.length === 0) return [];
+  const { command, baseArgs, style } = collectorCommand();
+  try {
+    const raw = execFileSync(command, [...baseArgs, ...pidsArgs(style, pids)], {
+      encoding: "utf8",
+      timeout: 30_000,
+      windowsHide: true,
+    });
+    const line = raw.trim().split(/\r?\n/).pop() ?? "{}";
+    return JSON.parse(line).rows ?? [];
+  } catch {
+    return [];
+  }
+}
+
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/uxnandesktop/scripts/resources/lib/scenarios.mjs
+++ b/uxnandesktop/scripts/resources/lib/scenarios.mjs
@@ -1,0 +1,297 @@
+/**
+ * The canonical scenarios — the questions the baseline exists to answer.
+ *
+ * A scenario is a *question*, a deterministic preparation, and a window in which
+ * to measure. Adding a capability to uxnan that spawns a process, a watcher, a
+ * poll or a webview means adding or extending a scenario here; that is what
+ * keeps the baseline a living artifact rather than a snapshot from the week it
+ * was written.
+ *
+ * Each scenario declares a `mode`:
+ *
+ * - **auto** — the harness prepares a profile and the app restores itself into
+ *   the state under test. Fully reproducible, runs unattended.
+ * - **assisted** — the state cannot be reached without a person driving the UI
+ *   (or an account the benchmark must never hold). The harness still measures,
+ *   still records, and the report labels the result as operator-driven. These
+ *   become `auto` when the E2E driver lands; the metric names will not change.
+ *
+ * `stabilizeS` is the window discarded before resting statistics start. It is
+ * not padding: a just-launched app is still paging in a webview, and folding
+ * that into a "cost at rest" figure publishes a number no user ever sees.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  GLOBAL_WORKSPACE,
+  group,
+  layout,
+  project,
+  shellRunning,
+  split,
+  terminalGrid,
+  terminalTab,
+} from "./profile.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const FIXTURES = path.join(HERE, "..", "fixtures");
+
+/** Terminals used by the multi-terminal scenarios, all in the same cwd. */
+function shellsIn(cwd, count) {
+  return terminalGrid(count, (i) => terminalTab({ title: `shell ${i + 1}`, cwd, sid: `bench-${i}` }));
+}
+
+export const SCENARIOS = [
+  {
+    id: "R00",
+    title: "Cold process",
+    mode: "auto",
+    question: "How long does launch take, and what does the app cost before anything is opened?",
+    defaults: { durationS: 45, stabilizeS: 15 },
+    prepare: () => ({
+      repos: [],
+      layout: null,
+      notes: ["empty profile: no projects, no terminals, no optional features"],
+    }),
+  },
+
+  {
+    id: "R01",
+    title: "Idle, default configuration",
+    mode: "auto",
+    question: "What does the app cost at rest with one small project open?",
+    defaults: { durationS: 300, stabilizeS: 60 },
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    prepare: ({ fixtures }) => ({
+      repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: group([]) }),
+      notes: [`fixture repo at commit ${fixtures.repo.head} (${fixtures.repo.files} files)`],
+    }),
+  },
+
+  {
+    id: "R02",
+    title: "One terminal",
+    mode: "auto",
+    question: "What does a single live shell add?",
+    defaults: { durationS: 120, stabilizeS: 30 },
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    baseline: "R01",
+    prepare: ({ fixtures }) => ({
+      repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: shellsIn(fixtures.repo.dir, 1) }),
+      notes: ["one region, one shell"],
+    }),
+  },
+
+  {
+    id: "R03",
+    title: "Four terminals in splits",
+    mode: "auto",
+    question: "What does each additional terminal cost?",
+    defaults: { durationS: 120, stabilizeS: 30 },
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    baseline: "R02",
+    prepare: ({ fixtures }) => ({
+      repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: shellsIn(fixtures.repo.dir, 4) }),
+      notes: ["2×2 split: four regions, four live shells"],
+    }),
+  },
+
+  {
+    id: "R04",
+    title: "Sleeping workspace",
+    mode: "auto",
+    question: "How much does a slept workspace actually give back?",
+    defaults: { durationS: 120, stabilizeS: 30 },
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    baseline: "R03",
+    prepare: ({ fixtures }) => {
+      const asleep = terminalGrid(4, (i) =>
+        terminalTab({
+          title: `shell ${i + 1}`,
+          cwd: fixtures.repo.dir,
+          sid: `bench-${i}`,
+          asleep: true,
+        }),
+      );
+      return {
+        repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+        layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: asleep }),
+        notes: [
+          "the same four regions as R03, restored asleep — compare against R03 for what sleep gives back",
+          "waking is a UI action: wake latency and fidelity are measured in the assisted checklist",
+        ],
+      };
+    },
+    checklist: [
+      "Activate each sleeping tab and confirm its scrollback is replayed intact.",
+      "Note the delay between the click and an interactive prompt.",
+    ],
+  },
+
+  {
+    id: "R05",
+    title: "Agent working",
+    mode: "auto",
+    question: "What does the app cost while an agent streams output, and what is the agent's own cost?",
+    defaults: { durationS: 120, stabilizeS: 20 },
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    baseline: "R02",
+    prepare: ({ fixtures }) => {
+      // Launched *inside* a shell, exactly as the app launches a real agent —
+      // which is also what puts its cost in the `external` bucket instead of
+      // uxnan's (see `shellRunning`).
+      const tab = terminalTab({
+        title: "fixture agent",
+        cwd: fixtures.repo.dir,
+        sid: "bench-agent",
+        ...shellRunning(["node", path.join(FIXTURES, "agent-fixture.mjs"), "--rate", "20", "--hooks"]),
+      });
+      return {
+        repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+        layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: group([tab]) }),
+        notes: [
+          "the fixture agent is offline and deterministic; it runs inside a shell, so its cost lands in the `external` bucket and is never folded into uxnan's",
+        ],
+      };
+    },
+  },
+
+  {
+    id: "R06",
+    title: "Large git repository",
+    mode: "auto",
+    question: "What do the git watcher and the status sweeps cost on a big, dirty checkout?",
+    defaults: { durationS: 180, stabilizeS: 30 },
+    fixtures: { repo: { name: "large", files: 10_000, dirs: 200, dirty: 250 } },
+    prepare: ({ fixtures }) => ({
+      repos: [project({ id: "bench-large", name: "large", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: shellsIn(fixtures.repo.dir, 1) }),
+      notes: [
+        `fixture repo at commit ${fixtures.repo.head} (${fixtures.repo.files} files, 250 modified)`,
+        "covers the 3 s active-worktree watcher and the 15 s all-worktree sweep",
+      ],
+    }),
+  },
+
+  {
+    id: "R07",
+    title: "Integrated browser",
+    mode: "assisted",
+    question: "Does the browser cost anything while closed, and what does opening it add?",
+    defaults: { durationS: 180, stabilizeS: 30 },
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 }, http: { weight: "light" } },
+    prepare: ({ fixtures }) => ({
+      repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: shellsIn(fixtures.repo.dir, 1) }),
+      notes: [
+        "the automatic half asserts the closed browser owns no process; opening it is the operator's part",
+      ],
+    }),
+    checklist: [
+      "Leave the browser closed for the first minute — the run asserts no browser webview exists.",
+      "Open the browser panel and navigate to the fixture URL printed above.",
+      "Leave it on that page for a minute, then close the panel.",
+      "Confirm the browser's webview process disappears when the panel closes.",
+    ],
+  },
+
+  {
+    id: "R08",
+    title: "GitHub panel",
+    mode: "assisted",
+    question: "What do the GitHub polls, cache and open panel cost?",
+    defaults: { durationS: 240, stabilizeS: 30 },
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    prepare: ({ fixtures }) => ({
+      repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: shellsIn(fixtures.repo.dir, 1) }),
+      notes: [
+        "requires a real `gh` login, which is why this scenario is never automated and never runs in CI",
+      ],
+    }),
+    checklist: [
+      "Point the project at a repository your `gh` login can read.",
+      "Leave the GitHub panel closed for the first minute.",
+      "Open Pull Requests, then Actions, then Issues, pausing on each.",
+      "Close the panel and let the run settle before it ends.",
+    ],
+  },
+
+  {
+    id: "R09",
+    title: "Pet companion",
+    mode: "auto",
+    question: "Does the pet cost anything when off, and what do the layer and overlay modes cost?",
+    defaults: { durationS: 120, stabilizeS: 30 },
+    variants: ["off", "layer", "overlay"],
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    baseline: "R02",
+    prepare: ({ fixtures, variant = "off" }) => ({
+      repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: shellsIn(fixtures.repo.dir, 1) }),
+      settingsOverrides: {
+        pets: {
+          enabled: variant !== "off",
+          overlay: variant === "overlay",
+        },
+      },
+      notes: [`pet variant: ${variant}`, "compare the three variants: 'off' must cost nothing at all"],
+    }),
+  },
+
+  {
+    id: "R10",
+    title: "Soak",
+    mode: "auto",
+    question: "Does anything grow over two hours — memory, handles, processes?",
+    defaults: { durationS: 7200, stabilizeS: 300, intervalMs: 5000 },
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    prepare: ({ fixtures }) => ({
+      repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: shellsIn(fixtures.repo.dir, 2) }),
+      notes: [
+        "the slope metrics are the point of this scenario; a single-hour run is not a substitute",
+      ],
+    }),
+  },
+
+  {
+    id: "R11",
+    title: "Restart and restore",
+    mode: "auto",
+    question: "How long does restoring a saved session take, and does it come back whole?",
+    defaults: { durationS: 120, stabilizeS: 30 },
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    baseline: "R03",
+    // Two launches against the same profile: the first writes the session, the
+    // second is the one measured — a restore is only a restore if something was
+    // there to restore.
+    warmup: true,
+    prepare: ({ fixtures }) => ({
+      repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: shellsIn(fixtures.repo.dir, 4) }),
+      notes: ["measured launch is the second one, against a profile the first launch already used"],
+    }),
+  },
+];
+
+export function getScenario(id) {
+  const found = SCENARIOS.find((s) => s.id === id.toUpperCase());
+  if (!found) {
+    throw new Error(`unknown scenario ${id}; known: ${SCENARIOS.map((s) => s.id).join(", ")}`);
+  }
+  return found;
+}
+
+/** Scenario ids that run unattended — what CI and `--all` use. */
+export function autoScenarioIds() {
+  return SCENARIOS.filter((s) => s.mode === "auto").map((s) => s.id);
+}
+
+/** Re-exported so `run.mjs` can build ad-hoc layouts without a second import. */
+export { GLOBAL_WORKSPACE, group, layout, split, terminalTab };

--- a/uxnandesktop/scripts/resources/lib/scenarios.test.mjs
+++ b/uxnandesktop/scripts/resources/lib/scenarios.test.mjs
@@ -1,0 +1,202 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { autoScenarioIds, getScenario, SCENARIOS } from "./scenarios.mjs";
+import { isShell } from "./tree.mjs";
+import {
+  liveTerminalCount,
+  STATE_SCHEMA_VERSION,
+  terminalGrid,
+  terminalTab,
+  writeProfile,
+} from "./profile.mjs";
+import { SCENARIO_IDS } from "./schema.mjs";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "uxnan-bench-test-"));
+afterAll(() => fs.rmSync(TMP, { recursive: true, force: true }));
+
+/** Count the regions in a layout tree — one live PTY each. */
+function countRegions(node) {
+  if (!node) return 0;
+  return node.type === "group" ? 1 : countRegions(node.a) + countRegions(node.b);
+}
+
+const FIXTURES = {
+  repo: { dir: path.join(TMP, "repo"), head: "0".repeat(40), files: 200 },
+  http: { url: "http://127.0.0.1:1234/" },
+};
+
+describe("the scenario table", () => {
+  it("covers exactly the scenario ids the schema accepts", () => {
+    expect(SCENARIOS.map((s) => s.id)).toEqual(SCENARIO_IDS);
+  });
+
+  it("gives every scenario a question, a mode and a measurement window", () => {
+    for (const s of SCENARIOS) {
+      expect(s.question, `${s.id} has no question`).toBeTruthy();
+      expect(["auto", "assisted"]).toContain(s.mode);
+      expect(s.defaults.durationS).toBeGreaterThan(0);
+      expect(s.defaults.stabilizeS).toBeGreaterThanOrEqual(0);
+      expect(
+        s.defaults.stabilizeS,
+        `${s.id} discards more than it measures`,
+      ).toBeLessThan(s.defaults.durationS);
+    }
+  });
+
+  it("marks the account-dependent scenario as operator-driven, never automatic", () => {
+    // R08 needs a real `gh` login; CI must never be handed one.
+    expect(getScenario("R08").mode).toBe("assisted");
+    expect(autoScenarioIds()).not.toContain("R08");
+  });
+
+  it("names the scenario each delta is meaningful against", () => {
+    expect(getScenario("R03").baseline).toBe("R02");
+    expect(getScenario("R04").baseline).toBe("R03");
+  });
+
+  it("rejects an unknown id with the list of known ones", () => {
+    expect(() => getScenario("R42")).toThrow(/unknown scenario R42/);
+  });
+});
+
+describe("scenario preparation", () => {
+  it("R00 seeds an empty profile", () => {
+    const prepared = getScenario("R00").prepare({ fixtures: {} });
+    expect(prepared.repos).toEqual([]);
+    expect(prepared.layout).toBeNull();
+  });
+
+  it("R02 and R03 differ only in the number of live regions", () => {
+    const one = getScenario("R02").prepare({ fixtures: FIXTURES });
+    const four = getScenario("R03").prepare({ fixtures: FIXTURES });
+    expect(countRegions(one.layout.workspaces[FIXTURES.repo.dir])).toBe(1);
+    expect(countRegions(four.layout.workspaces[FIXTURES.repo.dir])).toBe(4);
+  });
+
+  it("R04 restores the same four regions asleep", () => {
+    const prepared = getScenario("R04").prepare({ fixtures: FIXTURES });
+    const tree = prepared.layout.workspaces[FIXTURES.repo.dir];
+    expect(countRegions(tree)).toBe(4);
+    const tabs = [];
+    (function walk(n) {
+      if (n.type === "group") tabs.push(...n.tabs);
+      else {
+        walk(n.a);
+        walk(n.b);
+      }
+    })(tree);
+    expect(tabs.every((t) => t.asleep === true)).toBe(true);
+  });
+
+  it("R05 launches the offline fixture agent, not a real CLI", () => {
+    const prepared = getScenario("R05").prepare({ fixtures: FIXTURES });
+    const tab = prepared.layout.workspaces[FIXTURES.repo.dir].tabs[0];
+    expect(tab.args.join(" ")).toMatch(/agent-fixture\.mjs/);
+  });
+
+  it("R05 runs the agent inside a shell, which is what makes its cost external", () => {
+    // Launched *as* the shell, the fixture would be a direct child of the app
+    // and land in `managed` — uxnan would be charged for the agent's memory.
+    const prepared = getScenario("R05").prepare({ fixtures: FIXTURES });
+    const tab = prepared.layout.workspaces[FIXTURES.repo.dir].tabs[0];
+    expect(isShell(tab.shell)).toBe(true);
+    expect(tab.shell).not.toBe(process.execPath);
+    // …and the shell outlives the command, so the tab still holds a terminal
+    // for the rest of the measurement window.
+    expect(tab.args.join(" ")).toMatch(process.platform === "win32" ? /^\/k / : /exec \/bin\/sh$/);
+  });
+
+  it("R09 varies only the pet settings across its variants", () => {
+    const scenario = getScenario("R09");
+    const off = scenario.prepare({ fixtures: FIXTURES, variant: "off" });
+    const layer = scenario.prepare({ fixtures: FIXTURES, variant: "layer" });
+    const overlay = scenario.prepare({ fixtures: FIXTURES, variant: "overlay" });
+    expect(off.settingsOverrides.pets).toEqual({ enabled: false, overlay: false });
+    expect(layer.settingsOverrides.pets).toEqual({ enabled: true, overlay: false });
+    expect(overlay.settingsOverrides.pets).toEqual({ enabled: true, overlay: true });
+  });
+
+  it("R11 asks for a warm-up launch, because a restore needs something to restore", () => {
+    expect(getScenario("R11").warmup).toBe(true);
+  });
+});
+
+describe("profile seeding", () => {
+  it("writes a state document with the fields the app requires", () => {
+    const dir = writeProfile(path.join(TMP, "profile"), {
+      repos: [],
+      layout: null,
+    });
+    const state = JSON.parse(fs.readFileSync(path.join(dir, "state.json"), "utf8"));
+    expect(state.version).toBe(STATE_SCHEMA_VERSION);
+    expect(state.settings.theme).toBe("system");
+    expect(state.settings.leftSidebarWidth).toBeTypeOf("number");
+  });
+
+  it("turns off everything a resting measurement must not include", () => {
+    const dir = writeProfile(path.join(TMP, "profile-quiet"), {});
+    const { settings } = JSON.parse(fs.readFileSync(path.join(dir, "state.json"), "utf8"));
+    expect(settings.updater.autoCheck).toBe(false);
+    expect(settings.usageProviders).toEqual([]);
+    expect(settings.pets.enabled).toBe(false);
+    // Installing hook configs would write outside the scenario's own directory.
+    expect(settings.autoInstallHooks).toBe(false);
+  });
+
+  it("builds a balanced grid, so four terminals are four regions", () => {
+    const tree = terminalGrid(4, (i) => terminalTab({ title: `t${i}` }));
+    expect(countRegions(tree)).toBe(4);
+    expect(tree.type).toBe("split");
+    expect(tree.dir).toBe("row");
+    expect(tree.a.dir).toBe("col");
+  });
+
+  it("collapses to a single group for one terminal", () => {
+    expect(terminalGrid(1, () => terminalTab({})).type).toBe("group");
+  });
+});
+
+describe("liveTerminalCount — what the harness asserts against", () => {
+  const count = (id, variant) =>
+    liveTerminalCount(getScenario(id).prepare({ fixtures: FIXTURES, variant }).layout);
+
+  it("matches what each scenario seeds", () => {
+    expect(count("R00")).toBe(0); // no layout at all
+    expect(count("R01")).toBe(0); // a project, but no terminal
+    expect(count("R02")).toBe(1);
+    expect(count("R03")).toBe(4);
+    expect(count("R05")).toBe(1);
+    expect(count("R06")).toBe(1);
+    expect(count("R10")).toBe(2);
+    expect(count("R11")).toBe(4);
+  });
+
+  it("counts a sleeping workspace as zero live shells", () => {
+    // R04 restores four regions asleep: the PTYs are exactly what sleep gives
+    // back, so expecting them would fail every run.
+    expect(count("R04")).toBe(0);
+  });
+
+  it("counts only the active tab of a region", () => {
+    const doc = { active: "", workspaces: { "": { type: "group", tabs: [terminalTab({}), terminalTab({})], activeTab: 0 } } };
+    expect(liveTerminalCount(doc)).toBe(1);
+  });
+
+  it("ignores a workspace that is not the active one", () => {
+    const doc = {
+      active: "a",
+      workspaces: {
+        a: { type: "group", tabs: [terminalTab({})], activeTab: 0 },
+        b: { type: "group", tabs: [terminalTab({}), terminalTab({})], activeTab: 0 },
+      },
+    };
+    expect(liveTerminalCount(doc)).toBe(1);
+  });
+
+  it("is zero for no layout", () => {
+    expect(liveTerminalCount(null)).toBe(0);
+  });
+});

--- a/uxnandesktop/scripts/resources/lib/schema.mjs
+++ b/uxnandesktop/scripts/resources/lib/schema.mjs
@@ -1,0 +1,261 @@
+/**
+ * The result contract: what one scenario run produces, and what a valid
+ * document must contain.
+ *
+ * The schema is versioned, the raw results are not committed — only approved
+ * summaries, fixtures, budgets and this file. A reader two years from now has to
+ * be able to tell what a number meant, so every metric name encodes its bucket
+ * (`own` / `managed` / `external`), its statistic (`P50` / `P95`) and its unit
+ * (`Mb`, `Ms`, `Pct`).
+ *
+ * `null` always means **not measured on this platform** — never zero. That
+ * distinction is the whole reason a Linux run can be compared with a Windows one
+ * without inventing handles counts that don't exist there.
+ */
+
+import { percentile, round, slopePerHour, summarize } from "./stats.mjs";
+
+/** Bump only for a breaking change to the document shape. */
+export const SCHEMA_VERSION = 1;
+
+/** Verdict values, worst last — `worstOf` relies on the order. */
+export const VERDICTS = ["pass", "warn", "fail", "unknown"];
+
+/** Shortest stable window a memory slope is reported over (10 minutes). Below
+ *  it, the fit is dominated by warm-up and the per-hour extrapolation is noise
+ *  wearing a leak's clothes. */
+export const SLOPE_MIN_WINDOW_MS = 10 * 60 * 1000;
+
+/** Every canonical scenario id the schema accepts. */
+export const SCENARIO_IDS = [
+  "R00",
+  "R01",
+  "R02",
+  "R03",
+  "R04",
+  "R05",
+  "R06",
+  "R07",
+  "R08",
+  "R09",
+  "R10",
+  "R11",
+];
+
+/**
+ * Build an empty, valid run document. Callers fill `samples`, `phases`,
+ * `summary` and `verdict` as the run progresses, so a crashed run still writes
+ * something a human can read.
+ */
+export function newRun({ scenario, commit, platform, configuration }) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    commit: commit ?? "unknown",
+    platform,
+    scenario,
+    configuration,
+    startedAt: new Date().toISOString(),
+    durationMs: 0,
+    phases: [],
+    samples: [],
+    /** Executable basenames present in the tree at teardown — enough to tell a
+     *  run with a shell from one without, and nothing more (see `redact.mjs`). */
+    processes: { atEnd: [] },
+    orphans: [],
+    notes: [],
+    summary: null,
+    verdict: { status: "unknown", budgetVersion: null, checks: [] },
+  };
+}
+
+/**
+ * Validate a run document. Returns `{ ok, errors }` where each error is a
+ * sentence a person can act on ("samples[3].t is not a number") rather than a
+ * schema path.
+ */
+export function validateRun(doc) {
+  const errors = [];
+  const need = (cond, message) => {
+    if (!cond) errors.push(message);
+  };
+
+  need(doc && typeof doc === "object", "the document is not an object");
+  if (errors.length > 0) return { ok: false, errors };
+
+  need(
+    doc.schemaVersion === SCHEMA_VERSION,
+    `schemaVersion is ${JSON.stringify(doc.schemaVersion)}; this tool reads version ${SCHEMA_VERSION}`,
+  );
+  need(typeof doc.commit === "string" && doc.commit.length > 0, "commit is missing");
+  need(
+    SCENARIO_IDS.includes(doc.scenario),
+    `scenario ${JSON.stringify(doc.scenario)} is not one of ${SCENARIO_IDS.join(", ")}`,
+  );
+
+  const p = doc.platform;
+  need(p && typeof p === "object", "platform is missing");
+  if (p && typeof p === "object") {
+    need(typeof p.os === "string" && p.os.length > 0, "platform.os is missing");
+    need(typeof p.arch === "string" && p.arch.length > 0, "platform.arch is missing");
+    need(
+      "webview" in p,
+      "platform.webview is missing (use null when the runtime version can't be read)",
+    );
+    need(
+      Number.isFinite(p.cpuCores) && p.cpuCores > 0,
+      "platform.cpuCores must be a positive number (CPU percentages are meaningless without it)",
+    );
+  }
+
+  need(
+    doc.configuration && typeof doc.configuration === "object",
+    "configuration is missing (record the build profile and settings the run used)",
+  );
+  if (doc.configuration && typeof doc.configuration === "object") {
+    need(
+      doc.configuration.buildProfile === "release" || doc.configuration.buildProfile === "debug",
+      "configuration.buildProfile must be 'release' or 'debug' — debug and release numbers are never comparable",
+    );
+  }
+
+  need(Array.isArray(doc.samples), "samples must be an array");
+  if (Array.isArray(doc.samples)) {
+    doc.samples.forEach((s, i) => {
+      if (!s || typeof s !== "object") {
+        errors.push(`samples[${i}] is not an object`);
+        return;
+      }
+      if (!Number.isFinite(s.t)) errors.push(`samples[${i}].t is not a number (ms since start)`);
+      for (const bucket of ["own", "managed", "external"]) {
+        if (!s[bucket] || typeof s[bucket] !== "object") {
+          errors.push(`samples[${i}].${bucket} is missing`);
+          continue;
+        }
+        if (!Number.isFinite(s[bucket].rssMb)) {
+          errors.push(`samples[${i}].${bucket}.rssMb is not a number`);
+        }
+      }
+    });
+  }
+
+  need(
+    doc.verdict && typeof doc.verdict === "object" && VERDICTS.includes(doc.verdict.status),
+    `verdict.status must be one of ${VERDICTS.join(", ")}`,
+  );
+
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Reduce a run's samples to the published summary.
+ *
+ * `stableFromMs` drops the stabilisation window: an app that just launched is
+ * still paging in its webview, and folding that into a "resting cost" figure
+ * would report a number no user ever experiences. Samples before that mark still
+ * live in the document (they *are* the launch measurement) but never reach the
+ * resting statistics.
+ */
+export function summarizeRun(doc, { stableFromMs = 0 } = {}) {
+  const stable = (doc.samples ?? []).filter((s) => Number.isFinite(s.t) && s.t >= stableFromMs);
+  const pick = (bucket, field) => stable.map((s) => s[bucket]?.[field]).filter((v) => v !== null);
+  // A memory trend is only a trend over a long window. See the slope metrics.
+  const span = stable.length > 1 ? stable[stable.length - 1].t - stable[0].t : 0;
+  const longEnough = span >= SLOPE_MIN_WINDOW_MS;
+
+  const summary = {
+    stableFromMs,
+    stableSamples: stable.length,
+
+    // Memory, one figure per bucket — never summed across buckets.
+    //
+    // Two families, because neither alone is honest about a multi-process
+    // webview. `Rss` is the sum of per-process working sets: it double-counts
+    // the pages the WebView2/WebKit processes share with each other, so it
+    // over-reports the machine's actual burden while staying a good
+    // like-for-like signal between runs. `Private` sums private committed
+    // bytes: nothing is counted twice, which makes it the defensible answer to
+    // "how much memory is this costing me". Windows reports both; the Unix
+    // collector has no cheap private figure, so there it is `null`.
+    ownRssP50Mb: round(percentile(pick("own", "rssMb"), 0.5)),
+    ownRssP95Mb: round(percentile(pick("own", "rssMb"), 0.95)),
+    managedRssP50Mb: round(percentile(pick("managed", "rssMb"), 0.5)),
+    managedRssP95Mb: round(percentile(pick("managed", "rssMb"), 0.95)),
+    externalRssP50Mb: round(percentile(pick("external", "rssMb"), 0.5)),
+    ownPrivateP50Mb: round(percentile(pick("own", "privateMb"), 0.5)),
+    ownPrivateP95Mb: round(percentile(pick("own", "privateMb"), 0.95)),
+    managedPrivateP50Mb: round(percentile(pick("managed", "privateMb"), 0.5)),
+    externalPrivateP50Mb: round(percentile(pick("external", "privateMb"), 0.5)),
+
+    // CPU is percent of ONE core; divide by platform.cpuCores for the machine.
+    cpuP50: round(percentile(pick("managed", "cpuPct"), 0.5)),
+    cpuP95: round(percentile(pick("managed", "cpuPct"), 0.95)),
+    ownCpuP95: round(percentile(pick("own", "cpuPct"), 0.95)),
+
+    ownProcsP50: round(percentile(pick("own", "procs"), 0.5), 0),
+    managedProcsP50: round(percentile(pick("managed", "procs"), 0.5), 0),
+    threadsP95: round(percentile(pick("managed", "threads"), 0.95), 0),
+    handlesP95: round(percentile(pick("managed", "handles"), 0.95), 0),
+
+    // Soak signal: is resting memory going anywhere? Only computed over a
+    // window long enough for the answer to mean something — extrapolating a
+    // one-minute warm-up to an hour produces four-digit "leaks" that are pure
+    // artefact, and a fabricated alarm costs more trust than a missing number.
+    ownRssSlopeMbPerHour: longEnough
+      ? round(slopePerHour(stable.map((s) => ({ x: s.t, y: s.own?.rssMb }))), 2)
+      : null,
+    managedRssSlopeMbPerHour: longEnough
+      ? round(slopePerHour(stable.map((s) => ({ x: s.t, y: s.managed?.rssMb }))), 2)
+      : null,
+
+    orphanCount: Array.isArray(doc.orphans) ? doc.orphans.length : null,
+    durationMs: doc.durationMs ?? null,
+  };
+
+  // Phase timings become first-class metrics so a budget can gate them.
+  for (const phase of doc.phases ?? []) {
+    if (typeof phase?.name === "string" && Number.isFinite(phase.atMs)) {
+      summary[`${phase.name}Ms`] = round(phase.atMs, 0);
+    }
+  }
+  return summary;
+}
+
+/**
+ * Merge the per-repetition runs of one scenario into a single comparable record.
+ * Repetitions exist because a single launch on a busy desktop is noise; the
+ * median across them is what a budget is checked against, and the spread is
+ * published so a reader can see how noisy the box was.
+ */
+export function aggregateRepeats(runs) {
+  if (runs.length === 0) return null;
+  const first = runs[0];
+  const metrics = {};
+  const names = new Set(runs.flatMap((r) => Object.keys(r.summary ?? {})));
+  for (const name of names) {
+    if (name === "stableFromMs" || name === "stableSamples") continue;
+    const values = runs.map((r) => r.summary?.[name]).filter((v) => typeof v === "number");
+    const s = summarize(values);
+    if (s) metrics[name] = { median: s.p50, min: s.min, max: s.max, n: s.n };
+  }
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    scenario: first.scenario,
+    commit: first.commit,
+    platform: first.platform,
+    configuration: first.configuration,
+    repeats: runs.length,
+    metrics,
+    verdict: worstOf(runs.map((r) => r.verdict?.status ?? "unknown")),
+    notes: [...new Set(runs.flatMap((r) => r.notes ?? []))],
+  };
+}
+
+/** The worst status in a list (`unknown` counts as worse than `fail`: an
+ *  unevaluated result must never read as a pass). */
+export function worstOf(statuses) {
+  let worst = "pass";
+  for (const s of statuses) {
+    if (VERDICTS.indexOf(s) > VERDICTS.indexOf(worst)) worst = s;
+  }
+  return worst;
+}

--- a/uxnandesktop/scripts/resources/lib/schema.test.mjs
+++ b/uxnandesktop/scripts/resources/lib/schema.test.mjs
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregateRepeats,
+  newRun,
+  SCHEMA_VERSION,
+  summarizeRun,
+  validateRun,
+  worstOf,
+} from "./schema.mjs";
+
+const PLATFORM = {
+  os: "windows",
+  arch: "x86_64",
+  webview: "140.0.0.0",
+  cpuCores: 8,
+  totalMemMb: 32000,
+};
+
+function sample(t, own, managed, external = 0, extra = {}) {
+  const bucket = (rssMb, cpuPct = 1) => ({
+    procs: 1,
+    rssMb,
+    // Private is always lower than the working-set sum: the webview processes
+    // share pages, and only `rssMb` counts them more than once.
+    privateMb: Math.round(rssMb * 0.45),
+    threads: 20,
+    handles: 300,
+    cpuPct,
+  });
+  return {
+    t,
+    own: bucket(own, extra.cpu ?? 1),
+    managed: bucket(managed, extra.cpu ?? 2),
+    external: bucket(external, 0),
+  };
+}
+
+function validDoc(overrides = {}) {
+  const doc = newRun({
+    scenario: "R01",
+    commit: "abc1234",
+    platform: PLATFORM,
+    configuration: { buildProfile: "release" },
+  });
+  doc.samples = [sample(0, 200, 220), sample(1000, 210, 230)];
+  doc.verdict = { status: "pass", budgetVersion: 1, checks: [] };
+  return { ...doc, ...overrides };
+}
+
+describe("validateRun", () => {
+  it("accepts a well-formed document", () => {
+    expect(validateRun(validDoc())).toEqual({ ok: true, errors: [] });
+  });
+
+  it("names the exact field that is wrong", () => {
+    const doc = validDoc();
+    doc.samples[1] = { t: "later", own: {}, managed: {}, external: {} };
+    const { ok, errors } = validateRun(doc);
+    expect(ok).toBe(false);
+    expect(errors).toContain("samples[1].t is not a number (ms since start)");
+    expect(errors).toContain("samples[1].own.rssMb is not a number");
+  });
+
+  it("refuses a debug run rather than letting it be compared", () => {
+    const doc = validDoc();
+    doc.configuration = { buildProfile: "debug-ish" };
+    const { ok, errors } = validateRun(doc);
+    expect(ok).toBe(false);
+    expect(errors.join(" ")).toMatch(/buildProfile must be 'release' or 'debug'/);
+  });
+
+  it("rejects a document written by a future schema", () => {
+    const doc = validDoc({ schemaVersion: SCHEMA_VERSION + 1 });
+    expect(validateRun(doc).errors.join(" ")).toMatch(/this tool reads version/);
+  });
+
+  it("requires the machine facts a number is meaningless without", () => {
+    const doc = validDoc({ platform: { os: "windows", arch: "x86_64" } });
+    const { errors } = validateRun(doc);
+    expect(errors.join(" ")).toMatch(/platform.webview is missing/);
+    expect(errors.join(" ")).toMatch(/platform.cpuCores/);
+  });
+
+  it("rejects an unknown scenario id", () => {
+    expect(validateRun(validDoc({ scenario: "R99" })).ok).toBe(false);
+  });
+});
+
+describe("summarizeRun", () => {
+  it("discards the stabilisation window from the resting figures", () => {
+    const doc = validDoc();
+    doc.samples = [sample(0, 500, 520), sample(30_000, 200, 220), sample(60_000, 210, 230)];
+    const summary = summarizeRun(doc, { stableFromMs: 30_000 });
+    expect(summary.stableSamples).toBe(2);
+    expect(summary.ownRssP50Mb).toBe(205); // the 500 MB warm-up sample is excluded
+  });
+
+  it("promotes phase markers to gate-able metrics", () => {
+    const doc = validDoc();
+    doc.phases = [{ name: "launchToWindow", atMs: 1234.6 }];
+    expect(summarizeRun(doc).launchToWindowMs).toBe(1235);
+  });
+
+  it("reports a soak's growth as a slope per hour", () => {
+    const doc = validDoc();
+    doc.samples = [0, 1, 2, 3].map((i) => sample(i * 1_800_000, 200 + i * 5, 220 + i * 5));
+    expect(summarizeRun(doc).ownRssSlopeMbPerHour).toBeCloseTo(10, 5);
+  });
+
+  it("refuses to extrapolate a slope from a short window", () => {
+    // 45 s of warm-up would read as thousands of MB/h — an artefact, not a leak.
+    const doc = validDoc();
+    doc.samples = [0, 15, 30, 45].map((s) => sample(s * 1000, 200 + s, 220 + s));
+    expect(summarizeRun(doc).ownRssSlopeMbPerHour).toBeNull();
+    expect(summarizeRun(doc).managedRssSlopeMbPerHour).toBeNull();
+  });
+
+  it("publishes private memory beside working set, since the two answer different questions", () => {
+    const doc = validDoc();
+    expect(doc.samples[0].own.privateMb).toBeTypeOf("number");
+    const summary = summarizeRun(doc);
+    expect(summary.ownPrivateP50Mb).toBeTypeOf("number");
+    expect(summary.ownPrivateP50Mb).not.toBe(summary.ownRssP50Mb);
+  });
+
+  it("yields nulls, not zeros, when nothing was sampled", () => {
+    const doc = validDoc();
+    doc.samples = [];
+    const summary = summarizeRun(doc);
+    expect(summary.ownRssP50Mb).toBeNull();
+    expect(summary.cpuP95).toBeNull();
+  });
+});
+
+describe("aggregateRepeats", () => {
+  it("takes the median across repetitions and keeps the spread", () => {
+    const runs = [200, 210, 260].map((mb) => {
+      const doc = validDoc();
+      doc.summary = { ownRssP50Mb: mb };
+      doc.verdict = { status: "pass" };
+      return doc;
+    });
+    const agg = aggregateRepeats(runs);
+    expect(agg.repeats).toBe(3);
+    expect(agg.metrics.ownRssP50Mb).toEqual({ median: 210, min: 200, max: 260, n: 3 });
+  });
+
+  it("carries the worst verdict of the set", () => {
+    const runs = ["pass", "warn", "pass"].map((status) => {
+      const doc = validDoc();
+      doc.summary = { ownRssP50Mb: 1 };
+      doc.verdict = { status };
+      return doc;
+    });
+    expect(aggregateRepeats(runs).verdict).toBe("warn");
+  });
+
+  it("is null for no runs at all", () => {
+    expect(aggregateRepeats([])).toBeNull();
+  });
+});
+
+describe("worstOf", () => {
+  it("orders pass < warn < fail < unknown", () => {
+    expect(worstOf(["pass", "pass"])).toBe("pass");
+    expect(worstOf(["pass", "warn"])).toBe("warn");
+    expect(worstOf(["warn", "fail"])).toBe("fail");
+    // An unevaluated result must never read as a pass.
+    expect(worstOf(["fail", "unknown"])).toBe("unknown");
+    expect(worstOf([])).toBe("pass");
+  });
+});

--- a/uxnandesktop/scripts/resources/lib/stats.mjs
+++ b/uxnandesktop/scripts/resources/lib/stats.mjs
@@ -1,0 +1,137 @@
+/**
+ * Summary statistics for a scenario's samples.
+ *
+ * Every number the benchmark publishes is produced here, so the definitions live
+ * in one place: which percentile method, how a rate is derived from cumulative
+ * CPU time, and how a soak's memory trend is fitted. All functions are pure and
+ * return `null` for "not measurable" — never `0`, which would read as a real
+ * measurement of nothing (the same rule the collectors follow with
+ * `unsupported`).
+ */
+
+/** Sort a copy ascending, dropping anything that isn't a finite number. */
+function finiteSorted(values) {
+  return values.filter((v) => typeof v === "number" && Number.isFinite(v)).sort((a, b) => a - b);
+}
+
+/**
+ * Linear-interpolated percentile (the "R-7" definition — what NumPy and Excel
+ * use). `p` is a fraction: `0.95` for P95. Returns `null` for an empty sample.
+ */
+export function percentile(values, p) {
+  const xs = finiteSorted(values);
+  if (xs.length === 0) return null;
+  if (xs.length === 1) return xs[0];
+  const rank = (xs.length - 1) * Math.min(Math.max(p, 0), 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return xs[lo];
+  return xs[lo] + (xs[hi] - xs[lo]) * (rank - lo);
+}
+
+/** Arithmetic mean, or `null` for an empty sample. */
+export function mean(values) {
+  const xs = finiteSorted(values);
+  if (xs.length === 0) return null;
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+/** Largest value, or `null` for an empty sample. */
+export function max(values) {
+  const xs = finiteSorted(values);
+  return xs.length === 0 ? null : xs[xs.length - 1];
+}
+
+/** Smallest value, or `null` for an empty sample. */
+export function min(values) {
+  const xs = finiteSorted(values);
+  return xs.length === 0 ? null : xs[0];
+}
+
+/**
+ * Least-squares slope of `points` (`{x, y}`) — the memory trend a soak run is
+ * really asking about. `x` is in milliseconds and the result is **per hour**, so
+ * a verdict can be phrased as "grew 12 MB/h". Needs at least two distinct `x`
+ * values; otherwise `null`.
+ */
+export function slopePerHour(points) {
+  const pts = points.filter(
+    (p) => Number.isFinite(p?.x) && typeof p?.y === "number" && Number.isFinite(p.y),
+  );
+  if (pts.length < 2) return null;
+  const n = pts.length;
+  const sumX = pts.reduce((a, p) => a + p.x, 0);
+  const sumY = pts.reduce((a, p) => a + p.y, 0);
+  const meanX = sumX / n;
+  const meanY = sumY / n;
+  let num = 0;
+  let den = 0;
+  for (const p of pts) {
+    num += (p.x - meanX) * (p.y - meanY);
+    den += (p.x - meanX) ** 2;
+  }
+  if (den === 0) return null;
+  return (num / den) * 3_600_000;
+}
+
+/**
+ * Turn two cumulative CPU-time readings into a rate.
+ *
+ * Collectors report **cumulative** processor time per process (that is what
+ * every OS exposes cheaply and without a perf-counter subscription), so a rate
+ * only exists between two samples. The result is *percent of one core*: 100
+ * means one core fully busy, 400 means four. Dividing by the core count is left
+ * to the caller ([`cpuPercentOfMachine`]) so both framings stay explicit in the
+ * report rather than being silently mixed.
+ *
+ * A negative delta (a process died and its time left the total) clamps to 0.
+ */
+export function cpuPercentOfCore(prevCpuMs, cpuMs, elapsedMs) {
+  if (![prevCpuMs, cpuMs, elapsedMs].every((v) => typeof v === "number" && Number.isFinite(v))) {
+    return null;
+  }
+  if (elapsedMs <= 0) return null;
+  return Math.max(0, ((cpuMs - prevCpuMs) / elapsedMs) * 100);
+}
+
+/** Re-express a percent-of-one-core figure against the whole machine. */
+export function cpuPercentOfMachine(percentOfCore, cores) {
+  if (percentOfCore === null || !Number.isFinite(cores) || cores <= 0) return null;
+  return percentOfCore / cores;
+}
+
+/** Round to `digits` decimals, passing `null`/non-finite through untouched. */
+export function round(value, digits = 2) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const f = 10 ** digits;
+  return Math.round(value * f) / f;
+}
+
+/**
+ * Relative change from `base` to `candidate`, as a fraction (`0.15` = +15 %).
+ * `null` when either side is missing, or when the baseline is 0 (a percentage
+ * against zero is not a meaningful statement — the absolute delta carries it).
+ */
+export function relativeDelta(base, candidate) {
+  if (typeof base !== "number" || typeof candidate !== "number") return null;
+  if (!Number.isFinite(base) || !Number.isFinite(candidate) || base === 0) return null;
+  return (candidate - base) / Math.abs(base);
+}
+
+/**
+ * Summarise one metric across a scenario's samples: the shape every metric in
+ * the result document uses. Returns `null` when nothing was measurable, so a
+ * missing metric stays visibly missing.
+ */
+export function summarize(values, digits = 2) {
+  const xs = finiteSorted(values);
+  if (xs.length === 0) return null;
+  return {
+    n: xs.length,
+    p50: round(percentile(xs, 0.5), digits),
+    p95: round(percentile(xs, 0.95), digits),
+    mean: round(mean(xs), digits),
+    min: round(min(xs), digits),
+    max: round(max(xs), digits),
+  };
+}

--- a/uxnandesktop/scripts/resources/lib/stats.test.mjs
+++ b/uxnandesktop/scripts/resources/lib/stats.test.mjs
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cpuPercentOfCore,
+  cpuPercentOfMachine,
+  max,
+  mean,
+  percentile,
+  relativeDelta,
+  round,
+  slopePerHour,
+  summarize,
+} from "./stats.mjs";
+
+describe("percentile", () => {
+  it("interpolates between neighbours (R-7)", () => {
+    expect(percentile([1, 2, 3, 4], 0.5)).toBe(2.5);
+    expect(percentile([10, 20, 30, 40, 50], 0.95)).toBe(48);
+  });
+
+  it("handles the degenerate sizes", () => {
+    expect(percentile([], 0.5)).toBeNull();
+    expect(percentile([7], 0.95)).toBe(7);
+  });
+
+  it("ignores values that are not finite numbers", () => {
+    expect(percentile([1, null, 3, NaN, undefined, 5], 0.5)).toBe(3);
+  });
+
+  it("clamps p to [0, 1]", () => {
+    expect(percentile([1, 2, 3], 2)).toBe(3);
+    expect(percentile([1, 2, 3], -1)).toBe(1);
+  });
+});
+
+describe("mean / max", () => {
+  it("returns null rather than 0 for nothing measured", () => {
+    expect(mean([])).toBeNull();
+    expect(max([])).toBeNull();
+  });
+
+  it("averages only the finite values", () => {
+    expect(mean([2, 4, null])).toBe(3);
+  });
+});
+
+describe("slopePerHour", () => {
+  it("reports growth per hour from millisecond timestamps", () => {
+    // +1 MB every 10 minutes = 6 MB/h.
+    const points = [0, 1, 2, 3].map((i) => ({ x: i * 600_000, y: 100 + i }));
+    expect(slopePerHour(points)).toBeCloseTo(6, 6);
+  });
+
+  it("is zero for a flat series and null when there is nothing to fit", () => {
+    expect(slopePerHour([{ x: 0, y: 5 }, { x: 60_000, y: 5 }])).toBe(0);
+    expect(slopePerHour([{ x: 0, y: 5 }])).toBeNull();
+    expect(slopePerHour([{ x: 10, y: 1 }, { x: 10, y: 2 }])).toBeNull();
+  });
+
+  it("detects a decline as a negative slope", () => {
+    const points = [0, 1, 2].map((i) => ({ x: i * 3_600_000, y: 200 - 10 * i }));
+    expect(slopePerHour(points)).toBeCloseTo(-10, 6);
+  });
+});
+
+describe("cpuPercentOfCore", () => {
+  it("turns a cumulative delta into a rate", () => {
+    // 500 ms of CPU in a 1 s window = half a core.
+    expect(cpuPercentOfCore(1000, 1500, 1000)).toBe(50);
+  });
+
+  it("clamps a negative delta (a process left the tree) to zero", () => {
+    expect(cpuPercentOfCore(2000, 1500, 1000)).toBe(0);
+  });
+
+  it("refuses to divide by a non-positive window", () => {
+    expect(cpuPercentOfCore(0, 100, 0)).toBeNull();
+    expect(cpuPercentOfCore(0, 100, -5)).toBeNull();
+  });
+
+  it("normalises against the machine only when asked", () => {
+    expect(cpuPercentOfMachine(400, 8)).toBe(50);
+    expect(cpuPercentOfMachine(null, 8)).toBeNull();
+    expect(cpuPercentOfMachine(400, 0)).toBeNull();
+  });
+});
+
+describe("relativeDelta", () => {
+  it("expresses change as a fraction of the baseline", () => {
+    expect(relativeDelta(200, 230)).toBeCloseTo(0.15, 10);
+    expect(relativeDelta(200, 170)).toBeCloseTo(-0.15, 10);
+  });
+
+  it("refuses a percentage against zero", () => {
+    expect(relativeDelta(0, 10)).toBeNull();
+  });
+});
+
+describe("round / summarize", () => {
+  it("passes null through untouched", () => {
+    expect(round(null)).toBeNull();
+    expect(round(1.23456, 2)).toBe(1.23);
+  });
+
+  it("summarises a series into the published shape", () => {
+    expect(summarize([1, 2, 3, 4, 5])).toEqual({ n: 5, p50: 3, p95: 4.8, mean: 3, min: 1, max: 5 });
+  });
+
+  it("returns null for a series with nothing measurable", () => {
+    expect(summarize([null, undefined, NaN])).toBeNull();
+  });
+});

--- a/uxnandesktop/scripts/resources/lib/tree.mjs
+++ b/uxnandesktop/scripts/resources/lib/tree.mjs
@@ -1,0 +1,273 @@
+/**
+ * Who in the process tree is uxnan's cost, and who is someone else's.
+ *
+ * The single most misleading number a desktop benchmark can publish is "the app
+ * used N MB" when N quietly includes a shell, a `node`, and whatever agent CLI
+ * the user happened to launch. So every process the collector reports is placed
+ * in exactly one of three buckets:
+ *
+ * - **own** — the app process plus the helpers its *runtime* creates (the
+ *   WebView2/WebKit hosts, the crash handler). This is uxnan's own shell: the
+ *   number that has to stay small.
+ * - **managed** — own, plus what uxnan spawns *on the user's behalf*: PTY shells
+ *   and their ConPTY host, `git`/`gh` invocations, sidecars. Uxnan is
+ *   responsible for these existing, so they belong in a "what does uxnan cost me"
+ *   answer — but they are not the app's own footprint.
+ * - **external** — the program the user ran inside a shell (an agent CLI, a dev
+ *   server, a build) and everything under it. Reported, never folded in.
+ *
+ * The shell is the boundary, and that works because it matches how uxnan
+ * actually starts things: every terminal is a *profile* (cmd, PowerShell, bash),
+ * and an agent — typed by the user or auto-launched — runs inside it. A program
+ * uxnan spawns directly, with no shell in between, is uxnan's own doing (`git`,
+ * `gh`, a sidecar) and stays `managed`. A benchmark scenario must therefore
+ * launch its fixture agent through a shell too, or it would charge uxnan for the
+ * agent (see `profile.shellRunning`).
+ *
+ * Attribution is by **parent/child relation from a root PID we spawned
+ * ourselves**, not by name: a name-only match would claim an unrelated
+ * `node.exe` started before the benchmark, and would miss a renamed one. Names
+ * are consulted only to answer "is this a shell / a runtime helper", i.e. to
+ * decide *which* bucket a descendant lands in — never *whether* it is ours.
+ */
+
+export const OWN = "own";
+export const MANAGED = "managed";
+export const EXTERNAL = "external";
+
+/**
+ * Helper processes a webview runtime spawns for the app itself. They exist
+ * because the app has a window, so they are part of its own footprint.
+ * Extension-stripped, lowercased basenames.
+ */
+const RUNTIME_HELPERS = new Set([
+  "msedgewebview2", // Windows — WebView2 render/GPU/utility children
+  "webkitwebprocess", // Linux — WebKitGTK
+  "webkitnetworkprocess",
+  "webkitgpuprocess",
+  "com.apple.webkit.webcontent", // macOS
+  "com.apple.webkit.networking",
+  "com.apple.webkit.gpu",
+  "crashpad_handler", // crash reporter shipped with the webview
+]);
+
+/**
+ * Console/PTY plumbing the OS inserts between uxnan and a shell. Not a program
+ * the user ran, so it stays on uxnan's managed side.
+ */
+const PTY_HELPERS = new Set(["conhost", "openconsole"]);
+
+/**
+ * Shells we look *through*. A program running inside one of these is the user's,
+ * not uxnan's — that boundary is what separates `managed` from `external`.
+ * Mirrors the shell list `procscan.rs` descends through, so the benchmark and
+ * the agent detector agree on what a shell is.
+ */
+const SHELLS = new Set([
+  "cmd",
+  "powershell",
+  "pwsh",
+  "bash",
+  "sh",
+  "dash",
+  "zsh",
+  "fish",
+  "ksh",
+  "nu",
+  "wsl",
+  "login",
+]);
+
+/** Lowercased basename with a known executable extension removed. */
+export function normalizeName(name) {
+  if (typeof name !== "string") return "";
+  const base = name.replace(/\\/g, "/").split("/").pop() ?? "";
+  const lower = base.toLowerCase();
+  for (const ext of [".exe", ".cmd", ".bat", ".ps1", ".com"]) {
+    if (lower.endsWith(ext)) return lower.slice(0, -ext.length);
+  }
+  return lower;
+}
+
+export function isShell(name) {
+  return SHELLS.has(normalizeName(name));
+}
+
+export function isRuntimeHelper(name) {
+  return RUNTIME_HELPERS.has(normalizeName(name));
+}
+
+export function isPtyHelper(name) {
+  return PTY_HELPERS.has(normalizeName(name));
+}
+
+/**
+ * Walk the tree rooted at `rootPid` and label every reachable process.
+ *
+ * `rows` is the collector's raw snapshot: `{ pid, ppid, name, ... }`. Returns a
+ * `Map<pid, "own"|"managed"|"external">` holding only processes actually
+ * descended from `rootPid` — anything else on the machine is invisible to the
+ * benchmark by construction.
+ *
+ * The rules, applied top-down:
+ *
+ * | parent bucket | this process        | bucket     |
+ * |---------------|---------------------|------------|
+ * | (root)        | —                   | `own`      |
+ * | `own`         | runtime helper      | `own`      |
+ * | `own`         | anything else       | `managed`  |
+ * | `managed`     | parent is a shell   | `external` unless this is a shell too |
+ * | `managed`     | parent is a sidecar | `managed`  |
+ * | `external`    | anything            | `external` |
+ *
+ * The nested-shell exception ("a shell under a shell is still managed") exists
+ * because agent CLIs are routinely launched through a `.cmd`/`.ps1` shim; the
+ * shim is plumbing, and only what it finally runs is the user's program.
+ *
+ * A PID recycled onto a *different* subtree cannot smuggle itself in: the walk
+ * only follows edges, and a cycle (which a recycled parent PID can forge) is cut
+ * by the visited set rather than looping forever.
+ */
+export function classifyTree(rows, rootPid) {
+  const byPid = new Map();
+  const children = new Map();
+  for (const row of rows ?? []) {
+    if (!Number.isInteger(row?.pid)) continue;
+    byPid.set(row.pid, row);
+    const ppid = Number.isInteger(row.ppid) ? row.ppid : -1;
+    if (!children.has(ppid)) children.set(ppid, []);
+    children.get(ppid).push(row.pid);
+  }
+
+  const classes = new Map();
+  if (!byPid.has(rootPid)) return classes;
+
+  const queue = [{ pid: rootPid, bucket: OWN, parentName: null }];
+  classes.set(rootPid, OWN);
+
+  while (queue.length > 0) {
+    const { pid, bucket } = queue.shift();
+    const parentName = byPid.get(pid)?.name ?? "";
+    for (const childPid of children.get(pid) ?? []) {
+      if (classes.has(childPid)) continue; // visited — also cuts a forged cycle
+      const child = byPid.get(childPid);
+      const childBucket = childClass(bucket, parentName, child?.name ?? "");
+      classes.set(childPid, childBucket);
+      queue.push({ pid: childPid, bucket: childBucket, parentName });
+    }
+  }
+  return classes;
+}
+
+/** The table above, as a function — exported so the rules are unit-testable. */
+export function childClass(parentBucket, parentName, childName) {
+  if (parentBucket === EXTERNAL) return EXTERNAL;
+  if (parentBucket === OWN) {
+    return isRuntimeHelper(childName) ? OWN : MANAGED;
+  }
+  // parentBucket === MANAGED
+  if (isShell(parentName)) {
+    return isShell(childName) || isPtyHelper(childName) ? MANAGED : EXTERNAL;
+  }
+  return MANAGED;
+}
+
+/**
+ * Fold one collector snapshot into per-bucket totals.
+ *
+ * `prev` is the previous snapshot's per-pid cumulative CPU milliseconds, used to
+ * derive a rate; pass `null` for the first sample (its CPU is then `null`, not
+ * a fabricated 0). Returns the totals plus the per-pid CPU map to feed the next
+ * call.
+ */
+export function aggregate(rows, rootPid, { prevCpuMs = null, elapsedMs = null } = {}) {
+  const classes = classifyTree(rows, rootPid);
+  const buckets = {
+    [OWN]: emptyBucket(),
+    [MANAGED]: emptyBucket(),
+    [EXTERNAL]: emptyBucket(),
+  };
+  const cpuMsByPid = new Map();
+
+  for (const row of rows ?? []) {
+    const bucket = classes.get(row.pid);
+    if (!bucket) continue;
+    if (Number.isFinite(row.cpuMs)) cpuMsByPid.set(row.pid, row.cpuMs);
+    const b = buckets[bucket];
+    b.procs += 1;
+    if (Number.isFinite(row.rssKb)) b.rssKb += row.rssKb;
+    if (Number.isFinite(row.privateKb)) b.privateKb += row.privateKb;
+    if (Number.isFinite(row.threads)) b.threads += row.threads;
+    if (Number.isFinite(row.handles)) b.handles += row.handles;
+    if (prevCpuMs && Number.isFinite(row.cpuMs)) {
+      const before = prevCpuMs.get(row.pid);
+      // A process that appeared since the last sample has no previous reading;
+      // counting its whole lifetime CPU as if it burned in this interval would
+      // spike the rate, so its first interval contributes nothing.
+      if (Number.isFinite(before)) b.cpuDeltaMs += Math.max(0, row.cpuMs - before);
+    }
+  }
+
+  // `managed` is defined as own + the shells/sidecars — fold `own` in rather
+  // than making callers remember to add the two.
+  const managed = mergeBuckets(buckets[OWN], buckets[MANAGED]);
+
+  return {
+    own: finishBucket(buckets[OWN], prevCpuMs, elapsedMs),
+    managed: finishBucket(managed, prevCpuMs, elapsedMs),
+    external: finishBucket(buckets[EXTERNAL], prevCpuMs, elapsedMs),
+    cpuMsByPid,
+    classes,
+  };
+}
+
+function emptyBucket() {
+  return { procs: 0, rssKb: 0, privateKb: 0, threads: 0, handles: 0, cpuDeltaMs: 0 };
+}
+
+function mergeBuckets(a, b) {
+  return {
+    procs: a.procs + b.procs,
+    rssKb: a.rssKb + b.rssKb,
+    privateKb: a.privateKb + b.privateKb,
+    threads: a.threads + b.threads,
+    handles: a.handles + b.handles,
+    cpuDeltaMs: a.cpuDeltaMs + b.cpuDeltaMs,
+  };
+}
+
+function finishBucket(b, prevCpuMs, elapsedMs) {
+  const measurable = prevCpuMs !== null && Number.isFinite(elapsedMs) && elapsedMs > 0;
+  return {
+    procs: b.procs,
+    rssMb: b.procs === 0 ? 0 : b.rssKb / 1024,
+    privateMb: b.privateKb > 0 ? b.privateKb / 1024 : null,
+    threads: b.threads > 0 ? b.threads : null,
+    handles: b.handles > 0 ? b.handles : null,
+    cpuPct: measurable ? Math.max(0, (b.cpuDeltaMs / elapsedMs) * 100) : null,
+  };
+}
+
+/**
+ * Processes that were part of the managed tree at teardown and are still alive
+ * afterwards — the "cerrar Uxnan deja cero procesos administrados" check. Takes
+ * the last snapshot before quitting and one taken after, and reports the
+ * survivors by bucket (names only; see `redact.mjs` for why nothing else).
+ */
+export function findOrphans(lastRows, rootPid, afterRows) {
+  const classes = classifyTree(lastRows, rootPid);
+  const alive = new Set((afterRows ?? []).map((r) => r.pid));
+  const startTimes = new Map((afterRows ?? []).map((r) => [r.pid, r.startedAt ?? null]));
+  const before = new Map((lastRows ?? []).map((r) => [r.pid, r]));
+  const orphans = [];
+  for (const [pid, bucket] of classes) {
+    if (!alive.has(pid)) continue;
+    // A PID reused by an unrelated process after teardown would look alive; when
+    // the collector reports a start time, require it to match what we saw.
+    const wasStartedAt = before.get(pid)?.startedAt ?? null;
+    const isStartedAt = startTimes.get(pid) ?? null;
+    if (wasStartedAt !== null && isStartedAt !== null && wasStartedAt !== isStartedAt) continue;
+    orphans.push({ bucket, name: normalizeName(before.get(pid)?.name ?? "") });
+  }
+  return orphans;
+}

--- a/uxnandesktop/scripts/resources/lib/tree.test.mjs
+++ b/uxnandesktop/scripts/resources/lib/tree.test.mjs
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregate,
+  childClass,
+  classifyTree,
+  EXTERNAL,
+  findOrphans,
+  isShell,
+  MANAGED,
+  normalizeName,
+  OWN,
+} from "./tree.mjs";
+
+/** Build a row with sane defaults so a test only states what it cares about. */
+function row(pid, ppid, name, extra = {}) {
+  return { pid, ppid, name, rssKb: 1024, cpuMs: 0, threads: 1, handles: 10, ...extra };
+}
+
+/**
+ * The tree a real Windows run produces:
+ *
+ *   100 uxnan-desktop.exe            own
+ *   ├─ 101 msedgewebview2.exe        own (runtime helper)
+ *   ├─ 102 conhost.exe               managed (ConPTY plumbing)
+ *   ├─ 103 cmd.exe                   managed (a shell uxnan spawned)
+ *   │   └─ 104 node.exe (agent)      external (what the user ran)
+ *   │       └─ 105 rg.exe            external
+ *   └─ 106 git.exe                   managed (uxnan's own sidecar)
+ *       └─ 107 git-remote-https.exe  managed
+ */
+const TREE = [
+  row(100, 1, "uxnan-desktop.exe", { rssKb: 200 * 1024 }),
+  row(101, 100, "msedgewebview2.exe", { rssKb: 80 * 1024 }),
+  row(102, 100, "conhost.exe", { rssKb: 6 * 1024 }),
+  row(103, 100, "cmd.exe", { rssKb: 4 * 1024 }),
+  row(104, 103, "node.exe", { rssKb: 120 * 1024 }),
+  row(105, 104, "rg.exe", { rssKb: 30 * 1024 }),
+  row(106, 100, "git.exe", { rssKb: 12 * 1024 }),
+  row(107, 106, "git-remote-https.exe", { rssKb: 8 * 1024 }),
+];
+
+describe("normalizeName", () => {
+  it("strips the path and a known executable extension", () => {
+    expect(normalizeName("C:\\Windows\\System32\\cmd.exe")).toBe("cmd");
+    expect(normalizeName("/bin/bash")).toBe("bash");
+    expect(normalizeName("Node.EXE")).toBe("node");
+  });
+
+  it("leaves an unknown extension alone", () => {
+    expect(normalizeName("uxnan-desktop")).toBe("uxnan-desktop");
+    expect(normalizeName("weird.thing")).toBe("weird.thing");
+  });
+
+  it("recognises the shells the agent detector descends through", () => {
+    for (const s of ["cmd.exe", "powershell.exe", "pwsh", "bash", "zsh", "fish", "nu"]) {
+      expect(isShell(s)).toBe(true);
+    }
+    expect(isShell("node.exe")).toBe(false);
+  });
+});
+
+describe("classifyTree", () => {
+  it("labels every node of a realistic tree", () => {
+    const classes = classifyTree(TREE, 100);
+    expect(classes.get(100)).toBe(OWN);
+    expect(classes.get(101)).toBe(OWN); // webview helper
+    expect(classes.get(102)).toBe(MANAGED); // conhost
+    expect(classes.get(103)).toBe(MANAGED); // shell
+    expect(classes.get(104)).toBe(EXTERNAL); // the agent the user launched
+    expect(classes.get(105)).toBe(EXTERNAL); // and its own child
+    expect(classes.get(106)).toBe(MANAGED); // uxnan's git call
+    expect(classes.get(107)).toBe(MANAGED); // git's own helper
+  });
+
+  it("sees through a shell shim to the real program", () => {
+    // cmd → powershell → node: the shim stays managed, the program is external.
+    const rows = [
+      row(1, 0, "uxnan-desktop.exe"),
+      row(2, 1, "cmd.exe"),
+      row(3, 2, "powershell.exe"),
+      row(4, 3, "node.exe"),
+    ];
+    const classes = classifyTree(rows, 1);
+    expect(classes.get(3)).toBe(MANAGED);
+    expect(classes.get(4)).toBe(EXTERNAL);
+  });
+
+  it("ignores a same-named process that is not a descendant", () => {
+    // A `uxnan-desktop.exe` the operator already had open must not be counted.
+    const rows = [...TREE, row(900, 1, "uxnan-desktop.exe", { rssKb: 999 * 1024 })];
+    const classes = classifyTree(rows, 100);
+    expect(classes.has(900)).toBe(false);
+  });
+
+  it("returns nothing when the root is absent (the app already exited)", () => {
+    expect(classifyTree(TREE, 555).size).toBe(0);
+  });
+
+  it("survives a cycle a recycled parent PID could forge", () => {
+    const rows = [row(1, 0, "uxnan-desktop.exe"), row(2, 1, "cmd.exe"), row(1, 2, "ghost.exe")];
+    const classes = classifyTree(rows, 1);
+    expect(classes.get(1)).toBe(OWN);
+    expect(classes.size).toBeLessThanOrEqual(2);
+  });
+
+  it("skips rows with no usable pid", () => {
+    const rows = [row(1, 0, "uxnan-desktop.exe"), { pid: null, ppid: 1, name: "junk" }];
+    expect(classifyTree(rows, 1).size).toBe(1);
+  });
+});
+
+describe("childClass rules", () => {
+  it("keeps everything under an external process external", () => {
+    expect(childClass(EXTERNAL, "node.exe", "cmd.exe")).toBe(EXTERNAL);
+  });
+
+  it("treats a non-shell sidecar's children as still managed", () => {
+    expect(childClass(MANAGED, "git.exe", "git-remote-https.exe")).toBe(MANAGED);
+  });
+});
+
+describe("aggregate", () => {
+  it("never folds external cost into own or managed", () => {
+    const folded = aggregate(TREE, 100);
+    expect(folded.own.rssMb).toBeCloseTo(280, 5); // app + webview
+    expect(folded.managed.rssMb).toBeCloseTo(310, 5); // + conhost, cmd, git, git helper
+    expect(folded.external.rssMb).toBeCloseTo(150, 5); // agent + ripgrep
+    expect(folded.own.procs).toBe(2);
+    expect(folded.managed.procs).toBe(6);
+    expect(folded.external.procs).toBe(2);
+  });
+
+  it("reports CPU as null on the first sample instead of inventing a zero", () => {
+    const folded = aggregate(TREE, 100);
+    expect(folded.own.cpuPct).toBeNull();
+  });
+
+  it("derives a rate once there is a previous reading", () => {
+    const first = aggregate(TREE, 100, { prevCpuMs: null, elapsedMs: null });
+    const later = TREE.map((r) => (r.pid === 100 ? { ...r, cpuMs: 500 } : r));
+    const second = aggregate(later, 100, { prevCpuMs: first.cpuMsByPid, elapsedMs: 1000 });
+    expect(second.own.cpuPct).toBeCloseTo(50, 5);
+  });
+
+  it("does not charge a newly-appeared process its whole lifetime CPU", () => {
+    const first = aggregate([row(1, 0, "uxnan-desktop.exe", { cpuMs: 0 })], 1);
+    const withChild = [
+      row(1, 0, "uxnan-desktop.exe", { cpuMs: 0 }),
+      row(2, 1, "cmd.exe", { cpuMs: 9_000 }),
+    ];
+    const second = aggregate(withChild, 1, { prevCpuMs: first.cpuMsByPid, elapsedMs: 1000 });
+    expect(second.managed.cpuPct).toBe(0);
+  });
+
+  it("marks unavailable per-process metrics as null, not zero", () => {
+    const rows = [row(1, 0, "uxnan-desktop", { threads: null, handles: null, privateKb: null })];
+    const folded = aggregate(rows, 1);
+    expect(folded.own.threads).toBeNull();
+    expect(folded.own.handles).toBeNull();
+    expect(folded.own.privateMb).toBeNull();
+  });
+});
+
+describe("findOrphans", () => {
+  it("reports managed processes still alive after teardown", () => {
+    const after = [row(103, 1, "cmd.exe"), row(104, 103, "node.exe")];
+    const orphans = findOrphans(TREE, 100, after);
+    expect(orphans).toEqual([
+      { bucket: MANAGED, name: "cmd" },
+      { bucket: EXTERNAL, name: "node" },
+    ]);
+  });
+
+  it("is empty when the tree is gone", () => {
+    expect(findOrphans(TREE, 100, [])).toEqual([]);
+  });
+
+  it("does not blame a recycled PID now owned by something else", () => {
+    const before = [row(1, 0, "uxnan-desktop.exe"), row(2, 1, "cmd.exe", { startedAt: 1000 })];
+    const after = [row(2, 1, "cmd.exe", { startedAt: 9999 })];
+    expect(findOrphans(before, 1, after)).toEqual([]);
+  });
+});

--- a/uxnandesktop/scripts/resources/report.mjs
+++ b/uxnandesktop/scripts/resources/report.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Render the Markdown report for a results directory.
+ *
+ *   node scripts/resources/report.mjs [--out .resource-results] [--file report.md]
+ *
+ * Reads the per-scenario aggregates `run.mjs` wrote and produces the document a
+ * human reads before believing any of it. Prints to stdout as well, so it can be
+ * piped into a PR comment.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { renderReport } from "./lib/markdown.mjs";
+import { SCENARIOS } from "./lib/scenarios.mjs";
+import { evaluateBudget } from "./lib/budgets.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DESKTOP_ROOT = path.resolve(HERE, "..", "..");
+
+function parseArgs(argv) {
+  const args = {
+    out: path.join(DESKTOP_ROOT, ".resource-results"),
+    file: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--out") args.out = path.resolve(argv[++i]);
+    else if (argv[i] === "--file") args.file = path.resolve(argv[++i]);
+    else if (argv[i] === "--help" || argv[i] === "-h") args.help = true;
+    else throw new Error(`unknown argument ${argv[i]}`);
+  }
+  args.file ??= path.join(args.out, "report.md");
+  return args;
+}
+
+/** The platform's committed budget, or `null` (which reads as `unknown`). */
+function loadBudget(osKey) {
+  if (!osKey) return null;
+  const file = path.join(HERE, "budgets", `${osKey}.json`);
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(
+      "node scripts/resources/report.mjs [--out <results dir>] [--file <report.md>]\n",
+    );
+    return 0;
+  }
+
+  const dir = path.join(args.out, "aggregates");
+  if (!fs.existsSync(dir)) {
+    process.stderr.write(`no aggregates in ${dir} — run scripts/resources/run.mjs first\n`);
+    return 1;
+  }
+
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .sort();
+  if (files.length === 0) {
+    process.stderr.write(`no aggregates in ${dir} — run scripts/resources/run.mjs first\n`);
+    return 1;
+  }
+
+  const scenarios = files.map((f) => {
+    const aggregate = JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
+    const definition = SCENARIOS.find((s) => s.id === aggregate.scenario) ?? null;
+    // A variant is a separate result with its own budget entry, so it is keyed
+    // and titled by the file name ("R09-overlay"), not by the scenario id —
+    // three rows all reading "Pet companion" would be unreadable.
+    const key = path.basename(f, ".json");
+    const variant = aggregate.configuration?.variant;
+    // Judge against the budget **in the tree now**, not the one that happened to
+    // exist when the run was recorded: a stored verdict goes stale the moment a
+    // limit moves, and a stale pass is worse than no pass.
+    const verdict = evaluateBudget({ ...aggregate, scenario: key }, loadBudget(aggregate.platform?.os));
+    return {
+      aggregate: { ...aggregate, scenario: key },
+      scenario: definition
+        ? { ...definition, title: variant ? `${definition.title} (${variant})` : definition.title }
+        : null,
+      verdict,
+    };
+  });
+
+  const first = scenarios[0].aggregate;
+  const markdown = renderReport({
+    scenarios,
+    platform: first.platform,
+    configuration: first.configuration,
+    commit: first.commit,
+    generatedAt: new Date().toISOString(),
+  });
+
+  fs.mkdirSync(path.dirname(args.file), { recursive: true });
+  fs.writeFileSync(args.file, markdown, "utf8");
+  process.stdout.write(markdown);
+  process.stderr.write(`\nwritten to ${args.file}\n`);
+  return 0;
+}
+
+process.exit(main());

--- a/uxnandesktop/scripts/resources/run.mjs
+++ b/uxnandesktop/scripts/resources/run.mjs
@@ -1,0 +1,440 @@
+#!/usr/bin/env node
+/**
+ * Run resource scenarios and write result documents.
+ *
+ *   node scripts/resources/run.mjs --scenario R01
+ *   node scripts/resources/run.mjs --all --repeats 5
+ *   node scripts/resources/run.mjs --scenario R09 --variant overlay
+ *
+ * Everything it writes goes under `--out` (default `.resource-results/`, which is
+ * git-ignored). It never touches the real application profile: each repetition
+ * gets a freshly-seeded one inside that directory and the app is pointed at it
+ * with `UXNAN_DATA_DIR`.
+ *
+ * Full documentation: `uxnandesktop/docs/resource-benchmarks.md`.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+import { execFileSync, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { findBinary, launchApp } from "./lib/app.mjs";
+import { Sampler, sleep, snapshotPids } from "./lib/sampler.mjs";
+import { readPlatform } from "./lib/platform.mjs";
+import { liveTerminalCount, writeProfile } from "./lib/profile.mjs";
+import { autoScenarioIds, getScenario, SCENARIOS } from "./lib/scenarios.mjs";
+import { aggregateRepeats, newRun, summarizeRun, validateRun } from "./lib/schema.mjs";
+import { classifyTree, findOrphans } from "./lib/tree.mjs";
+import { findLeaks, redact } from "./lib/redact.mjs";
+import { combineVerdicts, evaluateBudget } from "./lib/budgets.mjs";
+import {
+  checkBinaryEmbedsFrontend,
+  checkExpectedShells,
+  checkNoForeignInstance,
+  checkWebviewInTree,
+  waitForExit,
+} from "./lib/preflight.mjs";
+import { makeRepo } from "./fixtures/make-repo.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DESKTOP_ROOT = path.resolve(HERE, "..", "..");
+
+// --- argument parsing -------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {
+    scenario: null,
+    all: false,
+    repeats: 5,
+    duration: null,
+    stabilize: null,
+    interval: null,
+    variant: null,
+    out: path.join(DESKTOP_ROOT, ".resource-results"),
+    binary: null,
+    buildProfile: "release",
+    assisted: false,
+    keepSamples: true,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    const next = () => argv[(i += 1)];
+    switch (a) {
+      case "--scenario": args.scenario = next(); break;
+      case "--all": args.all = true; break;
+      case "--repeats": args.repeats = Number(next()); break;
+      case "--duration": args.duration = Number(next()); break;
+      case "--stabilize": args.stabilize = Number(next()); break;
+      case "--interval": args.interval = Number(next()); break;
+      case "--variant": args.variant = next(); break;
+      case "--out": args.out = path.resolve(next()); break;
+      case "--binary": args.binary = path.resolve(next()); break;
+      case "--profile": args.buildProfile = next(); break;
+      case "--assisted": args.assisted = true; break;
+      case "--no-samples": args.keepSamples = false; break;
+      case "--help":
+      case "-h": args.help = true; break;
+      default:
+        throw new Error(`unknown argument ${a} (try --help)`);
+    }
+  }
+  return args;
+}
+
+function usage() {
+  const list = SCENARIOS.map((s) => `    ${s.id}  ${s.mode.padEnd(8)} ${s.title}`).join("\n");
+  return `Uxnan desktop resource benchmarks
+
+  node scripts/resources/run.mjs --scenario <id> [options]
+  node scripts/resources/run.mjs --all [options]
+
+Options
+  --scenario <id>     one scenario (see below)
+  --all               every unattended scenario
+  --repeats <n>       repetitions per scenario (default 5)
+  --duration <s>      override the measurement window
+  --stabilize <s>     override the discarded warm-up window
+  --interval <ms>     sampling interval (default 1000)
+  --variant <name>    scenario variant (R09: off | layer | overlay)
+  --out <dir>         results directory (default .resource-results)
+  --binary <path>     app binary to measure (default: the release build)
+  --profile <name>    build profile recorded in the result (default release)
+  --assisted          also run scenarios that need an operator at the keyboard
+  --no-samples        drop the raw samples from the written document
+
+Scenarios
+${list}
+`;
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+/** Build (or reuse) the fixtures a scenario declares. Shared across repetitions:
+ *  regenerating 10 000 files per repetition would measure the generator. */
+function prepareFixtures(scenario, outDir) {
+  const built = {};
+  const spec = scenario.fixtures ?? {};
+  if (spec.repo) {
+    const dir = path.join(outDir, "fixtures", `repo-${spec.repo.name}`);
+    built.repo = makeRepo({ ...spec.repo, dir });
+  }
+  if (spec.http) {
+    built.http = startHttpFixture(spec.http);
+  }
+  return built;
+}
+
+function startHttpFixture({ weight = "light" }) {
+  const child = spawn(
+    process.execPath,
+    [path.join(HERE, "fixtures", "http-server.mjs"), "--weight", weight],
+    { stdio: ["ignore", "pipe", "inherit"], windowsHide: true },
+  );
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: child.stdout });
+    rl.once("line", (line) => {
+      let url = null;
+      try {
+        url = JSON.parse(line).url;
+      } catch {
+        /* leave null */
+      }
+      resolve({ url, stop: () => child.kill() });
+    });
+  });
+}
+
+// --- one repetition ---------------------------------------------------------
+
+async function runOnce({ scenario, rep, args, platform, commit, binary, fixtures, outDir }) {
+  const label = `${scenario.id}${args.variant ? `-${args.variant}` : ""}-r${rep + 1}`;
+  const workDir = path.join(outDir, "work", label);
+  // Only ever inside our own output directory — the harness must not be able to
+  // delete anything a mistyped flag could point it at.
+  if (!workDir.startsWith(path.join(outDir, "work"))) {
+    throw new Error(`refusing to prepare a work directory outside ${outDir}`);
+  }
+  fs.rmSync(workDir, { recursive: true, force: true });
+  const dataDir = path.join(workDir, "data");
+
+  const prepared = scenario.prepare({ fixtures, variant: args.variant, workDir });
+  writeProfile(dataDir, prepared);
+  const expectedShells = liveTerminalCount(prepared.layout);
+
+  const durationS = args.duration ?? scenario.defaults.durationS;
+  const stabilizeS = args.stabilize ?? scenario.defaults.stabilizeS;
+  const intervalMs = args.interval ?? scenario.defaults.intervalMs ?? 1000;
+
+  const doc = newRun({
+    scenario: scenario.id,
+    commit,
+    platform,
+    configuration: {
+      buildProfile: args.buildProfile,
+      variant: args.variant ?? null,
+      durationS,
+      stabilizeS,
+      intervalMs,
+      repetition: rep + 1,
+      mode: scenario.mode,
+    },
+  });
+  doc.notes.push(...(prepared.notes ?? []));
+
+  // A restore is only a restore if the profile has been lived in: launch once,
+  // let it settle, close it, and measure the launch that comes after.
+  if (scenario.warmup) {
+    const warm = launchApp(binary, { dataDir });
+    await warm.waitForBackend(120_000);
+    await sleep(8000);
+    await warm.quit();
+    await sleep(2000);
+    doc.notes.push("a warm-up launch wrote the session this run restores");
+  }
+
+  process.stderr.write(`  ${label}: launching…\n`);
+  const startedAt = Date.now();
+  const app = launchApp(binary, { dataDir });
+  const sampler = new Sampler(app.pid, { intervalMs });
+  // "A restored terminal is live" is observed as the first managed process
+  // beside the app itself. Only meaningful where the scenario actually seeded a
+  // terminal: with none, the first managed process is whatever uxnan happened to
+  // spawn on its own (a git call, a CLI-detection probe), and calling that
+  // `launchToShell` would publish a confident answer to a question nobody asked.
+  let shellReadyMs = null;
+  if (expectedShells > 0) {
+    sampler.onSample = (sample) => {
+      if (shellReadyMs === null && sample.managed.procs > sample.own.procs) {
+        shellReadyMs = Date.now() - startedAt;
+      }
+    };
+  }
+  sampler.start();
+
+  const [windowMs, backendMs] = await Promise.all([
+    app.waitForWindow(120_000),
+    app.waitForBackend(120_000),
+  ]);
+  if (windowMs !== null) doc.phases.push({ name: "launchToWindow", atMs: windowMs });
+  if (backendMs !== null) doc.phases.push({ name: "launchToBackend", atMs: backendMs });
+  else doc.notes.push("the hook server never wrote its endpoint file within the timeout");
+
+  if (app.exited) {
+    sampler.stop();
+    doc.notes.push(`the app exited during launch (code ${app.exitCode})`);
+    doc.verdict = { status: "fail", budgetVersion: null, checks: [] };
+    return { doc, label };
+  }
+
+  const checklist = scenario.checklist ?? [];
+  if (checklist.length > 0) {
+    process.stderr.write(`\n  Operator checklist for ${scenario.id}:\n`);
+    checklist.forEach((step, i) => process.stderr.write(`    ${i + 1}. ${step}\n`));
+    if (fixtures.http?.url) process.stderr.write(`    fixture page: ${fixtures.http.url}\n`);
+    process.stderr.write(`  (measuring for ${durationS}s)\n\n`);
+  }
+
+  await sleep(durationS * 1000);
+  if (shellReadyMs !== null) doc.phases.push({ name: "launchToShell", atMs: shellReadyMs });
+
+  // Snapshot the tree before asking the app to close, so we know which PIDs we
+  // were responsible for when we look for survivors.
+  const lastRows = sampler.lastRows;
+  const managedPids = [...classifyTree(lastRows, app.pid).keys()];
+  const quit = await app.quit();
+  doc.phases.push({ name: "close", atMs: quit.closeMs ?? 0 });
+  if (quit.forced) doc.notes.push("the app had to be force-killed: it did not close on request");
+  sampler.stop();
+
+  // Wait for the tree to actually go away before calling anything an orphan.
+  // This is also what stops the next repetition from adopting a webview browser
+  // process this one left behind (see `preflight.mjs`).
+  const survivors = await waitForExit(managedPids, { timeoutMs: 20_000 });
+  doc.orphans = findOrphans(lastRows, app.pid, snapshotPids(survivors));
+
+  doc.durationMs = Date.now() - startedAt;
+  doc.processes = {
+    atEnd: [...new Set(lastRows.map((r) => r.name))].sort(),
+  };
+  if (sampler.droppedLines > 0) {
+    doc.notes.push(`${sampler.droppedLines} collector line(s) were unparseable and skipped`);
+  }
+  if (sampler.samples.length === 0) {
+    doc.notes.push("the collector produced no samples — check that it can run on this machine");
+  }
+  // Two ways a run can look excellent and mean nothing: the webview landing
+  // outside the tree, and the seeded session never coming back. Both are
+  // invalid runs, not good ones.
+  for (const problem of [
+    checkWebviewInTree(sampler.samples),
+    checkExpectedShells(sampler.samples, expectedShells),
+  ]) {
+    if (problem) {
+      doc.notes.push(problem);
+      doc.invalid = true;
+    }
+  }
+  doc.samples = sampler.samples;
+  doc.summary = summarizeRun(doc, { stableFromMs: stabilizeS * 1000 });
+  if (!args.keepSamples) doc.samples = [];
+
+  return { doc, label };
+}
+
+// --- scenario driver --------------------------------------------------------
+
+async function runScenario(scenario, args, ctx) {
+  process.stderr.write(`\n${scenario.id} — ${scenario.title} (${scenario.mode})\n`);
+  const fixtures = prepareFixtures(scenario, args.out);
+  if (fixtures.http instanceof Promise) fixtures.http = await fixtures.http;
+
+  const runs = [];
+  try {
+    for (let rep = 0; rep < args.repeats; rep += 1) {
+      const { doc, label } = await runOnce({
+        scenario,
+        rep,
+        args,
+        fixtures,
+        outDir: args.out,
+        ...ctx,
+      });
+
+      const budget = loadBudget(ctx.platform.os, args.out);
+      const partial = aggregateRepeats([doc]);
+      doc.verdict = doc.invalid
+        ? { status: "fail", budgetVersion: null, checks: [], notes: ["invalid run — see notes"] }
+        : combineVerdicts(evaluateBudget(partial, budget));
+
+      const check = validateRun(doc);
+      if (!check.ok) {
+        process.stderr.write(`  ${label}: invalid result document:\n`);
+        for (const e of check.errors) process.stderr.write(`    - ${e}\n`);
+      }
+      writeResult(path.join(args.out, "runs", `${label}.json`), doc);
+      const s = doc.summary ?? {};
+      process.stderr.write(
+        `  ${label}: own ${fmtMb(s.ownPrivateP50Mb)} private / ${fmtMb(s.ownRssP50Mb)} ws · managed ${fmtMb(s.managedPrivateP50Mb)} private · cpu P95 ${s.cpuP95 ?? "—"}% · orphans ${doc.orphans.length}\n`,
+      );
+      runs.push(doc);
+    }
+  } finally {
+    fixtures.http?.stop?.();
+  }
+
+  const aggregate = aggregateRepeats(runs);
+  const budget = loadBudget(ctx.platform.os, args.out);
+  const verdict = combineVerdicts(evaluateBudget(aggregate, budget));
+  aggregate.verdict = verdict.status;
+  const name = `${scenario.id}${args.variant ? `-${args.variant}` : ""}`;
+  writeResult(path.join(args.out, "aggregates", `${name}.json`), aggregate);
+  return { aggregate, scenario, verdict };
+}
+
+function fmtMb(v) {
+  return v === null || v === undefined ? "—" : `${v} MB`;
+}
+
+/** Budgets ship in the repo; a local override in the results dir is allowed so
+ *  an operator can experiment without editing tracked files. */
+function loadBudget(osKey, outDir) {
+  const candidates = [
+    path.join(outDir, "budgets", `${osKey}.json`),
+    path.join(HERE, "budgets", `${osKey}.json`),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) {
+      try {
+        return JSON.parse(fs.readFileSync(c, "utf8"));
+      } catch (err) {
+        process.stderr.write(`  budget file ${c} is not valid JSON: ${err.message}\n`);
+      }
+    }
+  }
+  return null;
+}
+
+/** Write a document after scrubbing it, refusing if anything personal survived. */
+function writeResult(file, doc) {
+  const clean = redact(doc);
+  const leaks = findLeaks(clean);
+  if (leaks.length > 0) {
+    throw new Error(
+      `refusing to write ${path.basename(file)}: ${leaks.length} value(s) still look personal, first is ${JSON.stringify(leaks[0]).slice(0, 120)}`,
+    );
+  }
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(clean, null, 2), "utf8");
+}
+
+// --- entry point ------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || (!args.scenario && !args.all)) {
+    process.stdout.write(usage());
+    return 0;
+  }
+
+  const ids = args.all ? autoScenarioIds() : [args.scenario];
+  const scenarios = ids.map(getScenario);
+  const skipped = scenarios.filter((s) => s.mode === "assisted" && !args.assisted);
+  const runnable = scenarios.filter((s) => s.mode !== "assisted" || args.assisted);
+
+  const binary = findBinary({
+    root: DESKTOP_ROOT,
+    profile: args.buildProfile,
+    explicit: args.binary,
+  });
+  for (const blocker of [checkBinaryEmbedsFrontend(binary), checkNoForeignInstance(binary)]) {
+    if (blocker) {
+      process.stderr.write(`\n${blocker}\n`);
+      return 2;
+    }
+  }
+
+  const platform = readPlatform();
+  const commit = readCommit();
+
+  process.stderr.write(
+    `binary: ${path.basename(binary)} (${args.buildProfile}) · commit ${commit} · ${platform.os}/${platform.arch}\n`,
+  );
+  if (skipped.length > 0) {
+    process.stderr.write(
+      `skipping operator-driven scenario(s): ${skipped.map((s) => s.id).join(", ")} (pass --assisted to include them)\n`,
+    );
+  }
+
+  const results = [];
+  for (const scenario of runnable) {
+    results.push(await runScenario(scenario, args, { platform, commit, binary }));
+  }
+
+  process.stderr.write("\nresults written to ");
+  process.stderr.write(`${args.out}\n`);
+  process.stderr.write("build a report with:  node scripts/resources/report.mjs\n");
+
+  return results.some((r) => r.verdict.status === "fail") ? 1 : 0;
+}
+
+function readCommit() {
+  try {
+    return execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: DESKTOP_ROOT,
+      encoding: "utf8",
+      windowsHide: true,
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`\n${err?.message ?? err}\n`);
+    process.exit(1);
+  },
+);

--- a/uxnandesktop/src-tauri/src/automations/store.rs
+++ b/uxnandesktop/src-tauri/src/automations/store.rs
@@ -61,8 +61,14 @@ struct DefinitionsDoc {
 
 /// Resolve the app data directory **without** a Tauri handle, matching what
 /// `app.path().app_data_dir()` returns on each platform. Used by the headless
-/// runner, which has no app at all.
+/// runner, which has no app at all. Honours the same `UXNAN_DATA_DIR` override
+/// the app applies, so a run started from a disposable profile finds that
+/// profile's automations rather than the real ones.
 pub fn app_data_dir() -> Result<PathBuf, AppError> {
+    if let Some(dir) = crate::datadir::override_dir() {
+        return Ok(dir);
+    }
+
     #[cfg(target_os = "windows")]
     let base = std::env::var_os("APPDATA").map(PathBuf::from);
 

--- a/uxnandesktop/src-tauri/src/commands.rs
+++ b/uxnandesktop/src-tauri/src/commands.rs
@@ -58,10 +58,12 @@ pub async fn quick_commands_set(
 // `pet.json` + spritesheet format the Codex CLI uses (so community packs load
 // unmodified). uxnan bundles only its own pet — see `pets.rs`.
 
-/// Resolve `<app-data>`, the root every pet path hangs off.
-fn pets_data_dir(app: &AppHandle) -> Result<std::path::PathBuf, CommandError> {
+/// Resolve `<app-data>` — the root every persisted file hangs off, honouring the
+/// `UXNAN_DATA_DIR` override so a disposable profile really is self-contained.
+fn app_data_dir(app: &AppHandle) -> Result<std::path::PathBuf, CommandError> {
     app.path()
         .app_data_dir()
+        .map(crate::datadir::resolve)
         .map_err(|e| CommandError::new("IO_ERROR", e.to_string()))
 }
 
@@ -69,7 +71,7 @@ fn pets_data_dir(app: &AppHandle) -> Result<std::path::PathBuf, CommandError> {
 /// [`pets_sheet`] so listing a large library stays cheap).
 #[tauri::command]
 pub async fn pets_list(app: AppHandle) -> Result<Vec<crate::pets::InstalledPet>, CommandError> {
-    let dir = pets_data_dir(&app)?;
+    let dir = app_data_dir(&app)?;
     tokio::task::spawn_blocking(move || crate::pets::list(&dir))
         .await
         .map_err(|e| CommandError::new("IO_ERROR", e.to_string()))?
@@ -79,7 +81,7 @@ pub async fn pets_list(app: AppHandle) -> Result<Vec<crate::pets::InstalledPet>,
 /// One installed pet's spritesheet as an inline `data:<mime>;base64,…` URL.
 #[tauri::command]
 pub async fn pets_sheet(app: AppHandle, id: String) -> Result<String, CommandError> {
-    let dir = pets_data_dir(&app)?;
+    let dir = app_data_dir(&app)?;
     tokio::task::spawn_blocking(move || crate::pets::read_sheet(&dir, &id))
         .await
         .map_err(|e| CommandError::new("IO_ERROR", e.to_string()))?
@@ -93,7 +95,7 @@ pub async fn pets_scan(
     app: AppHandle,
     source: String,
 ) -> Result<Vec<crate::pets::ImportablePet>, CommandError> {
-    let dir = pets_data_dir(&app)?;
+    let dir = app_data_dir(&app)?;
     tokio::task::spawn_blocking(move || crate::pets::scan(&dir, std::path::Path::new(&source)))
         .await
         .map_err(|e| CommandError::new("IO_ERROR", e.to_string()))?
@@ -118,7 +120,7 @@ pub async fn pets_import(
     origin: String,
     overwrite: bool,
 ) -> Result<crate::pets::InstalledPet, CommandError> {
-    let dir = pets_data_dir(&app)?;
+    let dir = app_data_dir(&app)?;
     tokio::task::spawn_blocking(move || {
         crate::pets::import(&dir, std::path::Path::new(&source), &origin, overwrite)
     })
@@ -130,7 +132,7 @@ pub async fn pets_import(
 /// Delete an installed pet (idempotent).
 #[tauri::command]
 pub async fn pets_delete(app: AppHandle, id: String) -> Result<(), CommandError> {
-    let dir = pets_data_dir(&app)?;
+    let dir = app_data_dir(&app)?;
     tokio::task::spawn_blocking(move || crate::pets::delete(&dir, &id))
         .await
         .map_err(|e| CommandError::new("IO_ERROR", e.to_string()))?
@@ -1082,10 +1084,7 @@ pub(crate) async fn read_term_buffers(path: &std::path::Path) -> Option<serde_js
 /// the app then simply restores without scrollback).
 #[tauri::command]
 pub async fn term_buffers_get(app: AppHandle) -> Result<Option<serde_json::Value>, CommandError> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| CommandError::new("IO_ERROR", e.to_string()))?;
+    let dir = app_data_dir(&app)?;
     Ok(read_term_buffers(&term_buffers_path(&dir)).await)
 }
 
@@ -1096,10 +1095,7 @@ pub async fn term_buffers_set(
     app: AppHandle,
     buffers: serde_json::Value,
 ) -> Result<(), CommandError> {
-    let dir = app
-        .path()
-        .app_data_dir()
-        .map_err(|e| CommandError::new("IO_ERROR", e.to_string()))?;
+    let dir = app_data_dir(&app)?;
     let path = term_buffers_path(&dir);
     let text = serde_json::to_string(&buffers).map_err(AppError::from)?;
     tokio::task::spawn_blocking(move || agent_hooks::write_json_atomic(&path, &text))

--- a/uxnandesktop/src-tauri/src/datadir.rs
+++ b/uxnandesktop/src-tauri/src/datadir.rs
@@ -1,0 +1,93 @@
+//! Where the ADE keeps its state on disk, and the one way to move it.
+//!
+//! Everything the app persists — `state.json` + its backups, the terminal
+//! scrollback sidecar, `hooks/`, `pets/`, `automations/` — hangs off a single
+//! per-user directory: `app.path().app_data_dir()` inside the app, and the
+//! hand-rolled equivalent in [`crate::automations::store::app_data_dir`] for the
+//! headless runner, which has no Tauri handle at all.
+//!
+//! [`UXNAN_DATA_DIR`](DATA_DIR_ENV) overrides that directory for the whole
+//! process. It exists so a run of the app can be given a **disposable profile**:
+//! the resource benchmarks (`scripts/resources/`) seed a scenario's projects and
+//! terminal layout into a temp directory and launch the release binary against
+//! it, which is both what makes a scenario reproducible and what keeps the
+//! harness from ever writing into the real profile. The same override is what a
+//! future E2E driver needs to start from a known state.
+//!
+//! It is deliberately inert in normal use: one `env::var_os` at startup, no
+//! effect on anything measured. A relative path is **refused** (it would resolve
+//! against whatever the working directory happened to be, so the same command
+//! could point at two different profiles) — the app then falls back to the
+//! platform location rather than persisting somewhere surprising.
+
+use std::path::{Path, PathBuf};
+
+/// Environment variable that relocates the application data directory.
+pub const DATA_DIR_ENV: &str = "UXNAN_DATA_DIR";
+
+/// The override, if one is set and usable. `None` when unset, empty, or
+/// relative.
+pub fn override_dir() -> Option<PathBuf> {
+    parse_override(std::env::var_os(DATA_DIR_ENV).as_deref().map(Path::new))
+}
+
+/// The directory the app should use: the override when it is usable, else the
+/// platform default the caller resolved.
+pub fn resolve(platform_default: PathBuf) -> PathBuf {
+    override_dir().unwrap_or(platform_default)
+}
+
+/// Pure half of [`override_dir`], so the rules are testable without touching
+/// the process environment.
+fn parse_override(raw: Option<&Path>) -> Option<PathBuf> {
+    let path = raw?;
+    if path.as_os_str().is_empty() || !path.is_absolute() {
+        return None;
+    }
+    Some(path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_means_no_override() {
+        assert_eq!(parse_override(None), None);
+    }
+
+    #[test]
+    fn empty_is_ignored() {
+        assert_eq!(parse_override(Some(Path::new(""))), None);
+    }
+
+    #[test]
+    fn relative_is_refused() {
+        // Resolving against the working directory would make the same command
+        // mean different profiles, so the platform default wins instead.
+        assert_eq!(parse_override(Some(Path::new("profile"))), None);
+        assert_eq!(parse_override(Some(Path::new("./profile"))), None);
+        assert_eq!(parse_override(Some(Path::new("../profile"))), None);
+    }
+
+    #[test]
+    fn absolute_is_taken_as_is() {
+        #[cfg(windows)]
+        let raw = Path::new(r"C:\tmp\uxnan-bench\data");
+        #[cfg(not(windows))]
+        let raw = Path::new("/tmp/uxnan-bench/data");
+
+        assert_eq!(parse_override(Some(raw)), Some(raw.to_path_buf()));
+    }
+
+    #[test]
+    fn resolve_falls_back_to_the_platform_default() {
+        // No override is set in the test process, so the caller's own path wins.
+        let fallback = PathBuf::from(if cfg!(windows) {
+            r"C:\Users\example\AppData\Roaming\dev.luisgamas.uxnandesktop"
+        } else {
+            "/home/example/.local/share/dev.luisgamas.uxnandesktop"
+        });
+        assert_eq!(resolve(fallback.clone()), fallback);
+    }
+}

--- a/uxnandesktop/src-tauri/src/lib.rs
+++ b/uxnandesktop/src-tauri/src/lib.rs
@@ -16,6 +16,9 @@ mod browse;
 mod browser;
 mod codex_trust;
 mod commands;
+// Public so the headless runner (`main.rs` → `automations::store`) resolves the
+// data directory through exactly the same override the app does.
+pub mod datadir;
 mod editors;
 mod error;
 mod fonts;
@@ -75,9 +78,11 @@ pub fn run() {
         // window config provides the first-run defaults.
         .plugin(tauri_plugin_window_state::Builder::default().build())
         .setup(|app| {
-            // Resolve the OS-specific app data directory and load (or default)
-            // the persisted state, then publish it as managed state.
-            let data_dir = app.path().app_data_dir()?;
+            // Resolve the app data directory (the OS-specific one, unless
+            // `UXNAN_DATA_DIR` points the process at a disposable profile) and
+            // load (or default) the persisted state, then publish it as managed
+            // state.
+            let data_dir = crate::datadir::resolve(app.path().app_data_dir()?);
             let persistence = PersistenceManager::new(&data_dir);
             let mut data = persistence.load().unwrap_or_else(|err| {
                 eprintln!("[uxnan-desktop] failed to load persisted state ({err}); starting fresh");

--- a/uxnandesktop/vitest.config.ts
+++ b/uxnandesktop/vitest.config.ts
@@ -4,12 +4,17 @@ import { fileURLToPath } from "node:url";
 // Minimal Vitest setup for the pure logic modules (no SvelteKit plugin needed —
 // these tests don't render components). The `$lib` alias mirrors the app so the
 // modules import exactly as they do in the app.
+//
+// `scripts/**` is included for the resource-benchmark harness: its schema,
+// process-tree attribution, statistics, budgets and redaction are pure
+// functions, and they decide what every published number means — so they run in
+// the same suite as the app's own logic.
 export default defineConfig({
   resolve: {
     alias: { $lib: fileURLToPath(new URL("./src/lib", import.meta.url)) },
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.mjs"],
   },
 });

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -11,6 +11,18 @@ grouped by the date they landed rather than by a version number.
 
 ### Changed
 
+- **The RAM claim is now a measurement.** `RAM_TARGET = "30–100 MB"` is replaced
+  by `RAM_FOOTPRINT = "~250 MB"` and `RAM_CORE = "~40 MB"`, taken from the desktop
+  app's first approved benchmark baseline (Windows 11, WebView2 150, release
+  build, median of five repetitions, private bytes across the whole process
+  tree). The old figure described the Rust core alone — the row Task Manager
+  shows — while the app also runs six OS-webview processes Windows lists under
+  their own name, so quoting the smaller number as the app's footprint was
+  disprovable by anyone who opened Task Manager. The hero, the OG/schema
+  description, the feature card and the two-apps summary all follow from those
+  constants, and `docs/content.md` records the source file and how to re-derive
+  it. The Electron range is unchanged and stays explicitly *not* a benchmark of
+  any named product.
 - **Contract counts refreshed to 68 methods / 10 notifications**
   (`BRIDGE_METHOD_COUNT`, `BRIDGE_NOTIFICATION_COUNT`). The mobile message queue
   added `queue/resume` + `queue/clear` and the `stream/turn/cancelled` +

--- a/web/docs/content.md
+++ b/web/docs/content.md
@@ -26,8 +26,9 @@ value.
 | "7 agents in the picker" | `PHONE_AGENT_COUNT` | `uxnanmobile/README.md` → *Provider-agnostic, real multi-agent support* (Gemini CLI is wired but hidden) |
 | Agent names and marks | `WIRED_AGENTS` | the same two READMEs; logos copied from `uxnandesktop/static/agents/` and `uxnanmobile/assets/images/agents/` |
 | Agents that "run in the terminal" | `TERMINAL_ONLY_AGENTS` | real command-line coding agents only. The apps ship extra marks (Gemma, Kimi, …) that are **models, not CLIs** — they must not be listed as agents |
-| "30–100 MB of RAM" | `RAM_TARGET` | `uxnandesktop/README.md` → *Why it helps, even in alpha* |
-| "200–500 MB" for an Electron shell | `ELECTRON_RAM` | the same section — stated as a range those apps commonly idle in, **not** a benchmark of a named product |
+| "~250 MB of RAM" | `RAM_FOOTPRINT` | **measured**, not a target: `uxnandesktop/scripts/resources/baselines/windows/R02.json` (median of 5 repetitions, private bytes across the process tree). Re-measure with `npm run bench` before changing it, and keep the platform/build beside the figure |
+| "~40 MB core" | `RAM_CORE` | the same baseline — the Rust process alone, without the OS webview the UI renders in |
+| "200–500 MB" for an Electron shell | `ELECTRON_RAM` | stated as a range those apps commonly idle in, **not** a benchmark of a named product — nobody has measured one for this repo |
 | "68 JSON-RPC methods, 10 notifications" | `BRIDGE_METHOD_COUNT`, `BRIDGE_NOTIFICATION_COUNT` | `bridge/README.md` → *Architecture*; re-derive from `shared/src/jsonrpc/` rather than trusting the old number |
 | `npm install -g uxnan-bridge` | `BRIDGE_INSTALL_COMMAND` | `bridge/README.md` → *Install* |
 | `xattr -dr com.apple.quarantine …` | `MACOS_QUARANTINE_COMMAND` | `uxnandesktop/docs/install-macos.md` → *Tier 2* |
@@ -110,8 +111,10 @@ making sense.
 
 For anyone writing new copy:
 
-- **Say the specific thing.** "30–100 MB" beats "lightweight". "One git worktree
-  per task" beats "powerful workflow".
+- **Say the specific thing, and only if it is measured.** "~250 MB" beats
+  "lightweight" — but only because a benchmark produced it. A number nobody has
+  measured is worse than the adjective it replaced, because it can be checked.
+  "One git worktree per task" beats "powerful workflow".
 - **Name the pain before the fix.** The reader should recognise their own week in
   the problem section before the product is mentioned — especially people on
   modest hardware and people who refuse a single vendor's phone+desktop leash.

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -15,8 +15,9 @@ companion phone app".
 
 - **Uxnan Desktop** — a terminal-native workspace (Tauri 2 + Rust + Svelte 5) that
   runs several CLI agents in parallel on the PC, each in its own git worktree and
-  pseudoterminal. It targets 30–100 MB of RAM by rendering through the operating
-  system's own webview, where a typical Electron shell idles at 200–500 MB. Any
+  pseudoterminal. It uses about 250 MB of RAM — a ~40 MB Rust core plus the
+  operating system's own webview — where a typical Electron shell, which bundles
+  a second browser, idles at 200–500 MB. Any
   CLI agent runs in it unmodified. Platforms: Windows (developed/tested), Linux
   (built in CI), macOS (experimental, unsigned — Gatekeeper blocks the first
   launch until authorised once).

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 
-import { ELECTRON_RAM, links, RAM_TARGET, SITE_URL } from "@/lib/site";
+import { ELECTRON_RAM, links, RAM_CORE, RAM_FOOTPRINT, SITE_URL } from "@/lib/site";
 import "./globals.css";
 
 /**
@@ -12,8 +12,10 @@ import "./globals.css";
  */
 const siteUrl = SITE_URL;
 
-const description =
-  "Two independent apps for the CLI agents you already use. Uxnan Desktop runs them on 30–100 MB so modest PCs stay in the game. Uxnan Mobile steers those agents from your phone without a vendor app stack — end-to-end encrypted, open source.";
+// Interpolated from `site.ts` rather than typed out: this string is the meta
+// description, the OG card and the Twitter card, and a hand-written copy of a
+// claim is how the site ends up contradicting the app it describes.
+const description = `Two independent apps for the CLI agents you already use. Uxnan Desktop runs them in about ${RAM_FOOTPRINT} so modest PCs stay in the game. Uxnan Mobile steers those agents from your phone without a vendor app stack — end-to-end encrypted, open source.`;
 
 /** Social preview card (`public/og.png`), 1200×630. */
 const ogImage = {
@@ -109,7 +111,7 @@ const jsonLd = {
       name: "Uxnan Desktop",
       applicationCategory: "DeveloperApplication",
       operatingSystem: "Windows, macOS, Linux",
-      description: `A terminal-native workspace that runs several CLI coding agents in parallel on ${RAM_TARGET} of RAM, where a typical Electron shell uses ${ELECTRON_RAM}.`,
+      description: `A terminal-native workspace that runs several CLI coding agents in parallel in about ${RAM_FOOTPRINT} of RAM — a ${RAM_CORE} core plus the OS webview, rather than the second browser an Electron shell bundles (${ELECTRON_RAM}).`,
       url: `${siteUrl}/`,
       downloadUrl: links.releases,
       license: links.license,

--- a/web/src/components/hero/hero.tsx
+++ b/web/src/components/hero/hero.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/mockups/satellites";
 import { LinkButton } from "@/components/ui/button";
 import { useScrollProgress } from "@/lib/hooks";
-import { RAM_TARGET } from "@/lib/site";
+import { RAM_FOOTPRINT } from "@/lib/site";
 
 /**
  * The satellites that surround the main window once it has settled.
@@ -95,7 +95,7 @@ export function Hero() {
             Two independent apps for the CLI coding agents you already use — not
             another agent, not another vendor lock-in.{" "}
             <b className="font-medium text-foreground">Desktop</b> runs several on{" "}
-            {RAM_TARGET} so modest PCs stay in the game.{" "}
+            {RAM_FOOTPRINT} so modest PCs stay in the game.{" "}
             <b className="font-medium text-foreground">Mobile</b> steers those agents
             from your phone without their app, their stack, or their wall. Use one or
             both. Neither needs the other.

--- a/web/src/components/mockups/satellites.tsx
+++ b/web/src/components/mockups/satellites.tsx
@@ -1,6 +1,6 @@
 import { AgentMark, Bar, Chip, StatusDot, type AgentStatus } from "./primitives";
 import { AgentRow, ProjectGroup, type AgentEntry, type ProjectEntry } from "./sidebar";
-import { RAM_TARGET, WIRED_AGENTS } from "@/lib/site";
+import { RAM_FOOTPRINT, WIRED_AGENTS } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 /**
@@ -738,7 +738,7 @@ export function MemoryCard({ className }: { className?: string }) {
     >
       <div className="flex items-baseline justify-between gap-3">
         <span className="text-[12px] font-medium">App shell</span>
-        <span className="font-mono text-[12px] text-accent">{RAM_TARGET}</span>
+        <span className="font-mono text-[12px] text-accent">{RAM_FOOTPRINT}</span>
       </div>
       <div className="mt-2.5 h-2 overflow-hidden rounded-full bg-surface-sunken">
         <div

--- a/web/src/components/sections/features.tsx
+++ b/web/src/components/sections/features.tsx
@@ -11,7 +11,7 @@ import {
   PullRequestPanel,
   UsageCard,
 } from "@/components/mockups/satellites";
-import { PHONE_AGENT_COUNT, RAM_TARGET } from "@/lib/site";
+import { PHONE_AGENT_COUNT, RAM_FOOTPRINT } from "@/lib/site";
 
 /**
  * Home “see it first” strip — Desktop + Mobile surfaces in one marquee.
@@ -22,7 +22,7 @@ const FEATURES: MockupMarqueeItem[] = [
     key: "light",
     product: "Desktop",
     title: "RAM for agents, not chrome",
-    body: `Targets ${RAM_TARGET} via the OS webview — no second browser bundled in.`,
+    body: `Measured at ${RAM_FOOTPRINT} on the OS webview — no second browser bundled in.`,
     visual: <MemoryCard className="w-[260px]" />,
   },
   {

--- a/web/src/components/sections/two-apps.tsx
+++ b/web/src/components/sections/two-apps.tsx
@@ -2,7 +2,7 @@ import { ArrowRight, Check, Monitor, Smartphone } from "lucide-react";
 
 import { Section, SectionHeading } from "./shared";
 import { LinkButton } from "@/components/ui/button";
-import { BRIDGE_INSTALL_COMMAND, links, PHONE_AGENT_COUNT, RAM_TARGET } from "@/lib/site";
+import { BRIDGE_INSTALL_COMMAND, links, PHONE_AGENT_COUNT, RAM_FOOTPRINT } from "@/lib/site";
 import { cn } from "@/lib/utils";
 
 /**
@@ -32,7 +32,7 @@ export function TwoApps() {
             tagline="Agents on your machine — without eating it."
             href="#features"
             cta="See Desktop surfaces"
-            summary={`A terminal-native workspace that organises CLI agents, worktrees and review. Targets ${RAM_TARGET} so RAM stays with the agents, not a second browser inside the app.`}
+            summary={`A terminal-native workspace that organises CLI agents, worktrees and review. Measured at ${RAM_FOOTPRINT} — RAM stays with the agents, not with a second browser inside the app.`}
             requires="Standalone. No phone, no bridge, no account with us."
             points={[
               "Native OS webview — not Electron’s full Chromium tax",

--- a/web/src/lib/site.ts
+++ b/web/src/lib/site.ts
@@ -101,6 +101,21 @@ export const TERMINAL_ONLY_AGENTS = [
 export const BRIDGE_METHOD_COUNT = 68;
 export const BRIDGE_NOTIFICATION_COUNT = 10;
 
-/** Memory envelope the desktop app targets, and what an Electron shell costs. */
-export const RAM_TARGET = "30–100 MB";
+/**
+ * What the desktop app actually costs, and what an Electron shell costs.
+ *
+ * `RAM_FOOTPRINT` is **measured**, not a target: the median of five repetitions
+ * of the "one project, one terminal" scenario on Windows 11 (WebView2
+ * 150.0.4078.105, release build), counting private committed bytes across the
+ * whole process tree so pages shared between the webview's processes are not
+ * counted twice. `RAM_CORE` is the Rust process on its own — everything above it
+ * is the OS webview the interface renders in.
+ *
+ * Source: `uxnandesktop/scripts/resources/baselines/windows/`. Re-measure before
+ * changing them, and keep the conditions beside the figure wherever it is shown:
+ * a memory number without its platform and build is not a claim anyone can
+ * defend. Method: `uxnandesktop/docs/resource-benchmarks.md`.
+ */
+export const RAM_FOOTPRINT = "~250 MB";
+export const RAM_CORE = "~40 MB";
 export const ELECTRON_RAM = "200–500 MB";


### PR DESCRIPTION
## Summary

Turns the desktop app's efficiency claim from an assertion into a measurement: a
reproducible resource benchmark (twelve scenarios, versioned result schema,
per-platform budgets, baseline comparator), the first approved Windows baseline,
and a restatement of the published RAM figure to match what was measured.

## Affected component(s)

- [ ] `shared` — contracts / JSON-RPC / E2EE schemas
- [ ] `bridge` — PC daemon (uxnan-bridge)
- [ ] `relay` — E2EE relay server (uxnan-relay)
- [x] `uxnandesktop` — Tauri desktop app
- [ ] `uxnanmobile` — Flutter mobile app
- [x] Cross-cutting / tooling / CI / docs

## Type of change

- [ ] `fix` — bug fix
- [x] `feat` — new feature
- [ ] `refactor` — no behavior change
- [x] `docs`
- [x] `test`
- [x] `chore` / `ci` / `build`

## What is in here

**The harness** (`uxnandesktop/scripts/resources/`) — `npm run bench:build`,
`bench`, `bench:report`, `bench:compare`. Twelve canonical scenarios: cold start,
idle, 1 and 4 terminals, a sleeping workspace, an agent working, a 10 000-file
repo, browser, GitHub, pet off/layer/overlay, a two-hour soak, restart-and-restore.

Attribution is **structural**, never by name: the harness spawns the app, so it
walks parent/child edges from a PID it owns. Three buckets that are never summed —
`own` (app + webview helpers), `managed` (+ shells and sidecars uxnan spawned),
`external` (what the user ran inside a shell). A same-named process that was
already running cannot be counted; a renamed one cannot escape.

Scenarios reach their state by **seeding the app's own persisted profile** rather
than driving the UI, so they are reproducible today without an E2E driver. That
needs one small production affordance: `UXNAN_DATA_DIR`
(`src-tauri/src/datadir.rs`, +26/−19 lines) relocates the app data directory for
one process — which is also what keeps the harness from ever writing into a real
profile. A relative path is refused.

**Fixtures** are offline and deterministic: a generated git repository whose
commit hash is a function of its arguments, a stand-in agent that reproduces an
agent's *shape* of load without a model, a network or credentials, and a fixed
loopback page.

## Three failures it now refuses to measure

Each of these produced a believable **wrong** number rather than an error, which
is the failure mode the harness exists to prevent. All three were found by
building it:

1. **WebView2 keeps one browser process per user-data folder.** A second uxnan
   attaches to the first one's, so the run's webview is spawned outside the tree
   being sampled: the result reads ~27 MB and silently omits the entire webview.
   The harness refuses to start while another instance is running.
2. **`cargo build --release` alone leaves Tauri in dev mode** (no
   `custom-protocol`): real window, real Rust backend, real WebView2 processes —
   and a connection-refused page for a UI. Every signal a harness would trust is
   present; only the product is missing. The binary is now scanned for embedded
   frontend assets.
3. **A scenario whose seeded terminals never came back** is marked invalid, which
   also catches a broken restore path on its own.

## Measured baseline

Windows 11 Pro 10.0.26200 (x64) · WebView2 150.0.4078.105 · i7-13620H · release ·
5 repetitions · medians · private bytes across the tree.

| Scenario | own private | working set | CPU P95 | procs |
|---|---:|---:|---:|---:|
| R00 cold | 236 MB | 479 MB | 1.6 % | 7 |
| R02 one terminal | 252 MB | 506 MB | 6.4 % | 9 |
| R03 four terminals | 274 MB | 574 MB | 7.2 % | 15 |
| R04 workspace asleep | 226 MB | 470 MB | 4.6 % | 7 |
| R09 pet as overlay | 330 MB | 637 MB | 24.2 % | 10 |
| R11 restart + restore | 266 MB | 568 MB | 8.7 % | 15 |

- **Sleep gives back 48 MB and 8 processes.**
- **Restore comes back whole** — same 15 managed processes, within 3 % of memory.
- **The pet costs nothing off**, 28 MB as a layer, **88 MB + double CPU as a
  desktop overlay** (it is a second webview window).
- **The agent's cost stays out of uxnan's figure** — the fixture agent is reported
  in `external` at 48 MB working set / 27 MB private.

Both memory families are published, because neither alone is honest about a
webview: working set over-counts pages the six webview processes share; private
bytes double-count nothing.

## The RAM claim, restated

The published **"30–100 MB" described the Rust process alone** (~40 MB — the row
Task Manager shows) while the app also runs six OS-webview processes Windows lists
under their own name. The honest total is **~250 MB private**. Changed together in
the two root READMEs, the desktop README (badge + a breakdown of *why* Task Manager
shows 40 MB), the architecture comparison tables, and `web/src/lib/site.ts`, where
`RAM_TARGET` becomes a measured `RAM_FOOTPRINT` + `RAM_CORE` pair carrying platform,
build and method. `web/docs/content.md` records how to re-derive it.

Two related fixes: the site's meta/OG description had the figure typed out by hand
instead of interpolated from the constant — exactly how a centralised claim drifts
— and the Electron range now says explicitly that nobody has benchmarked a named
product for this repo.

## How was it tested?

1. `cd uxnandesktop && npm run check` → 1357 files, **0 errors / 0 warnings**.
2. `npm test` → **517 Vitest tests** pass (131 new: process-tree attribution,
   schema + validation messages, percentile / CPU-rate / slope maths, budgets and
   the regression policy, the redaction gate, the scenario table, the pre-flight
   checks, the Unix collector's awk parser lifted from the script, and the git
   fixture's determinism including a path with spaces and non-ASCII characters).
3. `npm run build` → SPA build succeeds.
4. `cd src-tauri && cargo test` → **377 pass**; `cargo clippy --all-targets -- -D warnings`
   and `cargo fmt --check` clean.
5. `cd web && npx tsc --noEmit && npm run build` → clean, static export succeeds.
6. **55 real app launches on Windows**: eleven scenarios × 5 repetitions against a
   release build, plus the comparator and budget gate exercised end to end
   (`compare.mjs` against the promoted baseline → all pass; every scenario
   evaluated against `budgets/windows.json`).
7. Verified on-screen that a seeded profile restores its project, its terminal and
   its file tree — which is how failure (2) above was found.

## Resource impact (`uxnandesktop` only)

Adds no runtime process, watcher, poll or webview. `UXNAN_DATA_DIR` is one
`env::var_os` at startup. The benchmark itself only runs when invoked.

## Checklist

- [x] Lint/format pass for the touched component(s).
- [x] Tests added or updated, and the suite passes.
- [x] `CHANGELOG.md` updated for each affected component (desktop + web).
- [x] Docs / `architecture/` updated (spec-drift control: `04-technical-reference.md`
      records the harness under Phase 5; `01-product-vision.md` turns "bajo consumo"
      into a measured contract).
- [x] Commits follow Conventional Commits.
- [ ] **If this is a `uxnanmobile` release:** n/a.
- [x] If a `shared` contract changed, all consumers updated — n/a, none changed.
- [x] Resource scenario run and numbers above.

## What is deliberately not here

- **macOS and Linux budgets ship empty.** The Unix collector is implemented and its
  parser is tested, but it has never run on real hardware; those platforms report
  `unknown` rather than borrowing a Windows number.
- **R07, R08 and R10 have no baseline** — two need an operator, the two-hour soak
  has never been run. They report `unknown`, because "not judged" and "passed" must
  not read alike.
- **The gate is warn-only.** Flipping to `enforce` is a one-line change once the
  noise floor is known on a second machine. Tracked in `FOR-DEV.md`.
