### PR TITLE
fix(desktop): keep right panel data live

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -123,7 +123,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   start while another instance is running, and marks any run that never grew a
   webview inside its own tree as invalid. A benchmarking constraint only — it
   does not affect normal use.
+### Fixed — right-panel Git and GitHub data could stay stale
 
+- **History now follows commits made outside Uxnan.** The 3-second Git snapshot
+  includes the current `HEAD` via a cheap ref lookup on the repository already
+  opened for status, so an agent commit or amend refreshes an already-loaded log
+  even on a clean branch without an upstream. Uxnan commit/push/pull actions also
+  refresh the cached log immediately. Async guards prevent slow History, Changes
+  and numstat responses from repainting a worktree after a fast A → B → A switch.
+- **The right-panel GitHub digest now follows its configured poll.** Previously
+  the poll refreshed only the active branch context; the five recent PRs, Actions
+  runs and issues reloaded only when the worktree or branch name changed. Every
+  completed context poll now refreshes all three lists, while request sequencing
+  and eager clearing prevent data from the previous repository appearing after a
+  worktree switch.
 ### Fixed — most agent logos never rendered, and the catalog didn't notice an uninstall
 
 - **Every logo that came from a favicon was blocked.** Only 7 of the 32 catalog

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -18,7 +18,7 @@ OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
 with" external editors/IDEs**, **automations**, **pets**, **a reproducible
-resource benchmark**). 377 Rust backend tests + 517 frontend Vitest unit tests
+resource benchmark**). 379 Rust backend tests + 517 frontend Vitest unit tests
 (pure logic, the benchmark harness included); **no Svelte component or E2E tests
 yet**. macOS now ships an
 **experimental, unsigned** build (Intel + Apple Silicon; CI verifies `{ubuntu,
@@ -878,7 +878,7 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 377 Rust + 517 Vitest tests.
+  keeps the default `{ubuntu, windows}`. 379 Rust + 517 Vitest tests.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →
   draft GitHub Release, **and signs the updater artifacts** when the signing secrets
   are set. Builds Windows + Linux + **experimental unsigned macOS** (two ad-hoc-signed

--- a/uxnandesktop/architecture/02c-git-worktrees.md
+++ b/uxnandesktop/architecture/02c-git-worktrees.md
@@ -156,6 +156,13 @@ El estado git se mantiene actualizado con un ciclo de polling:
 - **Detección de conflictos**: Se detecta si hay un merge, rebase o cherry-pick en curso.
 - **Estado upstream**: Se calcula cuántos commits está "ahead" y "behind" respecto a la rama remota.
 
+Cada snapshot emitido también incluye el commit `HEAD` actual. Esta consulta de
+referencia reutiliza el repositorio ya abierto para el escaneo de estado, por lo
+que no añade un segundo recorrido del working tree. Así, un commit o amend
+externo sobre un árbol limpio también cambia el snapshot: Cambios se mantiene al
+día, se refresca el Historial cacheado y se relee el contexto GitHub activo aunque
+la rama no tenga upstream y `ahead`/`behind` sigan en cero.
+
 La sidebar mantiene además una reconciliación ligera cada 3 segundos de la lista
 de worktrees de cada repositorio registrado. Esto cubre worktrees creados fuera
 del ADE por agentes o por Git; solo se reasigna una lista cuando cambian sus
@@ -363,7 +370,12 @@ con `shadcn-svelte` Tabs). De izquierda a derecha:
    GitHub del proyecto y refresca (con tooltip que dice qué relee). Los iconos y
    tonos de estado son los de `$lib/githubDisplay`, compartidos con la vista
    inline. Solo aparece cuando el repo es de GitHub y el tab está habilitado
-   (`AppSettings.github.rightPanelTab`). Las vistas grandes (review/diff/logs) se
+   (`AppSettings.github.rightPanelTab`). Cada poll configurado de GitHub refresca
+   tanto el contexto de la rama como las tres listas del resumen del repositorio
+   (PR, ejecuciones de CI e issues), incluso si no cambiaron el nombre de la rama
+   ni el JSON del contexto. Las respuestas async llevan guardas de secuencia y se
+   limpian al cambiar de worktree, por lo que una petición lenta del repositorio
+   anterior no puede repintar el panel activo. Las vistas grandes (review/diff/logs) se
    abren en la **vista GitHub inline por-proyecto** (`GitHub.svelte`), que ocupa el
    centro + panel derecho dejando visibles el sidebar izquierdo y el navegador. Se
    abre desde el menú **⋯** de cada tarjeta de proyecto y desde el menú contextual
@@ -376,11 +388,13 @@ con `shadcn-svelte` Tabs). De izquierda a derecha:
    (`app.githubInline`; integración `gh`-backed; ver `docs/github.md`). La sección de
    ajustes/cuenta de GitHub vive en **Configuración → GitHub** (`GithubSettings.svelte`).
 
-El estado git del worktree activo se carga en el padre `RightPanel` (siempre
-montado), de modo que la pestaña Archivos colorea su árbol aunque la pestaña
-Cambios esté desmontada. La pestaña Historial mantiene su propio store
-(`history.svelte.ts`) que sobrevive al cambio de pestaña y se refresca tras
-commit/push/pull.
+El estado git del worktree activo se carga en el shell siempre montado
+(`+page.svelte`), de modo que la pestaña Archivos colorea su árbol aunque el
+panel derecho esté cerrado o la pestaña Cambios esté desmontada. La pestaña
+Historial mantiene su propio store (`history.svelte.ts`), que sobrevive al cambio
+de pestaña. Las operaciones commit/push/pull de Uxnan refrescan inmediatamente un
+log ya cargado, y el watcher de estado hace lo mismo cuando un commit externo
+cambia `HEAD`.
 
 ### 6.1 Árbol de Archivos
 
@@ -577,8 +591,11 @@ worktree activo. Características:
 - **Log paginado y virtualizado**: el backend devuelve commits del más reciente
   al más antiguo en orden topológico (`git_log(path, limit, skip)`); el frontend
   los renderiza con `VirtualList` y pagina con un botón **Cargar más**. El estado
-  vive en `history.svelte.ts` (sobrevive al cambio de pestaña; se marca obsoleto
-  tras commit/push/pull para refrescarse la próxima vez que se muestra).
+  vive en `history.svelte.ts` y sobrevive al cambio de pestaña. Las operaciones
+  commit/push/pull de Uxnan refrescan inmediatamente un log ya cargado. El watcher
+  de 3 segundos hace lo mismo cuando cambia el `HEAD` de su snapshot, cubriendo
+  commits y amends hechos por agentes o clientes Git externos; un log aún no
+  cargado conserva la carga perezosa hasta mostrarse por primera vez.
 - **Fila de commit**: badges de decoración (`HEAD`, ramas, `tag:`), resumen,
   hash corto, autor y **tiempo relativo localizado** (`Intl.RelativeTimeFormat`).
 - **Estados**: sin worktree, no es repo (el log falla), repo sin commits, sin

--- a/uxnandesktop/architecture/03-implementation-guide.md
+++ b/uxnandesktop/architecture/03-implementation-guide.md
@@ -195,7 +195,7 @@ Los commands siguen un patron request/response: el frontend pide, el backend res
 
 | Evento | Origen | Payload | Proposito |
 |--------|--------|---------|-----------|
-| `git:status-changed` | Timer Tokio (polling cada 3s) | Lista de archivos con estado (modified/staged/untracked) | Actualizar sidebar derecha con cambios del worktree activo |
+| `git:status-changed` | Timer Tokio (polling cada 3s) | Archivos, ahead/behind y `HEAD` actual | Mantener Cambios al día y refrescar Historial/GitHub tras commits o amends externos |
 | `agent:status-changed` | Servidor de hooks HTTP | ID del agente, nuevo estado (working/waiting/blocked/done) | Actualizar badges e indicadores en sidebar izquierda |
 | `pty:output:{id}` | PTY Manager | Bytes crudos del stdout del PTY | Alimentar xterm.js con output del terminal en tiempo real |
 | `notification:agent-completed` | Modulo de notificaciones | ID del agente, worktree, timestamp | Disparar notificacion nativa del OS |
@@ -1298,7 +1298,7 @@ if !window_visible.load(Ordering::Relaxed) {
 
 Al volver a enfocar la ventana, se ejecuta inmediatamente un ciclo de polling para actualizar el estado.
 
-Ademas, cada tick del watcher realiza **un unico recorrido del working tree** (no dos): una sola funcion combinada (`git::status_with_summary`, ruta rapida `gitfast::status_with_summary` con el mismo fallback `git2`->CLI) devuelve tanto la lista de archivos como el resumen ahead/behind desde el mismo `statuses()`. El conteo `dirty` es la longitud de esa lista, por lo que no hace falta un segundo escaneo.
+Ademas, cada tick del watcher realiza **un unico recorrido del working tree** (no dos): una sola funcion combinada (`git::status_with_summary`, ruta rapida `gitfast::status_with_summary` con el mismo fallback `git2`->CLI) devuelve tanto la lista de archivos como el resumen ahead/behind desde el mismo `statuses()`. El conteo `dirty` es la longitud de esa lista, por lo que no hace falta un segundo escaneo. El mismo snapshot incluye `HEAD` mediante una consulta barata de referencia sobre el repositorio ya abierto; así se detectan commits externos sobre un árbol limpio sin otro recorrido de estado.
 
 #### Escaneo de Procesos de Agentes (focus-gated + off-worker)
 

--- a/uxnandesktop/docs/github.md
+++ b/uxnandesktop/docs/github.md
@@ -257,6 +257,11 @@ discontinued until you pick another.
 Settings persist in `AppSettings.github` (`GithubSettings`); all fields default, so
 older state loads unchanged.
 
+The refresh interval drives the complete right-panel digest: the active branch's
+PR context plus the repository's five recent PRs, workflow runs and issues. Each
+list request is sequence-guarded, so switching worktrees cannot let a slower
+response from the previous repository overwrite the current panel.
+
 ## Backend commands
 
 All 38 GitHub commands live in `src-tauri/src/github.rs` (thin wrappers in

--- a/uxnandesktop/src-tauri/src/commands.rs
+++ b/uxnandesktop/src-tauri/src/commands.rs
@@ -1506,6 +1506,9 @@ pub struct GitStatusEvent {
     pub files: Vec<git::FileChange>,
     pub ahead: u32,
     pub behind: u32,
+    /// Current HEAD commit. Changes even when a new local branch has no upstream
+    /// and its working tree is clean, which is what keeps History live.
+    pub head: Option<String>,
 }
 
 /// Set (or clear with `None`) the worktree the background watcher polls. The

--- a/uxnandesktop/src-tauri/src/git.rs
+++ b/uxnandesktop/src-tauri/src/git.rs
@@ -589,15 +589,15 @@ async fn worktree_status_cli(worktree_path: &str) -> Result<WorktreeStatus, AppE
     Ok(parse_status_porcelain(&out))
 }
 
-/// Combined [`status_files`] + [`worktree_status`] in a single working-tree
-/// scan — for the 3 s status watcher, which needs both and would otherwise walk
-/// the tree twice per tick. Fast path: one `git2` scan
+/// Combined [`status_files`] + [`worktree_status`] plus the current HEAD in a
+/// single working-tree scan — for the 3 s status watcher, which needs all three
+/// and would otherwise walk the tree twice per tick. Fast path: one `git2` scan
 /// ([`crate::gitfast::status_with_summary`]). On a WSL path or a `git2` failure
 /// it falls back to running the two existing CLI fallbacks sequentially — the
 /// CLI path is the rare case, so paying for two scans there is acceptable.
 pub async fn status_with_summary(
     worktree_path: &str,
-) -> Result<(Vec<FileChange>, WorktreeStatus), AppError> {
+) -> Result<(Vec<FileChange>, WorktreeStatus, Option<String>), AppError> {
     // WSL repos go straight to the CLI (routed through wsl.exe); see worktree_status.
     if !crate::wsl::is_wsl_path(worktree_path) {
         let p = worktree_path.to_string();
@@ -609,7 +609,14 @@ pub async fn status_with_summary(
     }
     let files = status_files_cli(worktree_path).await?;
     let status = worktree_status_cli(worktree_path).await?;
-    Ok((files, status))
+    // WSL and the rare libgit2 fallback still carry HEAD in the same logical
+    // snapshot. `rev-parse` failing is expected for an unborn branch.
+    let head = git(worktree_path, &["rev-parse", "--verify", "HEAD"])
+        .await
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    Ok((files, status, head))
 }
 
 /// Parse `git status --porcelain=v1 --branch` output: the first `## ` line

--- a/uxnandesktop/src-tauri/src/gitfast.rs
+++ b/uxnandesktop/src-tauri/src/gitfast.rs
@@ -158,12 +158,14 @@ pub fn worktree_status(path: &str) -> Result<WorktreeStatus, git2::Error> {
 }
 
 /// One-scan combination of [`status_files`] + [`worktree_status`]: the file
-/// list, plus a summary whose `dirty` is the list's length (same `IGNORED`
+/// list, a summary whose `dirty` is the list's length (same `IGNORED`
 /// filter) and whose ahead/behind comes from the cheap graph walk — so the
 /// 3 s watcher pays for one working-tree scan, not two. Because both parts read
 /// from the same `statuses()` walk, `summary.dirty == files.len()` holds by
-/// construction.
-pub fn status_with_summary(path: &str) -> Result<(Vec<FileChange>, WorktreeStatus), git2::Error> {
+/// construction. The current HEAD comes from the already-open repository.
+pub fn status_with_summary(
+    path: &str,
+) -> Result<(Vec<FileChange>, WorktreeStatus, Option<String>), git2::Error> {
     let repo = Repository::open(path)?;
     let mut opts = status_options();
     let statuses = repo.statuses(Some(&mut opts))?;
@@ -187,7 +189,15 @@ pub fn status_with_summary(path: &str) -> Result<(Vec<FileChange>, WorktreeStatu
         ahead,
         behind,
     };
-    Ok((files, summary))
+    // Reading HEAD is a ref lookup on the repository we already opened, not a
+    // second working-tree scan. Including it in the watch snapshot lets the
+    // frontend distinguish an external commit/amend from a merely clean tree.
+    let head = repo
+        .head()
+        .ok()
+        .and_then(|reference| reference.target())
+        .map(|oid| oid.to_string());
+    Ok((files, summary, head))
 }
 
 /// Render a `git2::Diff` to a unified-diff string (the format the frontend's
@@ -489,7 +499,7 @@ mod tests {
         std::fs::write(dir.join("b.txt"), "new\n").unwrap();
 
         let path = dir.to_string_lossy().to_string();
-        let (files, summary) = status_with_summary(&path).unwrap();
+        let (files, summary, head) = status_with_summary(&path).unwrap();
         let parts_files = status_files(&path).unwrap();
         let parts_status = worktree_status(&path).unwrap();
 
@@ -503,10 +513,44 @@ mod tests {
             (summary.ahead, summary.behind),
             (parts_status.ahead, parts_status.behind)
         );
+        assert_eq!(
+            head,
+            repo.head().unwrap().target().map(|oid| oid.to_string())
+        );
     }
 
-    /// Commit a file to `repo`, returning the new commit oid. Stages the whole
-    /// working tree onto the current `HEAD`.
+    #[test]
+    fn clean_external_commit_still_changes_the_watch_snapshot_head() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let repo = Repository::init(dir).unwrap();
+        let mut cfg = repo.config().unwrap();
+        cfg.set_str("user.name", "Tester").unwrap();
+        cfg.set_str("user.email", "t@t").unwrap();
+
+        commit_file(&repo, dir, "a.txt", "one\n", "first");
+        let path = dir.to_string_lossy().to_string();
+        let (before_files, before_status, before_head) = status_with_summary(&path).unwrap();
+
+        // Simulate an agent/Git client committing outside Uxnan. Both status
+        // summaries remain all-zero (clean, no upstream); HEAD is the only
+        // signal that can invalidate the right-panel History cache.
+        commit_file(&repo, dir, "a.txt", "one\ntwo\n", "second");
+        let (after_files, after_status, after_head) = status_with_summary(&path).unwrap();
+
+        assert!(before_files.is_empty());
+        assert!(after_files.is_empty());
+        assert_eq!(before_status, WorktreeStatus::default());
+        assert_eq!(after_status, WorktreeStatus::default());
+        assert_ne!(before_head, after_head);
+        assert_eq!(
+            after_head,
+            repo.head().unwrap().target().map(|oid| oid.to_string())
+        );
+    }
+
+    /// Commit a file to `repo`. Stages the whole working tree onto the current
+    /// `HEAD`.
     fn commit_file(repo: &Repository, dir: &std::path::Path, name: &str, content: &str, msg: &str) {
         std::fs::write(dir.join(name), content).unwrap();
         let mut index = repo.index().unwrap();

--- a/uxnandesktop/src-tauri/src/lib.rs
+++ b/uxnandesktop/src-tauri/src/lib.rs
@@ -181,9 +181,9 @@ pub fn run() {
                         continue;
                     };
                     // One working-tree scan per tick: `status_with_summary`
-                    // returns the file list and the ahead/behind summary from a
-                    // single `git2` walk instead of two separate scans.
-                    let (files, status) = crate::git::status_with_summary(&path)
+                    // returns the file list, ahead/behind and HEAD from a single
+                    // `git2` walk plus a ref lookup instead of two tree scans.
+                    let (files, status, head) = crate::git::status_with_summary(&path)
                         .await
                         .unwrap_or_default();
                     let payload = GitStatusEvent {
@@ -191,6 +191,7 @@ pub fn run() {
                         files,
                         ahead: status.ahead,
                         behind: status.behind,
+                        head,
                     };
                     let snapshot = serde_json::to_string(&payload).ok();
                     if snapshot != last {

--- a/uxnandesktop/src/lib/components/ChangesPanel.svelte
+++ b/uxnandesktop/src/lib/components/ChangesPanel.svelte
@@ -34,8 +34,8 @@
 
   type Area = "staged" | "changes";
 
-  // The active worktree's git status is loaded by the parent (RightPanel), which
-  // stays mounted across tab switches; this panel just renders the shared store.
+  // The active worktree's git status is loaded by the always-mounted page shell;
+  // this panel just renders the shared store.
   // Amend can reword the previous commit with nothing staged, so it relaxes the
   // "needs staged changes" requirement.
   const canCommit = $derived(

--- a/uxnandesktop/src/lib/components/GithubPanel.svelte
+++ b/uxnandesktop/src/lib/components/GithubPanel.svelte
@@ -43,6 +43,8 @@
   let prsLoading = $state(false);
   let issuesLoading = $state(false);
   let showCreate = $state(false);
+  let listsPath = $state<string | null>(null);
+  let listSeq = 0;
 
   // Worktree-from-issue, using the very dialog the section uses (branch name,
   // agent, folder preview) — it owns the `gh issue develop` call.
@@ -50,7 +52,11 @@
   let worktreeIssueNumber = $state<number | null>(null);
   let worktreeIssueTitle = $state("");
 
-  const ctx = $derived(github.context);
+  const activePath = $derived(projects.activeWorktreePath);
+  // Never render the previous worktree's repo while the next context request is
+  // in flight. The store clears on a path change too; this is the view-level
+  // invariant that keeps the digest scoped to exactly the active worktree.
+  const ctx = $derived(github.contextPath === activePath ? github.context : null);
   /** The repo the section should open on — a worktree's own path works for `gh`,
    *  but the section is per *project*, so it gets the project root. */
   const repoPath = $derived(projects.activeRepo?.path ?? null);
@@ -60,44 +66,59 @@
    *  is happening in this repo", and a branch filter is what made the CI list
    *  show the same handful of runs forever. */
   async function loadLists() {
-    const p = projects.activeWorktreePath;
-    if (!p || !github.available) {
+    const seq = ++listSeq;
+    const p = activePath;
+    if (p !== listsPath) {
+      listsPath = p;
       runs = [];
       prs = [];
       issues = [];
+      showCreate = false;
+    }
+    if (!p || !github.available || !ctx) {
+      runs = [];
+      prs = [];
+      issues = [];
+      runsLoading = false;
+      prsLoading = false;
+      issuesLoading = false;
       return;
     }
     runsLoading = true;
     prsLoading = true;
     issuesLoading = true;
-    // Independent: one failing list must not blank the other two.
-    void githubRunList(p, null, LIMIT)
-      .then((r) => (runs = r))
-      .catch(() => (runs = []))
-      .finally(() => (runsLoading = false));
-    void githubPrList(p, "all", null, LIMIT)
-      .then((r) => (prs = r))
-      .catch(() => (prs = []))
-      .finally(() => (prsLoading = false));
-    void githubIssueList(p, "all", null, LIMIT)
-      .then((r) => (issues = r))
-      .catch(() => (issues = []))
-      .finally(() => (issuesLoading = false));
+    // Independent results, applied atomically only if this is still the newest
+    // request for the same worktree. This closes the A → B → A stale-response
+    // race without making one failed list blank the other two.
+    const [nextRuns, nextPrs, nextIssues] = await Promise.allSettled([
+      githubRunList(p, null, LIMIT),
+      githubPrList(p, "all", null, LIMIT),
+      githubIssueList(p, "all", null, LIMIT),
+    ]);
+    if (seq !== listSeq || activePath !== p) return;
+    runs = nextRuns.status === "fulfilled" ? nextRuns.value : [];
+    prs = nextPrs.status === "fulfilled" ? nextPrs.value : [];
+    issues = nextIssues.status === "fulfilled" ? nextIssues.value : [];
+    runsLoading = false;
+    prsLoading = false;
+    issuesLoading = false;
   }
 
-  // Reload whenever the active worktree changes (its repo may differ), the branch
-  // context is refreshed, or sign-in becomes available — a late `gh` login has to
-  // fill the lists that loaded empty before it.
+  // Reload after every successful context poll, not only when the branch name
+  // changes: PRs, CI and issues can change while the checked-out branch stays
+  // exactly the same. Wait for the matching context load to settle first.
   $effect(() => {
-    void projects.activeWorktreePath;
-    void ctx?.branch;
+    void activePath;
     void github.available;
+    void github.contextRevision;
+    if (activePath && (github.contextPath !== activePath || github.contextLoading)) return;
     void loadLists();
   });
 
-  function refreshAll() {
-    void github.refreshContext();
-    void loadLists();
+  async function refreshAll() {
+    // The completed context refresh advances `contextRevision`, which drives the
+    // list reload above. Keeping one path avoids six duplicate `gh` calls.
+    await github.refreshContext();
   }
 
   function checkColor(state: string): string {
@@ -148,6 +169,10 @@
     <div class="flex flex-col items-center gap-2 px-3 py-10 text-center">
       <GitPullRequestIcon class="size-6 text-muted-foreground/50" />
       <p class={cn("text-muted-foreground", text.meta)}>{i18n.t("github.panel.noWorktree")}</p>
+    </div>
+  {:else if github.contextLoading || github.contextPath !== activePath}
+    <div class="px-3 py-8 text-center">
+      <p class={cn("text-muted-foreground", text.meta)}>{i18n.t("github.loading")}</p>
     </div>
   {:else if !ctx}
     <div class="px-3 py-8 text-center">

--- a/uxnandesktop/src/lib/components/RightPanel.svelte
+++ b/uxnandesktop/src/lib/components/RightPanel.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-  // Right panel: two tabbed views over the active worktree. "Files" (first) is a
-  // lazy file tree of the whole working tree; "Changes" (second) is the git
-  // version-control review. Tab state is local; each panel keeps its own state in
-  // a store, so flipping tabs preserves the tree expansion and the commit draft.
+  // Right panel: Files, Changes, History and the optional GitHub digest over the
+  // active worktree. Tab state is local; persistent data lives in the relevant
+  // stores so flipping tabs preserves tree expansion and review state.
   import * as Tabs from "$lib/components/ui/tabs";
   import FileTreePanel from "./FileTreePanel.svelte";
   import ChangesPanel from "./ChangesPanel.svelte";

--- a/uxnandesktop/src/lib/state/git.svelte.ts
+++ b/uxnandesktop/src/lib/state/git.svelte.ts
@@ -1,9 +1,9 @@
 // Git review state for the right panel (Svelte 5 runes).
 //
 // Holds the changed-file list, staging actions, the selected file's diff and the
-// commit message for the **active worktree**. The panel reloads on demand (after
-// each action, on a manual refresh, and when the active worktree changes); the
-// real-time 3 s status polling + Tauri events are a Phase 3 follow-up (FOR-DEV).
+// commit message for the **active worktree**. The panel reloads on demand and
+// applies the backend's live 3 s status snapshots, including HEAD changes made
+// by an agent or another Git client.
 
 import { listen } from "@tauri-apps/api/event";
 import {
@@ -89,6 +89,13 @@ class GitStore {
   /** A remote fetch (checking for new upstream commits) is in flight. */
   fetching = $state(false);
   private listening = false;
+  /** Async guards cover fast A → B → A worktree switches and overlapping manual
+   *  refreshes; comparing only the path cannot reject the first A response. */
+  private loadSeq = 0;
+  private numstatSeq = 0;
+  /** Last HEAD seen for each watched path. Keeping the baseline per worktree
+   *  catches commits made while the user was looking at another workspace. */
+  private headsByPath = new Map<string, string | null>();
 
   /** Files with a staged change / with a working-tree (or untracked) change. */
   staged = $derived(this.files.filter((f) => f.staged));
@@ -103,14 +110,22 @@ class GitStore {
     try {
       await listen<GitStatusEvent>("git:status-changed", (e) => {
         const ev = e.payload;
+        if (ev.path !== this.path) return;
+
+        const hadHead = this.headsByPath.has(ev.path);
+        const previousHead = this.headsByPath.get(ev.path);
+        this.headsByPath.set(ev.path, ev.head);
         if (
-          ev.path !== this.path ||
-          this.busy ||
-          this.committing ||
-          this.syncing ||
-          this.fetching
-        )
-          return;
+          (hadHead && previousHead !== ev.head) ||
+          (!hadHead && history.loadedHeadDiffers(ev.path, ev.head))
+        ) {
+          // A clean tree can still have a new HEAD (external commit/amend). The
+          // changed snapshot is the signal History and GitHub were missing.
+          history.refreshIfLoaded(ev.path);
+          void github.refreshContext();
+        }
+
+        if (this.busy || this.committing || this.syncing || this.fetching) return;
         this.files = ev.files.map(classify);
         this.ahead = ev.ahead;
         this.behind = ev.behind;
@@ -131,12 +146,23 @@ class GitStore {
   /** Point the panel at a worktree (or clear it), load its status, and tell the
    *  backend watcher to poll it. */
   async load(path: string | null): Promise<void> {
+    const seq = ++this.loadSeq;
+    const pathChanged = this.path !== path;
     this.path = path;
     this.error = null;
     this.ahead = 0;
     this.behind = 0;
+    if (pathChanged) {
+      // Never display the previous worktree's files or line counts while the
+      // newly selected path is still loading.
+      this.files = [];
+      this.numstat = {};
+      this.numstatSeq++;
+    }
     void gitSetWatch(path).catch(() => {});
     if (!path) {
+      this.loading = false;
+      this.numstatSeq++;
       this.files = [];
       this.numstat = {};
       return;
@@ -144,22 +170,23 @@ class GitStore {
     this.loading = true;
     try {
       const files = (await gitStatus(path)).map(classify);
-      if (this.path !== path) return;
+      if (seq !== this.loadSeq || this.path !== path) return;
       this.files = files;
       void this.loadNumstat(path);
       const st = await worktreeStatus(path);
-      if (this.path !== path) return;
+      if (seq !== this.loadSeq || this.path !== path) return;
       this.ahead = st.ahead;
       this.behind = st.behind;
       // Keep the project card badge in sync (e.g. after a commit clears it).
       projects.setStatus(path, st);
     } catch (e) {
-      if (this.path !== path) return;
+      if (seq !== this.loadSeq || this.path !== path) return;
       this.error = msg(e);
       toastError(e);
       this.files = [];
+      this.numstat = {};
     } finally {
-      if (this.path === path) this.loading = false;
+      if (seq === this.loadSeq && this.path === path) this.loading = false;
     }
   }
 
@@ -171,9 +198,10 @@ class GitStore {
   /** Refresh the per-file added/deleted line counts (best-effort; only applied if
    *  we're still showing the same worktree when it resolves). */
   async loadNumstat(path: string): Promise<void> {
+    const seq = ++this.numstatSeq;
     try {
       const stats = await gitNumstat(path);
-      if (this.path !== path) return;
+      if (seq !== this.numstatSeq || this.path !== path) return;
       const map: Record<string, { added: number; deleted: number }> = {};
       for (const s of stats) map[s.path] = { added: s.added, deleted: s.deleted };
       this.numstat = map;
@@ -291,8 +319,9 @@ class GitStore {
     try {
       await gitCommit(path, message, this.amend, this.signOff);
       this.resetComposer();
-      history.markStale();
+      history.refreshIfLoaded(path);
       await this.refresh();
+      void github.refreshContext();
       // Our own git actions move more than this worktree's card: a commit here
       // changes what a sibling worktree is ahead/behind by, and those cards are
       // only re-read by the background sweep.
@@ -320,8 +349,9 @@ class GitStore {
     this.error = null;
     try {
       await fn(path);
-      history.markStale();
+      history.refreshIfLoaded(path);
       await this.refresh();
+      void github.refreshContext();
       projects.requestStatusSweep();
       toast.success(okMsg);
     } catch (e) {

--- a/uxnandesktop/src/lib/state/github.svelte.ts
+++ b/uxnandesktop/src/lib/state/github.svelte.ts
@@ -47,6 +47,10 @@ class GithubStore {
   contextPath = $state<string | null>(null);
   /** Whether a context load is in flight. */
   contextLoading = $state(false);
+  /** Advances after every successful active-context read, even when the JSON is
+   *  identical. The right-panel digest uses it as its poll tick for repo-wide
+   *  PR, run and issue lists, which are separate API reads. */
+  contextRevision = $state(0);
   /** Per-path context cache so recently-visited worktree cards keep their PR
    *  badge without re-fetching every switch. */
   contextByPath = $state<Record<string, RepoContext | null>>({});
@@ -206,9 +210,12 @@ class GithubStore {
    *  repo, when no path is active, or when not signed in. */
   async loadContext(path: string | null): Promise<void> {
     const seq = ++this.#ctxSeq;
+    const pathChanged = this.contextPath !== path;
     this.contextPath = path;
+    if (pathChanged) this.context = null;
     if (!path || !this.available) {
       this.context = null;
+      this.contextLoading = false;
       return;
     }
     this.contextLoading = true;
@@ -221,6 +228,7 @@ class GithubStore {
       if (!sameJson(ctx, this.contextByPath[path])) {
         this.contextByPath = { ...this.contextByPath, [path]: ctx };
       }
+      this.contextRevision += 1;
     } catch {
       if (seq !== this.#ctxSeq) return;
       this.context = null;

--- a/uxnandesktop/src/lib/state/history.svelte.ts
+++ b/uxnandesktop/src/lib/state/history.svelte.ts
@@ -3,8 +3,7 @@
 // Holds the paginated commit log for the **active worktree**, a client-side
 // filter, and the list/graph view toggle. The log is fetched on demand (when the
 // tab first shows a worktree, on "load more", and on a manual refresh); it is
-// marked stale by the git store after a commit/push/pull so it re-fetches the
-// next time the tab is shown.
+// refreshed by the git store after Uxnan or an external client moves HEAD.
 
 import { gitLog, gitShow } from "$lib/api";
 import { toastError } from "$lib/toast";
@@ -80,6 +79,9 @@ class HistoryStore {
   /** The path whose log is currently loaded (so `ensure` is a no-op when the tab
    *  re-mounts on the same worktree). `null` means "nothing loaded yet". */
   private loadedPath: string | null = null;
+  /** Guards every async page load, including the A → B → A switch case where a
+   *  path-only check cannot distinguish the first A response from the latest. */
+  private loadSeq = 0;
 
   /** Commits matching the current filter (everything when the filter is empty). */
   filtered = $derived.by(() => {
@@ -103,25 +105,30 @@ class HistoryStore {
 
   /** (Re)load the first page of the log for `path` (or clear it). */
   async load(path: string | null): Promise<void> {
+    const seq = ++this.loadSeq;
     this.path = path;
     this.loadedPath = path;
     this.error = null;
     this.commits = [];
     this.reachedEnd = false;
+    this.loadingMore = false;
     // A different worktree's expansions/file caches don't apply here.
     this.expanded = {};
     this.fileCache = {};
-    if (!path) return;
+    if (!path) {
+      this.loading = false;
+      return;
+    }
     this.loading = true;
     try {
       const page = await gitLog(path, PAGE, 0);
-      if (this.path !== path) return; // a newer load superseded this one
+      if (seq !== this.loadSeq || this.path !== path) return;
       this.commits = page;
       this.reachedEnd = page.length < PAGE;
     } catch (e) {
-      this.error = msg(e);
+      if (seq === this.loadSeq && this.path === path) this.error = msg(e);
     } finally {
-      this.loading = false;
+      if (seq === this.loadSeq) this.loading = false;
     }
   }
 
@@ -129,16 +136,17 @@ class HistoryStore {
   async loadMore(): Promise<void> {
     const path = this.path;
     if (!path || this.loadingMore || this.loading || this.reachedEnd) return;
+    const seq = this.loadSeq;
     this.loadingMore = true;
     try {
       const page = await gitLog(path, PAGE, this.commits.length);
-      if (this.path !== path) return;
+      if (seq !== this.loadSeq || this.path !== path) return;
       this.commits = [...this.commits, ...page];
       if (page.length < PAGE) this.reachedEnd = true;
     } catch (e) {
-      toastError(e);
+      if (seq === this.loadSeq && this.path === path) toastError(e);
     } finally {
-      this.loadingMore = false;
+      if (seq === this.loadSeq) this.loadingMore = false;
     }
   }
 
@@ -147,10 +155,27 @@ class HistoryStore {
     return this.load(this.path);
   }
 
-  /** Mark the loaded log stale so the next `ensure` re-fetches it. Called by the
-   *  git store after a commit/amend/push/pull changes history. */
-  markStale(): void {
-    this.loadedPath = null;
+  /** HEAD (or one of its decorations after push/pull) changed while this path's
+   *  log was already cached. Refresh it immediately, even if the tab is not the
+   *  visible one; otherwise invalidate it for the next `ensure`. */
+  refreshIfLoaded(path: string): void {
+    if (this.path === path && this.loadedPath === path) {
+      void this.load(path);
+    } else if (this.loadedPath === path) {
+      this.loadedPath = null;
+    }
+  }
+
+  /** Compare a first watcher snapshot with the log itself. This closes the tiny
+   *  startup window where History loaded before the watcher established its own
+   *  per-path HEAD baseline. */
+  loadedHeadDiffers(path: string, head: string | null): boolean {
+    return (
+      !this.loading &&
+      this.path === path &&
+      this.loadedPath === path &&
+      (this.commits[0]?.hash ?? null) !== head
+    );
   }
 }
 

--- a/uxnandesktop/src/lib/types.ts
+++ b/uxnandesktop/src/lib/types.ts
@@ -838,6 +838,8 @@ export interface GitStatusEvent {
   files: FileChange[];
   ahead: number;
   behind: number;
+  /** Current HEAD commit; null for an unborn branch. */
+  head: string | null;
 }
 
 /** A worktree's working-tree status summary (mirror of Rust `WorktreeStatus`). */


### PR DESCRIPTION
## Summary

- Keep the right-panel Git changes and history data aligned with the currently selected worktree when asynchronous refreshes overlap.
- Detect external HEAD changes in the existing Git status watcher so clean commits, amends, and branch movement invalidate and refresh Git history.
- Refresh the GitHub tab's repository-wide pull request, workflow-run, and issue lists on every configured poll, with stale-response guards across worktree and repository switches.
- Update the desktop architecture, developer notes, and changelog alongside focused frontend and Rust regression coverage.

## Affected components

- [ ] `shared/`
- [ ] `relay/`
- [ ] `bridge/`
- [ ] `uxnanmobile/`
- [x] `uxnandesktop/`
- [ ] Cross-cutting contract / documentation

## Type of change

- [x] Fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Test coverage
- [ ] Build / CI
- [ ] Other

## How was this tested?

1. Windows 11: `npm run check` — 0 errors and 0 warnings.
2. Windows 11: `npm test` — 510 passed and 7 platform-skipped (517 total).
3. Windows 11: `cargo test` — 378 passed and 1 ignored Task Scheduler test (379 total).
4. Windows 11: `cargo clippy --all-targets --all-features -- -D warnings` — passed.
5. Windows 11: `cargo fmt --all -- --check` — passed.
6. Windows 11: `git diff --check` — passed.

The packaged Tauri UI was not exercised manually in this automated session. The refresh and stale-response behavior is covered by focused unit/backend tests plus the complete suites above.

## Resource impact

- No new background process, timer, watcher, webview, cache, or startup task is introduced.
- The existing Git status watcher now reads HEAD from the repository it already opened; it does not add another working-tree status walk.
- The existing configured GitHub poll performs three additional short-lived `gh` list reads per tick to keep the repository-wide PR, workflow-run, and issue summaries current.
- Desktop resource scenario: R08 (GitHub panel). R08 is assisted-only and currently has no approved baseline, so no trustworthy measured delta is available from this automated session; this PR does not claim one.

## Checklist

- [x] Formatting and lint checks pass.
- [x] Tests were added or updated for changed behavior.
- [x] `CHANGELOG.md` was updated.
- [x] Architecture / developer documentation was updated to avoid implementation drift.
- [x] Commit and PR title use Conventional Commits style.
- [ ] Mobile release metadata updated (not applicable).
- [ ] Shared contract version updated (not applicable).
- [x] Desktop resource impact is identified; no new resource-owning loop was added, and the relevant assisted scenario is documented above.