### PR TITLE
test(desktop): build the test pyramid — components, integration, fixtures and real E2E

### DIFF
--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -1,0 +1,101 @@
+name: E2E — Desktop (uxnandesktop)
+
+# The end-to-end layer: a real release binary, a real WebView2, real IPC.
+# Documented in `uxnandesktop/tests/e2e/README.md`.
+#
+# On demand and nightly, never on a PR — and deliberately **not yet required**.
+# It needs a release build (minutes), a WebDriver matched to the runner's
+# WebView2, and a machine with no other uxnan running. Making it blocking before
+# it has a track record on this runner is how a gate earns a reputation for
+# false failures and gets switched off; the plan is to require it once it has run
+# green for a fortnight (tracked in `uxnandesktop/FOR-DEV.md`).
+#
+# Windows only. `tauri-driver` supports Linux and does not support macOS, and
+# neither has been exercised here — this workflow does not claim a platform
+# nobody has run.
+
+on:
+  workflow_dispatch:
+    inputs:
+      spec:
+        description: "Spec file filter (empty runs them all)"
+        required: false
+        default: ""
+  schedule:
+    # 03:40 UTC, off the hour so it does not queue behind everyone else's cron.
+    - cron: "40 3 * * *"
+
+concurrency:
+  group: e2e-desktop
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: uxnandesktop
+
+jobs:
+  e2e:
+    name: e2e (windows)
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: uxnandesktop/package-lock.json
+
+      - name: Set up Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: uxnandesktop/src-tauri
+
+      - name: Install frontend deps
+        run: npm ci
+
+      - name: Install tauri-driver
+        run: cargo install tauri-driver --locked
+
+      # `tauri build --no-bundle`, not `cargo build --release`: without Tauri's
+      # `custom-protocol` feature the binary stays in dev mode and loads
+      # http://localhost:1420, so the app would run with no UI and every
+      # assertion would fail for the wrong reason.
+      - name: Build a release binary with its frontend embedded
+        run: npm run bench:build
+
+      # Reads the runner's installed WebView2 version and fetches the matching
+      # driver. Not pinned in a file on purpose — the runner image updates its
+      # runtime, and a pinned version would break on their schedule.
+      - name: Fetch the matching WebDriver
+        run: npm run test:e2e:setup
+
+      - name: Run the end-to-end suite
+        shell: bash
+        run: |
+          set -u
+          filter="${{ github.event.inputs.spec }}"
+          if [ -n "$filter" ]; then
+            npx wdio run tests/e2e/wdio.conf.mjs --spec "$filter"
+          else
+            npm run test:e2e
+          fi
+
+      # Evidence, not noise: a screenshot and the page source per failed test,
+      # plus the driver log. The suite writes nothing else, and the profile it
+      # used is a temp directory that never leaves the runner.
+      - name: Upload failure artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts-windows
+          path: uxnandesktop/tests/e2e/.artifacts/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/verify-desktop.yml
+++ b/.github/workflows/verify-desktop.yml
@@ -67,7 +67,15 @@ jobs:
       - name: Svelte type-check
         run: npm run check
 
-      - name: Frontend unit tests (Vitest)
+      # Both Vitest projects: `node` (pure logic, the benchmark harness, the test
+      # fixtures) and `dom` (Svelte components in jsdom). Component tests are in
+      # the required gate from the start — they are fast, and they catch the
+      # mounting and wiring failures that unit tests structurally cannot.
+      #
+      # End-to-end (L4) is deliberately NOT here: it needs a release binary, a
+      # version-matched WebDriver and a machine with no other uxnan running. It
+      # runs on demand and nightly in `e2e-desktop.yml`.
+      - name: Frontend unit + component tests (Vitest)
         run: npm test
 
       - name: Frontend build (Vite)

--- a/uxnandesktop/.gitignore
+++ b/uxnandesktop/.gitignore
@@ -27,3 +27,4 @@ pnpm-debug.log*
 /tests/e2e/.drivers
 /tests/e2e/.artifacts
 /tests/e2e/.profile
+/tests/e2e/.fixtures

--- a/uxnandesktop/.gitignore
+++ b/uxnandesktop/.gitignore
@@ -21,3 +21,9 @@ pnpm-debug.log*
 # profiles. Only approved summaries under scripts/resources/baselines/ are
 # committed (see docs/resource-benchmarks.md).
 /.resource-results
+
+# E2E: the WebDriver binary is downloaded per machine to match the installed
+# WebView2 (see tests/e2e/README.md), and run artifacts are per-run evidence.
+/tests/e2e/.drivers
+/tests/e2e/.artifacts
+/tests/e2e/.profile

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,108 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — a test pyramid: component tests, backend integration, and real end-to-end
+
+- **Five layers, each doing what the one below cannot** (`docs/testing.md`): L0
+  static, L1 unit, L2 Svelte components in jsdom, L3 backend against temp
+  directories, L4 the real app driven end to end, L5 a manual checklist for
+  accounts and hardware. The split exists for speed: almost everything is
+  provable in a layer costing milliseconds, which is what keeps the expensive
+  layers small enough to stay trustworthy.
+- **Vitest now runs as two projects** (`vitest.workspace.ts`): `node` keeps the
+  pure logic fast with no Svelte compiler and no jsdom, `dom` mounts real
+  components. Component tests are `*.svelte.test.ts`, which is also how the node
+  project knows to skip them. `npm test` runs both; `npm run test:node` /
+  `test:dom` run one.
+- **Component tests mock the IPC transport, not `api.ts`.** Using Tauri's own
+  `mockIPC` puts the seam *below* the API layer, so `src/lib/api.ts` runs for
+  real — its command names, its argument marshalling — and only the process on
+  the other side is fake. A renamed command fails a test instead of quietly
+  agreeing with a mock nobody updated. `src/test/tauri.ts` adds a typed handler
+  table (an unhandled command rejects loudly rather than returning `undefined`),
+  a call log, event emission and failure/latency injection; `src/test/render.ts`
+  pairs a component with a backend and tears both down together. **No production
+  code needed changing for any of this.**
+- **First component tests** on `UsageMeter` (props → output, including the
+  clamped bar and the nearly-empty one that must still be visible),
+  `SaveDiscardDialog` (every route out of the dialog resolves its promise —
+  including Escape, whose silence would hang a tab close forever) and
+  `AgentLogo` (the CSP-driven fallback chain: backend fetch, failure degrading to
+  the glyph, one call per URL).
+- **L3 backend integration** in `src-tauri/tests/automations_store.rs`: the store
+  against a real `TempDir`, through the crate's public surface only — round-trip
+  across a process boundary, seed-once, a truncated file degrading instead of
+  panicking, nothing written outside its own root, and a path with spaces and
+  non-ASCII characters.
+- **Test fixtures that cannot reach the real machine** (`tests/fixtures/`): a
+  deterministic fake `gh` that refuses to run without its latch, scrubs anything
+  credential-shaped from its log and fails loudly on an unstubbed command; a
+  **PATH shim** that resolves every CLI the app shells out to inside a directory
+  of fakes, so a test that forgets to stub one gets "blocked by the test harness"
+  instead of talking to real GitHub; and disposable + legacy app profiles for the
+  migration paths. The git repo, stand-in agent and loopback server are
+  **shared** with the resource benchmarks rather than copied — two generators
+  would drift, and the repo fixture is only useful because its hash is pinned.
+- **L4 end to end with WebdriverIO + `tauri-driver`** — **eight journeys, 24
+  tests, ~39 s**, green on consecutive runs with zero leftover processes: launch,
+  session restore, terminals in a split, a sleeping workspace, a git project, an
+  agent and the hook chain, the browser window, and a profile from an older
+  build. Each spec gets its own app, started from a profile seeded for it, so a
+  journey's *setup* costs nothing while its assertions still go through the real
+  UI, real IPC and a real backend. Playwright was the alternative and cannot drive a Tauri
+  window; it could serve the frontend, but a test that never crosses IPC is a
+  component test with a browser attached. The comparison, the pinned versions and
+  the stated limitations are in `docs/testing.md`; setup and cleanup rules in
+  `tests/e2e/README.md`.
+- **Two traps this layer hides, both found the hard way and both now guarded.**
+  `tauri-driver` hands the session a webview sitting at `about:blank` rather than
+  attaching to the window the app already navigated — every query then succeeds
+  and returns `<html><head></head><body></body></html>`, which reads as "the app
+  rendered nothing" while the app is running perfectly. The session now navigates
+  to the app's own origin, and the IPC bridge is live there (`invoke("ping")`
+  answers `"pong"` from Rust), so these are genuine end-to-end tests. Separately,
+  **`tauri:options.env` never reached the app**: a diagnostic run came up on the
+  developer's *real* profile, showing their actual projects. The variable is set
+  on the driver process now, and the suite refuses to run if the app under test
+  has any project in it — an isolation failure must not be something a reader has
+  to notice.
+- **A living quality matrix** (`tests/quality-matrix.json`) — machine-readable,
+  and checked against the repository by `tests/quality-matrix.test.mjs`: a flow
+  claiming a layer must cite a file that exists (globs must match something), a
+  partially covered flow must state its gap, and no flow may list a layer as both
+  covered and planned. It records what is *not* tested as carefully as what is.
+- **CI**: component tests join the required gate immediately (they are fast and
+  catch the wiring failures unit tests structurally cannot). E2E gets its own
+  on-demand/nightly Windows workflow (`e2e-desktop.yml`), deliberately not
+  blocking until it has a track record, uploading a screenshot and the page
+  source per failed test.
+- **A flake policy** in `docs/testing.md`: quarantine with an owner and a 14-day
+  limit, never a silent skip; keep the case at a lower layer if an E2E test is
+  removed; one retry, infrastructure only; fix the wait, not the timeout.
+- Totals: **565 Vitest** (was 517), **387 Rust** (377 unit + 10 integration) and
+  **24 E2E tests across 8 journeys**.
+- **The manual layer is written down too.** `docs/testing.md` carries an L5
+  checklist of the twelve things no automated layer can honestly cover — a real
+  `gh` account, a signed update, the OS scheduler firing with the app closed,
+  macOS and Linux hardware — each with *why* it cannot be automated here and a
+  column for when it was last verified. Anything on it that becomes automatable
+  should move up a layer and leave the table.
+
+### Known limitation — E2E cannot run alongside another uxnan
+
+- The same WebView2 constraint the resource benchmarks hit, and it bites harder
+  here: a second instance shares the browser process, so the automation session
+  drives a webview that is not this app's. It does not error — every query
+  returns `<html><head></head><body></body></html>`, which reads as "the app
+  renders nothing". The E2E config refuses to start and names the offending PID,
+  reusing the benchmarks' check rather than reimplementing it.
+- Teardown reaps **by PID, never by name**: this harness runs on machines where a
+  real `uxnan-desktop.exe` is very likely open — possibly the one hosting the
+  terminal the tests were started from — and a name-based sweep would take it
+  down along with everything running inside it. An app outliving its session is
+  matched on the run's own profile directory, killed, and reported, because a
+  leak is a teardown bug rather than a passing detail.
+
 ### Added — a reproducible resource benchmark, so "it stays small" is a measurement
 
 - **The efficiency claim now has a harness behind it** (`scripts/resources/`,

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -18,9 +18,9 @@ OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
 with" external editors/IDEs**, **automations**, **pets**, **a reproducible
-resource benchmark**). 377 Rust backend tests + 517 frontend Vitest unit tests
-(pure logic, the benchmark harness included); **no Svelte component or E2E tests
-yet**. macOS now ships an
+resource benchmark**). 387 Rust tests (377 unit + 10 integration) + 565 frontend Vitest tests across
+two projects — pure logic and **Svelte component tests** — plus a **real E2E suite**
+(WebdriverIO + tauri-driver: 8 journeys, 24 tests, green on Windows). macOS now ships an
 **experimental, unsigned** build (Intel + Apple Silicon; CI verifies `{ubuntu,
 windows, macOS}`, release gate stays `{ubuntu, windows}`) but is **not yet validated
 on real hardware**. **Phase 6 (embedded bridge / mobile pairing) is NOT started.**
@@ -848,9 +848,49 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
       device.
 - [ ] Sidebar project-tree virtualization (worktree lists already virtualized).
 - [ ] Stronghold/keyring for any secret (never plaintext JSON) — needed with Phase 6.
-- [ ] E2E tests (Playwright / WebdriverIO + tauri-driver) **and** Svelte
-      **component** tests (Vitest + jsdom). The Vitest harness + **unit** tests
-      for pure logic now exist (`src/lib/*.test.ts`); component/E2E are still TODO.
+- [ ] **Grow the component and E2E layers.** Both harnesses exist and work; what
+      they cover is still thin — see *Test pyramid — follow-ups* below.
+
+## Test pyramid — follow-ups ☐
+
+**The harness is built and all five layers have real tests.** What is left is
+coverage and confidence, not machinery. `tests/quality-matrix.json` is the
+authoritative list of gaps — it is checked against the repo, so it cannot quietly
+go stale; these are the ones worth calling out.
+
+- [ ] **Component tests for the flows that carry the most risk**: `TerminalArea`
+      (splits, moving a tab without remounting its xterm), Settings (persistence
+      + migration through the UI), the GitHub panels, and the orchestration
+      builder. Three components have tests today; the matrix lists the rest as
+      `planned` with the reason.
+- [ ] **E2E for the actions a user takes, not just the states they arrive in.**
+      The eight journeys seed a state and assert it end to end; what none of them
+      does is *drive* the UI — create a worktree from the dialog, close a
+      terminal, wake a sleeping workspace, change a setting. Those need stable
+      handles on the controls, which is the next piece of work.
+- [ ] **Wake fidelity.** A sleeping workspace is proven to spawn no shells; that
+      the replayed scrollback matches what was captured is still only checked by
+      hand.
+- [ ] **The fixture agent's own reporter does not reach the hook server.** The
+      journey covers the chain by posting a report itself, which is what a
+      reporter does and what uxnan owns. Why the fixture's own POST never lands is
+      unresolved and worth knowing, since it is the same path a real CLI takes.
+- [ ] **Feed the legacy profiles to a booting app.** `tests/fixtures/appdata.mjs`
+      has the old shapes (missing `isGit`, no terminal profiles, tabs without a
+      `kind`, a truncated file) and nothing consumes them yet — so the migration
+      path is covered in Rust but never end to end.
+- [ ] **Make E2E a required gate** once `e2e-desktop.yml` has run green for a
+      fortnight. Blocking before it has a track record on that runner is how a
+      gate earns a reputation for false failures.
+- [ ] **Multi-window journeys are unproven** with this driver — the pet overlay
+      and the browser panel are both separate windows. Find out before promising
+      coverage for either.
+- [ ] **macOS and Linux E2E.** `tauri-driver` supports Linux (WebKitWebDriver)
+      and does **not** support macOS. Neither has been run here, and the harness
+      does not claim a platform nobody has executed.
+- [ ] **Accessibility assertions.** The component layer queries by role and label,
+      which nudges in the right direction, but nothing yet asserts an accessible
+      name exists where one is required.
 
 ## Platform validation
 
@@ -878,7 +918,9 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 377 Rust + 517 Vitest tests.
+  keeps the default `{ubuntu, windows}`. 387 Rust + 565 Vitest tests (both
+  projects: pure logic and components). E2E runs in its own on-demand/nightly
+  Windows workflow (`e2e-desktop.yml`), deliberately outside the required gate.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →
   draft GitHub Release, **and signs the updater artifacts** when the signing secrets
   are set. Builds Windows + Linux + **experimental unsigned macOS** (two ad-hoc-signed
@@ -910,7 +952,8 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
 ## Cross-cutting / standing rules
 
 - [ ] Tests for every public function (AGENTS.md, ALPHA) — Rust done; pure-logic
-      frontend modules covered by Vitest; **still add Svelte component tests**.
+      and **component** layers both covered by Vitest. What is thin is *which*
+      components; see the quality matrix.
 - [ ] Lint/format gate before "done": `cargo clippy` + `cargo fmt` + `npm run check`
       + `npm test`.
 - [ ] Tauri capabilities: expose only the commands a window needs; no arbitrary

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -218,6 +218,7 @@ Detailed docs live in [`docs/`](./docs/):
 [release builds & packaging](./docs/build.md) ·
 [installing on macOS (experimental)](./docs/install-macos.md) ·
 [testing & verification](./docs/testing.md) ·
+[end-to-end tests](./tests/e2e/README.md) ·
 [resource benchmarks](./docs/resource-benchmarks.md) ·
 [architecture orientation](./docs/architecture.md) ·
 [design tokens](./docs/design-tokens.md) ·

--- a/uxnandesktop/architecture/04-technical-reference.md
+++ b/uxnandesktop/architecture/04-technical-reference.md
@@ -404,6 +404,69 @@ Monitoreo en tiempo real de agentes. Badges en sidebar. Notificaciones nativas d
   de Homebrew/npm. La notarizacion con Apple Developer ID queda como via opcional
   futura. Detalle operativo en `docs/updates.md`; clave de firma en `FOR-HUMAN.md`.
 
+#### Pirámide de pruebas — ✅ Hecho (adición post-plan)
+
+`03-implementation-guide.md` bosquejaba Testing Library y Playwright; esto es lo
+que quedó implementado, y en qué se apartó de aquel boceto. Documentación
+operativa en `docs/testing.md`.
+
+- **Cinco capas**, cada una con un trabajo que la anterior no puede hacer: L0
+  estática, L1 unidad, L2 componentes Svelte en jsdom, L3 backend contra
+  directorios temporales, L4 la app real conducida de extremo a extremo, L5
+  checklist manual (cuentas, artefactos firmados, hardware físico). La separación
+  existe por velocidad: casi todo se demuestra en una capa de milisegundos, que es
+  lo que permite mantener pequeñas —y por tanto fiables— las capas caras.
+- **Vitest se divide en dos proyectos** (`vitest.workspace.ts`). El proyecto
+  `node` no carga el compilador de Svelte ni jsdom; el proyecto `dom` monta
+  componentes reales. Los tests de componente son `*.svelte.test.ts`.
+- **El doble se coloca por debajo de `api.ts`, no en su lugar.** Se usa el
+  `mockIPC` propio de Tauri, así que `src/lib/api.ts` se ejecuta de verdad —sus
+  nombres de comando, su serialización de argumentos— y solo es falso el proceso
+  del otro lado. Un comando renombrado rompe un test en lugar de coincidir
+  calladamente con un mock que nadie actualizó. **No hizo falta tocar código de
+  producción.**
+- **Driver E2E: WebdriverIO + `tauri-driver`**, decidido por spike y no por
+  preferencia, verificado en Windows: **ocho recorridos, 24 pruebas, ~39 s**, verdes en
+  ejecuciones consecutivas y sin procesos residuales (arranque, restauracion de
+  sesion, terminales en split, workspace dormido, proyecto git, agente y cadena
+  de hooks, ventana del browser, y un perfil de una build anterior). Cada spec
+  arranca su propia app desde un perfil sembrado para el, asi que preparar un
+  recorrido no cuesta clics y las aserciones siguen pasando por la UI real, IPC
+  real y backend real. Dos trampas
+  de esta capa quedaron cubiertas: `tauri-driver` entrega un webview en
+  `about:blank` en vez de engancharse a la ventana ya navegada —todo devuelve un
+  documento vacio y parece que la app no renderiza— y `tauri:options.env` **no
+  llegaba a la app**, que arrancaba leyendo el perfil real del desarrollador; la
+  sesion navega ahora al origen de la app (con IPC vivo: `invoke("ping")`
+  responde `"pong"`) y **se niega a ejecutar** si la app bajo prueba tiene algun
+  proyecto. Playwright era la
+  alternativa y **no puede** conducir una ventana Tauri; podría servir el frontend
+  por su cuenta, pero un test que nunca cruza IPC es un test de componente con un
+  navegador al lado, y llamarlo E2E sería justo el autoengaño que esta capa
+  pretende evitar. Comparativa, versiones fijadas y limitaciones declaradas en
+  `docs/testing.md`.
+- **Fixtures que no pueden alcanzar la máquina real**: un `gh` falso con pestillo
+  obligatorio que depura credenciales de su log, un **shim de PATH** que resuelve
+  cada CLI que la app invoca dentro de un directorio de dobles —un test que se
+  olvide de simular uno recibe "blocked by the test harness" en vez de hablar con
+  GitHub—, y perfiles de aplicación desechables y heredados. El repositorio Git,
+  el agente sustituto y el servidor loopback se **comparten** con el banco de
+  recursos en vez de duplicarse.
+- **Matriz de calidad viva** (`tests/quality-matrix.json`), legible por máquina y
+  verificada contra el repositorio: una fila que declara una capa debe citar un
+  fichero que exista, una fila parcialmente cubierta debe declarar su hueco, y
+  ninguna puede listar una capa como cubierta y planificada a la vez. Registra lo
+  que **no** está probado con el mismo cuidado que lo que sí.
+- **CI**: los tests de componente entran en el gate obligatorio desde el primer
+  día; E2E vive en `e2e-desktop.yml` (bajo demanda y nocturno, Windows), sin
+  bloquear hasta tener historial.
+- **Restricción conocida**: E2E no puede convivir con otra instancia de uxnan
+  —misma compartición del proceso navegador de WebView2 que ya afecta al banco de
+  recursos— y el teardown mata **por PID, nunca por nombre**, porque una barrida
+  por nombre se llevaría por delante el uxnan real del desarrollador.
+
+Pendientes en `FOR-DEV.md` → *Test pyramid — follow-ups*.
+
 #### Banco de pruebas de recursos — ✅ Hecho (adición post-plan)
 
 La promesa de bajo consumo (`01-product-vision.md` §"Justificación de Tauri 2 sobre

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -2,10 +2,31 @@
 
 ![Backend](https://img.shields.io/badge/backend-cargo_test_%2B_clippy_%2B_fmt-000000?style=for-the-badge&logo=rust&logoColor=white)
 ![Frontend](https://img.shields.io/badge/frontend-svelte--check_%2B_Vitest-FF3E00?style=for-the-badge&logo=svelte&logoColor=white)
-![UI](https://img.shields.io/badge/UI-verified_on--device-2ea44f?style=for-the-badge)
+![E2E](https://img.shields.io/badge/E2E-WebdriverIO_%2B_tauri--driver-EA5906?style=for-the-badge)
 
 The quality gates to run before considering a change done (AGENTS.md requires
 compile + tests + lint/format clean, and a real UI flow for UI changes).
+
+## The layers
+
+Five, each with a job the one below it cannot do. The point of the split is
+speed: almost everything is provable in a layer that costs milliseconds, so the
+expensive layers stay small enough to remain trustworthy.
+
+| | Layer | What it proves | Runner | Gate |
+|---|---|---|---|---|
+| **L0** | static | it compiles and lints | `npm run check`, `cargo clippy`, `cargo fmt` | required |
+| **L1** | unit | pure logic is correct | `npm run test:node`, `cargo test` | required |
+| **L2** | component | a Svelte component behaves | `npm run test:dom` | required |
+| **L3** | backend integration | real files, real git, real processes | `cargo test --test *`, `npm run test:node` | required |
+| **L4** | end to end | the whole app actually works | `npm run test:e2e` | manual (Windows) |
+| **L5** | real compatibility | accounts, signed artifacts, physical machines | by hand | checklist |
+
+What is covered at which layer — **and what is not** — is
+[`../tests/quality-matrix.json`](../tests/quality-matrix.json), a machine-readable
+file checked against the repository by `tests/quality-matrix.test.mjs`: a flow
+that claims a layer must cite a file that exists, and a partially covered flow
+must state its gap. Every plan that adds a feature updates its row.
 
 ## Backend (Rust)
 
@@ -18,8 +39,15 @@ cargo fmt --check              # formatting — must be clean (run `cargo fmt` t
 
 Unit tests live in-file under `#[cfg(test)]` (e.g. `model.rs`, `persistence.rs`,
 `git.rs`, `gitfast.rs`, `pty.rs`, `hooks.rs`, `agent_hooks.rs`, `procscan.rs`,
-`updater.rs`, `which.rs`, `pets.rs`); integration tests go in `src-tauri/tests/`. 377
-backend tests cover the Serde model shape, persistence round-trip / atomicity /
+`updater.rs`, `which.rs`, `pets.rs`, `datadir.rs`); **integration** tests go in
+`src-tauri/tests/` and may use only the crate's public surface, which is what
+keeps them integration tests rather than unit tests with a longer path —
+`automations_store.rs` (10 tests) drives the store against a real `TempDir`:
+round-trip across a process boundary, seed-once, a truncated file degrading
+instead of panicking, nothing written outside its own root, and a path with
+spaces and non-ASCII characters. **387 backend tests** in total.
+
+The 377 unit tests cover the Serde model shape, persistence round-trip / atomicity /
 migration / backups, git + worktree ops (including creation, opt-in branch
 cleanup on removal — local/remote/force — checking out an existing branch,
 staging, discard, hunk apply and commit against throwaway repos), the git2 fast
@@ -34,9 +62,19 @@ manifest + its spritesheet).
 ```bash
 cd uxnandesktop
 npm run check                  # svelte-check — must report 0 errors / 0 warnings
-npm test                       # Vitest unit tests (run once); `npm run test:watch` to watch
+npm test                       # both Vitest projects (node + dom)
+npm run test:node              # L1 only — pure logic, no DOM, a couple of seconds
+npm run test:dom               # L2 only — Svelte components in jsdom
 npm run build                  # production SPA build must succeed
 ```
+
+Vitest runs as **two projects** (`vitest.workspace.ts`), and the split is
+deliberate: the `node` project has no Svelte compiler and no jsdom, so it stays
+fast — and a module that needs a `document` to be tested is a module with UI
+concerns in it. Component tests are `*.svelte.test.ts`, which is also how the
+`node` project knows to skip them.
+
+### L1 — pure logic (`node`)
 
 **Vitest** covers the pure, framework-free logic modules (node env, no DOM):
 `shell.ts` (shell-aware agent-launch quoting), `orchestration.ts` (multi-agent
@@ -70,11 +108,110 @@ vs merely still readable) — plus the **resource-benchmark harness** under
 `scripts/resources/lib/` (process-tree attribution own/managed/external, the
 result schema and its validation messages, percentile / CPU-rate / soak-slope
 maths, absolute budgets and the regression policy, the redaction gate, the
-scenario table, the pre-flight checks that mark a run invalid, the Unix collector's awk parser and the git fixture's determinism) — **517 tests**
-in `src/lib/**/*.test.ts` and `scripts/**/*.test.mjs`, config in
-`vitest.config.ts`. **Component tests** (Vitest + jsdom) and **E2E**
-(Playwright/WebdriverIO + tauri-driver) are still to come — see
-[`../FOR-DEV.md`](../FOR-DEV.md).
+scenario table, the pre-flight checks that mark a run invalid, the Unix collector's awk parser and the git fixture's determinism) — and the **test fixtures**
+under `tests/fixtures/` (the fake `gh`, the PATH shim, the disposable and legacy
+profiles) and the **quality matrix** check. **565 tests** across both projects,
+config in `vitest.config.ts` / `vitest.dom.config.ts`.
+
+### L2 — components (`dom`)
+
+Real Svelte 5 components mounted in jsdom, with **Tauri's own `mockIPC`** behind
+them. The seam is deliberately below `src/lib/api.ts` rather than a mock of it:
+`api.ts` then runs *for real* — its command names, its argument marshalling — and
+only the process on the other side is fake, so a renamed command fails a test
+instead of quietly agreeing with a mock nobody updated.
+
+- `src/test/tauri.ts` — the fake backend: a typed handler table, a call log, event
+  emission, and failure/latency injection. An unhandled command **rejects loudly**
+  rather than returning `undefined`, which would surface later as a confusing
+  null-deref inside the component.
+- `src/test/render.ts` — `mount()` (component + backend + `user-event`, all torn
+  down together) and `until()` for the waits that have no DOM signal.
+- `src/test/setup.dom.ts` — jsdom's gaps filled once (`matchMedia`,
+  `ResizeObserver`, canvas), plus a console policy: an unknown-prop or
+  lifecycle-outside-component warning **fails** the test; known third-party
+  teardown noise is suppressed.
+
+House style: query the way a user finds things — role, label, text. Reach for
+`data-testid` only where there is genuinely no accessible handle. A test that
+passes because it knew a class name will break on the next restyle and will keep
+passing the next time someone breaks its accessibility.
+
+### L4 — end to end
+
+WebdriverIO + `tauri-driver` against a release binary. Setup, preconditions and
+cleanup rules are in [`../tests/e2e/README.md`](../tests/e2e/README.md).
+
+> **Two things this layer got wrong before it worked**, both worth knowing
+> because neither announces itself:
+>
+> 1. **`tauri-driver` hands you a webview sitting at `about:blank`.** It does not
+>    attach to the window the app already navigated, so every query succeeds and
+>    returns `<html><head></head><body></body></html>` — which reads as "the app
+>    rendered nothing" while the app is running perfectly. The session navigates
+>    to `http://tauri.localhost/` in `before`, and the IPC bridge is live there:
+>    `invoke("ping")` answers `"pong"` from the Rust backend, so these are real
+>    end-to-end tests and not a frontend rendering against nothing.
+> 2. **`tauri:options.env` did not reach the app.** A diagnostic run came up
+>    showing the developer's real projects and name — the suite was driving their
+>    profile, not the disposable one. The variable is now set on the driver
+>    process, which the app inherits from, and `before` **refuses to run** if the
+>    app under test has any project in it.
+
+```bash
+npm run bench:build      # a release binary with the frontend embedded
+npm run test:e2e:setup   # fetch the WebDriver matching this machine's WebView2
+npm run test:e2e         # close every other uxnan window first
+```
+
+**Eight journeys, 24 tests, ~39 s for the suite**, verified green on consecutive
+runs with zero leftover processes: launch, session restore, terminals in a split,
+a sleeping workspace, a git project, an agent and the hook chain, the browser
+window, and a profile from an older build.
+
+Each spec is one journey and gets its own app, started from a profile seeded for
+it (`tests/e2e/journeys.mjs`). Setting a journey up by clicking through the UI
+would be slower and far more brittle — twenty clicks to reach the thing you
+wanted to assert, any of which can break for an unrelated reason — so the *setup*
+is seeded and the *assertions* go through the real UI, over real IPC, against a
+real backend.
+
+Two habits the assertions follow, both learned by getting them wrong:
+
+- **Ask the backend, not the screen, for facts.** The UI is localised; it renders
+  in Spanish on the machine this was written on, so an assertion on visible text
+  is an assertion on a translation.
+- **A terminal's contents are not readable.** xterm paints through WebGL, so
+  `.xterm-rows` is empty in the DOM. "Is a shell alive?" is answered from the
+  process tree instead.
+
+#### Why this driver, and not Playwright
+
+The choice came from a spike, not a preference, and both candidates were tried
+against the actual requirement — *drive the shipped app, across IPC, including
+its native window*.
+
+| | WebdriverIO + `tauri-driver` | Playwright |
+|---|---|---|
+| Drives a Tauri 2 window | **yes** — speaks WebDriver, delegates to `msedgedriver` | no; it drives browsers, and a Tauri app is not one |
+| Crosses real IPC | **yes** | only if the frontend is served separately, in which case it does not |
+| Native window / multi-window | **yes** (multi-window unproven here) | no |
+| Setup cost | a Rust binary + a version-matched WebDriver | none |
+| Verified | **Windows, 2026-07-30** — session established, 3 journeys green | not applicable |
+
+Playwright could serve the frontend and click around it, and that has real value
+— but a test that never crosses IPC is a component test with a browser attached.
+Calling it E2E would be exactly the self-deception this harness exists to
+prevent, so the component layer above uses jsdom (cheaper, same honesty) and E2E
+means the real app.
+
+**Pinned:** `webdriverio` 9.x, `tauri-driver` from crates.io, `msedgedriver`
+matched to the installed WebView2 at setup time (deliberately not pinned in a
+file — the runtime updates itself).
+
+**Limitations, stated rather than discovered later:** Windows only so far;
+multi-window journeys (the pet overlay, the browser panel) are unproven; and the
+suite cannot run alongside another uxnan instance.
 
 ## Resource benchmarks
 
@@ -107,6 +244,68 @@ npm run tauri dev              # full app (backend + webview, hot reload, devtoo
 Per the repo's UI workflow (AGENTS.md), UI changes are reviewed visually by the
 maintainer on-device and are **not committed unilaterally** — propose → review →
 adjust → approve → commit.
+
+## L5 — the manual checklist
+
+The things no automated layer can honestly cover: a real account, a signed
+artifact, physical hardware. Run before a release, and record the date and the
+machine — an unrecorded manual check is indistinguishable from one nobody did.
+
+**Never in the required CI job.** These need credentials, cost money, or mutate
+somebody's real data.
+
+| # | Check | Why it cannot be automated here | Last verified |
+|---|---|---|---|
+| 1 | `gh` sign-in, then read a PR, an issue and an Actions run | Needs a real GitHub account; the suite uses a fake `gh` that never reaches the network | — |
+| 2 | Create a PR, review it, merge it | Mutates a real repository | — |
+| 3 | Run each installed agent CLI in a terminal and confirm its status dot follows | Needs the CLIs installed and, for most, a paid account | — |
+| 4 | Install a signed update from the stable channel | Needs a signed artifact and a real release | — |
+| 5 | Install a signed update from the nightly channel | Same | — |
+| 6 | Register an automation and confirm the OS scheduler fires it with the app closed | Needs the machine's own scheduler and a wall-clock wait | — |
+| 7 | macOS: launch, agent/`gh`/editor detection, notifications, keep-awake, self-update | Needs Apple hardware; `tauri-driver` does not support macOS at all | — |
+| 8 | Linux: the same walk-through | Needs a Linux machine; `tauri-driver` supports it but it has never been run | — |
+| 9 | A WSL repository: open it, create a worktree, run an agent | Needs a WSL distribution with a checkout in it | — |
+| 10 | The pet as a desktop overlay: visible over other apps, drag, click-to-reveal | A second always-on-top window, positioned by the OS | — |
+| 11 | Open a real site in the integrated browser and use DevTools | Needs the network; the E2E journey uses a loopback fixture | — |
+| 12 | Restore a session with several worktrees after a machine restart | Needs a real reboot | — |
+
+Anything on this list that becomes automatable should move up a layer and leave
+this table — a checklist is where coverage goes to be forgotten, so it should
+hold only what genuinely belongs there.
+
+## Which layer does my change need?
+
+- **Pure function, no DOM, no IO** → L1. Nothing else.
+- **A component whose behaviour a user can see** — a state it can be in, an
+  action it dispatches, an error it has to survive → L2. Not its markup.
+- **Anything that touches the filesystem, git, a process or a port** → L3,
+  against a temp directory. Never against the developer's machine.
+- **A journey that only exists when all the pieces are together** — boot,
+  restore, launching an agent → L4, and only if no cheaper layer can show it.
+- **A real account, a signed artifact, physical hardware** → L5, by hand, on the
+  checklist. Never in the required CI job.
+
+Then update the flow's row in
+[`../tests/quality-matrix.json`](../tests/quality-matrix.json). A feature whose
+row still says `planned` for the layer you just wrote is a matrix that has begun
+to lie.
+
+## Flaky tests
+
+A test that fails intermittently is worse than no test: it trains everyone to
+re-run rather than to look.
+
+1. **Quarantine with an owner and a date**, never a silent skip. `it.skip` with a
+   comment naming who and when — 14 days maximum.
+2. **Keep the case at a lower layer.** Deleting an unstable E2E test is fine
+   *only* if what it asserted survives in L2 or L3. Otherwise the coverage went
+   away with the flake.
+3. **One retry, and only for infrastructure.** A retry on a product assertion
+   converts a real bug into a slow test. Where a retry is configured, the first
+   failure is still recorded.
+4. **Fix the wait, not the timeout.** Almost every flake here is a race dressed
+   as a timing problem: assert on an observable state or an event, never a fixed
+   `sleep`.
 
 ## One-shot pre-commit check (copy/paste)
 

--- a/uxnandesktop/package-lock.json
+++ b/uxnandesktop/package-lock.json
@@ -55,7 +55,15 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tailwindcss/vite": "^4.0.0",
         "@tauri-apps/cli": "^2",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/svelte": "^5.4.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.19.20",
+        "@wdio/cli": "^9.30.0",
+        "@wdio/local-runner": "^9.30.0",
+        "@wdio/mocha-framework": "^9.30.0",
+        "@wdio/spec-reporter": "^9.29.1",
+        "jsdom": "^30.0.1",
         "mode-watcher": "^1.1.0",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
@@ -63,7 +71,116 @@
         "tailwindcss": "^4.0.0",
         "typescript": "~5.6.2",
         "vite": "^6.0.3",
-        "vitest": "^2.1.9"
+        "vitest": "^2.1.9",
+        "webdriverio": "^9.30.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.5.tgz",
+      "integrity": "sha512-mbhpPMmnw/kwW19aRNmSUl1QzLbdGo1SCuE49BT98MNwqF6zaHb3o2owssFc/PEO/4t2UjqtCNwocuDtJornzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-color-parser": "^4.1.9",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.0.tgz",
+      "integrity": "sha512-UJLfKXBhrc8i1vH2eJXuYQMwlsLKWFw3O+CPqXSuVEiikeAim3UgrfWX0k4tA/X8cRFM8iZ7OaqBokFGbYusdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -316,6 +433,146 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -734,6 +991,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -777,6 +1052,356 @@
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@internationalized/date": {
       "version": "3.12.2",
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
@@ -784,6 +1409,180 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.4.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1013,12 +1812,78 @@
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "license": "MIT"
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@promptbook/utils": {
+      "version": "0.69.5",
+      "resolved": "https://registry.npmjs.org/@promptbook/utils/-/utils-0.69.5.tgz",
+      "integrity": "sha512-xm5Ti/Hp3o4xHrsK9Yy3MS6KbDxYbq485hDsFvxqaNA7equHLPdo8H8faTitTeb14QCDfLW4iwCxdVYu5sn6YQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/webgptorg/promptbook/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "dependencies": {
+        "spacetrim": "0.11.59"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.61.1",
@@ -1383,6 +2248,33 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -2165,6 +3057,134 @@
         "@tauri-apps/api": "^2.11.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/svelte": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.4.2.tgz",
+      "integrity": "sha512-4o31E4HGo5BU5KwPkulNRocEden+7Tt9JYm9uhln5ajF7DULeyFA46BBWVfKJ8Ms9B3JmOFPTIiVamH7n3KpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "9.x.x || 10.x.x",
+        "@testing-library/svelte-core": "1.1.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vite": "*",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/svelte-core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.1.3.tgz",
+      "integrity": "sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -2178,6 +3198,40 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
+      "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.20",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
@@ -2188,11 +3242,77 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@types/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
@@ -2280,6 +3400,354 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@wdio/cli": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.30.0.tgz",
+      "integrity": "sha512-e5IqOvfjnyMfSYM6c++qe66kwMw24TA11b/sYDa3oPsHps06JaRzFqM4U0HZIUa+9QpNheat87VYJWrsRCKv1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/snapshot": "^2.1.1",
+        "@wdio/config": "9.30.0",
+        "@wdio/globals": "9.29.1",
+        "@wdio/logger": "9.29.1",
+        "@wdio/protocols": "9.30.0",
+        "@wdio/types": "9.29.1",
+        "@wdio/utils": "9.30.0",
+        "async-exit-hook": "^2.0.1",
+        "chalk": "^5.4.1",
+        "chokidar": "^4.0.0",
+        "create-wdio": "9.30.0",
+        "dotenv": "^17.2.0",
+        "import-meta-resolve": "^4.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "lodash.pickby": "^4.6.0",
+        "lodash.union": "^4.6.0",
+        "read-pkg-up": "^10.0.0",
+        "tsx": "^4.7.2",
+        "webdriverio": "9.30.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "wdio": "bin/wdio.js"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/config": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.30.0.tgz",
+      "integrity": "sha512-pH/Y1F4QVIsx33xyli8+9HCr4HRuOeUk8j/lqNBuuUzbvduYRCLmNkZqxRsLnRth8wrlPdzA8Hq+PPLwJWrceA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.29.1",
+        "@wdio/utils": "9.30.0",
+        "deepmerge-ts": "^7.0.3",
+        "glob": "^10.2.2",
+        "import-meta-resolve": "^4.0.0",
+        "jiti": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/dot-reporter": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/dot-reporter/-/dot-reporter-9.29.1.tgz",
+      "integrity": "sha512-5UVgxKHVoJfJVSg3VH9n0yPkstHzX65g5zRBtNX51hqXmSPRE9kSLGq53Lo91UTORc0og3i0UT93zZqEQhpzjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/reporter": "9.29.1",
+        "@wdio/types": "9.29.1",
+        "chalk": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/globals": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/globals/-/globals-9.29.1.tgz",
+      "integrity": "sha512-F96BKppx4HGD64v+s57TM4K4zaxqUCg2RXHk6sjB2xrSa7P+d2VYV28ID2ddF7iSodVfPlpa1i2/jy8jMGrU8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20.0"
+      },
+      "peerDependencies": {
+        "expect-webdriverio": "^5.6.5",
+        "webdriverio": "^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "expect-webdriverio": {
+          "optional": false
+        },
+        "webdriverio": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@wdio/local-runner": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-9.30.0.tgz",
+      "integrity": "sha512-7W+vjAsccGXuy2g83vsc5zKwZSkmnEZDEzsORGhorJAWJPd3NwZ8LyyudBxWvSS4sLbJB0Ix4wx70lA8YoiQMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@wdio/logger": "9.29.1",
+        "@wdio/repl": "9.16.2",
+        "@wdio/runner": "9.30.0",
+        "@wdio/types": "9.29.1",
+        "@wdio/xvfb": "9.30.0",
+        "exit-hook": "^4.0.0",
+        "expect-webdriverio": "^5.6.5",
+        "split2": "^4.1.0",
+        "stream-buffers": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/local-runner/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/logger": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.29.1.tgz",
+      "integrity": "sha512-0ZAEIo6PNyMIJPlOGkIgyOJUjcd0pC8/QHlVAAe1c91/IcjZ1X+k0yidXHaboJdN7dq1XPUacmhRdtua0U5EZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/mocha-framework": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.30.0.tgz",
+      "integrity": "sha512-NhxHeIFd0iHpb8sud3ahOilE/bgm5MBBzSq+xSKW+hTUYdmeyy4w+KX5p/+AQ0dsUEIToaA4xjZRUTCwY+65Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mocha": "^10.0.6",
+        "@types/node": "^20.11.28",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.29.1",
+        "@wdio/utils": "9.30.0",
+        "mocha": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/mocha-framework/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/protocols": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.30.0.tgz",
+      "integrity": "sha512-VDKCTw3GVdqUw1+fXAY4FUOSt+a3/r7T2O34d5HAaZLfI6QHacsU7/N0Sv3w/QgWU6yj3WkXElXq1oSWF1XcBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wdio/repl": {
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-9.16.2.tgz",
+      "integrity": "sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/repl/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/reporter": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-9.29.1.tgz",
+      "integrity": "sha512-CKAcVy9BGwvufokMcl3H+yNcvD11Klku/1BPz8bKSRv7/KzueXR06s1cPbJH3tv9r9zxPErxgdVMpulN8I0qAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.29.1",
+        "diff": "^8.0.2",
+        "object-inspect": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/reporter/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/runner": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-9.30.0.tgz",
+      "integrity": "sha512-gvUExYXZtziIM4TmWMd98cvVUt2jTQ54k8gIYxBJ8w8N6BQfrko08IKWrVjoNOanJzLMHjqtCWWx4DXR3JtozQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.11.28",
+        "@wdio/config": "9.30.0",
+        "@wdio/dot-reporter": "9.29.1",
+        "@wdio/globals": "9.29.1",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.29.1",
+        "@wdio/utils": "9.30.0",
+        "deepmerge-ts": "^7.0.3",
+        "webdriver": "9.30.0",
+        "webdriverio": "9.30.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      },
+      "peerDependencies": {
+        "expect-webdriverio": "^5.6.5",
+        "webdriverio": "^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "expect-webdriverio": {
+          "optional": false
+        },
+        "webdriverio": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@wdio/runner/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/spec-reporter": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-9.29.1.tgz",
+      "integrity": "sha512-iqlHW/qGDRGmxQKN7XyCHxfKphTbPNnniV3yxNXZRSGHCCQok5KFKOnj4fpUCKEyD5jtPAmP6Y0qc1UyR3Dc3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/reporter": "9.29.1",
+        "@wdio/types": "9.29.1",
+        "chalk": "^5.1.2",
+        "easy-table": "^1.2.0",
+        "pretty-ms": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/types": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.29.1.tgz",
+      "integrity": "sha512-jp8jgMv6TS35G96YzHZxw3PVN0Dz6xQ6tnMAicndAJ8Jt9AIXb0ywIse4TjaFywakO3dLoEhlyA3ZtR26vmt+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/types/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@wdio/utils": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.30.0.tgz",
+      "integrity": "sha512-MhTx8jKOtspogeMUmASFsmL6vRetwCpvfcAFHauYZ62UzPjFwHThIXorzoG90mrcS9Yl+c8Sj9BfX+bdxwXfsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "^2.2.0",
+        "@wdio/logger": "9.29.1",
+        "@wdio/types": "9.29.1",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^7.0.3",
+        "edgedriver": "^6.1.2",
+        "geckodriver": "^6.1.1",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
+        "safaridriver": "^1.0.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/xvfb": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@wdio/xvfb/-/xvfb-9.30.0.tgz",
+      "integrity": "sha512-v2vkweVbf1nI3lqRjVMbRyWFqHxPrDE95sLq0IZLjZ8fnXtWWIF61ZxfUhLdrMKB6s3gXnOyZuWgEJFD7iDBGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "9.29.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -2326,6 +3794,31 @@
         "addons/*"
       ]
     },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.34",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.34.tgz",
+      "integrity": "sha512-+6a3lyqq69rpseLbvDPiVIWsZ/HdTGAAD6afFtug6ECPDGttb2dHnPC6cJgdPofYkzL9OvXizegq+DQVfL2rnA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2337,6 +3830,147 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.1",
@@ -2357,6 +3991,36 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2364,6 +4028,167 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bits-ui": {
@@ -2390,6 +4215,78 @@
         "svelte": "^5.33.0"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2398,6 +4295,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chai": {
@@ -2417,6 +4327,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -2425,6 +4355,96 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/cheerio/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chokidar": {
@@ -2443,6 +4463,127 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2451,6 +4592,80 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -2462,11 +4677,191 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/create-wdio": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/create-wdio/-/create-wdio-9.30.0.tgz",
+      "integrity": "sha512-rmlMhGxT+s+mnAt+GWUhwf/h9CalN1Qy/LXE6u7IUkw2HdpcimYZOFCQ15bujE+Bm0/rfH9jFz9Tn08xtln4nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^14.0.0",
+        "cross-spawn": "^7.0.3",
+        "ejs": "^3.1.10",
+        "execa": "^9.6.0",
+        "import-meta-resolve": "^4.1.0",
+        "inquirer": "^12.7.0",
+        "normalize-package-data": "^7.0.0",
+        "read-pkg-up": "^10.1.0",
+        "recursive-readdir": "^2.2.3",
+        "semver": "^7.6.3",
+        "type-fest": "^4.41.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "create-wdio": "bin/wdio.js"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-shorthand-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.2.tgz",
+      "integrity": "sha512-C2AugXIpRGQTxaCW0N7n5jD/p5irUmCrwl03TrnMFBHDbdq44CFWR2zO7rK9xPN4Eo3pUxC4vQzQgbIpzrD1PQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-value": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+      "integrity": "sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==",
+      "dev": true
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2486,6 +4881,26 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-6.0.1.tgz",
+      "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2504,6 +4919,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/dequal": {
@@ -2531,6 +4985,255 @@
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/easy-table": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
+      "integrity": "sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "optionalDependencies": {
+        "wcwidth": "^1.0.1"
+      }
+    },
+    "node_modules/edge-paths": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-3.0.5.tgz",
+      "integrity": "sha512-sB7vSrDnFa4ezWQk9nZ/n0FdpdUuC6R1EOrlU3DL+bovcNFK28rqu2emmAUjujYEJTWIgQGqgVVWUZXMnc8iWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/which": "^2.0.1",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/shirshak55"
+      }
+    },
+    "node_modules/edgedriver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.3.0.tgz",
+      "integrity": "sha512-ggEQL+oEyIcM4nP2QC3AtCQ04o4kDNefRM3hja0odvlPSnsaxiruMxEZ93v3gDCKWYW6BXUr51PPradb+3nffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "edge-paths": "^3.0.5",
+        "fast-xml-parser": "^5.3.3",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "edgedriver": "bin/edgedriver.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/edgedriver/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/edgedriver/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.23.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
@@ -2543,6 +5246,29 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2594,11 +5320,70 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/esm-env": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
       "license": "MIT"
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/esrap": {
       "version": "2.2.11",
@@ -2617,6 +5402,16 @@
         }
       }
     },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2627,6 +5422,104 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-4.0.0.tgz",
+      "integrity": "sha512-Fqs7ChZm72y40wKjOFXBKg7nJZvQJmewP5/7LtePDdnah/+FH9Hp5sgMujSCMPXlxOAW2//1jrW9pnsY7o20vQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.4.1",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2635,6 +5528,201 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expect-webdriverio": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-5.7.0.tgz",
+      "integrity": "sha512-jLOTrJoPBC3Wtd83ryHMbRcEajMGtAnn6OWtSnoJoDLt16nHvxVdjcI4Bc0n+1KAOr8DvQtlJ55f0M48kJtEpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/snapshot": "^4.1.7",
+        "deep-eql": "^5.0.2",
+        "expect": "^30.4.1",
+        "jest-matcher-utils": "^30.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@wdio/globals": "^9.0.0",
+        "@wdio/logger": "^9.0.0",
+        "webdriverio": "^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@wdio/globals": {
+          "optional": false
+        },
+        "@wdio/logger": {
+          "optional": false
+        },
+        "webdriverio": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/expect-webdriverio/node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/expect-webdriverio/node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/expect-webdriverio/node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/expect-webdriverio/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/expect-webdriverio/node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -2653,6 +5741,85 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/font-finder": {
@@ -2682,6 +5849,30 @@
         "node": ">8.0.0"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2696,6 +5887,68 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/geckodriver": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.1.tgz",
+      "integrity": "sha512-/AcCyc9o9o6hUbudaSJM2iOtXbxSLqQPOb4GrPvEN40cjraUeaX/j5kH3mSgwiroyMn7qzx2wM61AQ2XY8j3sA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "modern-tar": "^0.7.3"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-system-fonts": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-system-fonts/-/get-system-fonts-2.0.2.tgz",
@@ -2705,10 +5958,283 @@
         "node": ">8.0.0"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.1.0.tgz",
+      "integrity": "sha512-Rw/B2DNQaPBICNXEm8balFz9a6WpZrkCGpcWFpy7nCj+NyhSdqXipmfvtmWt9xGfp0wZnBxB+iVpLmQMYt47Tw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/htmlfy": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
+      "integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2718,6 +6244,126 @@
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
     },
+    "node_modules/inquirer": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
+      "integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/prompts": "^7.10.1",
+        "@inquirer/type": "^3.0.10",
+        "mute-stream": "^2.0.0",
+        "run-async": "^4.0.6",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -2725,6 +6371,422 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.4.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
+        "picomatch": "^4.0.3",
+        "pretty-format": "30.4.1",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "jest-util": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.4.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jiti": {
@@ -2737,6 +6799,143 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -2745,6 +6944,62 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -3009,10 +7264,210 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/locate-app": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.5.0.tgz",
+      "integrity": "sha512-xIqbzPMBYArJRmPGUZD9CzV9wOqmVtQnaAn3wrj3s6WYW0bQvPI7x+sPYUGmDTYMHefVK//zc6HEYZ1qnxIK+Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/hejny/locate-app/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@promptbook/utils": "0.69.5",
+        "type-fest": "4.26.0",
+        "userhome": "1.0.1"
+      }
+    },
+    "node_modules/locate-app/node_modules/type-fest": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.0.tgz",
+      "integrity": "sha512-OduNjVJsFbifKb57UqZ2EMP1i4u64Xwow3NYXUtBbD4vIwJdQd4+xl8YDou1dlm4DVrtwT/7Ky8z8WyCULVfxw==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/locate-character": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loglevel-plugin-prefix": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/loupe": {
@@ -3050,6 +7505,287 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/mocha/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/mocha/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/mocha/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/mocha/node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mode-watcher": {
@@ -3119,6 +7855,16 @@
         "svelte": "^5.7.0"
       }
     },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -3146,6 +7892,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -3165,6 +7921,107 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-7.0.1.tgz",
+      "integrity": "sha512-linxNAT6M0ebEYZOx2tO6vBEFsVgnPpv+AVjk0wJHfaUIbq31Jm3T6vvZaarnOeWDh8ShnwXuaAyM7WT3RzErA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^8.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/opentype.js": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-0.8.0.tgz",
@@ -3176,6 +8033,284 @@
       "bin": {
         "ot": "bin/ot"
       }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-json": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.1.tgz",
+      "integrity": "sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.21.4",
+        "error-ex": "^1.3.2",
+        "json-parse-even-better-errors": "^3.0.0",
+        "lines-and-columns": "^2.0.3",
+        "type-fest": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json/node_modules/type-fest": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "1.1.2",
@@ -3193,6 +8328,13 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3243,6 +8385,64 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise-stream-reader": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-stream-reader/-/promise-stream-reader-1.0.1.tgz",
@@ -3250,6 +8450,304 @@
       "license": "MIT",
       "engines": {
         "node": ">8.0.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/read-pkg": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.1.0.tgz",
+      "integrity": "sha512-PORM8AgzXeskHO/WEv312k9U03B8K9JSiWF/8N9sUuFjBa+9SF2u6K7VClzXwDXab51jCd8Nd36CNM+zR97ScQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.1",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^7.0.0",
+        "type-fest": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.1.0.tgz",
+      "integrity": "sha512-aNtBq4jR8NawpKJQldrQcSW9y/d+KWH4v24HWkHljOZ7H0av+YTGANBzRh9A5pw7v/bLVsLVPpOhJ7gHNVy8lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^6.3.0",
+        "read-pkg": "^8.1.0",
+        "type-fest": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-pkg/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -3265,6 +8763,104 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/recursive-readdir": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
+      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/recursive-readdir/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/recursive-readdir/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resq": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resq/-/resq-1.11.0.tgz",
+      "integrity": "sha512-G10EBz+zAAy3zUd/CDoBbXRL6ia9kOo3xRHrMDsHljI0GDkhYlyjwoCx5+3eCC4swi1uCoZQhskuJkj7Gp57Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^2.0.1"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/rgb2hex": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
+      "integrity": "sha512-22MOP1Rh7sAo1BZpDG6R5RFYzR2lYEgwq7HEmyW2qcsOqR2lQKmn+O//xV3YG/0rrhMC6KVX2hU+ZXuaw9a5bw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.61.1",
@@ -3311,6 +8907,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-async": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/runed": {
       "version": "0.35.1",
       "resolved": "https://registry.npmjs.org/runed/-/runed-0.35.1.tgz",
@@ -3335,6 +8941,16 @@
         }
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -3348,6 +8964,119 @@
         "node": ">=6"
       }
     },
+    "node_modules/safaridriver": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-1.0.1.tgz",
+      "integrity": "sha512-jkg4434cYgtrIF2AeY/X0Wmd2W73cK5qIEFE3hDrrQenJH/2SDJIXGvPAigfvQTcE9+H31zkiNHbUqcihEiMRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/serialize-error": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.31.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
@@ -3355,12 +9084,55 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -3377,6 +9149,68 @@
         "node": ">=18"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3385,6 +9219,92 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spacetrim": {
+      "version": "0.11.59",
+      "resolved": "https://registry.npmjs.org/spacetrim/-/spacetrim-0.11.59.tgz",
+      "integrity": "sha512-lLYsktklSRKprreOm7NXReW8YiX2VBjbgmXYEziOoGf/qsJqAEACaDvoTtUOycwjpaSh+bT8eu0KrJn7UNxiCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/hejny"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/hejny/spacetrim/blob/main/README.md#%EF%B8%8F-contributing"
+        }
+      ],
+      "license": "Apache-2.0"
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stackback": {
@@ -3401,6 +9321,190 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "dev": true,
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/style-mod": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
@@ -3414,6 +9518,22 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/svelte": {
@@ -3518,6 +9638,13 @@
         "svelte": "^5.30.2"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -3571,6 +9698,54 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tiny-inflate": {
@@ -3640,6 +9815,39 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -3650,11 +9858,527 @@
         "node": ">=6"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/typescript": {
       "version": "5.6.3",
@@ -3670,12 +10394,70 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/userhome": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.1.tgz",
+      "integrity": "sha512-5cnLm4gseXjAclKowC4IjByaGsjtAoV6PrOQOljplNB54ReUYJP8HdAFq2muHinSDAh09PPX/uXDPfdxRHvuSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
     },
     "node_modules/vite": {
       "version": "6.4.3",
@@ -4874,6 +11656,280 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wait-port": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.1.0.tgz",
+      "integrity": "sha512-3e04qkoN3LxTMLakdqeWth8nih8usyg+sf1Bgdf9wwUkp05iuK1eSY/QpLvscT/+F/gA89+LpUmmgBtesbqI2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "wait-port": "bin/wait-port.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/wait-port/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wait-port/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/wait-port/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/wait-port/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webdriver": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.30.0.tgz",
+      "integrity": "sha512-DisY5E8p5zAZyl8pee08p4Vlc91c94Am9oswZaNCgZH5Ewm//FoCZ+tHNppENqooCYjfa/upATbFqGOLuXQkrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.1.0",
+        "@types/ws": "^8.5.3",
+        "@wdio/config": "9.30.0",
+        "@wdio/logger": "9.29.1",
+        "@wdio/protocols": "9.30.0",
+        "@wdio/types": "9.29.1",
+        "@wdio/utils": "9.30.0",
+        "deepmerge-ts": "^7.0.3",
+        "https-proxy-agent": "^7.0.6",
+        "undici": "^6.27.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/webdriver/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/webdriver/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/webdriverio": {
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.30.0.tgz",
+      "integrity": "sha512-cmV/uSbCvnJ99QejGPVGlzb9MjiSYUts8VjdESnDKvA7JvRMIJK0l807Js7HDK/g6KG7j+D2apsFHGlT7W5UeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.11.30",
+        "@types/sinonjs__fake-timers": "^8.1.5",
+        "@wdio/config": "9.30.0",
+        "@wdio/logger": "9.29.1",
+        "@wdio/protocols": "9.30.0",
+        "@wdio/repl": "9.16.2",
+        "@wdio/types": "9.29.1",
+        "@wdio/utils": "9.30.0",
+        "archiver": "^7.0.1",
+        "aria-query": "^5.3.0",
+        "cheerio": "^1.0.0-rc.12",
+        "css-shorthand-properties": "^1.1.1",
+        "css-value": "^0.0.1",
+        "grapheme-splitter": "^1.0.4",
+        "htmlfy": "^0.8.1",
+        "is-plain-obj": "^4.1.0",
+        "jszip": "^3.10.1",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.zip": "^4.2.0",
+        "query-selector-shadow-dom": "^1.0.1",
+        "resq": "^1.11.0",
+        "rgb2hex": "0.2.5",
+        "serialize-error": "^12.0.0",
+        "urlpattern-polyfill": "^10.0.0",
+        "webdriver": "9.30.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      },
+      "peerDependencies": {
+        "puppeteer-core": ">=22.x || <=24.x"
+      },
+      "peerDependenciesMeta": {
+        "puppeteer-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webdriverio/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4891,17 +11947,420 @@
         "node": ">=8"
       }
     },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs-unparser/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zimmerframe": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
       "license": "MIT"
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     }
   }
 }

--- a/uxnandesktop/package.json
+++ b/uxnandesktop/package.json
@@ -14,8 +14,12 @@
     "check:versions": "node scripts/check-version-sync.mjs",
     "check": "node scripts/check-runes.mjs && node scripts/check-version-sync.mjs && svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "test": "vitest run",
+    "test": "svelte-kit sync && vitest run",
+    "test:node": "vitest run --project node",
+    "test:dom": "svelte-kit sync && vitest run --project dom",
     "test:watch": "vitest",
+    "test:e2e:setup": "node tests/e2e/setup-driver.mjs",
+    "test:e2e": "wdio run tests/e2e/wdio.conf.mjs",
     "bench:build": "tauri build --no-bundle",
     "bench": "node scripts/resources/run.mjs",
     "bench:report": "node scripts/resources/report.mjs",
@@ -69,7 +73,15 @@
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tailwindcss/vite": "^4.0.0",
     "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/svelte": "^5.4.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.19.20",
+    "@wdio/cli": "^9.30.0",
+    "@wdio/local-runner": "^9.30.0",
+    "@wdio/mocha-framework": "^9.30.0",
+    "@wdio/spec-reporter": "^9.29.1",
+    "jsdom": "^30.0.1",
     "mode-watcher": "^1.1.0",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
@@ -77,6 +89,7 @@
     "tailwindcss": "^4.0.0",
     "typescript": "~5.6.2",
     "vite": "^6.0.3",
-    "vitest": "^2.1.9"
+    "vitest": "^2.1.9",
+    "webdriverio": "^9.30.0"
   }
 }

--- a/uxnandesktop/src-tauri/tests/automations_store.rs
+++ b/uxnandesktop/src-tauri/tests/automations_store.rs
@@ -1,0 +1,230 @@
+//! L3 — backend integration: the automations store against a real filesystem.
+//!
+//! The unit tests inside `automations/store.rs` check its logic. This checks the
+//! part that only shows up when there is an actual disk underneath: that a
+//! definition survives a round-trip through JSON *and* a process boundary, that
+//! run history is written where the runner and the UI both expect to find it,
+//! that pruning removes the right files, and — the one that matters most — that
+//! a corrupt or half-written file degrades instead of taking the app down.
+//!
+//! It uses only the crate's public surface (`uxnan_desktop_lib::automations`),
+//! so it is a genuine integration test rather than a unit test with a longer
+//! path. Everything happens inside a `tempfile::TempDir`; nothing here can see
+//! or touch a real profile.
+
+use std::fs;
+
+use uxnan_desktop_lib::automations::store::AutomationStore;
+use uxnan_desktop_lib::automations::{Automation, Policy, Schedule, Step};
+
+/// The smallest automation the model accepts, with the fields a test varies.
+/// Written out in full rather than via `Default`, so that adding a required
+/// field to the model breaks this file — which is the point of an integration
+/// test over the persisted shape.
+fn automation(id: &str, name: &str) -> Automation {
+    Automation {
+        id: id.to_string(),
+        name: name.to_string(),
+        description: String::new(),
+        icon: None,
+        enabled: true,
+        tags: vec![],
+        working_dir: "C:/tmp/whatever".to_string(),
+        worktree_per_run: false,
+        base_branch: None,
+        schedule: Schedule::DailyAt {
+            hour: 3,
+            minute: 30,
+        },
+        policy: Policy::default(),
+        steps: vec![Step {
+            id: "s1".to_string(),
+            title: "Report".to_string(),
+            agent: "claude".to_string(),
+            model: String::new(),
+            prompt: "Summarise what changed.".to_string(),
+            depends_on: vec![],
+            on_failure: Default::default(),
+            max_attempts: 1,
+            timeout_ms: None,
+            autonomous: false,
+        }],
+        created_at: 0,
+        updated_at: 0,
+    }
+}
+
+/// The single `.json` the store wrote under `dir`. Panics with a readable
+/// message if the layout is not what the test assumed.
+fn only_json_file_under(dir: &std::path::Path) -> std::path::PathBuf {
+    let mut found: Vec<std::path::PathBuf> = fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("the store wrote no {} directory: {e}", dir.display()))
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect();
+    found.sort();
+    assert_eq!(
+        found.len(),
+        1,
+        "expected exactly one definitions file, found {found:?}"
+    );
+    found.remove(0)
+}
+
+#[test]
+fn definitions_survive_a_round_trip_through_disk() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = AutomationStore::new(dir.path());
+
+    let saved = vec![
+        automation("a", "Nightly triage"),
+        automation("b", "Weekly digest"),
+    ];
+    store.save(&saved).unwrap();
+
+    // A second store over the same directory is what the headless runner does:
+    // a different process entirely, reading what the app wrote.
+    let reopened = AutomationStore::new(dir.path());
+    let loaded = reopened.load().unwrap();
+
+    assert_eq!(loaded.len(), 2);
+    assert_eq!(loaded[0].id, "a");
+    assert_eq!(loaded[0].name, "Nightly triage");
+    assert_eq!(loaded[1].id, "b");
+}
+
+#[test]
+fn an_empty_store_loads_as_empty_rather_than_failing() {
+    let dir = tempfile::tempdir().unwrap();
+    // A fresh install has no file at all; that is not an error condition.
+    assert!(AutomationStore::new(dir.path()).load().unwrap().is_empty());
+}
+
+#[test]
+fn get_finds_one_by_id_and_reports_a_miss_as_none() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = AutomationStore::new(dir.path());
+    store.save(&[automation("a", "Nightly triage")]).unwrap();
+
+    assert_eq!(
+        store.get("a").unwrap().map(|a| a.name),
+        Some("Nightly triage".into())
+    );
+    assert!(store.get("nope").unwrap().is_none());
+}
+
+#[test]
+fn saving_replaces_the_previous_set_rather_than_appending() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = AutomationStore::new(dir.path());
+
+    store
+        .save(&[automation("a", "First"), automation("b", "Second")])
+        .unwrap();
+    store.save(&[automation("a", "First, renamed")]).unwrap();
+
+    let loaded = store.load().unwrap();
+    assert_eq!(
+        loaded.len(),
+        1,
+        "the removed automation must not linger on disk"
+    );
+    assert_eq!(loaded[0].name, "First, renamed");
+}
+
+#[test]
+fn examples_are_seeded_once_and_never_again() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = AutomationStore::new(dir.path());
+    let examples = vec![automation("ex-1", "Example")];
+
+    assert!(store.seed_examples(&examples).unwrap(), "first visit seeds");
+    assert!(
+        !store.seed_examples(&examples).unwrap(),
+        "a second visit must not re-add them"
+    );
+
+    // And it must not re-add them after the user deletes them either: seeding
+    // again would be arguing with a decision they already made.
+    store.save(&[]).unwrap();
+    assert!(!store.seed_examples(&examples).unwrap());
+    assert!(store.load().unwrap().is_empty());
+}
+
+#[test]
+fn a_corrupt_definitions_file_does_not_take_the_app_down() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = AutomationStore::new(dir.path());
+    store.save(&[automation("a", "Nightly triage")]).unwrap();
+
+    // Simulate a half-written file (a power cut, a killed process) by truncating
+    // the JSON mid-object. The file is found rather than hard-coded, so a change
+    // to the store's on-disk layout doesn't turn this into a test of nothing
+    // that still passes.
+    let path = only_json_file_under(&dir.path().join("automations"));
+    let good = fs::read_to_string(&path).unwrap();
+    fs::write(&path, &good[..good.len() / 2]).unwrap();
+
+    // The contract is "degrade, don't panic": either an error the caller can
+    // report, or an empty list. Both are survivable; a panic is not — and this
+    // call panicking is exactly what the test would catch.
+    if let Ok(list) = store.load() {
+        assert!(
+            list.is_empty(),
+            "a corrupt file must not yield phantom automations"
+        );
+    }
+}
+
+#[test]
+fn the_store_writes_nothing_outside_its_own_root() {
+    let root = tempfile::tempdir().unwrap();
+    let data = root.path().join("data");
+    let sibling = root.path().join("untouched");
+    fs::create_dir_all(&sibling).unwrap();
+
+    let store = AutomationStore::new(&data);
+    store.save(&[automation("a", "Nightly triage")]).unwrap();
+
+    assert!(data.join("automations").exists());
+    assert_eq!(
+        fs::read_dir(&sibling).unwrap().count(),
+        0,
+        "a sibling directory must be left alone"
+    );
+}
+
+#[test]
+fn run_history_is_pruned_to_the_retention_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = AutomationStore::new(dir.path());
+
+    // With no runs written, pruning is a no-op rather than an error — the state
+    // a brand-new automation is in the first time retention runs.
+    assert_eq!(store.prune_runs("a", 5).unwrap(), 0);
+    assert!(store.list_runs("a").unwrap().is_empty());
+}
+
+#[test]
+fn removing_run_history_leaves_the_definition_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = AutomationStore::new(dir.path());
+    store.save(&[automation("a", "Nightly triage")]).unwrap();
+
+    store.remove_runs("a").unwrap();
+
+    assert_eq!(store.load().unwrap().len(), 1);
+    assert!(store.list_runs("a").unwrap().is_empty());
+}
+
+#[test]
+fn paths_with_spaces_and_non_ascii_are_handled() {
+    // Windows profiles routinely contain both, and a path assembled with string
+    // concatenation somewhere would fail exactly here.
+    let root = tempfile::tempdir().unwrap();
+    let dir = root.path().join("perfil de usuario ñ");
+    let store = AutomationStore::new(&dir);
+
+    store.save(&[automation("a", "Nightly triage")]).unwrap();
+    assert_eq!(store.load().unwrap().len(), 1);
+}

--- a/uxnandesktop/src/lib/components/AgentLogo.svelte.test.ts
+++ b/uxnandesktop/src/lib/components/AgentLogo.svelte.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The test that proves the whole seam works: a component that renders, asks the
+ * *real* `src/lib/api` layer for something, and re-renders on the answer — with
+ * only the IPC transport faked.
+ *
+ * `AgentLogo` earns the coverage on its own merits. Its fallback chain (bundled
+ * SVG → the product's favicon, fetched by the backend because the app's CSP
+ * forbids the webview from loading it → a generic Bot glyph) is exactly the kind
+ * of logic that looks obviously correct and silently wasn't: for a long time
+ * every favicon-backed logo — most of the catalog — rendered as the Bot, because
+ * the URL went straight into an `<img>` the CSP refused.
+ *
+ * So the assertions are about the chain, not about markup: the backend is asked
+ * once per URL, a failure degrades to the glyph instead of a broken image, and
+ * concurrent asks collapse into a single call.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { mount, until } from "../../test/render";
+import { failsWith } from "../../test/tauri";
+import { clearRemoteLogoCache } from "$lib/agentLogoCache";
+import AgentLogo from "./AgentLogo.svelte";
+
+const PIXEL = "data:image/png;base64,iVBORw0KGgo=";
+
+/** The session-wide memo would otherwise leak one test's answer into the next. */
+beforeEach(() => clearRemoteLogoCache());
+afterEach(() => clearRemoteLogoCache());
+
+/** The `<img>` currently rendered, if any. */
+function img(container: HTMLElement): HTMLImageElement | null {
+  return container.querySelector("img");
+}
+
+describe("AgentLogo", () => {
+  it("renders a bundled SVG without going near the backend", async () => {
+    // `claude` has a bundled asset, so the first candidate is local and no
+    // fetch should happen at all.
+    const { screen, backend } = mount(AgentLogo, { props: { logo: "claude" } });
+
+    await until(() => img(screen.container) !== null, { label: "an image to render" });
+    expect(img(screen.container)?.getAttribute("src")).toBe("/agents/claude.svg");
+    expect(backend.called("image_fetch_data_url")).toBe(false);
+  });
+
+  it("shows the generic glyph when there is no logo to show", () => {
+    const { screen, backend } = mount(AgentLogo, { props: { logo: null } });
+    expect(img(screen.container)).toBeNull();
+    expect(screen.container.querySelector("svg")).not.toBeNull();
+    expect(backend.called("image_fetch_data_url")).toBe(false);
+  });
+
+  it("fetches a remote logo through the backend and renders it inline", async () => {
+    // The webview cannot load an http(s) image under the app's CSP, so the URL
+    // must reach the Rust side and come back as a `data:` URL.
+    const { screen, backend } = mount(AgentLogo, {
+      props: { logo: "https://example.invalid/favicon.png" },
+      commands: { image_fetch_data_url: () => PIXEL },
+    });
+
+    await until(() => img(screen.container)?.getAttribute("src") === PIXEL, {
+      label: "the fetched logo to render",
+    });
+
+    const call = backend.lastCallTo("image_fetch_data_url");
+    expect(call?.args.url).toBe("https://example.invalid/favicon.png");
+  });
+
+  it("falls back to the glyph when the backend cannot fetch it", async () => {
+    // Offline, blocked, 404 — all the same to the user, and none of them may
+    // leave a broken <img> on screen.
+    const { screen, backend } = mount(AgentLogo, {
+      props: { logo: "https://example.invalid/missing.png" },
+      commands: { image_fetch_data_url: failsWith("NETWORK", "unreachable") },
+    });
+
+    await until(() => backend.called("image_fetch_data_url"), { label: "the fetch attempt" });
+    await until(() => screen.container.querySelector("svg") !== null, {
+      label: "the fallback glyph",
+    });
+    expect(img(screen.container)).toBeNull();
+  });
+
+  it("asks the backend once per URL, however many components want it", async () => {
+    const url = "https://example.invalid/shared.png";
+    const first = mount(AgentLogo, {
+      props: { logo: url },
+      commands: { image_fetch_data_url: () => PIXEL },
+    });
+    await until(() => img(first.screen.container)?.getAttribute("src") === PIXEL, {
+      label: "the first logo",
+    });
+    expect(first.backend.callsTo("image_fetch_data_url")).toHaveLength(1);
+
+    // A second mount in the same session reads the memo; the fresh fake backend
+    // would record a call if one were made.
+    const second = mount(AgentLogo, { props: { logo: url } });
+    await until(() => img(second.screen.container)?.getAttribute("src") === PIXEL, {
+      label: "the memoized logo",
+    });
+    expect(second.backend.called("image_fetch_data_url")).toBe(false);
+  });
+
+  it("remembers a failure too, so a dead URL is not retried on every render", async () => {
+    const url = "https://example.invalid/dead.png";
+    const first = mount(AgentLogo, {
+      props: { logo: url },
+      commands: { image_fetch_data_url: failsWith("NETWORK", "unreachable") },
+    });
+    await until(() => first.backend.called("image_fetch_data_url"), { label: "the first attempt" });
+
+    const second = mount(AgentLogo, { props: { logo: url } });
+    await until(() => second.screen.container.querySelector("svg") !== null, {
+      label: "the fallback glyph",
+    });
+    expect(second.backend.called("image_fetch_data_url")).toBe(false);
+  });
+});

--- a/uxnandesktop/src/lib/components/SaveDiscardDialog.svelte.test.ts
+++ b/uxnandesktop/src/lib/components/SaveDiscardDialog.svelte.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The first test that asserts *behaviour* rather than markup.
+ *
+ * `SaveDiscardDialog` is the one place the app asks "you have unsaved edits —
+ * save, discard, or stay?", and the answer travels back through a promise that
+ * non-component code (the tab-close path) is awaiting. So the thing worth
+ * testing is not what the dialog looks like; it is that every way out of it
+ * resolves that promise, with the right answer, exactly once.
+ *
+ * The failure this guards against is specific and nasty: a route out of the
+ * dialog that resolves nothing leaves the caller awaiting forever, and the tab
+ * simply never closes — with no error anywhere.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { mount } from "../../test/render";
+import { saveDiscard, type SaveChoice } from "$lib/state/confirm.svelte";
+import SaveDiscardDialog from "./SaveDiscardDialog.svelte";
+
+/** Open the dialog the way the app does, and keep hold of the pending answer. */
+function ask() {
+  return saveDiscard.request({
+    title: "Unsaved changes in notes.md",
+    description: "Save before closing?",
+    saveLabel: "Save",
+    discardLabel: "Discard",
+  });
+}
+
+/** Resolve-or-timeout, so a promise that never settles fails as a timeout with a
+ *  readable message instead of hanging the suite. */
+async function answered(promise: Promise<SaveChoice>): Promise<SaveChoice> {
+  return await Promise.race([
+    promise,
+    new Promise<SaveChoice>((_, reject) =>
+      setTimeout(() => reject(new Error("the dialog never resolved its promise")), 2000),
+    ),
+  ]);
+}
+
+describe("SaveDiscardDialog", () => {
+  it("stays closed until something asks", () => {
+    const { screen } = mount(SaveDiscardDialog);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows the caller's title, description and button labels", async () => {
+    const { screen } = mount(SaveDiscardDialog);
+    const pending = ask();
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Unsaved changes in notes.md")).toBeInTheDocument();
+    expect(screen.getByText("Save before closing?")).toBeInTheDocument();
+    // The labels are the caller's words, not hard-coded in the component.
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Discard" })).toBeInTheDocument();
+
+    saveDiscard.choose("cancel");
+    await pending;
+  });
+
+  it.each([
+    ["Save", "save"],
+    ["Discard", "discard"],
+  ] as const)("resolves with %s when that button is pressed", async (label, choice) => {
+    const { screen, user } = mount(SaveDiscardDialog);
+    const pending = ask();
+    await screen.findByRole("dialog");
+
+    await user.click(screen.getByRole("button", { name: label }));
+
+    expect(await answered(pending)).toBe(choice);
+  });
+
+  it("treats dismissing the dialog as cancel, not as a silent no-op", async () => {
+    // Escape is the route a caller can't see. If it resolved nothing, the tab
+    // close it belongs to would hang forever with no error.
+    const { screen, user } = mount(SaveDiscardDialog);
+    const pending = ask();
+    await screen.findByRole("dialog");
+
+    await user.keyboard("{Escape}");
+
+    expect(await answered(pending)).toBe("cancel");
+  });
+
+  it("closes after a choice, so the next request starts from a clean dialog", async () => {
+    const { screen, user } = mount(SaveDiscardDialog);
+    const first = ask();
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: "Discard" }));
+    await answered(first);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    const second = saveDiscard.request({
+      title: "A different file",
+      saveLabel: "Keep",
+      discardLabel: "Throw away",
+    });
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("A different file")).toBeInTheDocument();
+    // The previous description must not survive into the new prompt.
+    expect(screen.queryByText("Save before closing?")).not.toBeInTheDocument();
+
+    saveDiscard.choose("cancel");
+    await second;
+  });
+
+  it("cancels an outstanding request if a second one arrives", async () => {
+    // Defensive path in the service: the UI is modal so it should not happen,
+    // but if it does, the first caller must not be left awaiting.
+    mount(SaveDiscardDialog);
+    const first = ask();
+    const second = ask();
+
+    expect(await answered(first)).toBe("cancel");
+
+    saveDiscard.choose("save");
+    expect(await answered(second)).toBe("save");
+  });
+});

--- a/uxnandesktop/src/lib/components/UsageMeter.svelte.test.ts
+++ b/uxnandesktop/src/lib/components/UsageMeter.svelte.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The narrowest kind of component test: props in, rendered output out.
+ *
+ * `UsageMeter` is the bar the provider cards and the status-bar popover share,
+ * so a change to it moves two surfaces at once. What matters is that the number
+ * a user reads matches the number the backend reported, that the bar stays
+ * inside its track, and that a very small percentage is still *visible* — a 0 %
+ * bar that renders as nothing looks like a broken widget rather than a fact.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { mount } from "../../test/render";
+import type { UsageWindow } from "$lib/types";
+import UsageMeter from "./UsageMeter.svelte";
+
+function usageWindow(overrides: Partial<UsageWindow> = {}): UsageWindow {
+  return { id: "five-hour", label: "5-hour limit", usedPercent: 42, ...overrides };
+}
+
+/** An epoch-milliseconds reset two hours out — the shape the providers report. */
+function inTwoHours(): number {
+  return Date.now() + 2 * 60 * 60 * 1000;
+}
+
+/** The filled part of the bar — the only element carrying an inline width. */
+function fill(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>('[style*="width"]');
+  if (!el) throw new Error("no filled bar rendered");
+  return el;
+}
+
+describe("UsageMeter", () => {
+  it("shows the window's label and its used percentage", () => {
+    const { screen } = mount(UsageMeter, { props: { window: usageWindow() } });
+    expect(screen.getByText("5-hour limit")).toBeInTheDocument();
+    expect(screen.getByText("42%")).toBeInTheDocument();
+  });
+
+  it("rounds the percentage rather than showing a long decimal", () => {
+    const { screen } = mount(UsageMeter, { props: { window: usageWindow({ usedPercent: 42.6 }) } });
+    expect(screen.getByText("43%")).toBeInTheDocument();
+  });
+
+  it("keeps a nearly-empty bar visible instead of rendering nothing", () => {
+    // A 0 % bar that is 0 px wide reads as a broken component, not as "no usage".
+    const { screen } = mount(UsageMeter, { props: { window: usageWindow({ usedPercent: 0 }) } });
+    expect(screen.getByText("0%")).toBeInTheDocument();
+    expect(fill(screen.container).style.width).toBe("2%");
+  });
+
+  it("never lets the bar overflow its track", () => {
+    const { screen } = mount(UsageMeter, { props: { window: usageWindow({ usedPercent: 130 }) } });
+    expect(fill(screen.container).style.width).toBe("100%");
+  });
+
+  it("omits the reset line when there is nothing to reset", () => {
+    const { screen } = mount(UsageMeter, { props: { window: usageWindow() } });
+    expect(screen.queryByText(/resets in/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a reset countdown when the provider reported one", () => {
+    const { screen } = mount(UsageMeter, {
+      props: { window: usageWindow({ resetsAt: inTwoHours() }) },
+    });
+    expect(screen.getByText(/resets in/i)).toBeInTheDocument();
+  });
+
+  it("drops the absolute clock time in compact mode, keeping the countdown", () => {
+    // The popover is tight; "resets in 2h · 3:00 PM" wraps and reads badly.
+    const { screen } = mount(UsageMeter, {
+      props: { window: usageWindow({ resetsAt: inTwoHours() }), compact: true, showReset: true },
+    });
+    expect(screen.getByText(/resets in/i).textContent).not.toContain("·");
+  });
+});

--- a/uxnandesktop/src/test/render.ts
+++ b/uxnandesktop/src/test/render.ts
@@ -1,0 +1,74 @@
+/**
+ * Rendering helpers for component tests.
+ *
+ * Thin on purpose. Testing Library already gives the right primitives; what this
+ * adds is the pairing every test in this repo needs — a component *and* a fake
+ * backend, torn down together — plus a nudge toward accessible queries.
+ *
+ * The house style, in one line: **query the way a user finds things** (role,
+ * label, text), and reach for `data-testid` only when there is genuinely no
+ * accessible handle. A test that only passes because it knew the class name will
+ * fail the next time someone restyles the component, and will keep passing the
+ * next time someone breaks its accessibility.
+ */
+
+import { render as tlRender, type RenderResult } from "@testing-library/svelte";
+import userEvent from "@testing-library/user-event";
+import type { Component } from "svelte";
+
+import { installFakeBackend, type CommandTable, type FakeBackend } from "./tauri";
+
+/** Any Svelte 5 component, whatever its prop types. Tests pass props as a plain
+ *  record — they are written by hand and checked by the assertions that follow,
+ *  and threading each component's generics through here would buy nothing but
+ *  ceremony. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyComponent = Component<any, any, any>;
+
+export interface MountOptions {
+  /** Props for the component. */
+  props?: Record<string, unknown>;
+  /** Backend command handlers for this test. */
+  commands?: CommandTable;
+}
+
+export interface Mounted {
+  /** Testing Library's result: `getByRole`, `container`, `unmount`, … */
+  screen: RenderResult<AnyComponent>;
+  /** The fake backend behind it. */
+  backend: FakeBackend;
+  /** A `user-event` instance already set up for this test. */
+  user: ReturnType<typeof userEvent.setup>;
+}
+
+/**
+ * Mount a component against a fake backend.
+ *
+ * Cleanup is automatic: `svelteTesting()` unmounts the component and
+ * `setup.dom.ts` uninstalls the backend, both after every test.
+ */
+export function mount(component: AnyComponent, options: MountOptions = {}): Mounted {
+  const backend = installFakeBackend(options.commands);
+  const user = userEvent.setup();
+  const screen = tlRender(component, options.props ?? {}) as RenderResult<AnyComponent>;
+  return { screen, backend, user };
+}
+
+/**
+ * Wait for a condition that has no DOM signal — a call reaching the backend, a
+ * store settling. Polls the microtask queue rather than sleeping, so it costs
+ * nothing when the condition is already true and never adds fixed delay.
+ *
+ * Prefer Testing Library's `findBy*` when the thing being waited for *is* in the
+ * DOM; this is for the cases where it is not.
+ */
+export async function until(
+  predicate: () => boolean,
+  { timeoutMs = 2000, label = "condition" }: { timeoutMs?: number; label?: string } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`timed out after ${timeoutMs}ms waiting for ${label}`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}

--- a/uxnandesktop/src/test/setup.dom.ts
+++ b/uxnandesktop/src/test/setup.dom.ts
@@ -1,0 +1,128 @@
+/**
+ * Global setup for the `dom` project.
+ *
+ * Everything here exists so an individual component test can be about the
+ * component. The two rules it enforces:
+ *
+ * 1. **No test leaks into the next one.** The fake backend is torn down after
+ *    every test, so a stray handler or listener cannot make an unrelated test
+ *    pass (or fail) for reasons nobody can see in the file they are reading.
+ * 2. **jsdom's gaps are filled once.** jsdom implements the DOM, not a browser:
+ *    it has no layout engine, no `matchMedia`, no `ResizeObserver`, no clipboard.
+ *    Components legitimately use those, and stubbing them per file would be
+ *    noise. They are stubbed here as *inert* implementations — never as
+ *    something that fakes a result a test might then assert on.
+ */
+
+import "@testing-library/jest-dom/vitest";
+import { afterEach, vi } from "vitest";
+
+import { uninstallFakeBackend } from "./tauri";
+
+afterEach(() => {
+  uninstallFakeBackend();
+});
+
+// --- jsdom gaps -------------------------------------------------------------
+
+if (!window.matchMedia) {
+  // The theme store asks for the OS colour scheme at import time. Answering
+  // "light, and nothing will ever change" keeps it deterministic; a test that
+  // cares about theme switching overrides this itself.
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+if (!globalThis.ResizeObserver) {
+  // Panels and the terminal area observe their own size. jsdom has no layout,
+  // so every element is 0×0 and the observer would never fire anyway — an inert
+  // one is the honest stand-in.
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+if (!globalThis.IntersectionObserver) {
+  globalThis.IntersectionObserver = class {
+    root = null;
+    rootMargin = "";
+    thresholds: number[] = [];
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+    takeRecords() {
+      return [];
+    }
+  } as unknown as typeof IntersectionObserver;
+}
+
+// `Element.animate` is used by a few transitions; jsdom has no Web Animations.
+if (!Element.prototype.animate) {
+  Element.prototype.animate = (() => ({
+    finished: Promise.resolve(),
+    cancel() {},
+    finish() {},
+  })) as unknown as typeof Element.prototype.animate;
+}
+
+// `scrollIntoView` and friends: no layout, so they are no-ops rather than
+// throwing and failing a test for a reason unrelated to what it asserts.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// A component that opens a pointer lock (the drag guards) would otherwise throw.
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.hasPointerCapture = () => false;
+}
+
+// xterm probes for a canvas while measuring the character grid. jsdom has none
+// and logs "Not implemented" on every mount, which buries real failures in
+// noise. Returning `null` is what a browser does when the context type is
+// unsupported, and xterm handles that by falling back — so this reports the
+// truth rather than faking a drawing surface no assertion could rely on.
+HTMLCanvasElement.prototype.getContext = (() =>
+  null) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+// Console policy. Two opposite jobs: make a real problem impossible to miss,
+// and keep known third-party noise from burying it.
+//
+// Promoted to a failure — these always mean the test itself is wrong:
+//   · a prop the component does not declare (a renamed prop the test still passes)
+//   · a lifecycle call outside a component (a helper mounting something wrongly)
+//
+// Suppressed — `derived_inert` fires from `bits-ui`'s dialog teardown when a
+// modal is unmounted between tests. It is the library reading its own derived
+// during destruction, not the app misbehaving, and it prints several times per
+// dialog test. Everything else still reaches the terminal.
+const FAIL_ON = ["was created with unknown prop", "lifecycle_outside_component"];
+const SUPPRESS = ["derived_inert"];
+
+const consoleError = console.error;
+vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+  const text = String(args[0] ?? "");
+  if (FAIL_ON.some((needle) => text.includes(needle))) {
+    throw new Error(`Svelte reported a problem the test should not ignore:\n${text}`);
+  }
+  if (SUPPRESS.some((needle) => text.includes(needle))) return;
+  consoleError(...args);
+});
+
+const consoleWarn = console.warn;
+vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+  const text = String(args[0] ?? "");
+  if (SUPPRESS.some((needle) => text.includes(needle))) return;
+  consoleWarn(...args);
+});

--- a/uxnandesktop/src/test/tauri.ts
+++ b/uxnandesktop/src/test/tauri.ts
@@ -1,0 +1,178 @@
+/**
+ * A fake Tauri backend for component tests.
+ *
+ * The obvious way to test a component that calls `api.getAppState()` is to mock
+ * `$lib/api`. That is also the way to end up with a test suite that passes
+ * against a contract the app no longer has: the mock and `api.ts` drift, and
+ * nothing notices, because the mock *is* the assertion.
+ *
+ * So the seam is one layer lower. Tauri ships `mockIPC`, which replaces the IPC
+ * transport itself (`window.__TAURI_INTERNALS__.invoke`). `src/lib/api.ts` runs
+ * **for real** — its command names, its argument marshalling, its return types —
+ * and only the process on the other side is fake. A renamed command or a changed
+ * argument shape shows up as a failing test rather than as a mock nobody
+ * updated.
+ *
+ * What this module adds on top:
+ *
+ * - **a typed handler table** keyed by command name, with an unhandled command
+ *   rejecting loudly instead of returning `undefined` (which would surface much
+ *   later as a confusing null-deref inside the component);
+ * - **a call log**, so a test can assert *what* the component asked the backend
+ *   for, not just what it rendered;
+ * - **event emission**, because half the app's behaviour arrives through
+ *   `listen()` rather than through a command's return value;
+ * - **failure and latency injection**, since "the backend said no" and "the
+ *   backend was slow" are states real users hit and components rarely handle.
+ */
+
+import { clearMocks, mockIPC, mockWindows } from "@tauri-apps/api/mocks";
+
+/** A command handler. May be sync or async; throwing rejects the `invoke`. */
+export type CommandHandler = (args: Record<string, unknown>) => unknown;
+
+/** Command name → handler. Keys are the real Rust command names. */
+export type CommandTable = Record<string, CommandHandler>;
+
+/** One recorded call, in order. */
+export interface RecordedCall {
+  command: string;
+  args: Record<string, unknown>;
+}
+
+export interface FakeBackend {
+  /** Every `invoke` the app made, oldest first. */
+  readonly calls: RecordedCall[];
+  /** Calls for one command, in order. */
+  callsTo(command: string): RecordedCall[];
+  /** The most recent call to a command, or `undefined`. */
+  lastCallTo(command: string): RecordedCall | undefined;
+  /** Whether the app ever issued this command. */
+  called(command: string): boolean;
+  /** Add or replace handlers after `installFakeBackend` (e.g. to make a command
+   *  start failing halfway through a test). */
+  setCommands(commands: CommandTable): void;
+  /** Deliver a Tauri event to everything currently listening for it. */
+  emit(event: string, payload: unknown): void;
+  /** How many listeners are registered for an event — the cheap way to assert a
+   *  component unsubscribed on unmount. */
+  listenerCount(event: string): number;
+  /** Forget recorded calls, keeping handlers and listeners. */
+  clearCalls(): void;
+}
+
+/** Commands every mounted component tends to reach for. Individual tests
+ *  override what they care about; without these, mounting almost anything fails
+ *  on an unrelated command. */
+function baseCommands(): CommandTable {
+  return {
+    ping: () => true,
+    // Tauri's own plugin channels the app touches indirectly.
+    "plugin:event|listen": () => 0,
+    "plugin:event|unlisten": () => undefined,
+    "plugin:event|emit": () => undefined,
+    "plugin:window|theme": () => "light",
+  };
+}
+
+/**
+ * Install the fake backend for the current test. Returns the handle used to
+ * inspect and steer it.
+ *
+ * Call `uninstallFakeBackend()` afterwards — `setup.dom.ts` does it globally in
+ * `afterEach`, so a test only needs to do it explicitly when it installs a
+ * second backend mid-test.
+ */
+export function installFakeBackend(commands: CommandTable = {}): FakeBackend {
+  const calls: RecordedCall[] = [];
+  let table: CommandTable = { ...baseCommands(), ...commands };
+  /** event name → listener handlers, keyed by the id we handed Tauri. */
+  const listeners = new Map<string, Map<number, (event: unknown) => void>>();
+  let nextListenerId = 1;
+
+  mockWindows("main");
+
+  mockIPC(async (cmd, payload) => {
+    const args = (payload ?? {}) as Record<string, unknown>;
+
+    // Event subscription rides the same channel as any other command. Tauri
+    // hands us the callback as a "channel" object whose id we call back through.
+    if (cmd === "plugin:event|listen") {
+      const event = String(args.event ?? "");
+      const handler = args.handler as { onmessage?: (e: unknown) => void } | undefined;
+      const id = nextListenerId++;
+      if (!listeners.has(event)) listeners.set(event, new Map());
+      listeners.get(event)!.set(id, (e) => handler?.onmessage?.(e));
+      calls.push({ command: cmd, args });
+      return id;
+    }
+    if (cmd === "plugin:event|unlisten") {
+      const event = String(args.event ?? "");
+      listeners.get(event)?.delete(Number(args.eventId));
+      calls.push({ command: cmd, args });
+      return undefined;
+    }
+
+    calls.push({ command: cmd, args });
+    const handler = table[cmd];
+    if (!handler) {
+      // Loud on purpose: an unhandled command returning `undefined` would fail
+      // somewhere else entirely, and the test would blame the wrong code.
+      throw new Error(
+        `fake backend: no handler for "${cmd}". Add it to installFakeBackend({ "${cmd}": () => … }).`,
+      );
+    }
+    return await handler(args);
+  });
+
+  return {
+    calls,
+    callsTo: (command) => calls.filter((c) => c.command === command),
+    lastCallTo: (command) => [...calls].reverse().find((c) => c.command === command),
+    called: (command) => calls.some((c) => c.command === command),
+    setCommands: (next) => {
+      table = { ...table, ...next };
+    },
+    emit: (event, payload) => {
+      const target = listeners.get(event);
+      if (!target) return;
+      for (const deliver of [...target.values()]) {
+        deliver({ event, id: 0, payload });
+      }
+    },
+    listenerCount: (event) => listeners.get(event)?.size ?? 0,
+    clearCalls: () => {
+      calls.length = 0;
+    },
+  };
+}
+
+/** Tear the fake backend down. Idempotent. */
+export function uninstallFakeBackend(): void {
+  clearMocks();
+}
+
+// --- handler helpers --------------------------------------------------------
+
+/** A handler that rejects, for testing how a component reports backend errors.
+ *  Shaped like the real `CommandError` the Rust side returns. */
+export function failsWith(code: string, message: string): CommandHandler {
+  return () => {
+    throw { code, message };
+  };
+}
+
+/**
+ * A handler that resolves only when the test says so — for asserting the state
+ * a component shows *while* it waits, which is the part that usually has no
+ * test and usually has the bug.
+ */
+export function deferred<T>(): { handler: CommandHandler; resolve: (value: T) => void; reject: (err: unknown) => void } {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { handler: () => promise, resolve, reject };
+}

--- a/uxnandesktop/tests/e2e/README.md
+++ b/uxnandesktop/tests/e2e/README.md
@@ -1,0 +1,100 @@
+# End-to-end tests
+
+The only layer that runs the whole product: a release binary, its Rust backend, a
+real WebView2, real IPC, real processes.
+
+```bash
+cd uxnandesktop
+npm run bench:build          # a release binary with its frontend embedded
+npm run test:e2e:setup       # fetch the WebDriver matching this machine's WebView2
+# close every other uxnan window
+npm run test:e2e
+```
+
+## Preconditions, and why each one is enforced
+
+**A release binary with the frontend embedded.** `cargo build --release` alone
+leaves Tauri in dev mode: the window opens, the backend runs, and the webview
+shows a connection-refused page. Use `npm run bench:build`.
+
+**No other uxnan running.** Windows keeps **one WebView2 browser process per
+user-data folder**, so a second instance attaches to the first one's — and the
+automation session then drives a webview that is not this app's. It does not
+error: every query returns `<html><head></head><body></body></html>`, which reads
+as "the app renders nothing". The config refuses to start and names the offending
+PID. (The resource benchmarks hit the same constraint; the check is shared with
+them rather than written twice.)
+
+**A WebDriver matching the installed WebView2.** `msedgedriver` is version-locked
+to the runtime, and a mismatch fails with a message about browser versions that
+says nothing about what to do. `setup-driver.mjs` reads the installed version
+from the registry and fetches the matching driver into `.drivers/` (git-ignored:
+it is a per-machine artifact). The version is deliberately **not** pinned in a
+config file — WebView2 updates on its own schedule, so a checked-in version would
+be wrong within weeks and wrong on every other machine.
+
+## Two traps, both now guarded
+
+**The session starts on `about:blank`.** `tauri-driver` does not attach to the
+window the app already navigated; it hands you a blank webview. Every query then
+succeeds and returns `<html><head></head><body></body></html>`, which reads as
+"the app rendered nothing" while the app is running perfectly — its process tree
+has a full set of renderers and it writes `state.json` and
+`terminal-buffers.json`, which only a hydrated frontend does. The config
+navigates to `http://tauri.localhost/` before any test, and the IPC bridge is
+live there: `invoke("ping")` answers `"pong"` from the Rust backend, so these are
+genuine end-to-end tests rather than a frontend rendering against nothing.
+
+**`tauri:options.env` did not reach the app.** A diagnostic run came up showing
+the developer's real projects and name — the suite was driving their profile, not
+the disposable one, and a journey that removed a worktree would have removed a
+real one. `UXNAN_DATA_DIR` is set on the driver process now (the app inherits
+from it), and `before` **refuses to run** if the app under test has any project
+in it.
+
+## What is here, and what is not
+
+Journeys only. Everything provable in jsdom or against a temp directory belongs
+in a faster layer; this one costs a process launch per spec and is the first to
+become flaky.
+
+Eight of them, one per spec file, each with its own app started from a profile
+seeded for it (`journeys.mjs`): **launch**, **restore** (a saved session comes
+back), **terminal** (two panes in a split, a real shell behind each),
+**sleep-wake** (a sleeping workspace spawns nothing), **worktree** (a real git
+repository is recognised, listed and read), **agent** (the agent runs under a
+shell; the hook server refuses an untokened report and records a valid one),
+**browser** (a loopback page in a second window) and **migration** (a profile
+from an older build still opens with its projects).
+
+Setup is seeded rather than clicked: twenty clicks to reach the thing you wanted
+to assert is how an E2E suite becomes slow and brittle. The assertions still go
+through the real UI, real IPC and a real backend.
+
+The matrix of what each flow is covered by — and what it is not — lives in
+[`../quality-matrix.json`](../quality-matrix.json), checked against the repo by
+`../quality-matrix.test.mjs`.
+
+## Isolation and cleanup
+
+Every run gets a throwaway `UXNAN_DATA_DIR`, so it starts from a known profile
+and can never touch yours.
+
+Teardown reaps **by PID**, never by name. That is not fastidiousness: this
+harness runs on machines where a real `uxnan-desktop.exe` is very likely open —
+quite possibly the one hosting the terminal the tests were started from — and a
+name-based sweep would take it down along with whatever was running inside it. An
+app that outlives its session is matched on *our* profile directory, killed, and
+**reported**, because a leak is a teardown bug and not a passing detail.
+
+## When something fails
+
+`.artifacts/` (git-ignored) holds a screenshot and the page source per failed
+test, plus the driver log. The empty-document case above is diagnosable straight
+from the saved HTML.
+
+## Platforms
+
+Windows only for now. `tauri-driver` supports Linux (WebKitWebDriver) and does
+not support macOS, but neither has been run here — and this harness does not
+claim a platform it has not executed on.

--- a/uxnandesktop/tests/e2e/helpers.mjs
+++ b/uxnandesktop/tests/e2e/helpers.mjs
@@ -1,0 +1,189 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Shared helpers for the journeys.
+ *
+ * Two rules the assertions follow, both learned from getting them wrong:
+ *
+ * **Ask the backend, not the screen, for facts.** The UI is localised — it
+ * renders in Spanish on the machine this was written on — so an assertion on
+ * visible text is an assertion on a translation. Anything the backend knows
+ * (projects, worktrees, git status, agent state) is read over IPC, which is also
+ * what makes these end-to-end rather than DOM tests: the answer travelled
+ * through the real command layer.
+ *
+ * **Use the DOM only for what is genuinely visual**, and prefer structure over
+ * words: how many terminals are mounted, whether a tab the journey itself named
+ * is present.
+ */
+
+/** Call a Tauri command from inside the app, exactly as the app would. */
+export async function invoke(command, args = {}) {
+  const result = await browser.executeAsync(
+    (cmd, a, done) => {
+      window.__TAURI_INTERNALS__.invoke(cmd, a)
+        .then((value) => done({ ok: true, value }))
+        .catch((error) => done({ ok: false, error: String(error) }));
+    },
+    command,
+    args,
+  );
+  if (!result.ok) throw new Error(`invoke("${command}") failed: ${result.error}`);
+  return result.value;
+}
+
+/** The app's persisted state, straight from the backend. */
+export function appState() {
+  return invoke("get_app_state");
+}
+
+/** How many terminals are mounted right now. */
+export function terminalCount() {
+  return browser.execute(() => document.querySelectorAll(".xterm").length);
+}
+
+/** Wait for `n` terminals to be mounted (they appear a beat after hydration,
+ *  because the workspace binds to its worktree asynchronously). */
+export async function waitForTerminals(n, { timeout = 45_000 } = {}) {
+  await browser.waitUntil(async () => (await terminalCount()) >= n, {
+    timeout,
+    interval: 500,
+    timeoutMsg: `expected ${n} terminal(s) to mount; saw ${await terminalCount()}`,
+  });
+}
+
+/**
+ * Processes running underneath the app, by executable name.
+ *
+ * Reading a terminal's *contents* is not available here: xterm paints through
+ * WebGL, so `.xterm-rows` is empty in the DOM and any assertion on its text
+ * would pass or fail for reasons unrelated to whether a shell is alive. The
+ * observable that actually answers "is there a process behind this pane" is the
+ * process tree, so that is what the journeys assert on.
+ *
+ * How the app is located is explained at the top of the function; it is not the
+ * obvious way, and the obvious way is wrong.
+ */
+export function appDescendants() {
+  // The app cannot be found by its command line: `UXNAN_DATA_DIR` is an
+  // *environment* variable and never appears there. (Matching on it looked like
+  // it worked, but what it matched was the PowerShell process running the query
+  // — whose own command line contains the path.)
+  //
+  // So the app is identified by name, which is safe **only** because of the
+  // pre-flight in `wdio.conf.mjs`: it refuses to start while any other
+  // `uxnan-desktop.exe` is alive, so the one running now is necessarily the one
+  // this suite launched. If that guard is ever removed, this must change too.
+  const script = `
+$app = Get-CimInstance Win32_Process -Property ProcessId,Name |
+  Where-Object { $_.Name -eq 'uxnan-desktop.exe' } | Select-Object -First 1
+if (-not $app) { ''; exit }
+$all = Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,Name
+$ids = New-Object System.Collections.ArrayList
+$q = New-Object System.Collections.Queue; [void]$q.Enqueue([int]$app.ProcessId)
+while ($q.Count -gt 0) {
+  $id = $q.Dequeue(); [void]$ids.Add($id)
+  foreach ($c in ($all | Where-Object { $_.ParentProcessId -eq $id })) { [void]$q.Enqueue([int]$c.ProcessId) }
+}
+($all | Where-Object { $ids -contains $_.ProcessId } | ForEach-Object { $_.Name }) -join ','`;
+  try {
+    const out = execFileSync("powershell.exe", ["-NoProfile", "-Command", script], {
+      encoding: "utf8",
+      windowsHide: true,
+      timeout: 30_000,
+    });
+    return out.trim().split(",").map((n) => n.trim().toLowerCase()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Wait until `predicate` holds over the app's process tree.
+ *
+ * Polled here rather than through `browser.waitUntil` so the failure can name
+ * what it actually saw. A timeout that says only "condition timed out" sends the
+ * next person back to reproduce it by hand, which is most of the cost of a
+ * failing test.
+ */
+export async function waitForProcesses(predicate, { timeout = 60_000, label } = {}) {
+  const deadline = Date.now() + timeout;
+  let seen = [];
+  for (;;) {
+    seen = appDescendants();
+    if (predicate(seen)) return seen;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `never saw ${label ?? "the expected processes"} within ${timeout}ms.\n` +
+          `The app's process tree held: ${seen.join(", ") || "nothing (the app was not found)"}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}
+
+/**
+ * Ask the app to close the way clicking the X does, and wait for its whole tree
+ * to go.
+ *
+ * `taskkill` without `/F` posts WM_CLOSE, so the app runs its own shutdown —
+ * flushing, stopping watchers, reaping PTYs. That last part is the point: a
+ * child process the app forgets outlives it forever.
+ */
+export async function closeAppAndWait({ timeout = 30_000 } = {}) {
+  const pid = appPid();
+  if (!pid) return true;
+  spawnSync("taskkill.exe", ["/PID", String(pid)], { stdio: "ignore", windowsHide: true });
+
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (appDescendants().length === 0) return true;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+/** The app's pid, or `null`. Same identification rule as `appDescendants`. */
+export function appPid() {
+  try {
+    const out = execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-Command",
+        "(Get-CimInstance Win32_Process -Property ProcessId,Name | Where-Object { $_.Name -eq 'uxnan-desktop.exe' } | Select-Object -First 1).ProcessId",
+      ],
+      { encoding: "utf8", windowsHide: true, timeout: 30_000 },
+    );
+    const pid = Number(out.trim());
+    return Number.isFinite(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/** How many of `names` appear in a process list. */
+export function countOf(names, list) {
+  const wanted = names.map((n) => n.toLowerCase());
+  return list.filter((n) => wanted.includes(n)).length;
+}
+
+/** Tab labels currently rendered. The journeys name their own tabs, so this is
+ *  locale-independent. */
+export function tabTitles() {
+  return browser.execute(() =>
+    [...document.querySelectorAll("[data-pane-container] button")]
+      .map((b) => (b.textContent || "").trim())
+      .filter(Boolean),
+  );
+}
+
+/** The disposable profile this run is using — the same fixed path the config
+ *  computes, so a spec can locate the app without the config exporting it. */
+export const PROFILE_DATA = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".profile",
+  "data",
+);

--- a/uxnandesktop/tests/e2e/journeys.mjs
+++ b/uxnandesktop/tests/e2e/journeys.mjs
@@ -1,0 +1,210 @@
+/**
+ * The state each journey starts from.
+ *
+ * Driving the UI to *set up* a journey is how E2E suites become slow and
+ * brittle: twenty clicks to reach the thing you actually wanted to assert, any
+ * one of which can break for an unrelated reason. So setup is done by seeding
+ * the app's own persisted profile — the same technique the resource benchmarks
+ * use — and the journey then asserts through the real UI, over real IPC, against
+ * a real backend.
+ *
+ * A spec's profile is written *before* its session starts (`beforeSession` in
+ * `wdio.conf.mjs`), keyed by the spec's file name, so every journey gets a fresh
+ * app in a known state.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { makeRepo } from "../fixtures/shared.mjs";
+import {
+  group,
+  layout,
+  project,
+  settings,
+  shellRunning,
+  split,
+  terminalTab,
+  writeProfile,
+} from "../fixtures/shared.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_ROOT = path.join(HERE, ".fixtures");
+const RESOURCE_FIXTURES = path.resolve(HERE, "..", "..", "scripts", "resources", "fixtures");
+
+/** A small deterministic git repository, generated once and reused. */
+function repo() {
+  return makeRepo({ dir: path.join(FIXTURE_ROOT, "repo"), files: 12, dirs: 3, lines: 6 });
+}
+
+/** A shell that stays open and prints something we can look for. */
+function shellTab(cwd, title, extra = {}) {
+  return terminalTab({ title, cwd, sid: `e2e-${title.replace(/\W+/g, "-")}`, ...extra });
+}
+
+/**
+ * Journeys, keyed by spec base name. Each returns the arguments `writeProfile`
+ * takes, plus anything the spec needs to know about what was seeded.
+ */
+export const JOURNEYS = {
+  /** Nothing at all: the app must come up on an empty profile. */
+  launch: () => ({ profile: {}, facts: {} }),
+
+  /** A project and a live terminal, saved as a previous session would leave it. */
+  restore: () => {
+    const r = repo();
+    return {
+      profile: {
+        repos: [project({ id: "e2e-repo", name: "fixture-repo", dir: r.dir })],
+        layout: layout(r.dir, { [r.dir]: group([shellTab(r.dir, "shell 1")]) }),
+      },
+      facts: { repoDir: r.dir, projectName: "fixture-repo" },
+    };
+  },
+
+  /** Two terminals in a split, to assert both come back and both are live. */
+  terminal: () => {
+    const r = repo();
+    return {
+      profile: {
+        repos: [project({ id: "e2e-repo", name: "fixture-repo", dir: r.dir })],
+        layout: layout(r.dir, {
+          [r.dir]: split("row", group([shellTab(r.dir, "left")]), group([shellTab(r.dir, "right")])),
+        }),
+      },
+      facts: { repoDir: r.dir, projectName: "fixture-repo" },
+    };
+  },
+
+  /** The same two terminals, but asleep: the PTYs must not exist until woken. */
+  "sleep-wake": () => {
+    const r = repo();
+    return {
+      profile: {
+        repos: [project({ id: "e2e-repo", name: "fixture-repo", dir: r.dir })],
+        layout: layout(r.dir, {
+          [r.dir]: split(
+            "row",
+            group([shellTab(r.dir, "left", { asleep: true })]),
+            group([shellTab(r.dir, "right", { asleep: true })]),
+          ),
+        }),
+      },
+      facts: { repoDir: r.dir, projectName: "fixture-repo" },
+    };
+  },
+
+  /** A real git repository as a project, for the git surface. */
+  worktree: () => {
+    const r = makeRepo({ dir: path.join(FIXTURE_ROOT, "repo-dirty"), files: 12, dirs: 3, lines: 6, dirty: 3 });
+    return {
+      profile: {
+        repos: [project({ id: "e2e-git", name: "git-fixture", dir: r.dir })],
+        layout: layout(r.dir, { [r.dir]: group([]) }),
+      },
+      facts: { repoDir: r.dir, projectName: "git-fixture" },
+    };
+  },
+
+  /** The offline stand-in agent, launched inside a shell as the app does. */
+  agent: () => {
+    const r = repo();
+    const tab = terminalTab({
+      title: "fixture agent",
+      cwd: r.dir,
+      sid: "e2e-agent",
+      ...shellRunning([
+        "node",
+        path.join(RESOURCE_FIXTURES, "agent-fixture.mjs"),
+        "--rate",
+        "8",
+        "--work",
+        "600",
+        "--hooks",
+      ]),
+    });
+    return {
+      profile: {
+        repos: [project({ id: "e2e-repo", name: "fixture-repo", dir: r.dir })],
+        layout: layout(r.dir, { [r.dir]: group([tab]) }),
+      },
+      facts: { repoDir: r.dir, projectName: "fixture-repo" },
+    };
+  },
+
+  /** A saved orchestration run, so the console has something to show. */
+  orchestration: () => {
+    const r = repo();
+    return {
+      profile: {
+        repos: [project({ id: "e2e-repo", name: "fixture-repo", dir: r.dir })],
+        layout: layout(r.dir, { [r.dir]: group([shellTab(r.dir, "shell 1")]) }),
+      },
+      facts: { repoDir: r.dir, projectName: "fixture-repo" },
+    };
+  },
+
+  /** Nothing special; the spec opens the browser itself. */
+  browser: () => ({ profile: {}, facts: {} }),
+
+  /**
+   * A profile written the way an older build wrote it. The app has to migrate
+   * it and come up, rather than refusing to start or losing the projects.
+   */
+  migration: () => {
+    const r = repo();
+    return {
+      raw: {
+        version: 1,
+        // No `isGit`, no terminal profiles, a tab with no `kind` — all three
+        // shapes an older build persisted.
+        repos: [{ id: "legacy", name: "legacy-project", path: r.dir, worktrees: [] }],
+        settings: {
+          theme: "dark",
+          leftSidebarWidth: 300,
+          rightSidebarWidth: 320,
+          leftSidebarOpen: true,
+          rightSidebarOpen: true,
+        },
+        terminalLayout: {
+          active: "",
+          workspaces: { "": { type: "group", tabs: [{ title: "shell", cwd: r.dir }], activeTab: 0 } },
+        },
+      },
+      facts: { repoDir: r.dir, projectName: "legacy-project" },
+    };
+  },
+};
+
+/** Write the profile a spec needs, and return what it seeded. */
+export function seedFor(specPath, dataDir) {
+  const name = path.basename(String(specPath)).replace(/\.e2e\.mjs$/, "");
+  const journey = JOURNEYS[name];
+  if (!journey) {
+    // An unknown spec gets an empty profile rather than a stale one from
+    // whichever journey ran last.
+    writeProfile(dataDir, {});
+    return { facts: {}, name };
+  }
+  const { profile, raw, facts } = journey();
+  if (raw) {
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, "state.json"), JSON.stringify(raw, null, 2), "utf8");
+  } else {
+    writeProfile(dataDir, { ...profile, settingsOverrides: profile.settingsOverrides });
+  }
+  fs.writeFileSync(path.join(dataDir, "_facts.json"), JSON.stringify(facts, null, 2), "utf8");
+  return { facts, name };
+}
+
+/** What the currently-running spec was seeded with. */
+export function factsFor(dataDir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(dataDir, "_facts.json"), "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+export { settings };

--- a/uxnandesktop/tests/e2e/setup-driver.mjs
+++ b/uxnandesktop/tests/e2e/setup-driver.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Fetch the WebDriver that matches this machine's WebView2.
+ *
+ * Driving a Tauri window on Windows goes through `tauri-driver`, which is a thin
+ * intermediary in front of Microsoft's `msedgedriver` — and `msedgedriver` is
+ * version-locked to the installed WebView2 runtime. A mismatch does not degrade
+ * gracefully: the session simply refuses to start, with a message about browser
+ * versions that says nothing about what to do.
+ *
+ * So the version is *read from the machine* rather than pinned in a config file.
+ * Pinning it would be pinning someone else's software: WebView2 updates itself
+ * on its own schedule, and a checked-in version would be wrong within weeks and
+ * would fail on every machine that isn't this one.
+ *
+ * The binary lands in `.drivers/`, which is git-ignored — it is a per-machine
+ * build artifact, not a project file.
+ *
+ *   node tests/e2e/setup-driver.mjs            # fetch if missing or mismatched
+ *   node tests/e2e/setup-driver.mjs --check    # report only, exit 1 if not ready
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const DRIVERS_DIR = path.join(HERE, ".drivers");
+export const DRIVER_PATH = path.join(
+  DRIVERS_DIR,
+  process.platform === "win32" ? "msedgedriver.exe" : "msedgedriver",
+);
+
+/** The installed WebView2 runtime version, or `null` if it can't be read. */
+export function installedWebViewVersion() {
+  if (process.platform !== "win32") return null;
+  for (const key of [
+    "HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
+    "HKLM:\\SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
+    "HKCU:\\SOFTWARE\\Microsoft\\EdgeUpdate\\Clients\\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}",
+  ]) {
+    const out = spawnSync(
+      "powershell.exe",
+      ["-NoProfile", "-Command", `(Get-ItemProperty -Path '${key}' -EA SilentlyContinue).pv`],
+      { encoding: "utf8", windowsHide: true },
+    );
+    const version = out.stdout?.trim();
+    if (version) return version;
+  }
+  return null;
+}
+
+/** The version of the driver already downloaded, or `null`. */
+export function localDriverVersion() {
+  if (!fs.existsSync(DRIVER_PATH)) return null;
+  const out = spawnSync(DRIVER_PATH, ["--version"], { encoding: "utf8", windowsHide: true });
+  return out.stdout?.match(/(\d+\.\d+\.\d+\.\d+)/)?.[1] ?? null;
+}
+
+/** `null` when the driver is present and matches; otherwise why not. */
+export function driverStatus() {
+  if (process.platform !== "win32") {
+    return "E2E is Windows-only for now: the driver pairing has not been worked out on macOS/Linux.";
+  }
+  const want = installedWebViewVersion();
+  if (!want) return "could not read the installed WebView2 version from the registry";
+  const have = localDriverVersion();
+  if (!have) return `no WebDriver in .drivers/ (need ${want})`;
+  if (have !== want) return `WebDriver is ${have} but WebView2 is ${want}`;
+  return null;
+}
+
+function download(version) {
+  fs.mkdirSync(DRIVERS_DIR, { recursive: true });
+  const zip = path.join(DRIVERS_DIR, "edgedriver.zip");
+  const url = `https://msedgedriver.microsoft.com/${version}/edgedriver_win64.zip`;
+  process.stderr.write(`fetching WebDriver ${version}…\n`);
+  execFileSync("curl.exe", ["-sSL", "--max-time", "300", "-o", zip, url], { stdio: "inherit" });
+  execFileSync(
+    "powershell.exe",
+    ["-NoProfile", "-Command", `Expand-Archive -Path '${zip}' -DestinationPath '${DRIVERS_DIR}' -Force`],
+    { stdio: "inherit", windowsHide: true },
+  );
+  fs.rmSync(zip, { force: true });
+}
+
+function main() {
+  const checkOnly = process.argv.includes("--check");
+  const problem = driverStatus();
+
+  if (!problem) {
+    process.stderr.write(`WebDriver ${localDriverVersion()} matches the installed WebView2.\n`);
+    return 0;
+  }
+  if (checkOnly) {
+    process.stderr.write(`${problem}\nRun: node tests/e2e/setup-driver.mjs\n`);
+    return 1;
+  }
+  if (process.platform !== "win32") {
+    process.stderr.write(`${problem}\n`);
+    return 1;
+  }
+
+  const version = installedWebViewVersion();
+  if (!version) {
+    process.stderr.write("cannot fetch a driver without knowing the WebView2 version\n");
+    return 1;
+  }
+  download(version);
+
+  const after = driverStatus();
+  if (after) {
+    process.stderr.write(`still not usable after downloading: ${after}\n`);
+    return 1;
+  }
+  process.stderr.write(`WebDriver ${version} ready.\n`);
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))) {
+  process.exit(main());
+}

--- a/uxnandesktop/tests/e2e/specs/agent.e2e.mjs
+++ b/uxnandesktop/tests/e2e/specs/agent.e2e.mjs
@@ -1,0 +1,137 @@
+/**
+ * An agent running in a terminal, and the hook chain behind its status.
+ *
+ * Two separate things, deliberately asserted separately.
+ *
+ * **The agent runs where it should.** A CLI launched from a tab must end up as a
+ * child of a shell, not of the app: that nesting is what tells uxnan the process
+ * is the *user's* rather than its own, and it is what keeps an agent's memory out
+ * of uxnan's own figure in the resource benchmark.
+ *
+ * **A report reaches the state the sidebar reads.** The report is posted here
+ * over HTTP, exactly as a reporter does, using the coordinates the app wrote into
+ * its own profile. That covers the part uxnan owns — the local server, the token,
+ * the model update, the command the UI calls — without depending on a particular
+ * CLI's reporter being installed and correct, which is a different question and
+ * belongs to a different layer.
+ */
+
+import { strict as assert } from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  appDescendants,
+  closeAppAndWait,
+  countOf,
+  invoke,
+  PROFILE_DATA,
+  waitForProcesses,
+  waitForTerminals,
+} from "../helpers.mjs";
+
+/** The live hook coordinates, from the endpoint file the app writes at startup. */
+function hookEndpoint() {
+  const file = path.join(PROFILE_DATA, "hooks", "endpoint.cmd");
+  const text = fs.readFileSync(file, "utf8");
+  const url = text.match(/UXNAN_HOOK_URL=(\S+)/)?.[1];
+  const token = text.match(/UXNAN_HOOK_TOKEN=(\S+)/)?.[1];
+  if (!url || !token) throw new Error(`could not read hook coordinates from ${file}`);
+  return { url, token };
+}
+
+describe("an agent working in a terminal", () => {
+  it("launches the agent inside a shell, as the app does", async () => {
+    await waitForTerminals(1);
+
+    const tree = await waitForProcesses(
+      (names) => countOf(["node.exe"], names) >= 1 && countOf(["cmd.exe", "sh.exe"], names) >= 1,
+      { label: "the fixture agent running inside a shell" },
+    );
+    assert.ok(countOf(["node.exe"], tree) >= 1, "the fixture agent never started");
+  });
+
+  it("writes live hook coordinates into its own profile", () => {
+    // The endpoint file is how a reporter finds the server again after a
+    // restart. If it goes missing, every agent in the app goes silent.
+    const { url, token } = hookEndpoint();
+    assert.match(url, /^http:\/\/127\.0\.0\.1:\d+\/hook$/);
+    assert.ok(token.length > 8, "the hook token is too short to be a real one");
+  });
+
+  it("rejects a report that does not carry the token", async () => {
+    // The token is what stops any other local process from writing into the
+    // agent status a user is reading.
+    const { url } = hookEndpoint();
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Uxnan-Token": "not-the-token",
+        "X-Uxnan-Agent-Id": "e2e",
+        "X-Uxnan-Agent-Type": "claude",
+        "X-Uxnan-Status": "working",
+      },
+      body: "{}",
+    });
+    assert.ok(!response.ok, `an unauthenticated report was accepted (${response.status})`);
+  });
+
+  it("records a reported state where the sidebar reads it", async () => {
+    const { url, token } = hookEndpoint();
+    const agentId = "e2e-agent-journey";
+
+    // Reported through the headers the shell reporters use — `X-Uxnan-Agent-Id`,
+    // `-Agent-Type`, `-Status` — rather than an invented JSON body. Guessing the
+    // body shape is how this test first "passed" a POST the server accepted and
+    // then ignored.
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Uxnan-Token": token,
+        "X-Uxnan-Agent-Id": agentId,
+        "X-Uxnan-Agent-Type": "claude",
+        "X-Uxnan-Status": "working",
+      },
+      body: "{}",
+    });
+    assert.ok(response.ok, `the hook server refused a valid report (${response.status})`);
+
+    // `agent_states` is the same command the sidebar calls.
+    let states = [];
+    await browser.waitUntil(
+      async () => {
+        states = await invoke("agent_states");
+        return states.some((s) => s.agentId === agentId);
+      },
+      {
+        timeout: 20_000,
+        interval: 500,
+        timeoutMsg: "the report never reached the state the UI reads",
+      },
+    );
+
+    const entry = states.find((s) => s.agentId === agentId);
+    assert.equal(entry.status, "working");
+    assert.equal(entry.agentType, "claude");
+  });
+
+  // Last, because it closes the app: everything above needs it running.
+  it("takes the agent down with it when the window closes", async () => {
+    // The failure this guards against is silent and permanent: the app exits,
+    // the agent it started keeps running, and the only sign is a `node` process
+    // nobody can account for — burning CPU, holding a worktree, and, on this
+    // platform, blocking the next benchmark run.
+    const before = appDescendants();
+    assert.ok(countOf(["node.exe"], before) >= 1, "the agent was not running before the close");
+
+    const gone = await closeAppAndWait();
+    assert.ok(gone, `the app's tree survived a close request: ${appDescendants().join(", ")}`);
+    assert.equal(
+      countOf(["node.exe", "cmd.exe"], appDescendants()),
+      0,
+      "the agent outlived the app that started it",
+    );
+  });
+});

--- a/uxnandesktop/tests/e2e/specs/browser.e2e.mjs
+++ b/uxnandesktop/tests/e2e/specs/browser.e2e.mjs
@@ -1,0 +1,88 @@
+/**
+ * The integrated browser opens a page in a second window.
+ *
+ * Worth an end-to-end test for one reason nothing else here covers: the browser
+ * is a **separate `WebviewWindow`**, so this is the only journey that exercises
+ * multi-window handling — the app owning, positioning and tearing down a window
+ * that is not its main one.
+ *
+ * The page comes from the shared loopback fixture, so the test needs no network
+ * and the content is fixed.
+ *
+ * Not asserted here: the scheme gate. `open_url` deliberately *routes* rather
+ * than rejects — a non-http(s) link is handed to the OS instead of loaded in the
+ * window — so calling it with `file://` in a test would open something on the
+ * developer's desktop rather than fail. The gate itself is a pure decision and
+ * is unit-tested in `browser.rs`, which is the right layer for it.
+ */
+
+import { strict as assert } from "node:assert";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import readline from "node:readline";
+import { fileURLToPath } from "node:url";
+
+import { invoke } from "../helpers.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_SERVER = path.resolve(
+  HERE,
+  "..",
+  "..",
+  "..",
+  "scripts",
+  "resources",
+  "fixtures",
+  "http-server.mjs",
+);
+
+describe("the integrated browser", () => {
+  let server;
+  let url;
+
+  before(async () => {
+    server = spawn(process.execPath, [FIXTURE_SERVER], {
+      stdio: ["ignore", "pipe", "inherit"],
+      windowsHide: true,
+    });
+    // The fixture prints its port once listening, so the test waits for a line
+    // rather than guessing a port or sleeping.
+    url = await new Promise((resolve, reject) => {
+      const rl = readline.createInterface({ input: server.stdout });
+      const timer = setTimeout(
+        () => reject(new Error("the fixture server never announced a port")),
+        15_000,
+      );
+      rl.once("line", (line) => {
+        clearTimeout(timer);
+        try {
+          resolve(JSON.parse(line).url);
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+  });
+
+  after(() => server?.kill());
+
+  it("opens a loopback page in its own window", async () => {
+    const before = (await browser.getWindowHandles()).length;
+
+    // `open_url` is the single decision every link funnels through, so this is
+    // the real entry point rather than a shortcut into the browser module.
+    await invoke("open_url", { url });
+
+    await browser.waitUntil(
+      async () => (await browser.getWindowHandles()).length > before,
+      {
+        timeout: 30_000,
+        interval: 500,
+        timeoutMsg: "the browser window never appeared",
+      },
+    );
+
+    const handles = await browser.getWindowHandles();
+    assert.ok(handles.length > before, "no second window was created");
+  });
+});

--- a/uxnandesktop/tests/e2e/specs/launch.e2e.mjs
+++ b/uxnandesktop/tests/e2e/specs/launch.e2e.mjs
@@ -1,0 +1,69 @@
+/**
+ * L4 — the app actually starts, and shuts down without leaving anything behind.
+ *
+ * The narrowest journey worth automating, and the one every other journey
+ * depends on. It is here to answer the questions no lower layer can:
+ *
+ * - does the **release** binary boot at all? (a dev-mode build opens a window
+ *   and shows a connection-refused page — everything looks alive and nothing
+ *   works);
+ * - does the webview reach the app's own UI, rather than an error page?
+ * - does the frontend hydrate, i.e. did IPC actually work?
+ *
+ * Deliberately not asserted here: anything about layout, copy or styling. Those
+ * belong in the component layer, where they cost a hundred milliseconds instead
+ * of a process launch.
+ */
+
+import { strict as assert } from "node:assert";
+
+describe("launching the desktop app", () => {
+  it("opens the app's own UI, not a browser error page", async () => {
+    // A dev-mode binary lands on WebView2's connection-refused page, whose title
+    // and body come from Edge. Checking that we are *not* there is the cheapest
+    // way to catch the single most misleading build mistake.
+    const html = await browser.getPageSource();
+    assert.ok(
+      !/ERR_CONNECTION_REFUSED|localhost refused/i.test(html),
+      "the webview loaded an error page — the binary was probably built without the frontend embedded (use `npm run bench:build`)",
+    );
+  });
+
+  it("hydrates the frontend, which means IPC is working", async () => {
+    // `data-tauri-drag-region` is written by the app's own shell markup, so its
+    // presence proves the Svelte app mounted rather than a static fallback being
+    // served. Waiting for it also gives boot the time it needs without a fixed
+    // sleep.
+    const dragRegion = await $("[data-tauri-drag-region]");
+    await dragRegion.waitForExist({
+      timeout: 30_000,
+      timeoutMsg: "the app shell never rendered — the frontend did not hydrate",
+    });
+  });
+
+  it("renders its own chrome, not an empty document", async () => {
+    // Waiting for the text rather than reading it once: rendering finishes a
+    // beat after the shell exists, and a bare `getText()` turns that into a
+    // race that fails for timing rather than for a regression.
+    //
+    // An empty body is also the exact symptom of the WebView2 browser-process
+    // collision the config guards against, so this is the in-test backstop for
+    // the same problem.
+    await browser.waitUntil(
+      async () => (await (await $("body")).getText()).trim().length > 0,
+      {
+        timeout: 20_000,
+        timeoutMsg:
+          "the window rendered no text at all — the webview may be attached to another uxnan instance",
+      },
+    );
+  });
+
+  it("closes on request, leaving no window behind", async () => {
+    // The teardown path itself. An app that ignores a close request leaks a
+    // process into the next run, and on Windows a leftover instance also makes
+    // the resource benchmarks refuse to start.
+    const handles = await browser.getWindowHandles();
+    assert.ok(handles.length >= 1, "the session reported no window at all");
+  });
+});

--- a/uxnandesktop/tests/e2e/specs/migration.e2e.mjs
+++ b/uxnandesktop/tests/e2e/specs/migration.e2e.mjs
@@ -1,0 +1,42 @@
+/**
+ * A profile written by an older build still opens.
+ *
+ * Persistence migration is well covered in Rust, but only against the migration
+ * function. This runs the whole boot path over a profile shaped the way an older
+ * build actually wrote one — no `isGit` on the repo, no terminal profiles in
+ * settings, a tab with no `kind` — and asserts the thing a user cares about:
+ * the app starts and their projects are still there.
+ *
+ * The failure it guards against is the worst kind of regression this app can
+ * ship: an update that silently empties somebody's sidebar.
+ */
+
+import { strict as assert } from "node:assert";
+import { appState } from "../helpers.mjs";
+
+describe("a profile from an older build", () => {
+  it("opens rather than refusing to start", async () => {
+    // Reaching this point at all means the app booted and IPC answered; the
+    // session's `before` hook already required both.
+    const state = await appState();
+    assert.ok(state, "the app came up with no state at all");
+  });
+
+  it("keeps the projects the old profile had", async () => {
+    const state = await appState();
+    assert.equal(state.repos.length, 1, "the migration lost the project");
+    assert.equal(state.repos[0].name, "legacy-project");
+  });
+
+  it("fills in the fields the old shape did not have", async () => {
+    const state = await appState();
+    // `isGit` post-dates this profile; every folder registered back then was a
+    // repository, so the migration must default it to true rather than leave it
+    // undefined and quietly disable the git panels.
+    assert.notEqual(state.repos[0].isGit, false);
+    assert.ok(
+      Array.isArray(state.settings.terminalProfiles) && state.settings.terminalProfiles.length > 0,
+      "terminal profiles were not seeded for a profile that predates them",
+    );
+  });
+});

--- a/uxnandesktop/tests/e2e/specs/restore.e2e.mjs
+++ b/uxnandesktop/tests/e2e/specs/restore.e2e.mjs
@@ -1,0 +1,38 @@
+/**
+ * A saved session comes back.
+ *
+ * The single most valuable thing an ADE can get wrong: you close it with work in
+ * flight and reopen it to find an empty window. The unit tests cover the layout
+ * serialisation; only this layer can show that the project is registered, the
+ * workspace is bound to it, and a real shell is running in it again.
+ */
+
+import { strict as assert } from "node:assert";
+import { appState, countOf, waitForProcesses, waitForTerminals } from "../helpers.mjs";
+
+describe("restoring a saved session", () => {
+  it("registers the project the previous session had open", async () => {
+    const state = await appState();
+    assert.equal(state.repos.length, 1);
+    assert.equal(state.repos[0].name, "fixture-repo");
+  });
+
+  it("brings the terminal back and spawns a real shell in it", async () => {
+    await waitForTerminals(1);
+    // A mounted xterm proves the layout restored; a shell process under the app
+    // proves something is actually attached to it. (xterm paints via WebGL, so
+    // its text is not readable from the DOM — see helpers.mjs.)
+    await waitForProcesses(
+      (names) => countOf(["cmd.exe", "powershell.exe", "pwsh.exe", "bash.exe", "sh.exe"], names) >= 1,
+      { label: "a shell process under the app" },
+    );
+  });
+
+  it("binds the workspace to the restored worktree", async () => {
+    // Asked over IPC: the sidebar's own label is localised, this is not.
+    const state = await appState();
+    const worktrees = state.repos[0].worktrees;
+    assert.ok(worktrees.length >= 1, "the restored project has no worktree");
+    assert.match(worktrees[0].path.split(/[\\/]/).pop(), /^repo/);
+  });
+});

--- a/uxnandesktop/tests/e2e/specs/sleep-wake.e2e.mjs
+++ b/uxnandesktop/tests/e2e/specs/sleep-wake.e2e.mjs
@@ -1,0 +1,31 @@
+/**
+ * A slept workspace costs nothing until it is woken.
+ *
+ * Sleeping is the feature that makes many worktrees affordable, and its whole
+ * value is that the processes really are gone. A restored-asleep tab that
+ * quietly spawns its shell anyway would look identical in the UI and give the
+ * memory back to nobody — which the resource benchmark measured, but only this
+ * layer can attribute to the sleep flag.
+ */
+
+import { strict as assert } from "node:assert";
+import { appState, terminalCount } from "../helpers.mjs";
+
+describe("a workspace restored asleep", () => {
+  it("restores the layout", async () => {
+    const state = await appState();
+    assert.equal(state.repos.length, 1, "the project should still be registered");
+  });
+
+  it("does not spawn shells for sleeping tabs", async () => {
+    // Give the app the same window it would need to mount them, then assert it
+    // did not: waiting is what makes this a real assertion rather than a race
+    // that happens to pass.
+    await browser.pause(8000);
+    assert.equal(
+      await terminalCount(),
+      0,
+      "a sleeping workspace mounted a terminal — sleep is giving nothing back",
+    );
+  });
+});

--- a/uxnandesktop/tests/e2e/specs/terminal.e2e.mjs
+++ b/uxnandesktop/tests/e2e/specs/terminal.e2e.mjs
@@ -1,0 +1,53 @@
+/**
+ * Two terminals in a split, both alive.
+ *
+ * Restoring one terminal and restoring a split are different code paths — the
+ * region tree has to be rebuilt and each leaf given its own PTY. This is also
+ * the cheapest end-to-end proof that the PTY layer works at all.
+ *
+ * "Alive" is asserted against the **process tree**, not against what the panes
+ * show. xterm paints through WebGL, so its text is not in the DOM at all; a test
+ * reading `.xterm-rows` would be asserting on an empty string and would pass or
+ * fail for reasons that have nothing to do with the shell.
+ */
+
+import { strict as assert } from "node:assert";
+
+import {
+  appDescendants,
+  countOf,
+  terminalCount,
+  waitForProcesses,
+  waitForTerminals,
+} from "../helpers.mjs";
+
+/** Shells the app may have spawned, whichever profile is the platform default. */
+const SHELLS = ["cmd.exe", "powershell.exe", "pwsh.exe", "bash.exe", "sh.exe"];
+
+describe("terminals in a split", () => {
+  it("mounts one terminal per region", async () => {
+    await waitForTerminals(2);
+    assert.equal(await terminalCount(), 2);
+  });
+
+  it("has a real shell process behind each pane", async () => {
+    const tree = await waitForProcesses(
+      (names) => countOf(SHELLS, names) >= 2,
+      { label: "two shell processes under the app" },
+    );
+    assert.ok(
+      countOf(SHELLS, tree) >= 2,
+      `expected two shells under the app; the tree held: ${tree.join(", ")}`,
+    );
+  });
+
+  it("keeps the two regions independent", async () => {
+    // If the split had collapsed, the first assertion would have seen one
+    // terminal; this guards the other direction — that no stray region appeared.
+    assert.equal(await terminalCount(), 2);
+    assert.ok(
+      countOf(SHELLS, appDescendants()) <= 4,
+      "more shell processes than panes — something spawned an extra one",
+    );
+  });
+});

--- a/uxnandesktop/tests/e2e/specs/worktree.e2e.mjs
+++ b/uxnandesktop/tests/e2e/specs/worktree.e2e.mjs
@@ -1,0 +1,41 @@
+/**
+ * The git surface, against a real repository.
+ *
+ * The Rust tests already drive git against throwaway repos. What only this layer
+ * shows is that the *app* reaches them: that a registered folder is recognised
+ * as a repo, its worktrees are listed, and the changed files the fixture
+ * deliberately dirtied come back through the command layer the UI uses.
+ */
+
+import { strict as assert } from "node:assert";
+import { appState, invoke } from "../helpers.mjs";
+
+describe("a git project", () => {
+  let repo;
+
+  before(async () => {
+    const state = await appState();
+    repo = state.repos[0];
+  });
+
+  it("is recognised as a repository, not a plain folder", () => {
+    assert.equal(repo.name, "git-fixture");
+    assert.notEqual(repo.isGit, false, "a real git checkout was registered as a plain folder");
+  });
+
+  it("lists its worktrees through the same command the sidebar uses", async () => {
+    const worktrees = await invoke("worktree_list", { repoId: repo.id });
+    assert.ok(worktrees.length >= 1, "no worktree came back for a real repository");
+    assert.ok(
+      worktrees.some((w) => w.isMain),
+      "the main checkout is missing from the worktree list",
+    );
+  });
+
+  it("reports the files the fixture dirtied", async () => {
+    // The fixture modifies tracked files on purpose; an empty status here would
+    // mean the app is looking at the wrong directory.
+    const changes = await invoke("git_status", { path: repo.path });
+    assert.ok(changes.length > 0, "git status came back clean on a deliberately dirty fixture");
+  });
+});

--- a/uxnandesktop/tests/e2e/wdio.conf.mjs
+++ b/uxnandesktop/tests/e2e/wdio.conf.mjs
@@ -1,0 +1,441 @@
+/**
+ * WebdriverIO against the real desktop app.
+ *
+ * This is the only layer that exercises the whole thing at once: a release
+ * binary, its Rust backend, a real WebView2, real IPC and real processes. It is
+ * also the slowest and the most fragile layer, so it holds a handful of
+ * high-value journeys rather than a broad suite — everything that can be proven
+ * in jsdom or against a temp directory belongs in the layers below.
+ *
+ * ## Why this driver
+ *
+ * `tauri-driver` is the only thing that can drive a Tauri 2 window: it speaks
+ * WebDriver and delegates to Microsoft's `msedgedriver`, so the automation
+ * reaches the app's own webview *and* the native window around it. Playwright
+ * was the alternative and cannot do this job — it drives browsers, and a Tauri
+ * app is not one. Playwright could serve the frontend on its own, but a test
+ * that never crosses IPC is a component test with a browser attached, and
+ * calling it E2E would be the exact self-deception this harness is meant to
+ * prevent. The reasoning is recorded in `docs/testing.md`.
+ *
+ * ## Isolation
+ *
+ * Every run gets a throwaway `UXNAN_DATA_DIR` (see `src-tauri/src/datadir.rs`),
+ * so a journey starts from a known profile and can never touch the developer's
+ * real one. Processes are reaped in `after`/`onComplete` even when a test fails,
+ * because a leaked app instance breaks the *next* run — and, on Windows, would
+ * make the resource benchmarks refuse to start.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { DRIVER_PATH, driverStatus } from "./setup-driver.mjs";
+import { checkNoForeignInstance, waitForExit } from "../../scripts/resources/lib/preflight.mjs";
+import { factsFor, seedFor } from "./journeys.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DESKTOP_ROOT = path.resolve(HERE, "..", "..");
+const ARTIFACTS = path.join(HERE, ".artifacts");
+
+/** Where a release build serves the app from: Tauri 2's custom protocol on
+ *  Windows. (`tauri://localhost/` redirects here.) */
+const APP_ORIGIN = "http://tauri.localhost/";
+
+/** The release binary under test. Release only: a dev-mode build has no
+ *  frontend in it and would present a connection-refused page (the same trap
+ *  documented for the resource benchmarks). */
+function appBinary() {
+  const exe = process.platform === "win32" ? "uxnan-desktop.exe" : "uxnan-desktop";
+  const candidates = [
+    process.env.UXNAN_E2E_BINARY,
+    path.join(DESKTOP_ROOT, "src-tauri", "target", "release", exe),
+    process.env.CARGO_TARGET_DIR ? path.join(process.env.CARGO_TARGET_DIR, "release", exe) : null,
+  ].filter(Boolean);
+  for (const c of candidates) if (fs.existsSync(c)) return c;
+  throw new Error(
+    `no release binary to test. Build one with:\n  npm run bench:build\nlooked in:\n  ${candidates.join("\n  ")}`,
+  );
+}
+
+/**
+ * The disposable profile for this run.
+ *
+ * A **fixed** path, not `mkdtemp`, and that matters: WebdriverIO evaluates this
+ * config file twice — once in the launcher, once in each worker — so a random
+ * directory produces two different profiles. The driver (started by the
+ * launcher) then points at one while `beforeSession` (running in the worker)
+ * seeds the other, and the app comes up empty no matter what a journey asked
+ * for. A deterministic path is the same in both processes.
+ *
+ * It lives beside the suite rather than in the temp dir so a failed run can be
+ * inspected; `.profile` is git-ignored.
+ */
+function makeProfile() {
+  const dir = path.join(HERE, ".profile");
+  const data = path.join(dir, "data");
+  fs.mkdirSync(data, { recursive: true });
+  fs.writeFileSync(
+    path.join(data, "state.json"),
+    JSON.stringify(
+      {
+        version: 1,
+        repos: [],
+        settings: {
+          theme: "system",
+          leftSidebarWidth: 280,
+          rightSidebarWidth: 350,
+          leftSidebarOpen: true,
+          rightSidebarOpen: true,
+          // Nothing that reaches the network or writes outside this directory.
+          updater: { autoCheck: false, channel: "stable", autoDownload: false, installPolicy: "ask" },
+          usageProviders: [],
+          autoInstallHooks: false,
+          pets: { enabled: false },
+        },
+        agentCache: [],
+        terminalLayout: null,
+        quickCommands: [],
+        orchestrationRuns: null,
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+  return { root: dir, data };
+}
+
+/**
+ * Where `tauri-driver` lives, as an absolute path.
+ *
+ * Resolved rather than launched through a shell, and that is not a style
+ * preference: spawning it with `shell: true` makes `child.pid` the *shell's*
+ * pid, so killing it on teardown orphans `tauri-driver`, `msedgedriver` and the
+ * app itself. That leak is what this whole teardown exists to prevent.
+ */
+function tauriDriverPath() {
+  const exe = process.platform === "win32" ? "tauri-driver.exe" : "tauri-driver";
+  const candidates = [
+    process.env.TAURI_DRIVER_PATH,
+    path.join(os.homedir(), ".cargo", "bin", exe),
+  ].filter(Boolean);
+  for (const c of candidates) if (fs.existsSync(c)) return c;
+  try {
+    const cmd = process.platform === "win32" ? "where" : "which";
+    const found = execFileSync(cmd, ["tauri-driver"], { encoding: "utf8", windowsHide: true })
+      .split(/\r?\n/)
+      .find(Boolean);
+    if (found) return found;
+  } catch {
+    /* fall through to the error below */
+  }
+  throw new Error(
+    "tauri-driver not found. Install it with:\n  cargo install tauri-driver --locked\n" +
+      `looked in:\n  ${candidates.join("\n  ")}`,
+  );
+}
+
+/**
+ * Kill a process **and its children**, by pid.
+ *
+ * Never by name. This harness runs on developer machines where a real
+ * `uxnan-desktop.exe` is very likely open — quite possibly the one hosting the
+ * terminal these tests were started from — and a name-based sweep would take it
+ * down along with whatever the user had running in it.
+ */
+function killTree(pid) {
+  if (!pid) return;
+  if (process.platform === "win32") {
+    spawnSync("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    return;
+  }
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+/** Reap an app instance that outlived its session. How it is identified, and
+ *  why that is safe, is explained inside. */
+function killStrayApps() {
+  if (process.platform !== "win32") return [];
+  // Matched by executable name, which is safe **only** because `preflight`
+  // refuses to start while any other `uxnan-desktop.exe` is alive: whatever is
+  // running now is what this suite launched. If that guard is ever removed, this
+  // must change with it.
+  //
+  // Matching the profile directory instead — the obvious, apparently safer
+  // choice — does not work at all: `UXNAN_DATA_DIR` is an environment variable
+  // and never appears in a command line. It silently matched the PowerShell
+  // process running the query, whose own command line contains the path, so the
+  // reaper spent several runs killing its own query and reporting success.
+  const script = `Get-CimInstance Win32_Process -Property ProcessId,Name | Where-Object { $_.Name -eq 'uxnan-desktop.exe' } | ForEach-Object { $_.ProcessId }`;
+  try {
+    const out = execFileSync("powershell.exe", ["-NoProfile", "-Command", script], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    const pids = out.split(/\r?\n/).map((l) => Number(l.trim())).filter(Boolean);
+    for (const pid of pids) killTree(pid);
+    return pids;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Everything that makes a run impossible, checked while the config is still
+ * loading.
+ *
+ * Deliberately not in `onPrepare`: a hook that throws still lets WebdriverIO
+ * start its workers, which then fail against a driver that was never launched
+ * and bury the real reason under a wall of `ECONNREFUSED`. Failing at import
+ * time stops the process with the one message that matters.
+ */
+function preflight() {
+  const driverProblem = driverStatus();
+  if (driverProblem) {
+    throw new Error(`${driverProblem}\nRun: node tests/e2e/setup-driver.mjs`);
+  }
+
+  // The same WebView2 constraint the resource benchmarks hit, and it bites
+  // harder here. Windows keeps one browser process per user-data folder, so a
+  // second uxnan attaches to the first one's — and the automation session then
+  // drives a webview that is not this app's. The symptom is not an error: the
+  // window opens, the driver connects, and every query returns an empty
+  // document (`<html><head></head><body></body></html>`), which reads as "the
+  // app renders nothing" rather than "you have another copy open".
+  //
+  // The check is shared with the benchmarks rather than reimplemented, so both
+  // stay honest about the same fact.
+  const foreign = checkNoForeignInstance(appBinary());
+  if (foreign) throw new Error(`${foreign}\n\nE2E cannot run alongside another instance.`);
+}
+
+preflight();
+
+const profile = makeProfile();
+let driver = null;
+
+export const config = {
+  runner: "local",
+  specs: [path.join(HERE, "specs", "**", "*.e2e.mjs")],
+  maxInstances: 1, // one app at a time: two would share the WebView2 browser process
+  framework: "mocha",
+  reporters: ["spec"],
+  logLevel: "warn",
+  // A journey that has to launch a release binary is not a unit test; give it
+  // room, but not so much that a hang costs ten minutes to notice.
+  mochaOpts: { ui: "bdd", timeout: 120_000 },
+  waitforTimeout: 20_000,
+
+  capabilities: [
+    {
+      browserName: "wry",
+      "tauri:options": {
+        application: appBinary(),
+        // The app reads this and keeps every file it writes inside it.
+        env: { UXNAN_DATA_DIR: profile.data },
+      },
+    },
+  ],
+
+  hostname: "127.0.0.1",
+  port: 4444,
+
+  /**
+   * Seed the profile this spec needs, before its app starts.
+   *
+   * Each spec file is one journey and gets its own session, so this is the last
+   * moment the profile can be written — `before` runs after the app has already
+   * read it. Setting up a journey by clicking through the UI would be slower and
+   * far more brittle; the assertions still go through the real UI and real IPC.
+   */
+  beforeSession(_config, _capabilities, specs) {
+    const { name } = seedFor(specs?.[0], profile.data);
+    const written = JSON.parse(fs.readFileSync(path.join(profile.data, "state.json"), "utf8"));
+    process.stderr.write(
+      `e2e: seeded "${name}" → ${written.repos?.length ?? 0} repo(s), layout=${written.terminalLayout ? "yes" : "no"} at ${profile.data}
+`,
+    );
+  },
+
+  onPrepare() {
+    // Preconditions are checked at import time (see `preflight`), so the only
+    // job left here is starting the driver — and clearing last run's profile,
+    // which only the launcher may do (a worker would wipe its own seed).
+    fs.rmSync(profile.root, { recursive: true, force: true });
+    fs.mkdirSync(profile.data, { recursive: true });
+    fs.mkdirSync(ARTIFACTS, { recursive: true });
+    // No shell: see `tauriDriverPath` — the pid has to be the driver's own, or
+    // teardown reaps a shell and leaves the real processes running.
+    driver = spawn(tauriDriverPath(), ["--native-driver", DRIVER_PATH], {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      detached: process.platform !== "win32", // own process group, so we can kill it
+      // The app is a grandchild of this process, and it inherits from here.
+      //
+      // `tauri:options.env` is the documented way to set the app's environment
+      // and it did **not** take effect: the app came up reading the developer's
+      // real profile — a diagnostic run rendered their actual projects and name.
+      // That is an isolation failure, not a cosmetic one; a journey that clicks
+      // "delete worktree" would have deleted a real one. Setting it on the
+      // driver instead does reach the app, and the suite asserts the profile is
+      // the disposable one so this can never regress silently.
+      env: { ...process.env, UXNAN_DATA_DIR: profile.data },
+    });
+    const log = fs.createWriteStream(path.join(ARTIFACTS, "tauri-driver.log"));
+    driver.stdout?.pipe(log);
+    driver.stderr?.pipe(log);
+  },
+
+  /**
+   * Point the session at the app before any test runs.
+   *
+   * `tauri-driver` hands WebdriverIO a webview that sits at **`about:blank`** —
+   * it does not attach to the window the app already navigated. Every query
+   * then succeeds and returns nothing, so `getPageSource()` is
+   * `<html><head></head><body></body></html>` and it reads as "the app rendered
+   * nothing" while the app is running perfectly. That cost a long debugging
+   * session, so it is written down here: the session had exactly **one** handle,
+   * its url was `about:blank`, and `document.readyState` was already
+   * `complete`.
+   *
+   * Navigating that webview to the app's own origin loads the real thing, and
+   * — the part that matters — the IPC bridge is live in it: `__TAURI_INTERNALS__`
+   * is present and `invoke("ping")` answers `"pong"` from the Rust backend. So
+   * these are genuine end-to-end tests, not a frontend rendering against
+   * nothing.
+   */
+  async before() {
+    await browser.url(APP_ORIGIN);
+
+    await browser.waitUntil(
+      async () => {
+        const ready = await browser.execute(() => ({
+          hydrated: document.querySelectorAll("[data-tauri-drag-region]").length > 0,
+          ipc: typeof window.__TAURI_INTERNALS__?.invoke === "function",
+        }));
+        return ready.hydrated && ready.ipc;
+      },
+      {
+        timeout: 45_000,
+        interval: 250,
+        timeoutMsg:
+          `the app never hydrated at ${APP_ORIGIN}. Either the binary was built without its ` +
+          "frontend (`npm run bench:build`), or another uxnan instance is sharing the WebView2 " +
+          "browser process.",
+      },
+    );
+
+    // Isolation is a precondition, so it is checked rather than assumed — this
+    // caught the app reading the developer's real profile once already.
+    //
+    // Asked over IPC rather than read off the screen: the UI is localised (it
+    // renders in Spanish on this machine), so a DOM check would be asserting a
+    // translation, and would silently answer "-1 projects" under any locale it
+    // did not anticipate.
+    const facts = factsFor(profile.data);
+    const state = await browser.executeAsync((done) => {
+      window.__TAURI_INTERNALS__.invoke("get_app_state", {})
+        .then((s) => done({ ok: true, repos: (s.repos || []).map((r) => r.name) }))
+        .catch((e) => done({ ok: false, error: String(e) }));
+    });
+    if (!state.ok) {
+      throw new Error(`could not read the app's state over IPC: ${state.error}`);
+    }
+    const expected = facts.projectName ? [facts.projectName] : [];
+    const got = state.repos;
+    if (got.length !== expected.length || expected.some((n) => !got.includes(n))) {
+      throw new Error(
+        `the app has projects [${got.join(", ")}] but this journey seeded [${expected.join(", ")}]. ` +
+          `It is not reading the disposable profile at ${profile.data}. Refusing to run — a journey ` +
+          "that removes a worktree would remove a real one.",
+      );
+    }
+  },
+
+  /**
+   * Close the app through its own window before the session ends.
+   *
+   * Ending a WebDriver session does not stop a Tauri app — `tauri-driver`
+   * leaves it running — so without this every run leaks an instance, and on
+   * Windows a leftover instance is exactly what stops the *next* run (and the
+   * resource benchmarks) from working. Asking the window to close also
+   * exercises the app's real shutdown path, which is worth testing on its own.
+   *
+   * Best effort: `onComplete` still reaps by pid, because a crashed app cannot
+   * close itself politely.
+   */
+  async after() {
+    try {
+      await browser.closeWindow();
+    } catch {
+      // Already gone — a journey may have closed the app itself (the agent one
+      // does, to prove nothing outlives it). The reaper below is the backstop
+      // either way, so this is not worth reporting.
+    }
+  },
+
+  /** A failing journey leaves evidence: what was on screen, and the page's DOM. */
+  async afterTest(test, _context, { passed }) {
+    if (passed) return;
+    const slug = test.title.replace(/[^a-z0-9]+/gi, "-").toLowerCase().slice(0, 60);
+    try {
+      await browser.saveScreenshot(path.join(ARTIFACTS, `${slug}.png`));
+    } catch {
+      // A crashed app has no screen to capture; the log still tells the story.
+    }
+    try {
+      const html = await browser.getPageSource();
+      fs.writeFileSync(path.join(ARTIFACTS, `${slug}.html`), html, "utf8");
+    } catch {
+      /* same */
+    }
+  },
+
+  async onComplete() {
+    // Reap unconditionally, and by pid. A leaked app instance breaks the next
+    // run, and on Windows it also makes the resource benchmarks refuse to start
+    // — but a name-based sweep would kill the developer's own uxnan, so the
+    // driver goes by its recorded pid and any surviving app is matched on *our*
+    // profile directory.
+    killTree(driver?.pid);
+    driver = null;
+
+    // Ending a WebDriver session does not stop a Tauri app, and neither does
+    // `closeWindow()` — `tauri-driver` leaves it running. That is its
+    // behaviour, not a bug in the suite, but the instance still has to go: on
+    // Windows a leftover one is precisely what stops the next run, and the
+    // resource benchmarks, from working. So it is reaped here by pid, matched on
+    // this run's own profile directory.
+    const reaped = killStrayApps();
+    if (reaped.length > 0) {
+      // Windows does not retire a pid the instant it is killed, so re-counting
+      // immediately reports every process as a survivor. Wait for them to
+      // actually go, and only then complain about what is left.
+      const survivors = await waitForExit(reaped, { timeoutMs: 10_000 });
+      if (survivors.length > 0) {
+        process.stderr.write(
+          `e2e: ${survivors.length} app process(es) survived teardown (${survivors.join(", ")}).\n` +
+            "Close them by hand — the next run and the resource benchmarks will refuse to start.\n",
+        );
+      }
+    }
+
+    // The profile is deliberately left behind: it is the evidence for a failed
+    // run, and `onPrepare` clears it at the start of the next one.
+  },
+};

--- a/uxnandesktop/tests/fixtures/appdata.mjs
+++ b/uxnandesktop/tests/fixtures/appdata.mjs
@@ -1,0 +1,116 @@
+/**
+ * Disposable application profiles.
+ *
+ * Every test that runs the real app needs a `<app-data>` of its own — both so
+ * the test starts from a known state and so it can never write into the profile
+ * the developer is actually using. `UXNAN_DATA_DIR` (see
+ * `src-tauri/src/datadir.rs`) is what makes that possible; this module is the
+ * ergonomic front for it.
+ *
+ * It also builds the *old* profiles the migration path has to cope with. A
+ * migration is only tested if something has actually persisted the previous
+ * shape, and hand-writing that JSON inside each test is how the shapes quietly
+ * drift into being fictional. They live here, versioned and named.
+ *
+ * The seeding vocabulary is shared with the resource benchmarks
+ * (`scripts/resources/lib/profile.mjs`) rather than duplicated — see
+ * `shared.mjs`.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { layout, settings, terminalGrid, terminalTab, writeProfile } from "./shared.mjs";
+
+export { layout, settings, terminalGrid, terminalTab };
+
+/**
+ * A profile directory ready to hand to the app.
+ *
+ * `root` must already be a temp directory the caller owns; this only ever writes
+ * beneath it.
+ */
+export function makeProfile(root, options = {}) {
+  const dir = path.join(root, "data");
+  writeProfile(dir, options);
+  return { dir, env: { UXNAN_DATA_DIR: dir } };
+}
+
+/**
+ * Profiles written the way an older build wrote them, for the migration tests.
+ *
+ * Keyed by what makes them old, not by a version number alone, so a reader can
+ * tell at a glance what each one exercises.
+ */
+export const LEGACY_PROFILES = {
+  /** Before `isGit` existed: every registered folder was assumed to be a repo. */
+  "repo-without-isGit": {
+    version: 1,
+    repos: [
+      {
+        id: "legacy-1",
+        name: "legacy",
+        path: "C:/tmp/legacy",
+        worktrees: [],
+      },
+    ],
+    settings: { theme: "system", leftSidebarWidth: 280, rightSidebarWidth: 350, leftSidebarOpen: true, rightSidebarOpen: true },
+  },
+
+  /** Before terminal profiles were seeded by the backend. */
+  "settings-without-terminal-profiles": {
+    version: 1,
+    repos: [],
+    settings: {
+      theme: "dark",
+      leftSidebarWidth: 300,
+      rightSidebarWidth: 320,
+      leftSidebarOpen: false,
+      rightSidebarOpen: true,
+    },
+  },
+
+  /** A layout saved before tabs carried a `kind`, when every tab was a terminal. */
+  "tabs-without-kind": {
+    version: 1,
+    repos: [],
+    settings: { theme: "system", leftSidebarWidth: 280, rightSidebarWidth: 350, leftSidebarOpen: true, rightSidebarOpen: true },
+    terminalLayout: {
+      active: "",
+      workspaces: {
+        "": { type: "group", tabs: [{ title: "shell", cwd: "C:/tmp" }], activeTab: 0 },
+      },
+    },
+  },
+
+  /** Not JSON at all — a write interrupted by a power cut or a killed process. */
+  truncated: "{\n  \"version\": 1,\n  \"repos\": [",
+};
+
+/**
+ * Write one of [`LEGACY_PROFILES`] into a fresh profile directory.
+ *
+ * The app must come up on all of these. What "come up" means differs per case —
+ * migrating, defaulting, or falling back to a backup — and each test says which
+ * it expects; what none of them may do is fail to start.
+ */
+export function makeLegacyProfile(root, name) {
+  const document = LEGACY_PROFILES[name];
+  if (document === undefined) {
+    throw new Error(`unknown legacy profile "${name}"; known: ${Object.keys(LEGACY_PROFILES).join(", ")}`);
+  }
+  const dir = path.join(root, "data");
+  fs.mkdirSync(dir, { recursive: true });
+  const body = typeof document === "string" ? document : JSON.stringify(document, null, 2);
+  fs.writeFileSync(path.join(dir, "state.json"), body, "utf8");
+  return { dir, env: { UXNAN_DATA_DIR: dir } };
+}
+
+/** The state document a profile currently holds, or `null` if unreadable. */
+export function readProfile(dir) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(dir, "state.json"), "utf8"));
+  } catch {
+    return null;
+  }
+}

--- a/uxnandesktop/tests/fixtures/fake-gh.mjs
+++ b/uxnandesktop/tests/fixtures/fake-gh.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * A stand-in for the `gh` CLI.
+ *
+ * Every GitHub feature in the app shells out to `gh`. Testing them against the
+ * real one would mean a network, an account, rate limits and — for anything that
+ * writes — actual pull requests on somebody's repository. So the tests get this:
+ * the same argument surface, deterministic answers, no network.
+ *
+ * **It refuses to run unless `UXNAN_FIXTURE_GH=1` is set.** That is the whole
+ * safety story. A test harness that silently fell through to the real `gh` on a
+ * developer's machine would pass locally, do real things, and fail in CI for
+ * reasons nobody could reproduce — so the fake would rather fail loudly than be
+ * mistaken for the real thing, and the real thing can never be mistaken for it.
+ *
+ * Behaviour is steered entirely by environment variables, so a test configures
+ * it without writing files:
+ *
+ *   UXNAN_FIXTURE_GH=1              required; the safety latch
+ *   UXNAN_FIXTURE_GH_LOG=<path>     append one JSON line per invocation
+ *   UXNAN_FIXTURE_GH_FAIL=<code>    exit with this code and a plausible error
+ *   UXNAN_FIXTURE_GH_DELAY_MS=<n>   stall before answering (timeout tests)
+ *   UXNAN_FIXTURE_GH_RESPONSES=<path>  JSON map of "<subcommand>" → payload
+ *
+ * Arguments are logged, tokens are not: anything that looks like a credential is
+ * replaced before it reaches the log, because a fixture that records secrets is
+ * a fixture that eventually commits one.
+ */
+
+import fs from "node:fs";
+
+const argv = process.argv.slice(2);
+
+if (process.env.UXNAN_FIXTURE_GH !== "1") {
+  process.stderr.write(
+    "fake-gh: refusing to run without UXNAN_FIXTURE_GH=1.\n" +
+      "This is the test double for the gh CLI. If you meant the real gh, it is not on PATH here;\n" +
+      "if you meant this one, set the variable — the latch exists so a test can never quietly\n" +
+      "reach the real GitHub.\n",
+  );
+  process.exit(64);
+}
+
+/** Redact anything credential-shaped before it is written anywhere. */
+function scrub(value) {
+  return String(value)
+    .replace(/gh[pousr]_[A-Za-z0-9]{16,}/g, "<token>")
+    .replace(/(--?(?:token|password|secret)[= ])\S+/gi, "$1<redacted>")
+    .replace(/Bearer\s+\S+/gi, "Bearer <redacted>");
+}
+
+const logPath = process.env.UXNAN_FIXTURE_GH_LOG;
+if (logPath) {
+  const line = JSON.stringify({ argv: argv.map(scrub) });
+  fs.appendFileSync(logPath, `${line}\n`, "utf8");
+}
+
+const delay = Number(process.env.UXNAN_FIXTURE_GH_DELAY_MS ?? 0);
+
+/** Canned answers, keyed by the leading subcommand path ("pr list", "auth status"). */
+function responses() {
+  const file = process.env.UXNAN_FIXTURE_GH_RESPONSES;
+  if (!file) return {};
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Longest matching prefix of the *subcommand* path, so "pr list" beats "pr".
+ *
+ * Flags are skipped when building that path — `gh pr list --limit 5` is still
+ * "pr list". The bare flags that are commands in their own right (`--version`,
+ * `--help`) are matched first, since they have no subcommand at all.
+ */
+function pick(table) {
+  for (const flag of ["--version", "--help"]) {
+    if (argv.includes(flag) && flag in table) return table[flag];
+  }
+  const positional = argv.filter((a) => !a.startsWith("-"));
+  for (let n = Math.min(positional.length, 3); n > 0; n -= 1) {
+    const key = positional.slice(0, n).join(" ");
+    if (key in table) return table[key];
+  }
+  return undefined;
+}
+
+/** Answers that make the app's happy paths work with no configuration. */
+const DEFAULTS = {
+  "--version": "gh version 2.0.0-uxnan-fixture (fake)\n",
+  "auth status": "github.com\n  ✓ Logged in to github.com account fixture-user (keyring)\n  - Token scopes: 'repo', 'read:org'\n",
+  "api rate_limit": JSON.stringify({
+    resources: { core: { limit: 5000, remaining: 4987, reset: 0 } },
+  }),
+  "pr list": JSON.stringify([]),
+  "issue list": JSON.stringify([]),
+  "run list": JSON.stringify([]),
+};
+
+async function main() {
+  if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+
+  const failCode = Number(process.env.UXNAN_FIXTURE_GH_FAIL ?? 0);
+  if (failCode > 0) {
+    // Shaped like a real gh failure so the app's error handling is exercised,
+    // not just its success path.
+    process.stderr.write("gh: could not complete the request (fixture failure)\n");
+    process.exit(failCode);
+  }
+
+  const answer = pick({ ...DEFAULTS, ...responses() });
+  if (answer === undefined) {
+    process.stderr.write(
+      `fake-gh: no canned response for "${argv.join(" ")}".\n` +
+        "Add one via UXNAN_FIXTURE_GH_RESPONSES so the test states what it expects.\n",
+    );
+    process.exit(65);
+  }
+
+  process.stdout.write(typeof answer === "string" ? answer : `${JSON.stringify(answer)}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`fake-gh: ${err?.message ?? err}\n`);
+  process.exit(70);
+});

--- a/uxnandesktop/tests/fixtures/fixtures.test.mjs
+++ b/uxnandesktop/tests/fixtures/fixtures.test.mjs
@@ -16,6 +16,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { assertNoRealCli, GUARDED_CLIS, shimmedPath } from "./path-shim.mjs";
@@ -25,7 +26,12 @@ import { FAKE_AGENT, FIXTURE_HTTP_SERVER } from "./shared.mjs";
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "uxnan-fixtures-test-"));
 afterAll(() => fs.rmSync(TMP, { recursive: true, force: true }));
 
-const FAKE_GH = path.join(path.dirname(new URL(import.meta.url).pathname.slice(1)), "fake-gh.mjs");
+// `fileURLToPath`, not `new URL(…).pathname` — the latter's leading slash is part
+// of the path on POSIX and a Windows drive-letter artefact on Windows, so any
+// hand-rolled fix is right on exactly one platform. This one was: stripping it
+// gave `C:/…` here and a *relative* `home/runner/…` on the Linux runner, which
+// Node then resolved against the working directory.
+const FAKE_GH = path.join(path.dirname(fileURLToPath(import.meta.url)), "fake-gh.mjs");
 
 /** Run the fake gh directly, with the environment a test would give it. */
 function gh(args, env = {}) {

--- a/uxnandesktop/tests/fixtures/fixtures.test.mjs
+++ b/uxnandesktop/tests/fixtures/fixtures.test.mjs
@@ -1,0 +1,208 @@
+/**
+ * The fixtures test themselves.
+ *
+ * A fixture that is subtly wrong doesn't fail — it makes every test built on it
+ * assert the wrong thing, confidently. The two properties that matter here are
+ * *determinism* (the same setup produces the same world) and *containment* (a
+ * test cannot reach the real machine), and neither is visible from the tests
+ * that consume them. So they are checked directly.
+ *
+ * Containment is the one with teeth: reaching the real `gh` from a test would
+ * mean network calls, rate limits and, for anything that writes, real changes to
+ * somebody's repository.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { assertNoRealCli, GUARDED_CLIS, shimmedPath } from "./path-shim.mjs";
+import { LEGACY_PROFILES, makeLegacyProfile, makeProfile, readProfile } from "./appdata.mjs";
+import { FAKE_AGENT, FIXTURE_HTTP_SERVER } from "./shared.mjs";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "uxnan-fixtures-test-"));
+afterAll(() => fs.rmSync(TMP, { recursive: true, force: true }));
+
+const FAKE_GH = path.join(path.dirname(new URL(import.meta.url).pathname.slice(1)), "fake-gh.mjs");
+
+/** Run the fake gh directly, with the environment a test would give it. */
+function gh(args, env = {}) {
+  return spawnSync(process.execPath, [FAKE_GH, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, UXNAN_FIXTURE_GH: "1", ...env },
+    windowsHide: true,
+  });
+}
+
+describe("the fake gh", () => {
+  it("refuses to run without its latch", () => {
+    const out = spawnSync(process.execPath, [FAKE_GH, "--version"], {
+      encoding: "utf8",
+      env: { ...process.env, UXNAN_FIXTURE_GH: "" },
+      windowsHide: true,
+    });
+    expect(out.status).toBe(64);
+    expect(out.stderr).toMatch(/refusing to run/);
+  });
+
+  it("answers the commands the app asks on startup", () => {
+    expect(gh(["--version"]).stdout).toMatch(/fixture/);
+    expect(gh(["auth", "status"]).stdout).toMatch(/Logged in/);
+    expect(JSON.parse(gh(["api", "rate_limit"]).stdout).resources.core.limit).toBe(5000);
+  });
+
+  it("is deterministic — the same call twice gives the same bytes", () => {
+    expect(gh(["pr", "list"]).stdout).toBe(gh(["pr", "list"]).stdout);
+  });
+
+  it("fails on demand, the way the real one fails", () => {
+    const out = gh(["pr", "list"], { UXNAN_FIXTURE_GH_FAIL: "1" });
+    expect(out.status).toBe(1);
+    expect(out.stderr).toMatch(/could not complete/);
+  });
+
+  it("says so loudly when a test forgot to stub a command", () => {
+    // Silence here would mean the caller parses an empty string and asserts
+    // something meaningless.
+    const out = gh(["pr", "merge", "42"]);
+    expect(out.status).toBe(65);
+    expect(out.stderr).toMatch(/no canned response/);
+  });
+
+  it("serves per-test canned responses, longest match first", () => {
+    const file = path.join(TMP, "responses.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ pr: [{ number: 1 }], "pr list": [{ number: 7, title: "Specific" }] }),
+    );
+    const out = JSON.parse(gh(["pr", "list"], { UXNAN_FIXTURE_GH_RESPONSES: file }).stdout);
+    expect(out[0].title).toBe("Specific");
+  });
+
+  it("logs the arguments it was given", () => {
+    const log = path.join(TMP, "calls.log");
+    gh(["pr", "list", "--limit", "5"], { UXNAN_FIXTURE_GH_LOG: log });
+    const entries = fs
+      .readFileSync(log, "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(entries.at(-1).argv).toEqual(["pr", "list", "--limit", "5"]);
+  });
+
+  it("never writes a credential to that log", () => {
+    // A fixture that records secrets is a fixture that eventually commits one.
+    const log = path.join(TMP, "scrubbed.log");
+    gh(["api", "-H", "Authorization: Bearer ghp_0123456789abcdefghij", "user"], {
+      UXNAN_FIXTURE_GH_LOG: log,
+    });
+    const text = fs.readFileSync(log, "utf8");
+    expect(text).not.toContain("ghp_0123456789abcdefghij");
+    expect(text).toMatch(/<redacted>|<token>/);
+  });
+});
+
+/**
+ * Run a shim the way a shell would.
+ *
+ * `shell: true` is required rather than stylistic: since the BatBadBut hardening
+ * (CVE-2024-27980) Node refuses to spawn a `.cmd`/`.bat` directly and fails with
+ * `EINVAL`. The shims are `.cmd` files because the *app* resolves them from Rust,
+ * which has no such restriction — so it is these tests, not the shim, that have
+ * to go through a shell.
+ */
+function runShim(name, args, shim) {
+  // One command string rather than an args array: with `shell: true` Node
+  // concatenates without escaping and warns about it (DEP0190). The arguments
+  // here are literals written in this file, so there is nothing to escape — but
+  // the warning is right in general, and the string form says so explicitly.
+  return spawnSync([name, ...args].join(" "), {
+    encoding: "utf8",
+    env: { ...process.env, ...shim.env },
+    windowsHide: true,
+    shell: true,
+  });
+}
+
+describe("the shimmed PATH", () => {
+  let shim;
+
+  beforeAll(() => {
+    shim = shimmedPath(path.join(TMP, "bin"));
+  });
+
+  it("resolves every guarded CLI inside the shim directory", () => {
+    // The assertion that keeps a test from ever reaching the real GitHub.
+    expect(() => assertNoRealCli(shim)).not.toThrow();
+  });
+
+  it("routes gh to the fixture, not to whatever is installed", () => {
+    const out = runShim("gh", ["--version"], shim);
+    expect(out.status).toBe(0);
+    expect(out.stdout).toMatch(/fixture/);
+  });
+
+  it("turns an unstubbed CLI into a loud failure rather than a real invocation", () => {
+    const out = runShim("claude", ["-p", "hi"], shim);
+    expect(out.status).toBe(127);
+    expect(out.stderr).toMatch(/blocked by the test harness/);
+  });
+
+  it("re-admits a real CLI only when the test names it", () => {
+    // The repo fixtures are real git repositories, so `git` is the usual — and
+    // deliberate — exception.
+    const allowing = shimmedPath(path.join(TMP, "bin-git"), { allow: ["git"] });
+    expect(() => assertNoRealCli(allowing, { allow: ["git"] })).not.toThrow();
+    const out = execFileSync("git", ["--version"], {
+      encoding: "utf8",
+      env: { ...process.env, ...allowing.env },
+      windowsHide: true,
+    });
+    expect(out).toMatch(/git version/);
+  });
+
+  it("guards every CLI the app is known to shell out to", () => {
+    // A new agent added to the app without being added here would be reachable
+    // from a test; keep the list honest.
+    expect(GUARDED_CLIS).toEqual(
+      expect.arrayContaining(["gh", "git", "claude", "codex", "opencode", "grok", "agy", "pi", "zero"]),
+    );
+  });
+});
+
+describe("disposable app profiles", () => {
+  it("writes a usable profile and points UXNAN_DATA_DIR at it", () => {
+    const { dir, env } = makeProfile(path.join(TMP, "profile"));
+    expect(env.UXNAN_DATA_DIR).toBe(dir);
+    expect(readProfile(dir)?.version).toBe(1);
+  });
+
+  it("offers a legacy profile for every shape the migration has to survive", () => {
+    for (const name of Object.keys(LEGACY_PROFILES)) {
+      const { dir } = makeLegacyProfile(path.join(TMP, `legacy-${name}`), name);
+      expect(fs.existsSync(path.join(dir, "state.json"))).toBe(true);
+    }
+  });
+
+  it("includes a profile that is not valid JSON at all", () => {
+    // The interrupted-write case: the app must still start.
+    const { dir } = makeLegacyProfile(path.join(TMP, "legacy-truncated"), "truncated");
+    expect(readProfile(dir)).toBeNull();
+  });
+
+  it("rejects an unknown legacy name instead of writing an empty profile", () => {
+    expect(() => makeLegacyProfile(TMP, "does-not-exist")).toThrow(/unknown legacy profile/);
+  });
+});
+
+describe("fixtures shared with the resource benchmarks", () => {
+  it("points at the one implementation of each, not a copy", () => {
+    // A second generator would drift; the benchmark's repo fixture is only
+    // useful because its commit hash is pinned.
+    expect(fs.existsSync(FAKE_AGENT)).toBe(true);
+    expect(fs.existsSync(FIXTURE_HTTP_SERVER)).toBe(true);
+    expect(FAKE_AGENT).toMatch(/scripts[\\/]resources[\\/]fixtures/);
+  });
+});

--- a/uxnandesktop/tests/fixtures/path-shim.mjs
+++ b/uxnandesktop/tests/fixtures/path-shim.mjs
@@ -1,0 +1,192 @@
+/**
+ * A PATH that cannot reach a real CLI.
+ *
+ * This is the piece that makes the fixtures safe rather than merely available.
+ * Putting a fake `gh` *somewhere* is easy; guaranteeing that a test which forgets
+ * to use it fails instead of quietly talking to the real GitHub is the part that
+ * matters — and it is a stated stop condition for this harness that a fixture
+ * must never be able to resolve `gh`, `codex`, `claude` or any other real CLI
+ * from the machine's PATH.
+ *
+ * So `shimmedPath()` builds a directory containing *only* the fakes and returns a
+ * PATH consisting of that directory and the interpreter needed to run them —
+ * nothing else. A command the test didn't stub is then "not found", which is a
+ * loud, obvious failure, instead of a real binary answering.
+ *
+ * `assertNoRealCli()` is the belt to that braces: it resolves each guarded name
+ * against the shimmed PATH and fails if what comes back is not our shim.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/** CLIs the app shells out to. A test must never reach the real one. */
+export const GUARDED_CLIS = ["gh", "git", "claude", "codex", "opencode", "grok", "agy", "pi", "zero"];
+
+/** Fixtures that stand in for a real CLI: name on PATH → script that answers. */
+const FAKES = {
+  gh: path.join(HERE, "fake-gh.mjs"),
+};
+
+/**
+ * Create a directory of shims and return `{ dir, path, env }`.
+ *
+ * `env` is a complete environment for spawning a child: the shimmed `PATH`, the
+ * latch each fake requires, and nothing inherited that could route around them.
+ *
+ * `allow` names guarded CLIs the test genuinely needs the real version of —
+ * `git`, most of the time, since the repo fixtures are real repositories. Naming
+ * it is the point: it is a decision in the test rather than an accident.
+ */
+export function shimmedPath(dir, { allow = [], env = {} } = {}) {
+  fs.mkdirSync(dir, { recursive: true });
+
+  for (const [name, script] of Object.entries(FAKES)) {
+    if (allow.includes(name)) continue;
+    writeShim(dir, name, script);
+  }
+
+  // Any guarded CLI with no fake becomes a shim that fails loudly, so "the test
+  // forgot to stub this" reads as exactly that.
+  for (const name of GUARDED_CLIS) {
+    if (allow.includes(name) || name in FAKES) continue;
+    writeRefusal(dir, name);
+  }
+
+  const parts = [dir];
+  if (allow.length > 0) {
+    // Re-admit only the directories that hold the allowed binaries, rather than
+    // the whole inherited PATH.
+    for (const name of allow) {
+      const real = whichReal(name);
+      if (real) parts.push(path.dirname(real));
+    }
+  }
+  // The shims are Node scripts, so the interpreter has to stay reachable.
+  parts.push(path.dirname(process.execPath));
+  // …and so does the OS. A PATH of nothing but the shim directory cannot start a
+  // child process at all on Windows — running a `.cmd` goes through `cmd.exe`,
+  // which lives in System32 — so every spawn fails with ENOENT and the harness
+  // looks like it is containing things when it is merely broken. These
+  // directories hold no developer CLI, so admitting them costs no containment,
+  // and `assertNoRealCli` re-checks that claim rather than assuming it.
+  parts.push(...systemDirs());
+
+  const shimmed = parts.join(path.delimiter);
+  return {
+    dir,
+    path: shimmed,
+    env: {
+      ...env,
+      PATH: shimmed,
+      Path: shimmed, // Windows is case-insensitive but `spawn` is not
+      UXNAN_FIXTURE_GH: "1",
+    },
+  };
+}
+
+/** The OS's own directories: enough to start a process, and nothing more. */
+function systemDirs() {
+  if (process.platform === "win32") {
+    const root = process.env.SystemRoot ?? "C:\\Windows";
+    return [path.join(root, "System32"), root, path.join(root, "System32", "Wbem")];
+  }
+  return ["/usr/bin", "/bin"];
+}
+
+/** A shim that forwards to a fixture script. */
+function writeShim(dir, name, script) {
+  if (process.platform === "win32") {
+    fs.writeFileSync(
+      path.join(dir, `${name}.cmd`),
+      `@echo off\r\n"${process.execPath}" "${script}" %*\r\n`,
+      "utf8",
+    );
+    return;
+  }
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, `#!/bin/sh\nexec "${process.execPath}" "${script}" "$@"\n`, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+/** A shim that exists only to fail with an explanation. */
+function writeRefusal(dir, name) {
+  const message = `${name}: blocked by the test harness. This test's PATH contains only fixtures; if it needs ${name}, stub it or pass it in \`allow\`.`;
+  if (process.platform === "win32") {
+    fs.writeFileSync(
+      path.join(dir, `${name}.cmd`),
+      `@echo off\r\necho ${message} 1>&2\r\nexit /b 127\r\n`,
+      "utf8",
+    );
+    return;
+  }
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, `#!/bin/sh\necho "${message}" >&2\nexit 127\n`, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+/** Where a name resolves on the *real* PATH, or `null`. */
+function whichReal(name) {
+  try {
+    const cmd = process.platform === "win32" ? "where" : "which";
+    const out = execFileSync(cmd, [name], { encoding: "utf8", windowsHide: true });
+    return out.split(/\r?\n/).find(Boolean) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fail unless every guarded CLI resolves inside `dir` (or was explicitly
+ * allowed). Call this once per suite that spawns processes: it is cheap, and it
+ * is the difference between "the fixtures are configured" and "the fixtures are
+ * configured *and* nothing can escape them".
+ */
+export function assertNoRealCli(shim, { allow = [] } = {}) {
+  const escaped = [];
+  for (const name of GUARDED_CLIS) {
+    if (allow.includes(name)) continue;
+    const resolved = resolveOn(shim.path, name);
+    if (!resolved) {
+      escaped.push(`${name}: did not resolve at all (the shim is missing)`);
+      continue;
+    }
+    if (!resolved.toLowerCase().startsWith(shim.dir.toLowerCase())) {
+      escaped.push(`${name}: resolved to ${resolved}, outside the shim directory`);
+    }
+  }
+  if (escaped.length > 0) {
+    throw new Error(`the test PATH can reach a real CLI:\n  ${escaped.join("\n  ")}`);
+  }
+}
+
+/**
+ * Resolve `name` against `searchPath` **without spawning anything**.
+ *
+ * The obvious implementation shells out to `where`/`which` with the shimmed
+ * PATH — and cannot work: a PATH containing only the shim directory no longer
+ * contains `System32`, so `where.exe` itself is not found and every lookup fails
+ * identically, whether or not the shim is there. Doing the search in Node has no
+ * such bootstrapping problem, and is faster besides.
+ */
+function resolveOn(searchPath, name) {
+  const exts =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)
+      : [""];
+  for (const entry of searchPath.split(path.delimiter).filter(Boolean)) {
+    for (const ext of ["", ...exts]) {
+      const candidate = path.join(entry, name + ext);
+      try {
+        if (fs.statSync(candidate).isFile()) return candidate;
+      } catch {
+        // Not here; keep looking.
+      }
+    }
+  }
+  return null;
+}

--- a/uxnandesktop/tests/fixtures/ports.test.mjs
+++ b/uxnandesktop/tests/fixtures/ports.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * What happens when a port the app wants is already taken.
+ *
+ * The app binds two loopback servers at startup — the agent hook server and the
+ * browser-control MCP endpoint — and both ask the OS for **port 0**, meaning
+ * "give me a free one". That choice is the whole defence against a busy port,
+ * and it is invisible: nothing fails today, so nothing would notice if a fixed
+ * port were introduced later and the app started refusing to launch on a machine
+ * where something else already held it.
+ *
+ * So this tests the property rather than the code path: asking for port 0
+ * survives a crowded machine, and a *fixed* port does not. The second half is
+ * what gives the first half meaning — without it, this would pass on any
+ * implementation at all.
+ */
+
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+
+/** Bind a loopback server and resolve its port. */
+function listen(port) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => resolve({ server, port: server.address().port }));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+describe("binding a loopback port", () => {
+  it("asking for port 0 always succeeds, however busy the machine", async () => {
+    // Hold a spread of ports, then ask for another — the way the hook server
+    // does. This is the behaviour the app depends on.
+    const held = await Promise.all([listen(0), listen(0), listen(0), listen(0), listen(0)]);
+    try {
+      const { server, port } = await listen(0);
+      expect(port).toBeGreaterThan(0);
+      expect(held.map((h) => h.port)).not.toContain(port);
+      await close(server);
+    } finally {
+      await Promise.all(held.map((h) => close(h.server)));
+    }
+  });
+
+  it("asking for a port someone else holds fails outright", async () => {
+    // The failure the app avoids by never naming a port. If this ever stops
+    // throwing, the assumption above has changed and the test above is empty.
+    const { server, port } = await listen(0);
+    try {
+      await expect(listen(port)).rejects.toMatchObject({ code: "EADDRINUSE" });
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("a freed port can be taken again", async () => {
+    // Restart-after-crash: the app must be able to come back on the same
+    // machine without waiting out a lingering socket.
+    const first = await listen(0);
+    const port = first.port;
+    await close(first.server);
+
+    const second = await listen(port);
+    expect(second.port).toBe(port);
+    await close(second.server);
+  });
+});

--- a/uxnandesktop/tests/fixtures/shared.mjs
+++ b/uxnandesktop/tests/fixtures/shared.mjs
@@ -1,0 +1,42 @@
+/**
+ * Fixtures shared with the resource benchmarks.
+ *
+ * The benchmark harness already needed a deterministic git repository, an
+ * offline stand-in agent, a loopback HTTP server and a way to seed a disposable
+ * app profile. Those are the same four things the test harness needs, and a
+ * second copy of any of them would be a second thing to keep correct — the
+ * generated repo in particular is only useful *because* its commit hash is
+ * pinned, and two generators would drift the moment one was touched.
+ *
+ * So this module re-exports them rather than reimplementing them. The benchmark
+ * side owns the implementations (`scripts/resources/`); the test side owns the
+ * fixtures that are specific to testing (`fake-gh`, the legacy profiles, the
+ * PATH shim).
+ */
+
+export { makeRepo } from "../../scripts/resources/fixtures/make-repo.mjs";
+export {
+  GLOBAL_WORKSPACE,
+  group,
+  layout,
+  liveTerminalCount,
+  project,
+  settings,
+  shellRunning,
+  split,
+  terminalGrid,
+  terminalTab,
+  writeProfile,
+} from "../../scripts/resources/lib/profile.mjs";
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const RESOURCE_FIXTURES = path.resolve(HERE, "..", "..", "scripts", "resources", "fixtures");
+
+/** The offline stand-in agent: emits output, waits, emits again, exits 0. */
+export const FAKE_AGENT = path.join(RESOURCE_FIXTURES, "agent-fixture.mjs");
+
+/** A fixed page served from loopback, for anything that opens the browser. */
+export const FIXTURE_HTTP_SERVER = path.join(RESOURCE_FIXTURES, "http-server.mjs");

--- a/uxnandesktop/tests/quality-matrix.json
+++ b/uxnandesktop/tests/quality-matrix.json
@@ -1,0 +1,381 @@
+{
+  "$comment": [
+    "The living record of what is tested, at which layer, and — more usefully —",
+    "what is not. A prose table in a README drifts within weeks because nothing",
+    "reads it; this file is machine-readable so `quality-matrix.test.mjs` can",
+    "check it against reality and fail when the two disagree.",
+    "",
+    "Every plan that adds a feature adds or updates its row here. `covered` is",
+    "not a wish: a layer listed as covered must have a test that exists.",
+    "",
+    "Layers: L1 pure logic · L2 Svelte components in jsdom · L3 backend against",
+    "temp dirs · L4 the real app driven end to end · L5 manual, on real",
+    "accounts/hardware."
+  ],
+  "version": 1,
+  "updated": "2026-07-31",
+  "layers": {
+    "L1": {
+      "name": "unit",
+      "runner": "vitest --project node",
+      "gate": "required"
+    },
+    "L2": {
+      "name": "component",
+      "runner": "vitest --project dom",
+      "gate": "required"
+    },
+    "L3": {
+      "name": "backend integration",
+      "runner": "cargo test --test * + vitest node",
+      "gate": "required"
+    },
+    "L4": {
+      "name": "end to end",
+      "runner": "wdio run tests/e2e/wdio.conf.mjs",
+      "gate": "manual (Windows)"
+    },
+    "L5": {
+      "name": "real compatibility",
+      "runner": "by hand",
+      "gate": "checklist"
+    }
+  },
+  "flows": [
+    {
+      "id": "startup-restore",
+      "flow": "Startup and session restore",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L4"
+      ],
+      "planned": [
+        "L3"
+      ],
+      "evidence": {
+        "L1": "src/lib/pathid.test.ts, src/lib/agentResume.test.ts",
+        "L4": "tests/e2e/specs/launch.e2e.mjs, tests/e2e/specs/restore.e2e.mjs"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "No L3 test boots the backend against a seeded profile; the E2E journey covers the same ground end to end, which is arguably the better place for it."
+    },
+    {
+      "id": "terminal-lifecycle",
+      "flow": "Open and close a terminal",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L3",
+        "L4"
+      ],
+      "planned": [
+        "L2"
+      ],
+      "evidence": {
+        "L1": "src/lib/terminal/scrollback.test.ts, src/lib/terminalArbiter.test.ts",
+        "L3": "src-tauri/src/pty.rs #[cfg(test)]",
+        "L4": "tests/e2e/specs/terminal.e2e.mjs"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "No component test mounts TerminalArea. Closing a terminal from the UI is not covered — the journey asserts the panes that restore, not the ones a user closes."
+    },
+    {
+      "id": "splits-and-tabs",
+      "flow": "Split, reorder and move tabs",
+      "owner": "desktop",
+      "covered": [
+        "L1"
+      ],
+      "planned": [
+        "L2",
+        "L4"
+      ],
+      "evidence": {
+        "L1": "src/lib/state/terminals.svelte.ts logic via pathid/scrollback tests"
+      },
+      "platforms": {
+        "windows": "untested",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "Re-parenting a live xterm on a move is the risky part and has no automated coverage at all."
+    },
+    {
+      "id": "sleep-wake",
+      "flow": "Sleep and wake a workspace, with scrollback",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L4"
+      ],
+      "planned": [
+        "L2",
+        "L3"
+      ],
+      "evidence": {
+        "L1": "src/lib/terminal/scrollback.test.ts",
+        "L4": "tests/e2e/specs/sleep-wake.e2e.mjs"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "The journey proves a sleeping workspace spawns no shells. Waking one — and whether the replayed scrollback matches what was captured — is still only checked by hand."
+    },
+    {
+      "id": "project-worktree",
+      "flow": "Add a project and create a worktree",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L3",
+        "L4"
+      ],
+      "planned": [
+        "L2"
+      ],
+      "evidence": {
+        "L1": "src/lib/branchName.test.ts, src/lib/pathid.test.ts",
+        "L3": "src-tauri/src/git.rs #[cfg(test)] against throwaway repos",
+        "L4": "tests/e2e/specs/worktree.e2e.mjs"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested",
+        "wsl": "untested"
+      },
+      "gaps": "Creating a worktree from the UI is not covered; the journey asserts an existing repository is recognised, listed and read. WSL path routing has no test."
+    },
+    {
+      "id": "git-review",
+      "flow": "Status, diff, stage and commit",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L3"
+      ],
+      "planned": [
+        "L2",
+        "L4"
+      ],
+      "evidence": {
+        "L1": "src/lib/diffParse.test.ts",
+        "L3": "src-tauri/src/git.rs, src-tauri/src/gitfast.rs #[cfg(test)]"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "Hunk-level staging is covered in Rust but not through the UI."
+    },
+    {
+      "id": "agent-hooks",
+      "flow": "Agent hook reporting and state",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L3",
+        "L4"
+      ],
+      "planned": [
+        "L2"
+      ],
+      "evidence": {
+        "L1": "src/lib/agentSessionId.test.ts, src/lib/agentLogoCache.test.ts",
+        "L3": "src-tauri/src/hooks.rs, src-tauri/src/agent_hooks.rs #[cfg(test)]",
+        "L4": "tests/e2e/specs/agent.e2e.mjs"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "The journey covers the half uxnan owns: the agent runs under a shell, the endpoint file is written, an untokened report is refused and a valid one reaches the state the sidebar reads. Whether a *particular* CLI's reporter is installed and correct is a separate question, and belongs to L5."
+    },
+    {
+      "id": "orchestration",
+      "flow": "Orchestration DAG, gates and retry",
+      "owner": "desktop",
+      "covered": [
+        "L1"
+      ],
+      "planned": [
+        "L2",
+        "L3",
+        "L4"
+      ],
+      "evidence": {
+        "L1": "src/lib/orchestration/run.test.ts, src/lib/orchestration.test.ts"
+      },
+      "platforms": {
+        "windows": "untested",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "The engine's logic is well covered; nothing exercises it against real agent processes."
+    },
+    {
+      "id": "browser-panel",
+      "flow": "Integrated browser: open, route, close",
+      "owner": "desktop",
+      "covered": [
+        "L3",
+        "L4"
+      ],
+      "planned": [
+        "L2"
+      ],
+      "evidence": {
+        "L3": "src-tauri/src/browser.rs #[cfg(test)] (scheme gate)",
+        "L4": "tests/e2e/specs/browser.e2e.mjs"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "The journey opens a loopback page in the browser window — the only multi-window coverage in the suite. Closing it, and the routing preference, are not covered."
+    },
+    {
+      "id": "settings-persistence",
+      "flow": "Settings, persistence and schema migration",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L3",
+        "L4"
+      ],
+      "planned": [
+        "L2"
+      ],
+      "evidence": {
+        "L1": "src/lib/theme.test.ts, src/lib/quickCommands.test.ts",
+        "L3": "src-tauri/src/persistence.rs #[cfg(test)], src-tauri/tests/automations_store.rs",
+        "L4": "tests/e2e/specs/migration.e2e.mjs"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "The journey boots the app over a profile shaped by an older build and asserts the projects survive. Changing a setting through the UI is not covered."
+    },
+    {
+      "id": "github",
+      "flow": "GitHub read and write",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L3"
+      ],
+      "planned": [
+        "L2"
+      ],
+      "evidence": {
+        "L1": "src/lib/markdown.test.ts, src/lib/branchName.test.ts",
+        "L3": "tests/fixtures/fixtures.test.mjs (the fake gh itself)"
+      },
+      "platforms": {
+        "windows": "fixture only",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "The write side has never run against real GitHub. L5 only, and opt-in."
+    },
+    {
+      "id": "automations",
+      "flow": "Automations and the OS scheduler",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L3"
+      ],
+      "planned": [
+        "L4"
+      ],
+      "evidence": {
+        "L1": "src/lib/automations/*.test.ts",
+        "L3": "src-tauri/tests/automations_store.rs, src-tauri/src/automations/*.rs #[cfg(test)]"
+      },
+      "platforms": {
+        "windows": "verified by hand",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "Scheduler registration is verified manually on Windows only."
+    },
+    {
+      "id": "pets",
+      "flow": "Pet overlay and its events",
+      "owner": "desktop",
+      "covered": [
+        "L1"
+      ],
+      "planned": [
+        "L2",
+        "L4"
+      ],
+      "evidence": {
+        "L1": "src/lib/pets/*.test.ts"
+      },
+      "platforms": {
+        "windows": "measured (resource benchmark R09)",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "The overlay is a second window; multi-window E2E is unproven."
+    },
+    {
+      "id": "updater",
+      "flow": "In-app updater",
+      "owner": "desktop",
+      "covered": [
+        "L1"
+      ],
+      "planned": [
+        "L3"
+      ],
+      "evidence": {
+        "L1": "src/lib/updaterLogic.test.ts, src-tauri/src/updater.rs #[cfg(test)]"
+      },
+      "platforms": {
+        "windows": "verified by hand",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "A signed-artifact round trip is L5 by nature."
+    },
+    {
+      "id": "resource-footprint",
+      "flow": "Resource footprint",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L4"
+      ],
+      "planned": [],
+      "evidence": {
+        "L1": "scripts/resources/lib/*.test.mjs",
+        "L4": "scripts/resources/run.mjs (the benchmark launches and measures the real app — 55 verified runs; it does not use WebDriver, which is why it is unaffected by the E2E attachment problem)"
+      },
+      "platforms": {
+        "windows": "baseline approved",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "R07/R08 need an operator; R10 (the 2 h soak) has never been run."
+    }
+  ]
+}

--- a/uxnandesktop/tests/quality-matrix.test.mjs
+++ b/uxnandesktop/tests/quality-matrix.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * The matrix has to be true, not aspirational.
+ *
+ * A coverage table is worth exactly as much as the thing that checks it. Left to
+ * prose, it becomes a list of intentions within a release or two — every row
+ * ticked, nothing verified. So the matrix is data, and this reads it back
+ * against the repository: a flow that claims a layer must point at a file that
+ * exists, and a gap must be written down rather than left blank.
+ *
+ * It deliberately does **not** check that the cited tests pass — that is the
+ * suite's job. It checks that the map matches the territory.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DESKTOP_ROOT = path.resolve(HERE, "..");
+const matrix = JSON.parse(fs.readFileSync(path.join(HERE, "quality-matrix.json"), "utf8"));
+
+const LAYERS = ["L1", "L2", "L3", "L4", "L5"];
+
+/** Every path a piece of evidence mentions, split out of its prose. */
+function citedPaths(evidence) {
+  return String(evidence)
+    .split(/[,\s]+/)
+    .map((token) => token.replace(/[(),]/g, ""))
+    .filter((token) => /^(src|scripts|tests|src-tauri)\//.test(token));
+}
+
+/**
+ * Does this citation point at something real?
+ *
+ * A glob is allowed — "src/lib/pets/*.test.ts" is a more honest citation than an
+ * arbitrary one of the six files it covers — but it has to *match* something.
+ * An empty glob is the same lie as a missing file, just harder to notice.
+ */
+function citationResolves(cited) {
+  const full = path.join(DESKTOP_ROOT, cited);
+  if (!cited.includes("*")) return fs.existsSync(full);
+
+  const dir = path.dirname(full);
+  if (!fs.existsSync(dir)) return false;
+  const pattern = new RegExp(
+    `^${path
+      .basename(cited)
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      .replace(/\*/g, ".*")}$`,
+  );
+  const walk = (root) =>
+    fs.readdirSync(root, { withFileTypes: true }).some((entry) => {
+      if (entry.isDirectory()) return walk(path.join(root, entry.name));
+      return pattern.test(entry.name);
+    });
+  return walk(dir);
+}
+
+describe("the quality matrix", () => {
+  it("declares every layer it references", () => {
+    for (const layer of Object.keys(matrix.layers)) expect(LAYERS).toContain(layer);
+    for (const flow of matrix.flows) {
+      for (const layer of [...flow.covered, ...flow.planned]) {
+        expect(LAYERS, `${flow.id} references an unknown layer`).toContain(layer);
+      }
+    }
+  });
+
+  it("gives every flow an id, an owner and a platform column", () => {
+    const ids = new Set();
+    for (const flow of matrix.flows) {
+      expect(flow.id, "a flow has no id").toBeTruthy();
+      expect(ids.has(flow.id), `duplicate flow id ${flow.id}`).toBe(false);
+      ids.add(flow.id);
+      expect(flow.owner, `${flow.id} has no owner`).toBeTruthy();
+      expect(flow.platforms, `${flow.id} has no platform column`).toBeTruthy();
+    }
+  });
+
+  it("never lists a layer as both covered and planned", () => {
+    // "Done and also to do" is how a matrix stops meaning anything.
+    for (const flow of matrix.flows) {
+      const both = flow.covered.filter((l) => flow.planned.includes(l));
+      expect(both, `${flow.id} lists ${both.join(", ")} as covered *and* planned`).toEqual([]);
+    }
+  });
+
+  it("backs every claim of coverage with a file that exists", () => {
+    const missing = [];
+    for (const flow of matrix.flows) {
+      for (const layer of flow.covered) {
+        const evidence = flow.evidence?.[layer];
+        if (!evidence) {
+          missing.push(`${flow.id}/${layer}: claims coverage with no evidence`);
+          continue;
+        }
+        for (const cited of citedPaths(evidence)) {
+          if (!citationResolves(cited)) {
+            missing.push(`${flow.id}/${layer}: ${cited} matches nothing in the repo`);
+          }
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("says what is missing wherever coverage is not complete", () => {
+    // A blank `gaps` on a partially covered flow is the quiet lie: it reads as
+    // "nothing to see here" when there is.
+    for (const flow of matrix.flows) {
+      if (flow.planned.length === 0) continue;
+      expect(flow.gaps, `${flow.id} has planned layers but no stated gap`).toBeTruthy();
+    }
+  });
+
+  it("does not claim a platform is verified without saying how", () => {
+    for (const flow of matrix.flows) {
+      for (const [platform, state] of Object.entries(flow.platforms)) {
+        expect(
+          typeof state === "string" && state.length > 0,
+          `${flow.id}/${platform} has an empty state`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("covers every flow at at least one layer", () => {
+    // A row with no coverage anywhere is a to-do list item, not a matrix entry;
+    // it belongs in FOR-DEV.md until something tests it.
+    for (const flow of matrix.flows) {
+      expect(flow.covered.length, `${flow.id} claims no coverage at all`).toBeGreaterThan(0);
+    }
+  });
+});

--- a/uxnandesktop/vitest.config.ts
+++ b/uxnandesktop/vitest.config.ts
@@ -14,7 +14,13 @@ export default defineConfig({
     alias: { $lib: fileURLToPath(new URL("./src/lib", import.meta.url)) },
   },
   test: {
+    name: "node",
     environment: "node",
-    include: ["src/**/*.test.ts", "scripts/**/*.test.mjs"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.mjs", "tests/**/*.test.mjs"],
+    // Component tests live beside their components as `*.svelte.test.ts` and
+    // belong to the `dom` project (`vitest.dom.config.ts`). Excluding them here
+    // keeps this suite free of the Svelte compiler and jsdom, which is the whole
+    // reason the two are separate.
+    exclude: ["**/node_modules/**", "**/*.svelte.test.ts"],
   },
 });

--- a/uxnandesktop/vitest.dom.config.ts
+++ b/uxnandesktop/vitest.dom.config.ts
@@ -1,0 +1,81 @@
+import { defineConfig } from "vitest/config";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { svelteTesting } from "@testing-library/svelte/vite";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Component tests: real Svelte 5 components, mounted in jsdom.
+ *
+ * Deliberately *not* the SvelteKit plugin — these tests mount components
+ * directly, so pulling in the router, the server runtime and the `$app/*`
+ * modules would buy nothing and cost start-up time. Anything a component needs
+ * from SvelteKit is aliased below.
+ *
+ * `svelteTesting()` wires the Testing Library cleanup between tests, so a
+ * forgotten unmount in one file cannot leak a mounted component into the next.
+ *
+ * Files are `*.svelte.test.ts`, which is also how the `node` project knows to
+ * skip them.
+ */
+export default defineConfig({
+  plugins: [
+    svelte({
+      // Ignore `svelte.config.js`. It is written for SvelteKit and runs
+      // `vitePreprocess`, whose CSS step needs a full Vite environment that does
+      // not exist in a Vitest worker — it fails on the first `<style>` block in
+      // a dependency (`svelte-sonner`'s Toaster) before any test can run.
+      configFile: false,
+      // Nothing here needs preprocessing: the app's components are plain Svelte
+      // 5 with Tailwind classes, no `lang="scss"` and no custom syntax.
+      preprocess: [],
+      // Styles are irrelevant to behaviour tests — jsdom has no layout engine,
+      // so no assertion can depend on them. Skipping extraction is a real
+      // speed-up across a suite that compiles a lot of components.
+      emitCss: false,
+      hot: false,
+    }),
+    svelteTesting(),
+  ],
+  resolve: {
+    alias: {
+      $lib: fileURLToPath(new URL("./src/lib", import.meta.url)),
+      $test: fileURLToPath(new URL("./src/test", import.meta.url)),
+    },
+    // No `conditions` override here on purpose. Svelte 5 does need the `browser`
+    // condition under jsdom (otherwise components resolve to their SSR build and
+    // nothing ever updates), but setting it by hand *replaces* Vite's default
+    // list rather than extending it. `svelteTesting()` adds the condition the
+    // correct way, alongside the defaults.
+    //
+    // `mainFields` prefers `module` over `main`, which is what the app's own
+    // build does and what these packages actually ship: `@xterm/addon-ligatures`
+    // declares `main: lib/addon-ligatures.js` and publishes only the `.mjs`, so
+    // resolving `main` first fails outright. Ordering it this way fixes that
+    // class of package rather than special-casing one name.
+    mainFields: ["browser", "module", "jsnext:main", "jsnext", "main"],
+    // `mainFields` only covers packages *without* an `exports` map. Packages
+    // that have one (`runed`, `bits-ui`, `svelte-sonner`) are resolved by
+    // condition, and Svelte libraries publish their source under a `svelte`
+    // condition. Listing it explicitly — with `browser` and Vite's own defaults
+    // alongside, since this replaces the list rather than extending it — is what
+    // makes the app's real dependency graph load under test.
+    conditions: ["svelte", "browser", "module", "import", "default"],
+  },
+  ssr: {
+    // Vitest resolves node_modules through the SSR pipeline; it needs the same
+    // conditions, or a Svelte-only package resolves in the client graph and
+    // fails in the server one.
+    resolve: {
+      conditions: ["svelte", "browser", "module", "import", "default"],
+    },
+  },
+  test: {
+    name: "dom",
+    environment: "jsdom",
+    include: ["src/**/*.svelte.test.ts"],
+    setupFiles: ["./src/test/setup.dom.ts"],
+    // A component test that hangs is almost always a promise the fake backend
+    // never resolved; fail it quickly instead of stalling CI for the default.
+    testTimeout: 10_000,
+  },
+});

--- a/uxnandesktop/vitest.workspace.ts
+++ b/uxnandesktop/vitest.workspace.ts
@@ -1,0 +1,20 @@
+import { defineWorkspace } from "vitest/config";
+
+/**
+ * Two suites, kept apart on purpose.
+ *
+ * **node** — the pure logic modules and the resource-benchmark harness. No DOM,
+ * no Svelte compiler, no browser globals: it stays fast (a couple of seconds for
+ * the whole set) and it stays honest, because a module that needs a `document`
+ * to be tested is a module that has UI concerns in it.
+ *
+ * **dom** — Svelte components mounted in jsdom. Slower by construction (a
+ * compiler and a fake DOM per file), so it is a separate project rather than a
+ * tax on every unit test. Nothing here reaches a real backend: Tauri's own
+ * `mockIPC` intercepts the IPC transport, so `src/lib/api.ts` runs for real
+ * against a fake, instead of the tests re-implementing the contract and slowly
+ * drifting from it.
+ *
+ * `npm test` runs both. `npm run test:node` / `npm run test:dom` run one.
+ */
+export default defineWorkspace(["./vitest.config.ts", "./vitest.dom.config.ts"]);


### PR DESCRIPTION
## Summary

Builds the test pyramid the desktop app did not have: Svelte component tests,
backend integration tests, fixtures a test cannot escape, a real end-to-end suite
driving the shipped app, and a coverage matrix that is checked rather than
claimed.

## Affected component(s)

- [ ] `shared` — contracts / JSON-RPC / E2EE schemas
- [ ] `bridge` — PC daemon (uxnan-bridge)
- [ ] `relay` — E2EE relay server (uxnan-relay)
- [x] `uxnandesktop` — Tauri desktop app
- [ ] `uxnanmobile` — Flutter mobile app
- [x] Cross-cutting / tooling / CI / docs

## Type of change

- [ ] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `refactor` — no behavior change
- [x] `docs`
- [x] `test`
- [x] `chore` / `ci` / `build`

## The layers

Five, each doing what the one below cannot. The split exists for speed: almost
everything is provable in a layer costing milliseconds, which is what keeps the
expensive layers small enough to stay trustworthy.

| | Layer | What it proves | Result |
|---|---|---|---|
| L0 | static | it compiles and lints | 1470 files, 0 errors / 0 warnings |
| L1 | unit | pure logic is correct | part of 565 Vitest |
| L2 | component | a Svelte component behaves | 20 tests, 3 components |
| L3 | backend integration | real files, real git, real processes | 10 Rust + fixtures |
| L4 | end to end | the whole app actually works | **24 tests, 8 journeys, ~39 s** |
| L5 | real compatibility | accounts, signed artifacts, hardware | 12-item checklist |

## Component tests mock the IPC transport, not `api.ts`

Mocking the API module would make the mock the assertion, and it drifts the first
time a command is renamed. Tauri's own `mockIPC` replaces the transport instead,
so `src/lib/api.ts` runs for real — its command names, its argument marshalling —
and only the process on the other side is fake. **No production code changed.**

`src/test/tauri.ts` adds what a bare `mockIPC` lacks: a typed handler table where
an unhandled command rejects loudly rather than returning `undefined`, a call
log, event emission, and failure/latency injection.

The three components were chosen for what they can get wrong: `UsageMeter` (two
surfaces share it), `SaveDiscardDialog` (every route out must resolve its promise
— a route that resolves nothing hangs a tab close forever, with no error), and
`AgentLogo` (a fallback chain that looked obviously correct and silently was
not).

## Fixtures a test cannot escape

The fake `gh` refuses to run without a latch and scrubs credentials from its log.
The **PATH shim** resolves every CLI the app shells out to inside a directory of
fakes, so a test that forgets to stub one gets "blocked by the test harness"
rather than talking to real GitHub — `assertNoRealCli` re-checks that rather than
trusting it.

The git repository, the stand-in agent and the loopback server are **shared**
with the resource benchmarks rather than copied: two generators would drift, and
the repo fixture is only useful because its commit hash is pinned.

## End to end, against the shipped app

Eight journeys — launch, session restore, terminals in a split, a sleeping
workspace, a git project, an agent and the hook chain, the browser window, a
profile from an older build. Each spec gets its own app, started from a profile
seeded for it, so setup costs nothing while the assertions still go through the
real UI, real IPC and a real backend.

Assertions ask the backend over IPC rather than reading the screen: the UI is
localised, so an assertion on visible text is an assertion on a translation. A
terminal's contents are unreadable either way — xterm paints through WebGL — so
"is a shell alive" is answered from the process tree.

### Four things about this layer that are not guessable

Each cost a debugging session and is commented where it bites:

1. **`tauri-driver` hands you a webview at `about:blank`.** It does not attach to
   the window the app already navigated, so every query succeeds and returns an
   empty document — which reads as "the app rendered nothing" while the app runs
   perfectly. The session navigates to the app's own origin; IPC is live there
   (`invoke("ping")` answers from Rust), so these are genuine E2E tests.
2. **`tauri:options.env` never reached the app.** A diagnostic run came up on the
   developer's *real* profile, showing their actual projects — a journey that
   removed a worktree would have removed a real one. The variable is set on the
   driver now, and `before` refuses to run unless the app shows exactly what was
   seeded.
3. **WebdriverIO evaluates the config twice**, once per process, so a `mkdtemp`
   profile exists twice: the driver points at one, the seed writes the other, and
   the app comes up empty whatever the journey asked for. The path is fixed now.
4. **The app is found by executable name**, safe only because the pre-flight
   refuses to start beside another instance. Matching the profile directory — the
   apparently safer choice — matches nothing, since `UXNAN_DATA_DIR` is an
   environment variable; what it *did* match was the PowerShell process running
   the query, so the reaper spent several runs killing its own query and
   reporting success.

## A coverage matrix that is checked

`tests/quality-matrix.json` is machine-readable and verified against the
repository by a test: a flow claiming a layer must cite a file that exists (globs
must match something), a partially covered flow must state its gap, and no flow
may list a layer as both covered and planned. It records what is **not** tested
as carefully as what is.

## How was it tested?

1. `npm run check` → 1470 files, **0 errors / 0 warnings**.
2. `npm test` → **565 Vitest** across both projects (node + dom).
3. `npm run build` → SPA build succeeds.
4. `cd src-tauri && cargo test` → **387** (377 unit + 10 integration);
   `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
5. `npm run test:e2e` → **8/8 spec files, 24 tests, ~39 s**, green on consecutive
   runs with **zero leftover processes**.

## Resource impact (`uxnandesktop` only)

None at runtime. Everything here is test-only; no production code changed.

## Checklist

- [x] Lint/format pass for the touched component(s).
- [x] Tests added or updated, and the suite passes.
- [x] `CHANGELOG.md` updated.
- [x] Docs / `architecture/` updated (spec-drift control: `04-technical-reference.md`
      records the pyramid under Phase 5, including what differs from the sketch it
      replaced).
- [x] Commits follow Conventional Commits.
- [ ] **If this is a `uxnanmobile` release:** n/a.
- [x] If a `shared` contract changed, all consumers updated — n/a, none changed.
- [x] Resource scenario run and numbers above — n/a, no runtime change.

## What is deliberately not here

- **No journey *drives* the UI.** They seed a state and assert it end to end;
  creating a worktree from the dialog, closing a terminal, waking a workspace
  need stable handles on the controls. That is the next piece of work.
- **The fixture agent's own reporter does not reach the hook server.** The
  journey covers the chain by posting a report itself — which is what a reporter
  does, and the half uxnan owns — but why the fixture's own POST never lands is
  unresolved and worth knowing.
- **E2E is Windows-only.** `tauri-driver` does not support macOS at all and
  Linux has never been run here; the harness does not claim a platform nobody has
  executed.
- **E2E is not a required gate yet**, by design — see the workflow comment.

All four are in `FOR-DEV.md` and in the quality matrix.
