### PR TITLE
feat(desktop): local resource observability — attributed, demand-driven, zero-cost when idle

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,46 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — local resource observability: what uxnan, its terminals and its agents cost
+
+- **A demand-driven resource monitor** (`src-tauri/src/resources.rs`,
+  `docs/resource-monitoring.md`): CPU / memory / process attribution for the
+  desktop process, every PTY it spawned and the agents running inside them —
+  local only, never telemetry, never a general task manager. Attribution is
+  evidence-based (pid + start time + parent chain, plus the explicit link each
+  terminal registers at spawn with its workspace) and every figure carries a
+  confidence: **exact** (identity verified), **inferred** (parent-chain),
+  **unknown** (e.g. a recycled pid — the link is voided and nothing is
+  claimed). Absent data is never reported as zero.
+- **Zero cost unless consumed.** The sampler is fully parked (no timer, no OS
+  handle) until a consumer exists: 2 s while the backend popover is open (a
+  self-expiring lease the frontend renews), 3 s for a reserved budget consumer,
+  and the **opt-in** 15–30 s background orphan sweep — the only mode that runs
+  unasked. History is a ~10-minute in-memory circular buffer of aggregates;
+  nothing per-process is persisted.
+- **Surfaces**: the status bar's backend popover gains a compact *Resources*
+  section (Uxnan total with peak + memory trend, per-workspace and per-agent
+  rows with confidence marks, spike highlighting, ended groups frozen with a
+  note, and an amber warning for **processes that outlived their closed
+  terminal**); **Settings → Resources** holds the switches, explains the
+  confidence labels and hosts the diagnostics export.
+- **Consent-first sanitized export**: the dialog lists the JSON document's
+  exact fields before anything is written; workspace/terminal ids become
+  opaque labels, agent names survive only via a known-catalog allow-list, and
+  golden + schema-allow-list tests fail the build on any leak or un-reviewed
+  field. Command lines, environment, cwd and file names are never read at all.
+- **Benchmark scenario R12** measures the feature's own promise (off / parked
+  must equal the R02 baseline; the sweep is the only unattended cost), wired as
+  a one-command run with a provisional Windows budget until a real baseline is
+  captured with the app closed.
+- Tests: 38 Rust unit tests (cadence, attribution, deltas, buffer bounds,
+  orphans, the parked loop under a paused clock, the export golden tests),
+  3 integration tests against real spawned process trees, 24 pure-logic Vitest
+  tests and 18 component tests (states, confidence marks, the export consent
+  flow). Totals: **607 Vitest**, **429 Rust** (416 unit + 13 integration).
+  Full EN/ES i18n; the shared component-test harness gains
+  `mountWithProviders` for components that need the app-level tooltip context.
+
 ### Added — a test pyramid: component tests, backend integration, and real end-to-end
 
 - **Five layers, each doing what the one below cannot** (`docs/testing.md`): L0

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -41,7 +41,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   orphans, the parked loop under a paused clock, the export golden tests),
   3 integration tests against real spawned process trees, 24 pure-logic Vitest
   tests and 18 component tests (states, confidence marks, the export consent
-  flow). Totals: **607 Vitest**, **429 Rust** (416 unit + 13 integration).
+  flow). Totals: **608 Vitest**, **429 Rust** (416 unit + 13 integration).
   Full EN/ES i18n; the shared component-test harness gains
   `mountWithProviders` for components that need the app-level tooltip context.
 

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -18,7 +18,7 @@ OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
 with" external editors/IDEs**, **automations**, **pets**, **a reproducible
-resource benchmark**). 388 Rust tests (378 unit + 10 integration) + 565 frontend Vitest tests across
+resource benchmark**, **an in-app resource monitor**). 429 Rust tests (416 unit + 13 integration) + 607 frontend Vitest tests across
 two projects — pure logic and **Svelte component tests** — plus a **real E2E suite**
 (WebdriverIO + tauri-driver: 8 journeys, 24 tests, green on Windows). macOS now ships an
 **experimental, unsigned** build (Intel + Apple Silicon; CI verifies `{ubuntu,
@@ -276,6 +276,47 @@ not missing machinery.
       harness has to refuse to run alongside another uxnan. Isolating it per run
       would remove that precondition; it needs either a config-level
       `dataDirectory` uxnan controls per launch or an upstream hook.
+
+## Resource monitor — follow-ups ☐
+
+**The in-app resource monitor is built and tested** (`src-tauri/src/resources.rs`,
+`docs/resource-monitoring.md`): demand-driven sampling, pid+start-time
+attribution with explicit confidence, orphan detection, the popover + Settings
+surfaces, and the consent-first sanitized export. What is left is measurement
+and platform confidence, not machinery.
+
+- [ ] **Capture the R12 baseline and replace the provisional Windows budget.**
+      The scenario is wired end to end (`npm run bench -- --scenario R12
+      --variant off|parked|sweep`) and its budget entry is a verbatim copy of
+      R02's — which is exactly the claim under test ("parked adds nothing"),
+      but a copied ceiling is not a measurement. The harness (correctly)
+      refuses to run beside a live uxnan instance, so this **must run with the
+      app closed**; five repetitions per variant, then write the measured
+      medians + margins into `budgets/windows.json` (the `FOR-DEV:` note in its
+      `_comment` marks the spot).
+- [ ] **An L4 journey for the popover round trip.** No E2E spec opens the
+      backend popover against the real binary yet — the suite could not run
+      beside the live instance this feature was built next to, and an
+      unverifiable spec is worse than an honest gap. The journey is viable with
+      the existing WebdriverIO pattern (click the status-bar trigger, assert
+      the Resources section renders and the lease releases on close); until
+      then the round trip is covered at L2 (component) + L3 (monitor against
+      real processes), per `tests/quality-matrix.json` →
+      `resource-observability`.
+- [ ] **Validate the metrics on real macOS/Linux hardware.** The collector is
+      portable `sysinfo` and compiles everywhere, but only Windows figures have
+      been checked against reality — `capabilities.validated` is `false` off
+      Windows and the UI says "best effort" on purpose. Validating means: start
+      times round-trip (the identity scheme), CPU normalization looks sane, and
+      macOS's out-of-tree WebKit content process is measured for what the
+      `desktop` group misses there. Until then no non-Windows figure may be
+      published.
+- [ ] *(optional)* **A first consumer for the `budget` lease kind + the
+      internal event stream.** `ResourceMonitor::subscribe_events` broadcasts
+      every frame and the `budget` cadence (3 s) is implemented and tested, but
+      nothing subscribes with it yet — it is the designed hook for a future
+      resource-limits / orchestration-routing engine, kept in the contract so
+      that engine does not need a second sampler.
 
 ## Automations — follow-ups ☐
 
@@ -918,7 +959,7 @@ go stale; these are the ones worth calling out.
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 388 Rust + 565 Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 429 Rust + 607 Vitest tests (both
   projects: pure logic and components). E2E runs in its own on-demand/nightly
   Windows workflow (`e2e-desktop.yml`), deliberately outside the required gate.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -18,7 +18,7 @@ OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
 with" external editors/IDEs**, **automations**, **pets**, **a reproducible
-resource benchmark**, **an in-app resource monitor**). 429 Rust tests (416 unit + 13 integration) + 607 frontend Vitest tests across
+resource benchmark**, **an in-app resource monitor**). 429 Rust tests (416 unit + 13 integration) + 608 frontend Vitest tests across
 two projects — pure logic and **Svelte component tests** — plus a **real E2E suite**
 (WebdriverIO + tauri-driver: 8 journeys, 24 tests, green on Windows). macOS now ships an
 **experimental, unsigned** build (Intel + Apple Silicon; CI verifies `{ubuntu,
@@ -959,7 +959,7 @@ go stale; these are the ones worth calling out.
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 429 Rust + 607 Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 429 Rust + 608 Vitest tests (both
   projects: pure logic and components). E2E runs in its own on-demand/nightly
   Windows workflow (`e2e-desktop.yml`), deliberately outside the required gate.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -220,6 +220,7 @@ Detailed docs live in [`docs/`](./docs/):
 [testing & verification](./docs/testing.md) ·
 [end-to-end tests](./tests/e2e/README.md) ·
 [resource benchmarks](./docs/resource-benchmarks.md) ·
+[resource monitoring (in-app)](./docs/resource-monitoring.md) ·
 [architecture orientation](./docs/architecture.md) ·
 [design tokens](./docs/design-tokens.md) ·
 [theming & appearance](./docs/theming.md) ·

--- a/uxnandesktop/docs/resource-benchmarks.md
+++ b/uxnandesktop/docs/resource-benchmarks.md
@@ -232,6 +232,7 @@ judged" and "passed".
 | R09 | Pet companion | auto | off / layer / overlay — "off" must cost nothing |
 | R10 | Soak (2 h) | auto | does anything grow: memory, handles, processes |
 | R11 | Restart and restore | auto | restore time and fidelity |
+| R12 | Resource observer overhead | auto | off / parked / sweep — parked must equal R02; the sweep is the only unattended cost |
 
 **auto** scenarios prepare a profile and let the app restore itself into the state
 under test — no UI driving, fully unattended, and what `--all` and CI run.
@@ -243,6 +244,16 @@ samples and records; the report labels the result as operator-driven. They becom
 
 R04's *asleep* cost is automatic; **wake latency and fidelity are still on the
 operator checklist**, because waking is a click.
+
+R12 measures the in-app resource monitor (`src-tauri/src/resources.rs`,
+`docs/resource-monitoring.md`) against its own promise: `off` and `parked` must
+be indistinguishable from R02 (a parked collector holds no timer and no OS
+handle), and `sweep` — the opt-in background orphan check at its fastest allowed
+15 s — is the one unattended cost the feature can have. The popover's 2 s
+cadence needs the panel open, so it rides the operator checklist. **Its Windows
+budget entry is provisional** (copied from R02, which *is* the claim under
+test) until a real baseline is captured — the harness refuses to run beside a
+live uxnan instance, so that capture has to happen with the app closed.
 
 ### How a scenario reaches its state
 

--- a/uxnandesktop/docs/resource-monitoring.md
+++ b/uxnandesktop/docs/resource-monitoring.md
@@ -1,0 +1,132 @@
+# Resource monitoring
+
+Uxnan can tell you — locally, cheaply and honestly — what **it** costs: the
+desktop process, every terminal it spawned, and the agents running inside them,
+in CPU, memory and (where the OS reports it) I/O. It is **not** telemetry and
+**not** a system task manager: only processes Uxnan launched or can tie to
+itself by evidence are ever classified, nothing leaves the machine, and every
+figure carries a stated confidence instead of pretending precision.
+
+Two surfaces, both opt-out via Settings → **Resources**:
+
+- the **status bar's backend popover** gains a *Resources* section — the Uxnan
+  total (instant CPU/memory, peak, memory trend), one row per workspace and per
+  agent, and a warning block for processes that outlived their closed terminal;
+- **Settings → Resources** (Application group) holds the switches, explains the
+  confidence labels, and offers the sanitized diagnostics export.
+
+## Cost model: nothing runs unless something consumes it
+
+The collector (`src-tauri/src/resources.rs`) is **demand-driven**. With no
+consumer it is fully *parked*: no timer, no process-table walks, and no
+retained OS handle (the `sysinfo` state is dropped on park). The cadences:
+
+| State | Interval | Who causes it |
+|---|---|---|
+| Parked | — (nothing runs) | the default |
+| Popover open | 2 s | opening the backend popover takes a sampling lease |
+| Budget consumer | 3 s | reserved for a future limits/orchestration engine |
+| Orphan sweep | 15–30 s (default 20) | the **opt-in** background check |
+
+Leases are renewed by the frontend while its surface is open and **expire on
+their own** (90 s TTL), so a reloaded webview that never unsubscribed cannot pin
+the fast cadence. The orphan sweep is the only mode that samples with no UI
+open, and it is off by default — which is why the default configuration costs
+nothing at rest. The benchmark harness measures exactly this promise
+(scenario **R12**, [`resource-benchmarks.md`](resource-benchmarks.md)).
+
+## Attribution: evidence, with a confidence label
+
+Ownership is resolved from **pid + start time + parent chain**, plus the
+explicit link each PTY registers when it spawns (`pty_create` passes the tab's
+workspace; the agent detector feeds the terminal's agent command). Command
+lines, environment, sockets and file contents are **never read** here.
+
+- **exact** — pid *and* start time verified against a terminal Uxnan spawned
+  (±2 s tolerance). The shell processes themselves, and re-identified orphans.
+- **inferred** (`~` in the UI) — parent-chain evidence below a verified
+  process: a shell's descendants, the desktop tree's webview helpers, an
+  agent's subtree.
+- **unknown** (`?`) — identity could not be verified: typically a **recycled
+  pid** (same id, different start time). The link is voided, nothing is
+  claimed, and the row renders dashes — absent data is never shown as zero.
+
+Groups: the desktop tree (minus terminal subtrees), one group per **workspace**
+(its shells and their non-agent descendants), one per **agent** command (that
+subtree, with its workspace attached). A group that vanishes is reported as
+**ended** with its last-known figures for ~90 s rather than silently dropped.
+
+**Orphans:** closing a terminal snapshots its members (pid + start time). On
+later samples, any member still alive — re-verified by start time, so a
+recycled pid never counts — is reported as a *surviving process* until it ends.
+
+## What the numbers are
+
+Per group: instant CPU (normalized to the whole machine), a ~60 s short
+average, the buffered peak, resident + virtual memory, I/O rates, and a memory
+**trend** over the buffer. History lives in an in-memory circular buffer capped
+at **10 minutes** of aggregated frames — never per-process, never persisted.
+A first sighting (or a gap after a parked window) reports CPU/I-O as unknown
+rather than a made-up number; a partially-unknown group's rate is unknown too
+(a partial sum shown as a fact would under-report).
+
+## Privacy and the diagnostics export
+
+Settings → Resources → **Export diagnostics** writes a JSON snapshot of the
+current summary, and it is consent-first: the dialog lists **every field** the
+file will contain before anything is written, and you pick the destination in
+the OS save dialog. Sanitization is structural, not cosmetic:
+
+- workspace paths and terminal ids become opaque labels (`workspace-1`,
+  `terminal-2`);
+- agent names survive only when they match the known catalog (an allow-list —
+  an unknown name exports as `agent-N`, so drift degrades safely);
+- no command lines, environment, cwd, home paths or file names exist anywhere
+  in the pipeline to leak; pids are included (it is a process diagnostic);
+- a schema allow-list test fails the build if the export ever gains an
+  un-reviewed field, and a golden test feeds hostile values (paths, tokens,
+  env spellings) and asserts none survive serialization.
+
+There is no upload path. The document is versioned (`schemaVersion`).
+
+## Settings reference (`AppSettings.resources`)
+
+| Field | Default | Meaning |
+|---|---|---|
+| `enabled` | `true` | Master switch for the surfaces + data. A parked collector is free, which is why on-by-default costs nothing. |
+| `orphanSweep` | `false` | Opt-in background sweep so orphans are noticed with no UI open. |
+| `orphanSweepSeconds` | `20` | Sweep interval; clamped to 15–30 by the backend. |
+
+## Platform support
+
+Implemented portably over `sysinfo`. **Validated on Windows only** so far: on
+macOS/Linux the same code runs, `capabilities.validated` is `false`, and the UI
+adds a "best effort" note instead of claiming verified figures. Per-process
+I/O counters are unavailable on the BSDs (`capabilities.io = false` → dashes).
+A start time the OS reports as `0` is treated as absent, degrading that link's
+confidence to *inferred* instead of inventing identity.
+
+## For future consumers
+
+Every ingested frame's summary is also broadcast on an internal Rust channel
+(`ResourceMonitor::subscribe_events`), and a `budget` lease kind exists in the
+contract — that is the hook for resource-limit / orchestration-routing features
+to consume the same data without adding a second sampler.
+
+## Testing
+
+- **L1** — `src/lib/resources/*.test.ts` (formatting honesty, spike/ended/
+  unknown display rules).
+- **L2** — `ResourceSummary.svelte.test.ts` / `ResourceSettings.svelte.test.ts`
+  (loading/empty/unsupported states, confidence marks, orphan warning, the
+  whole export consent flow).
+- **L3** — `src-tauri/src/resources.rs` unit tests (cadence, attribution,
+  deltas, buffer bounds, the export golden tests, the parked loop under a
+  paused clock) and `src-tauri/tests/resources_processes.rs` against real
+  spawned process trees.
+- **Overhead** — benchmark scenario **R12** (`npm run bench -- --scenario R12
+  --variant sweep`); its Windows budget entry is provisional until a baseline
+  is captured with the app closed.
+
+Gaps are tracked honestly in `tests/quality-matrix.json`
+(`resource-observability`) and [`FOR-DEV.md`](../FOR-DEV.md).

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -115,7 +115,7 @@ result schema and its validation messages, percentile / CPU-rate / soak-slope
 maths, absolute budgets and the regression policy, the redaction gate, the
 scenario table, the pre-flight checks that mark a run invalid, the Unix collector's awk parser and the git fixture's determinism) — and the **test fixtures**
 under `tests/fixtures/` (the fake `gh`, the PATH shim, the disposable and legacy
-profiles) and the **quality matrix** check. **607 tests** across both projects,
+profiles) and the **quality matrix** check. **608 tests** across both projects,
 config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -45,17 +45,22 @@ keeps them integration tests rather than unit tests with a longer path —
 `automations_store.rs` (10 tests) drives the store against a real `TempDir`:
 round-trip across a process boundary, seed-once, a truncated file degrading
 instead of panicking, nothing written outside its own root, and a path with
-spaces and non-ASCII characters. **388 backend tests** in total.
+spaces and non-ASCII characters; `resources_processes.rs` (3 tests) drives the
+resource monitor against **real spawned process trees** — live attribution, the
+start-time probe agreeing with the full table read, and the orphan flow (owner
+closed, child survives, cleared when it ends). **429 backend tests** in total.
 
-The 378 unit tests cover the Serde model shape, persistence round-trip / atomicity /
+The 416 unit tests cover the Serde model shape, persistence round-trip / atomicity /
 migration / backups, git + worktree ops (including creation, opt-in branch
 cleanup on removal — local/remote/force — checking out an existing branch,
 staging, discard, hunk apply and commit against throwaway repos), the git2 fast
 path, the PTY lifecycle,
 the agent hook server, the integrated-browser scheme gate, process detection,
-the updater's per-channel endpoints, and the pets store (Codex-format manifest
+the updater's per-channel endpoints, the pets store (Codex-format manifest
 parsing, path-traversal refusal, and the import copy staying scoped to the
-manifest + its spritesheet).
+manifest + its spritesheet), and the resource monitor (`resources.rs`: cadence
+resolution, pid+start-time attribution, CPU/I-O delta honesty, buffer bounds,
+orphan detection, and the export sanitizer's golden + schema-allow-list tests).
 
 ## Frontend (Svelte / TypeScript)
 
@@ -110,7 +115,7 @@ result schema and its validation messages, percentile / CPU-rate / soak-slope
 maths, absolute budgets and the regression policy, the redaction gate, the
 scenario table, the pre-flight checks that mark a run invalid, the Unix collector's awk parser and the git fixture's determinism) — and the **test fixtures**
 under `tests/fixtures/` (the fake `gh`, the PATH shim, the disposable and legacy
-profiles) and the **quality matrix** check. **565 tests** across both projects,
+profiles) and the **quality matrix** check. **607 tests** across both projects,
 config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)
@@ -126,7 +131,10 @@ instead of quietly agreeing with a mock nobody updated.
   rather than returning `undefined`, which would surface later as a confusing
   null-deref inside the component.
 - `src/test/render.ts` — `mount()` (component + backend + `user-event`, all torn
-  down together) and `until()` for the waits that have no DOM signal.
+  down together), `mountWithProviders()` for components needing the app-level
+  context the root layout provides (bits-ui tooltips throw without their
+  provider — `ProviderHost.svelte`), and `until()` for the waits that have no
+  DOM signal.
 - `src/test/setup.dom.ts` — jsdom's gaps filled once (`matchMedia`,
   `ResizeObserver`, canvas), plus a console policy: an unknown-prop or
   lifecycle-outside-component warning **fails** the test; known third-party

--- a/uxnandesktop/scripts/resources/budgets/windows.json
+++ b/uxnandesktop/scripts/resources/budgets/windows.json
@@ -20,8 +20,9 @@
     "because the claim under test is exactly \"the parked resource monitor adds",
     "nothing a budget can see\", and the real measured baseline is still owed \u2014",
     "the harness refuses to run beside a live uxnan instance, so the capture",
-    "must happen with the app closed. Replace these with measured medians (+",
-    "the standard margins) on the first real R12 run."
+    "must happen with the app closed. FOR-DEV: replace these with measured",
+    "medians (+ the standard margins) on the first real R12 run \u2014 see",
+    "FOR-DEV.md \u2192 Resource monitor."
   ],
   "scenarios": {
     "R00": {

--- a/uxnandesktop/scripts/resources/budgets/windows.json
+++ b/uxnandesktop/scripts/resources/budgets/windows.json
@@ -9,12 +9,19 @@
     "margin: +15% warn / +35% fail for memory, +20/+40% for the managed bucket,",
     "+25/+50% for handles. CPU P95 and launch latency get much wider bands (x2.5",
     "/ x4 and x6 / x12, with floors) because they are the noisy metrics on a",
-    "desktop — a gate that fires on noise gets switched off, and then nothing is",
+    "desktop \u2014 a gate that fires on noise gets switched off, and then nothing is",
     "measured at all.",
     "",
     "mode: 'warn' downgrades every `fail` to a warning, so CI reports without",
     "blocking. Flip to 'enforce' after two weeks of real runs establish the noise",
-    "floor. Raising a limit afterwards needs the run that justifies it in the diff."
+    "floor. Raising a limit afterwards needs the run that justifies it in the diff.",
+    "",
+    "R12 is PROVISIONAL: its ceilings are copied verbatim from R02 (its baseline)",
+    "because the claim under test is exactly \"the parked resource monitor adds",
+    "nothing a budget can see\", and the real measured baseline is still owed \u2014",
+    "the harness refuses to run beside a live uxnan instance, so the capture",
+    "must happen with the app closed. Replace these with measured medians (+",
+    "the standard margins) on the first real R12 run."
   ],
   "scenarios": {
     "R00": {
@@ -297,6 +304,32 @@
       "cpuP95": {
         "warn": 22,
         "fail": 35
+      },
+      "launchToWindowMs": {
+        "warn": 400,
+        "fail": 800
+      }
+    },
+    "R12": {
+      "ownPrivateP50Mb": {
+        "warn": 290,
+        "fail": 341
+      },
+      "ownRssP50Mb": {
+        "warn": 582,
+        "fail": 683
+      },
+      "managedPrivateP50Mb": {
+        "warn": 309,
+        "fail": 360
+      },
+      "handlesP95": {
+        "warn": 4902,
+        "fail": 5882
+      },
+      "cpuP95": {
+        "warn": 16,
+        "fail": 26
       },
       "launchToWindowMs": {
         "warn": 400,

--- a/uxnandesktop/scripts/resources/lib/scenarios.mjs
+++ b/uxnandesktop/scripts/resources/lib/scenarios.mjs
@@ -278,6 +278,39 @@ export const SCENARIOS = [
       notes: ["measured launch is the second one, against a profile the first launch already used"],
     }),
   },
+
+  {
+    id: "R12",
+    title: "Resource observer overhead",
+    mode: "auto",
+    question:
+      "Does the resource monitor cost anything while parked, and what does the opt-in orphan sweep add?",
+    defaults: { durationS: 180, stabilizeS: 30 },
+    variants: ["off", "parked", "sweep"],
+    fixtures: { repo: { name: "small", files: 200, dirs: 20 } },
+    baseline: "R02",
+    prepare: ({ fixtures, variant = "parked" }) => ({
+      repos: [project({ id: "bench-small", name: "small", dir: fixtures.repo.dir })],
+      layout: layout(fixtures.repo.dir, { [fixtures.repo.dir]: shellsIn(fixtures.repo.dir, 1) }),
+      settingsOverrides: {
+        resources: {
+          enabled: variant !== "off",
+          orphanSweep: variant === "sweep",
+          orphanSweepSeconds: 15, // the sweep's worst allowed case
+        },
+      },
+      notes: [
+        `resource-monitor variant: ${variant}`,
+        "'off' and 'parked' must be indistinguishable from R02 — a parked collector holds no timer and no OS handle",
+        "'sweep' is the only unattended cost the feature can have; compare it against 'parked' for the sweep's price",
+        "the popover's fast cadence needs the panel open and is measured with the assisted checklist below",
+      ],
+    }),
+    checklist: [
+      "Open the status bar's backend popover and keep it open for two minutes (the 2 s cadence).",
+      "Close it and confirm CPU settles back to the resting figure within one interval.",
+    ],
+  },
 ];
 
 export function getScenario(id) {

--- a/uxnandesktop/scripts/resources/lib/scenarios.test.mjs
+++ b/uxnandesktop/scripts/resources/lib/scenarios.test.mjs
@@ -122,6 +122,31 @@ describe("scenario preparation", () => {
   it("R11 asks for a warm-up launch, because a restore needs something to restore", () => {
     expect(getScenario("R11").warmup).toBe(true);
   });
+
+  it("R12 varies only the resource-monitor settings across its variants", () => {
+    const scenario = getScenario("R12");
+    const off = scenario.prepare({ fixtures: FIXTURES, variant: "off" });
+    const parked = scenario.prepare({ fixtures: FIXTURES, variant: "parked" });
+    const sweep = scenario.prepare({ fixtures: FIXTURES, variant: "sweep" });
+    expect(off.settingsOverrides.resources).toEqual({
+      enabled: false,
+      orphanSweep: false,
+      orphanSweepSeconds: 15,
+    });
+    expect(parked.settingsOverrides.resources).toEqual({
+      enabled: true,
+      orphanSweep: false,
+      orphanSweepSeconds: 15,
+    });
+    expect(sweep.settingsOverrides.resources).toEqual({
+      enabled: true,
+      orphanSweep: true,
+      orphanSweepSeconds: 15,
+    });
+    // Same one-shell layout as its R02 baseline, so the delta means something.
+    expect(scenario.baseline).toBe("R02");
+    expect(countRegions(parked.layout.workspaces[FIXTURES.repo.dir])).toBe(1);
+  });
 });
 
 describe("profile seeding", () => {

--- a/uxnandesktop/scripts/resources/lib/schema.mjs
+++ b/uxnandesktop/scripts/resources/lib/schema.mjs
@@ -40,6 +40,7 @@ export const SCENARIO_IDS = [
   "R09",
   "R10",
   "R11",
+  "R12",
 ];
 
 /**

--- a/uxnandesktop/scripts/resources/run.mjs
+++ b/uxnandesktop/scripts/resources/run.mjs
@@ -97,7 +97,7 @@ Options
   --duration <s>      override the measurement window
   --stabilize <s>     override the discarded warm-up window
   --interval <ms>     sampling interval (default 1000)
-  --variant <name>    scenario variant (R09: off | layer | overlay)
+  --variant <name>    scenario variant (R09: off | layer | overlay; R12: off | parked | sweep)
   --out <dir>         results directory (default .resource-results)
   --binary <path>     app binary to measure (default: the release build)
   --profile <name>    build profile recorded in the result (default release)

--- a/uxnandesktop/src-tauri/Cargo.toml
+++ b/uxnandesktop/src-tauri/Cargo.toml
@@ -101,3 +101,9 @@ windows-sys = { version = "0.59", features = [
 
 [dev-dependencies]
 tempfile = "3"
+# `test-util` enables tokio's paused virtual clock, which is how the resource
+# sampler's park/wake behavior is tested without real waits (`resources.rs`).
+tokio = { version = "1", features = ["test-util"] }
+# The resource-observability integration tests (`tests/resources_processes.rs`)
+# read real process facts through the same sysinfo the app uses.
+sysinfo = "0.33"

--- a/uxnandesktop/src-tauri/src/commands.rs
+++ b/uxnandesktop/src-tauri/src/commands.rs
@@ -34,7 +34,55 @@ pub async fn update_settings(
     let mut data = state.data.write().await;
     data.settings = settings;
     state.persistence.save(&data).map_err(CommandError::from)?;
+    // Keep the resource monitor's cadence in step (no-op unless the resource
+    // settings actually changed — this command fires for every settings write).
+    state.resources.apply_settings(&data.settings.resources);
     Ok(data.clone())
+}
+
+// --- Resource observability (`resources.rs`) ---------------------------------
+
+/// The consolidated resource summary (from the buffered frames; no fresh
+/// sample). The live feed is the `resources:summary` event while subscribed.
+#[tauri::command]
+pub async fn resources_summary(
+    state: State<'_, AppState>,
+) -> Result<crate::resources::ResourceSummary, CommandError> {
+    Ok(state.resources.summary(crate::resources::now_ms()))
+}
+
+/// Take (or renew) a sampling lease. `token` identifies the consumer surface;
+/// leases expire on their own, so the frontend renews while its surface is open.
+#[tauri::command]
+pub async fn resources_subscribe(
+    state: State<'_, AppState>,
+    token: String,
+    kind: crate::resources::ConsumerKind,
+) -> Result<(), CommandError> {
+    state
+        .resources
+        .subscribe(&token, kind, crate::resources::now_ms());
+    Ok(())
+}
+
+/// Release a sampling lease (idempotent).
+#[tauri::command]
+pub async fn resources_unsubscribe(
+    state: State<'_, AppState>,
+    token: String,
+) -> Result<(), CommandError> {
+    state.resources.unsubscribe(&token);
+    Ok(())
+}
+
+/// The sanitized diagnostics document for a manual export. The frontend shows
+/// its `fields` list in a consent dialog and writes this exact document only
+/// after the user confirms — nothing is saved here.
+#[tauri::command]
+pub async fn resources_export(
+    state: State<'_, AppState>,
+) -> Result<crate::resources::ResourceExport, CommandError> {
+    Ok(state.resources.export(crate::resources::now_ms()))
 }
 
 /// Replace the full set of user-programmed quick commands. Create / edit /
@@ -337,6 +385,9 @@ pub async fn pty_create(
     env: Option<Vec<(String, String)>>,
     cols: u16,
     rows: u16,
+    // Workspace this terminal belongs to (the tab's workspace key), used only to
+    // attribute the shell's resource cost to its workspace (`resources.rs`).
+    workspace: Option<String>,
 ) -> Result<bool, CommandError> {
     let out_app = app.clone();
     let out_id = id.clone();
@@ -455,11 +506,11 @@ pub async fn pty_create(
         crate::mcpinject::prepare(&app, cwd.as_deref().unwrap_or_default()).await;
     }
 
-    state
+    let created = state
         .pty
         .create(
             crate::pty::PtySpec {
-                id,
+                id: id.clone(),
                 cwd,
                 shell,
                 args: args.unwrap_or_default(),
@@ -470,7 +521,20 @@ pub async fn pty_create(
             on_output,
             on_exit,
         )
-        .map_err(CommandError::from)
+        .map_err(CommandError::from)?;
+
+    // Register the fresh shell with the resource monitor: pid now, start time
+    // probed off-thread (fire-and-forget — attribution is best-effort and must
+    // never delay the spawn path).
+    if created {
+        if let Some(pid) = state.pty.pid_of(&id) {
+            let monitor = state.resources.clone();
+            tauri::async_runtime::spawn(crate::resources::register_terminal_probed(
+                monitor, id, pid, workspace,
+            ));
+        }
+    }
+    Ok(created)
 }
 
 /// Runtime info for the Settings → Browser MCP panel: the live `/mcp` endpoint +
@@ -650,6 +714,11 @@ pub async fn pty_resize(
 /// Kill a PTY's process and drop the session (idempotent).
 #[tauri::command]
 pub async fn pty_close(state: State<'_, AppState>, id: String) -> Result<(), CommandError> {
+    // Snapshot the terminal's last-known members first, so a subtree that
+    // survives the kill shows up as an orphan on the next resource sample.
+    state
+        .resources
+        .terminal_closed(&id, crate::resources::now_ms());
     state.pty.close(&id).map_err(CommandError::from)
 }
 

--- a/uxnandesktop/src-tauri/src/lib.rs
+++ b/uxnandesktop/src-tauri/src/lib.rs
@@ -37,6 +37,9 @@ mod pets;
 mod power;
 mod procscan;
 mod pty;
+// Public so the resource-observability integration tests (`tests/`) can drive
+// the monitor against real spawned processes through the crate's own API.
+pub mod resources;
 mod state;
 mod updater;
 mod usage;
@@ -101,7 +104,13 @@ pub fn run() {
             let focused = state.focused.clone();
             let hook_slot = state.hook.clone();
             let hook_install_slot = state.hook_install.clone();
+            let resources = state.resources.clone();
             app.manage(state);
+
+            // Resource observability sampler (`resources.rs`). Fully parked —
+            // no timer, no process-table walks — until a consumer subscribes
+            // (the backend popover) or the opt-in orphan sweep is enabled.
+            crate::resources::spawn_collector(app.handle().clone(), resources);
 
             // Start the local agent hook server (Layer 1). On success, publish its
             // url + token (+ the endpoint-file path it writes to `<data>/hooks/`)
@@ -249,6 +258,10 @@ pub fn run() {
                         let command = crate::procscan::detect_agent(&sys, pid, &commands);
                         if last.get(&pty_id) != Some(&command) {
                             last.insert(pty_id.clone(), command.clone());
+                            // Keep the resource monitor's terminal link in step,
+                            // so that terminal's subtree is attributed to the
+                            // agent (by kind) on the next resource sample.
+                            state.resources.set_terminal_agent(&pty_id, command.clone());
                             let _ = agent_handle
                                 .emit("agent:detected", AgentDetectedEvent { pty_id, command });
                         }
@@ -285,6 +298,10 @@ pub fn run() {
             commands::pet_window_hide,
             commands::pet_focus_main,
             commands::ping,
+            commands::resources_summary,
+            commands::resources_subscribe,
+            commands::resources_unsubscribe,
+            commands::resources_export,
             commands::usage_read,
             commands::usage_detect,
             commands::usage_codex_redeem_reset,

--- a/uxnandesktop/src-tauri/src/model.rs
+++ b/uxnandesktop/src-tauri/src/model.rs
@@ -506,6 +506,54 @@ pub struct AppSettings {
     /// (`SidebarProfile`), persisted opaquely. Absent by default.
     #[serde(default)]
     pub profile: Option<serde_json::Value>,
+    /// Local resource observability (`resources.rs`): the backend-popover summary
+    /// and Settings → Resources. All fields default, so older state loads
+    /// unchanged (the additive-field migration path every settings struct uses).
+    #[serde(default)]
+    pub resources: ResourceSettings,
+}
+
+/// Local resource observability (CPU / memory / process attribution for uxnan,
+/// its terminals and agents — `resources.rs`).
+///
+/// The collector is demand-driven: with `enabled` on it still samples **only**
+/// while a surface consumes it (the backend popover being open), so the default
+/// configuration costs nothing at rest. The only background sampling is the
+/// opt-in orphan sweep.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSettings {
+    /// Master switch for the whole feature (popover section + Settings pane
+    /// data). With no consumer the collector stays parked either way; off also
+    /// hides the surfaces. Default on — a parked collector is free.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Background sweep that keeps sampling slowly with no UI open, so orphaned
+    /// processes (a subtree that outlived its closed terminal) are noticed
+    /// without the popover. Off by default: it is the one mode that costs
+    /// anything unasked.
+    #[serde(default)]
+    pub orphan_sweep: bool,
+    /// Sweep interval in seconds. Clamped to 15–30 when applied — below that the
+    /// sweep would compete with the popover cadence, above it an orphan would
+    /// linger unnoticed.
+    #[serde(default = "default_orphan_sweep_seconds")]
+    pub orphan_sweep_seconds: u32,
+}
+
+/// Default orphan-sweep interval (seconds), the middle of the allowed 15–30 band.
+fn default_orphan_sweep_seconds() -> u32 {
+    20
+}
+
+impl Default for ResourceSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            orphan_sweep: false,
+            orphan_sweep_seconds: default_orphan_sweep_seconds(),
+        }
+    }
 }
 
 /// "Open with" configuration: user-added editors + hidden auto-detected ones.
@@ -1027,6 +1075,7 @@ impl Default for AppSettings {
             github: GithubSettings::default(),
             open_with: OpenWithSettings::default(),
             profile: None,
+            resources: ResourceSettings::default(),
         }
     }
 }

--- a/uxnandesktop/src-tauri/src/pty.rs
+++ b/uxnandesktop/src-tauri/src/pty.rs
@@ -241,6 +241,17 @@ impl PtyManager {
             .collect()
     }
 
+    /// The shell process id of one live session, or `None` when the id is
+    /// unknown to the manager or the child has no pid (already reaped). Used to
+    /// register the terminal with the resource monitor right after spawn.
+    pub fn pid_of(&self, id: &str) -> Option<u32> {
+        self.sessions
+            .lock()
+            .unwrap()
+            .get(id)
+            .and_then(|s| s.child.lock().unwrap().process_id())
+    }
+
     /// Number of live sessions (used by tests).
     #[cfg(test)]
     fn len(&self) -> usize {

--- a/uxnandesktop/src-tauri/src/resources.rs
+++ b/uxnandesktop/src-tauri/src/resources.rs
@@ -1,0 +1,2438 @@
+//! Local resource observability — CPU / memory / process attribution for uxnan
+//! itself, its terminals and the agents running inside them.
+//!
+//! This is **not** telemetry and **not** a general task manager: the collector
+//! only ever classifies the desktop process tree and the subtrees uxnan spawned
+//! (PTY shells and whatever runs inside them), answering "what is consuming
+//! resources on my behalf, and did anything outlive its owner?". Attribution is
+//! evidence-based — pid + start time + parent chain plus the explicit PTY links
+//! registered at spawn — and every figure carries a confidence
+//! (`exact` / `inferred` / `unknown`) instead of pretending precision.
+//!
+//! Deliberate boundaries, mirrored by the tests:
+//!
+//! - **Demand-driven sampling.** The sampler is fully parked (no timer, no
+//!   process-table walks, no retained `sysinfo` state) unless a consumer exists:
+//!   the backend popover (1–2 s), a budget consumer (2–5 s, reserved for the
+//!   future limits/orchestration engine) or the opt-in orphan sweep (15–30 s).
+//!   Parked must cost nothing observable.
+//! - **No content inspection.** Command lines, environment, sockets and file
+//!   paths of processes are never read here (identity comes from pids and the
+//!   registered links; the agent *name* comes from the existing detector). The
+//!   UI never receives a command line, and the export sanitizes every id.
+//! - **Absent data is never zero.** A metric the platform (or the first tick)
+//!   cannot provide is `None`, not `0`.
+//! - **Bounded memory.** Aggregated frames live in a circular buffer capped at
+//!   ~10 minutes; nothing per-process is persisted.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tauri::Emitter;
+use tokio::sync::{broadcast, Notify};
+
+// --- cadence & retention constants ------------------------------------------
+
+/// Sampling interval while the backend popover is open (the "live" view).
+pub const POPOVER_INTERVAL: Duration = Duration::from_secs(2);
+/// Sampling interval while a budget/orchestration consumer is subscribed.
+pub const BUDGET_INTERVAL: Duration = Duration::from_secs(3);
+/// Allowed band for the opt-in background orphan sweep (seconds).
+pub const SWEEP_MIN_SECS: u32 = 15;
+pub const SWEEP_MAX_SECS: u32 = 30;
+/// How much aggregated history the circular buffer retains (seconds).
+const BUFFER_MAX_SECONDS: u64 = 600;
+/// Hard frame-count cap for the buffer (safety net alongside the time cap).
+const BUFFER_MAX_FRAMES: usize = 640;
+/// Window for the "short average" statistics (ms).
+const SHORT_WINDOW_MS: u64 = 60_000;
+/// A group missing from the latest frame is still reported as `ended` for this
+/// long after its last appearance (ms).
+const ENDED_WINDOW_MS: u64 = 90_000;
+/// A UI subscription (lease) expires this long after its last renewal, so a
+/// webview reload that never unsubscribed cannot pin the fast cadence forever.
+const LEASE_TTL_MS: u64 = 90_000;
+/// Closed-terminal links whose identity cannot be verified (no start time) are
+/// dropped after this long instead of reporting an unverifiable orphan forever.
+const ORPHAN_UNVERIFIED_RETENTION_MS: u64 = 600_000;
+/// Start times within this many seconds count as the same process (different
+/// clocks truncate the boot-relative arithmetic differently).
+const START_TIME_TOLERANCE_SECS: u64 = 2;
+/// A gap between frames larger than this many × the interval invalidates the
+/// tick's rate metrics (CPU %, I/O per second) — they would average over the
+/// parked window and publish a number no user ever saw.
+const GAP_FACTOR: u32 = 3;
+/// Export document schema version.
+const EXPORT_SCHEMA_VERSION: u32 = 1;
+
+/// Epoch milliseconds now.
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+// --- contract types ----------------------------------------------------------
+
+/// Who a measured process (or aggregate) belongs to. `Bridge` and `Browser` are
+/// reserved for the embedded bridge / the integrated browser once either owns
+/// processes distinguishable without reading command lines; nothing produces
+/// them yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResourceOwnerKind {
+    Desktop,
+    Workspace,
+    Terminal,
+    Agent,
+    Bridge,
+    Browser,
+    Unknown,
+}
+
+/// How sure the attribution is. `Exact` = pid + start time verified against the
+/// registered link; `Inferred` = parent-chain evidence below a verified root;
+/// `Unknown` = identity could not be verified (e.g. a recycled pid).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AttributionConfidence {
+    Exact,
+    Inferred,
+    Unknown,
+}
+
+/// Direction of a group's memory over the buffered window.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Trend {
+    Rising,
+    Falling,
+    Steady,
+    #[default]
+    Unknown,
+}
+
+/// What kind of consumer holds a sampling lease (drives the cadence).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ConsumerKind {
+    /// The backend-popover live view (fast cadence, short-lived).
+    Popover,
+    /// A budget/limits or orchestration consumer (reserved; medium cadence).
+    Budget,
+}
+
+/// Which metrics this build/platform can provide. `validated` is the honest
+/// flag for "measured on real hardware": only Windows so far — the other
+/// platforms run the same portable `sysinfo` code but their figures have not
+/// been checked against reality, so surfaces should say "best effort".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceCapabilities {
+    pub cpu: bool,
+    pub memory: bool,
+    pub virtual_memory: bool,
+    pub io: bool,
+    pub start_time: bool,
+    pub validated: bool,
+}
+
+/// Capabilities of the running build.
+pub fn capabilities() -> ResourceCapabilities {
+    ResourceCapabilities {
+        cpu: true,
+        memory: true,
+        virtual_memory: true,
+        // sysinfo has no per-process I/O counters on the BSDs; everywhere else
+        // it reads them (validated on Windows only — see `validated`).
+        io: cfg!(any(
+            target_os = "windows",
+            target_os = "linux",
+            target_os = "macos"
+        )),
+        start_time: true,
+        validated: cfg!(target_os = "windows"),
+    }
+}
+
+/// One process's facts for a single tick, as read from the OS. Deliberately
+/// name-free: identity is the pid + start time, ownership is the parent chain.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ProcRow {
+    pub parent: Option<u32>,
+    /// Process start time (seconds since epoch); `None` when the platform
+    /// reports nothing (a raw `0` from the OS is mapped to `None`, never kept).
+    pub start_time_secs: Option<u64>,
+    /// CPU since the previous refresh, normalized to the whole machine (0–100).
+    /// `None` on a process's first sighting — sysinfo reports `0.0` there, and
+    /// absent data must not masquerade as an idle process.
+    pub cpu_percent: Option<f32>,
+    pub resident_bytes: u64,
+    pub virtual_bytes: u64,
+    /// Cumulative I/O totals (bytes), when the platform reports them.
+    pub io_read_total: Option<u64>,
+    pub io_write_total: Option<u64>,
+}
+
+/// The process table for one tick: pid → facts.
+pub type ProcTable = HashMap<u32, ProcRow>;
+
+/// Point-in-time metrics for one owner group. Every field that can be unknown
+/// is an `Option`: a `None` renders as "—", never as zero.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricSample {
+    pub processes: u32,
+    pub cpu_percent: Option<f32>,
+    pub resident_bytes: Option<u64>,
+    pub virtual_bytes: Option<u64>,
+    pub io_read_bytes_per_sec: Option<f64>,
+    pub io_write_bytes_per_sec: Option<f64>,
+}
+
+/// One owner group's aggregate within a single frame.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupSample {
+    pub kind: ResourceOwnerKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// The workspace an agent/terminal group belongs to, for grouping in the UI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<String>,
+    pub confidence: AttributionConfidence,
+    #[serde(flatten)]
+    pub metrics: MetricSample,
+}
+
+/// A subtree that outlived its closed owner, still alive on this tick.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrphanSample {
+    pub kind: ResourceOwnerKind,
+    pub id: String,
+    pub pids: Vec<u32>,
+    pub cpu_percent: Option<f32>,
+    pub resident_bytes: Option<u64>,
+    /// When the owner went away (epoch ms).
+    pub since_ms: u64,
+    pub confidence: AttributionConfidence,
+}
+
+/// One aggregated tick kept in the circular buffer. Never persisted.
+#[derive(Debug, Clone)]
+struct Frame {
+    at_ms: u64,
+    total: MetricSample,
+    groups: Vec<GroupSample>,
+    orphans: Vec<OrphanSample>,
+}
+
+/// Instant + short-average + peak + trend for one series, over the buffer.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricSummary {
+    pub processes: u32,
+    pub cpu_percent: Option<f32>,
+    pub cpu_avg_percent: Option<f32>,
+    pub cpu_peak_percent: Option<f32>,
+    pub resident_bytes: Option<u64>,
+    pub resident_avg_bytes: Option<u64>,
+    pub resident_peak_bytes: Option<u64>,
+    pub virtual_bytes: Option<u64>,
+    pub io_read_bytes_per_sec: Option<f64>,
+    pub io_write_bytes_per_sec: Option<f64>,
+    pub trend: Trend,
+}
+
+/// One owner group as the UI consumes it.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupSummary {
+    pub kind: ResourceOwnerKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<String>,
+    pub confidence: AttributionConfidence,
+    /// The group vanished from the latest frame (its processes ended) but is
+    /// still shown briefly so a just-finished agent doesn't silently disappear.
+    pub ended: bool,
+    #[serde(flatten)]
+    pub metrics: MetricSummary,
+}
+
+/// Whether/why/how fast the sampler is running right now.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SamplingState {
+    pub active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interval_ms: Option<u64>,
+    /// `"popover"` | `"budget"` | `"orphanSweep"` | `"off"`.
+    pub reason: &'static str,
+}
+
+/// The consolidated document the UI (and the internal event stream) consumes.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceSummary {
+    pub enabled: bool,
+    pub capabilities: ResourceCapabilities,
+    pub sampling: SamplingState,
+    /// Time of the newest buffered frame; `None` = nothing sampled yet.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at_ms: Option<u64>,
+    pub buffer_seconds: u32,
+    /// Everything attributed to uxnan (desktop + terminals + agents) combined.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<MetricSummary>,
+    pub groups: Vec<GroupSummary>,
+    pub orphans: Vec<OrphanSample>,
+    /// Registered live terminal links (context for the UI).
+    pub terminals_linked: u32,
+}
+
+// --- monitor configuration & registry ---------------------------------------
+
+/// Runtime configuration, derived from [`crate::model::ResourceSettings`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MonitorConfig {
+    pub enabled: bool,
+    pub orphan_sweep: bool,
+    /// Clamped to [`SWEEP_MIN_SECS`]–[`SWEEP_MAX_SECS`].
+    pub sweep_secs: u32,
+}
+
+impl Default for MonitorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            orphan_sweep: false,
+            sweep_secs: 20,
+        }
+    }
+}
+
+impl From<&crate::model::ResourceSettings> for MonitorConfig {
+    fn from(s: &crate::model::ResourceSettings) -> Self {
+        Self {
+            enabled: s.enabled,
+            orphan_sweep: s.orphan_sweep,
+            sweep_secs: s.orphan_sweep_seconds.clamp(SWEEP_MIN_SECS, SWEEP_MAX_SECS),
+        }
+    }
+}
+
+/// A live PTY link, registered at spawn: the explicit ownership evidence.
+#[derive(Debug, Clone)]
+struct TerminalLink {
+    pid: u32,
+    start_time_secs: Option<u64>,
+    workspace: Option<String>,
+    /// Agent command detected in this terminal (from the existing foreground
+    /// detector), if any. Advisory: it refines the owner *kind*, not identity.
+    agent: Option<String>,
+    /// A later sample saw a different process under this pid (start-time
+    /// mismatch): the link's evidence is void and its group reports `unknown`.
+    recycled: bool,
+}
+
+/// A closed terminal remembered so its survivors can be detected. Members are
+/// (pid, start time) pairs snapshotted from the last attribution before close.
+#[derive(Debug, Clone)]
+struct ClosedLink {
+    kind: ResourceOwnerKind,
+    id: String,
+    members: Vec<(u32, Option<u64>)>,
+    closed_at_ms: u64,
+}
+
+/// A consumer's sampling lease (renewed while its surface is open).
+#[derive(Debug, Clone, Copy)]
+struct Lease {
+    kind: ConsumerKind,
+    expires_at_ms: u64,
+}
+
+/// Per-pid state carried between ticks: identity + I/O totals for deltas.
+#[derive(Debug, Clone, Copy)]
+struct PrevSeen {
+    start_time_secs: Option<u64>,
+    io_read_total: Option<u64>,
+    io_write_total: Option<u64>,
+}
+
+#[derive(Debug, Default)]
+struct MonitorState {
+    config: MonitorConfig,
+    terminals: HashMap<String, TerminalLink>,
+    closed: Vec<ClosedLink>,
+    leases: HashMap<String, Lease>,
+    frames: VecDeque<Frame>,
+    /// pid → (start time, owner) from the newest attribution; feeds the member
+    /// snapshot a closing terminal takes.
+    last_attribution: HashMap<u32, (Option<u64>, OwnerRef)>,
+    /// pid → previous identity + I/O totals (drives deltas; cleared on park).
+    prev: HashMap<u32, PrevSeen>,
+    last_frame_at_ms: Option<u64>,
+    last_interval_ms: Option<u64>,
+}
+
+/// Who one process belongs to, resolved by [`attribute`].
+#[derive(Debug, Clone, PartialEq)]
+enum OwnerRef {
+    Desktop {
+        confidence: AttributionConfidence,
+    },
+    Terminal {
+        pty_id: String,
+        workspace: Option<String>,
+        confidence: AttributionConfidence,
+    },
+    Agent {
+        command: String,
+        workspace: Option<String>,
+        confidence: AttributionConfidence,
+    },
+}
+
+// --- the monitor -------------------------------------------------------------
+
+/// Owns the registry, the leases, the circular buffer and the derived
+/// summaries. All methods lock briefly and never across an await.
+pub struct ResourceMonitor {
+    state: Mutex<MonitorState>,
+    /// Wakes the sampler when the cadence may have changed (config, leases).
+    notify: Notify,
+    /// Internal event stream for future Rust-side consumers (budget engine,
+    /// orchestration): every ingested frame's summary is broadcast here.
+    events: broadcast::Sender<ResourceSummary>,
+}
+
+impl ResourceMonitor {
+    pub fn new(config: MonitorConfig) -> Arc<Self> {
+        let (events, _) = broadcast::channel(8);
+        Arc::new(Self {
+            state: Mutex::new(MonitorState {
+                config,
+                ..MonitorState::default()
+            }),
+            notify: Notify::new(),
+            events,
+        })
+    }
+
+    /// Apply new settings; wakes the sampler only when the config changed.
+    pub fn apply_settings(&self, settings: &crate::model::ResourceSettings) {
+        let next = MonitorConfig::from(settings);
+        let changed = {
+            let mut state = self.state.lock().unwrap();
+            let changed = state.config != next;
+            state.config = next;
+            changed
+        };
+        if changed {
+            self.notify.notify_waiters();
+        }
+    }
+
+    /// Subscribe to the internal per-frame summary stream (Rust-side consumers).
+    pub fn subscribe_events(&self) -> broadcast::Receiver<ResourceSummary> {
+        self.events.subscribe()
+    }
+
+    /// Wait until the cadence may have changed.
+    pub async fn changed(&self) {
+        self.notify.notified().await;
+    }
+
+    // --- registry -------------------------------------------------------------
+
+    /// Register a live terminal (called right after the PTY spawns). The start
+    /// time should come from a one-shot probe of that pid; `None` degrades the
+    /// link's confidence to `inferred` instead of failing.
+    pub fn register_terminal(
+        &self,
+        pty_id: &str,
+        pid: u32,
+        start_time_secs: Option<u64>,
+        workspace: Option<String>,
+    ) {
+        let mut state = self.state.lock().unwrap();
+        state.terminals.insert(
+            pty_id.to_string(),
+            TerminalLink {
+                pid,
+                start_time_secs,
+                workspace,
+                agent: None,
+                recycled: false,
+            },
+        );
+    }
+
+    /// Record (or clear) the agent detected in a terminal. Advisory — refines
+    /// the owner kind of that subtree's processes on the next tick.
+    pub fn set_terminal_agent(&self, pty_id: &str, agent: Option<String>) {
+        let mut state = self.state.lock().unwrap();
+        if let Some(link) = state.terminals.get_mut(pty_id) {
+            link.agent = agent;
+        }
+    }
+
+    /// A terminal closed: move its link to the closed list with a member
+    /// snapshot (from the last attribution), so survivors show up as orphans.
+    pub fn terminal_closed(&self, pty_id: &str, now_ms: u64) {
+        let mut state = self.state.lock().unwrap();
+        let Some(link) = state.terminals.remove(pty_id) else {
+            return;
+        };
+        let mut members: Vec<(u32, Option<u64>)> = state
+            .last_attribution
+            .iter()
+            .filter(|(_, (_, owner))| owner_is_terminal(owner, pty_id))
+            .map(|(pid, (start, _))| (*pid, *start))
+            .collect();
+        if !members.iter().any(|(pid, _)| *pid == link.pid) {
+            members.push((link.pid, link.start_time_secs));
+        }
+        let (kind, id) = match &link.agent {
+            Some(agent) => (ResourceOwnerKind::Agent, agent.clone()),
+            None => (ResourceOwnerKind::Terminal, pty_id.to_string()),
+        };
+        state.closed.push(ClosedLink {
+            kind,
+            id,
+            members,
+            closed_at_ms: now_ms,
+        });
+    }
+
+    // --- leases ---------------------------------------------------------------
+
+    /// Take or renew a sampling lease. Leases expire on their own (TTL), so a
+    /// consumer that vanished without unsubscribing cannot pin the cadence.
+    pub fn subscribe(&self, token: &str, kind: ConsumerKind, now_ms: u64) {
+        {
+            let mut state = self.state.lock().unwrap();
+            state.leases.insert(
+                token.to_string(),
+                Lease {
+                    kind,
+                    expires_at_ms: now_ms + LEASE_TTL_MS,
+                },
+            );
+        }
+        self.notify.notify_waiters();
+    }
+
+    /// Release a sampling lease (idempotent).
+    pub fn unsubscribe(&self, token: &str) {
+        let removed = self.state.lock().unwrap().leases.remove(token).is_some();
+        if removed {
+            self.notify.notify_waiters();
+        }
+    }
+
+    /// The interval + reason the sampler should run at, or `None` = fully
+    /// parked. Prunes expired leases as a side effect.
+    pub fn cadence(&self, now_ms: u64) -> Option<(Duration, &'static str)> {
+        let mut state = self.state.lock().unwrap();
+        state.leases.retain(|_, lease| lease.expires_at_ms > now_ms);
+        resolve_cadence(
+            state.config,
+            state.leases.values().map(|l| l.kind).collect::<Vec<_>>(),
+        )
+    }
+
+    /// Drop everything only sampling needs (delta state, the OS handle is the
+    /// caller's), so a parked collector holds no per-process state at all.
+    pub fn clear_transient(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.prev.clear();
+        state.last_frame_at_ms = None;
+        state.last_interval_ms = None;
+    }
+
+    // --- sampling pipeline ----------------------------------------------------
+
+    /// Ingest one process table: attribute, compute deltas, detect orphans,
+    /// push the aggregated frame into the buffer and return the fresh summary
+    /// (also broadcast to internal subscribers).
+    pub fn ingest(&self, now_ms: u64, desktop_pid: u32, table: ProcTable) -> ResourceSummary {
+        let mut state = self.state.lock().unwrap();
+        let interval_ms = self
+            .cadence_locked(&mut state, now_ms)
+            .map(|(d, _)| d.as_millis() as u64);
+
+        // A gap (parked window, missed ticks) invalidates rate metrics.
+        let gap = match (state.last_frame_at_ms, interval_ms) {
+            (Some(last), Some(interval)) => {
+                now_ms.saturating_sub(last) > interval * GAP_FACTOR as u64
+            }
+            _ => true,
+        };
+        let elapsed_secs = state
+            .last_frame_at_ms
+            .map(|last| (now_ms.saturating_sub(last)) as f64 / 1000.0)
+            .filter(|s| *s > 0.0);
+
+        // Per-pid deltas + first-sight / identity rules.
+        let mut rows: HashMap<u32, ProcRow> = HashMap::with_capacity(table.len());
+        for (pid, mut row) in table {
+            let prev = state.prev.get(&pid).copied();
+            let same_identity = prev
+                .map(|p| start_times_match(p.start_time_secs, row.start_time_secs))
+                .unwrap_or(false);
+            if gap || !same_identity {
+                row.cpu_percent = None;
+            }
+            let (read_ps, write_ps) = if gap || !same_identity {
+                (None, None)
+            } else {
+                (
+                    io_rate(
+                        prev.and_then(|p| p.io_read_total),
+                        row.io_read_total,
+                        elapsed_secs,
+                    ),
+                    io_rate(
+                        prev.and_then(|p| p.io_write_total),
+                        row.io_write_total,
+                        elapsed_secs,
+                    ),
+                )
+            };
+            // Reuse the total fields to carry the computed per-second rates into
+            // aggregation (the totals themselves never leave this function).
+            let io_read_total = row.io_read_total;
+            let io_write_total = row.io_write_total;
+            state.prev.insert(
+                pid,
+                PrevSeen {
+                    start_time_secs: row.start_time_secs,
+                    io_read_total,
+                    io_write_total,
+                },
+            );
+            row.io_read_total = read_ps.map(|v| v as u64);
+            row.io_write_total = write_ps.map(|v| v as u64);
+            rows.insert(pid, row);
+        }
+        state.prev.retain(|pid, _| rows.contains_key(pid));
+
+        // Attribution over the delta-adjusted table.
+        let (attribution, recycled) = attribute(&rows, desktop_pid, &state.terminals);
+        for pty_id in &recycled {
+            if let Some(link) = state.terminals.get_mut(pty_id) {
+                link.recycled = true;
+            }
+        }
+        let (total, groups) = aggregate(&rows, &attribution, &state.terminals);
+
+        // Orphans: closed links whose members are still alive.
+        let orphans = check_orphans(&mut state.closed, &rows, now_ms);
+
+        state.last_attribution = attribution
+            .into_iter()
+            .map(|(pid, owner)| {
+                let start = rows.get(&pid).and_then(|r| r.start_time_secs);
+                (pid, (start, owner))
+            })
+            .collect();
+
+        state.frames.push_back(Frame {
+            at_ms: now_ms,
+            total,
+            groups,
+            orphans,
+        });
+        trim_frames(&mut state.frames, now_ms);
+        state.last_frame_at_ms = Some(now_ms);
+        state.last_interval_ms = interval_ms;
+
+        let summary = build_summary(&state, now_ms);
+        drop(state);
+        let _ = self.events.send(summary.clone());
+        summary
+    }
+
+    /// The current summary from buffered frames (no fresh sample).
+    pub fn summary(&self, now_ms: u64) -> ResourceSummary {
+        let mut state = self.state.lock().unwrap();
+        state.leases.retain(|_, lease| lease.expires_at_ms > now_ms);
+        build_summary(&state, now_ms)
+    }
+
+    /// The sanitized diagnostics document for a manual export.
+    pub fn export(&self, now_ms: u64) -> ResourceExport {
+        let state = self.state.lock().unwrap();
+        let summary = build_summary(&state, now_ms);
+        sanitize_export(&summary, now_ms)
+    }
+
+    fn cadence_locked(
+        &self,
+        state: &mut MonitorState,
+        now_ms: u64,
+    ) -> Option<(Duration, &'static str)> {
+        state.leases.retain(|_, lease| lease.expires_at_ms > now_ms);
+        resolve_cadence(
+            state.config,
+            state.leases.values().map(|l| l.kind).collect::<Vec<_>>(),
+        )
+    }
+}
+
+fn owner_is_terminal(owner: &OwnerRef, pty_id: &str) -> bool {
+    match owner {
+        OwnerRef::Terminal { pty_id: id, .. } => id == pty_id,
+        // Agent processes still belong to the terminal that hosts them.
+        OwnerRef::Agent { .. } => false,
+        OwnerRef::Desktop { .. } => false,
+    }
+}
+
+// --- pure pipeline stages (unit-tested) --------------------------------------
+
+/// Resolve the sampling cadence from config + live lease kinds.
+/// Priority: popover (fastest) → budget → orphan sweep → parked.
+fn resolve_cadence(
+    config: MonitorConfig,
+    leases: Vec<ConsumerKind>,
+) -> Option<(Duration, &'static str)> {
+    if !config.enabled {
+        return None;
+    }
+    if leases.contains(&ConsumerKind::Popover) {
+        return Some((POPOVER_INTERVAL, "popover"));
+    }
+    if leases.contains(&ConsumerKind::Budget) {
+        return Some((BUDGET_INTERVAL, "budget"));
+    }
+    if config.orphan_sweep {
+        let secs = config.sweep_secs.clamp(SWEEP_MIN_SECS, SWEEP_MAX_SECS);
+        return Some((Duration::from_secs(secs as u64), "orphanSweep"));
+    }
+    None
+}
+
+/// Whether two optional start times identify the same process. Both unknown →
+/// cannot verify (treated as *not* matching for identity-sensitive paths that
+/// require proof, but links without a start time are handled explicitly).
+fn start_times_match(a: Option<u64>, b: Option<u64>) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => a.abs_diff(b) <= START_TIME_TOLERANCE_SECS,
+        _ => false,
+    }
+}
+
+/// Attribute every relevant process to an owner.
+///
+/// - Registered PTY shells claim their subtree: the shell `exact` (pid + start
+///   time verified; `inferred` when the platform gave no start time), each
+///   descendant `inferred`. A detected agent turns the descendants' kind into
+///   `Agent`.
+/// - A start-time mismatch on a link's pid = recycled pid: nothing is claimed
+///   and the pty id is reported so the link can be voided.
+/// - The desktop tree is everything under our own pid *minus* claimed subtrees
+///   (webview/gpu helpers land here). Unrelated processes are never classified.
+fn attribute(
+    table: &ProcTable,
+    desktop_pid: u32,
+    links: &HashMap<String, TerminalLink>,
+) -> (HashMap<u32, OwnerRef>, Vec<String>) {
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    for (pid, row) in table {
+        if let Some(parent) = row.parent {
+            children.entry(parent).or_default().push(*pid);
+        }
+    }
+
+    let mut owners: HashMap<u32, OwnerRef> = HashMap::new();
+    let mut recycled: Vec<String> = Vec::new();
+
+    for (pty_id, link) in links {
+        if link.recycled {
+            continue;
+        }
+        let Some(row) = table.get(&link.pid) else {
+            continue; // shell gone; the group will show as ended
+        };
+        let shell_confidence = match (link.start_time_secs, row.start_time_secs) {
+            (Some(_), Some(_)) if start_times_match(link.start_time_secs, row.start_time_secs) => {
+                AttributionConfidence::Exact
+            }
+            (Some(_), Some(_)) => {
+                recycled.push(pty_id.clone());
+                continue; // different process under the same pid — claim nothing
+            }
+            // Missing evidence on either side: attribute, but honestly.
+            _ => AttributionConfidence::Inferred,
+        };
+        owners.insert(
+            link.pid,
+            OwnerRef::Terminal {
+                pty_id: pty_id.clone(),
+                workspace: link.workspace.clone(),
+                confidence: shell_confidence,
+            },
+        );
+        // Claim descendants breadth-first (cycle-safe via the owners map).
+        let mut queue: Vec<u32> = children.get(&link.pid).cloned().unwrap_or_default();
+        let mut seen: HashSet<u32> = HashSet::new();
+        while let Some(pid) = queue.pop() {
+            if !seen.insert(pid) || owners.contains_key(&pid) {
+                continue;
+            }
+            let owner = match &link.agent {
+                Some(command) => OwnerRef::Agent {
+                    command: command.clone(),
+                    workspace: link.workspace.clone(),
+                    confidence: AttributionConfidence::Inferred,
+                },
+                None => OwnerRef::Terminal {
+                    pty_id: pty_id.clone(),
+                    workspace: link.workspace.clone(),
+                    confidence: AttributionConfidence::Inferred,
+                },
+            };
+            owners.insert(pid, owner);
+            if let Some(kids) = children.get(&pid) {
+                queue.extend(kids.iter().copied());
+            }
+        }
+    }
+
+    // Desktop tree: our pid + descendants, never descending into claimed nodes.
+    if table.contains_key(&desktop_pid) {
+        owners.entry(desktop_pid).or_insert(OwnerRef::Desktop {
+            confidence: AttributionConfidence::Exact,
+        });
+        let mut queue: Vec<u32> = children.get(&desktop_pid).cloned().unwrap_or_default();
+        let mut seen: HashSet<u32> = HashSet::new();
+        while let Some(pid) = queue.pop() {
+            if !seen.insert(pid) || owners.contains_key(&pid) {
+                continue;
+            }
+            owners.insert(
+                pid,
+                OwnerRef::Desktop {
+                    confidence: AttributionConfidence::Inferred,
+                },
+            );
+            if let Some(kids) = children.get(&pid) {
+                queue.extend(kids.iter().copied());
+            }
+        }
+    }
+
+    (owners, recycled)
+}
+
+/// I/O bytes/second from two cumulative totals, `None` when either side (or the
+/// elapsed window) is unknown.
+fn io_rate(
+    prev_total: Option<u64>,
+    now_total: Option<u64>,
+    elapsed_secs: Option<f64>,
+) -> Option<f64> {
+    let (prev, now, secs) = (prev_total?, now_total?, elapsed_secs?);
+    Some(now.saturating_sub(prev) as f64 / secs)
+}
+
+/// Fold one process's metrics into an accumulating [`MetricSample`].
+/// Rate metrics stay honest: one unknown member makes the group unknown for
+/// that tick (a partial sum shown as a fact would under-report).
+fn fold(acc: &mut MetricSample, row: &ProcRow, any_cpu_none: &mut bool, any_io_none: &mut bool) {
+    acc.processes += 1;
+    match row.cpu_percent {
+        Some(cpu) => *acc.cpu_percent.get_or_insert(0.0) += cpu,
+        None => *any_cpu_none = true,
+    }
+    *acc.resident_bytes.get_or_insert(0) += row.resident_bytes;
+    *acc.virtual_bytes.get_or_insert(0) += row.virtual_bytes;
+    // `io_*_total` carry per-second rates at this stage (see `ingest`).
+    match row.io_read_total {
+        Some(v) => *acc.io_read_bytes_per_sec.get_or_insert(0.0) += v as f64,
+        None => *any_io_none = true,
+    }
+    match row.io_write_total {
+        Some(v) => *acc.io_write_bytes_per_sec.get_or_insert(0.0) += v as f64,
+        None => *any_io_none = true,
+    }
+}
+
+/// Aggregate attributed processes into per-owner groups + the uxnan total.
+/// Recycled links contribute an explicit `unknown` group with no metrics, so
+/// the UI can say "identity lost" instead of silently dropping the terminal.
+fn aggregate(
+    table: &ProcTable,
+    owners: &HashMap<u32, OwnerRef>,
+    links: &HashMap<String, TerminalLink>,
+) -> (MetricSample, Vec<GroupSample>) {
+    #[derive(Default)]
+    struct Accum {
+        metrics: MetricSample,
+        confidence: Option<AttributionConfidence>,
+        workspace: Option<String>,
+        any_cpu_none: bool,
+        any_io_none: bool,
+    }
+    // Group keys: desktop → (Desktop, None); terminals fold into their
+    // workspace → (Workspace, path) or (Terminal, pty id) when unassigned;
+    // agents → (Agent, command).
+    let mut accums: HashMap<(ResourceOwnerKind, Option<String>), Accum> = HashMap::new();
+    let mut total = MetricSample::default();
+    let mut total_cpu_none = false;
+    let mut total_io_none = false;
+
+    for (pid, owner) in owners {
+        let Some(row) = table.get(pid) else { continue };
+        let (key, confidence, workspace) = match owner {
+            OwnerRef::Desktop { confidence } => {
+                ((ResourceOwnerKind::Desktop, None), *confidence, None)
+            }
+            OwnerRef::Terminal {
+                pty_id,
+                workspace,
+                confidence,
+            } => match workspace {
+                Some(ws) => (
+                    (ResourceOwnerKind::Workspace, Some(ws.clone())),
+                    *confidence,
+                    Some(ws.clone()),
+                ),
+                None => (
+                    (ResourceOwnerKind::Terminal, Some(pty_id.clone())),
+                    *confidence,
+                    None,
+                ),
+            },
+            OwnerRef::Agent {
+                command,
+                workspace,
+                confidence,
+            } => (
+                (ResourceOwnerKind::Agent, Some(command.clone())),
+                *confidence,
+                workspace.clone(),
+            ),
+        };
+        let acc = accums.entry(key).or_default();
+        fold(
+            &mut acc.metrics,
+            row,
+            &mut acc.any_cpu_none,
+            &mut acc.any_io_none,
+        );
+        fold(&mut total, row, &mut total_cpu_none, &mut total_io_none);
+        acc.workspace = acc.workspace.take().or(workspace);
+        // A group is only as sure as its least-sure member.
+        acc.confidence = Some(match acc.confidence {
+            Some(existing) => weakest(existing, confidence),
+            None => confidence,
+        });
+    }
+
+    let finish = |mut m: MetricSample, cpu_none: bool, io_none: bool| {
+        if cpu_none {
+            m.cpu_percent = None;
+        }
+        if io_none {
+            m.io_read_bytes_per_sec = None;
+            m.io_write_bytes_per_sec = None;
+        }
+        m
+    };
+
+    let mut groups: Vec<GroupSample> = accums
+        .into_iter()
+        .map(|((kind, id), acc)| GroupSample {
+            kind,
+            id,
+            workspace: acc.workspace,
+            confidence: acc.confidence.unwrap_or(AttributionConfidence::Unknown),
+            metrics: finish(acc.metrics, acc.any_cpu_none, acc.any_io_none),
+        })
+        .collect();
+
+    // Recycled links: an explicit unknown group with no metrics (never zeros).
+    for (pty_id, link) in links {
+        if link.recycled {
+            groups.push(GroupSample {
+                kind: ResourceOwnerKind::Terminal,
+                id: Some(pty_id.clone()),
+                workspace: link.workspace.clone(),
+                confidence: AttributionConfidence::Unknown,
+                metrics: MetricSample::default(),
+            });
+        }
+    }
+
+    groups.sort_by(|a, b| (kind_rank(a.kind), &a.id).cmp(&(kind_rank(b.kind), &b.id)));
+    (finish(total, total_cpu_none, total_io_none), groups)
+}
+
+fn weakest(a: AttributionConfidence, b: AttributionConfidence) -> AttributionConfidence {
+    use AttributionConfidence::*;
+    match (a, b) {
+        (Unknown, _) | (_, Unknown) => Unknown,
+        (Inferred, _) | (_, Inferred) => Inferred,
+        (Exact, Exact) => Exact,
+    }
+}
+
+fn kind_rank(kind: ResourceOwnerKind) -> u8 {
+    match kind {
+        ResourceOwnerKind::Desktop => 0,
+        ResourceOwnerKind::Workspace => 1,
+        ResourceOwnerKind::Terminal => 2,
+        ResourceOwnerKind::Agent => 3,
+        ResourceOwnerKind::Bridge => 4,
+        ResourceOwnerKind::Browser => 5,
+        ResourceOwnerKind::Unknown => 6,
+    }
+}
+
+/// Which closed-link members are still alive → orphan reports. Links whose
+/// members all died are dropped; unverifiable links (no start time to prove
+/// identity) are dropped after a retention window instead of claiming forever.
+fn check_orphans(
+    closed: &mut Vec<ClosedLink>,
+    table: &ProcTable,
+    now_ms: u64,
+) -> Vec<OrphanSample> {
+    let mut orphans = Vec::new();
+    closed.retain(|link| {
+        let mut alive: Vec<(u32, bool)> = Vec::new(); // (pid, identity verified)
+        for (pid, start) in &link.members {
+            let Some(row) = table.get(pid) else { continue };
+            match (start, row.start_time_secs) {
+                (Some(_), Some(_)) => {
+                    if start_times_match(*start, row.start_time_secs) {
+                        alive.push((*pid, true));
+                    } // else: recycled pid — not our survivor
+                }
+                _ => alive.push((*pid, false)), // alive, but unprovable
+            }
+        }
+        if alive.is_empty() {
+            return false; // everything ended — the link served its purpose
+        }
+        let verified = alive.iter().all(|(_, v)| *v);
+        if !verified && now_ms.saturating_sub(link.closed_at_ms) > ORPHAN_UNVERIFIED_RETENTION_MS {
+            return false; // cannot prove identity and it's been too long — stop claiming
+        }
+        let mut cpu: Option<f32> = None;
+        let mut cpu_unknown = false;
+        let mut rss: u64 = 0;
+        for (pid, _) in &alive {
+            if let Some(row) = table.get(pid) {
+                match row.cpu_percent {
+                    Some(v) => *cpu.get_or_insert(0.0) += v,
+                    None => cpu_unknown = true,
+                }
+                rss += row.resident_bytes;
+            }
+        }
+        orphans.push(OrphanSample {
+            kind: link.kind,
+            id: link.id.clone(),
+            pids: alive.iter().map(|(pid, _)| *pid).collect(),
+            cpu_percent: if cpu_unknown { None } else { cpu },
+            resident_bytes: Some(rss),
+            since_ms: link.closed_at_ms,
+            confidence: if verified {
+                AttributionConfidence::Exact
+            } else {
+                AttributionConfidence::Unknown
+            },
+        });
+        true
+    });
+    orphans
+}
+
+/// Drop frames past the time window and the hard count cap.
+fn trim_frames(frames: &mut VecDeque<Frame>, now_ms: u64) {
+    let horizon = now_ms.saturating_sub(BUFFER_MAX_SECONDS * 1000);
+    while frames.front().map(|f| f.at_ms < horizon).unwrap_or(false) {
+        frames.pop_front();
+    }
+    while frames.len() > BUFFER_MAX_FRAMES {
+        frames.pop_front();
+    }
+}
+
+/// Instant / short-average / peak / trend over one series of appearances.
+fn metric_summary(appearances: &[(u64, &MetricSample)], now_ms: u64) -> MetricSummary {
+    let Some((_, latest)) = appearances.last() else {
+        return MetricSummary {
+            trend: Trend::Unknown,
+            ..MetricSummary::default()
+        };
+    };
+    let short_horizon = now_ms.saturating_sub(SHORT_WINDOW_MS);
+    let short: Vec<&MetricSample> = appearances
+        .iter()
+        .filter(|(at, _)| *at >= short_horizon)
+        .map(|(_, m)| *m)
+        .collect();
+
+    let cpu_values: Vec<f32> = short.iter().filter_map(|m| m.cpu_percent).collect();
+    let cpu_avg = if cpu_values.is_empty() {
+        None
+    } else {
+        Some(cpu_values.iter().sum::<f32>() / cpu_values.len() as f32)
+    };
+    let rss_values: Vec<u64> = short.iter().filter_map(|m| m.resident_bytes).collect();
+    let rss_avg = if rss_values.is_empty() {
+        None
+    } else {
+        Some(rss_values.iter().sum::<u64>() / rss_values.len() as u64)
+    };
+
+    let cpu_peak = appearances
+        .iter()
+        .filter_map(|(_, m)| m.cpu_percent)
+        .fold(None::<f32>, |peak, v| Some(peak.map_or(v, |p| p.max(v))));
+    let rss_peak = appearances
+        .iter()
+        .filter_map(|(_, m)| m.resident_bytes)
+        .max();
+
+    MetricSummary {
+        processes: latest.processes,
+        cpu_percent: latest.cpu_percent,
+        cpu_avg_percent: cpu_avg,
+        cpu_peak_percent: cpu_peak,
+        resident_bytes: latest.resident_bytes,
+        resident_avg_bytes: rss_avg,
+        resident_peak_bytes: rss_peak,
+        virtual_bytes: latest.virtual_bytes,
+        io_read_bytes_per_sec: latest.io_read_bytes_per_sec,
+        io_write_bytes_per_sec: latest.io_write_bytes_per_sec,
+        trend: trend_of(appearances),
+    }
+}
+
+/// Memory trend over the buffered window: compare the two halves' mean RSS.
+/// Fewer than 6 points is `unknown` — a trend from 3 samples is a coin flip.
+fn trend_of(appearances: &[(u64, &MetricSample)]) -> Trend {
+    let rss: Vec<u64> = appearances
+        .iter()
+        .filter_map(|(_, m)| m.resident_bytes)
+        .collect();
+    if rss.len() < 6 {
+        return Trend::Unknown;
+    }
+    let mid = rss.len() / 2;
+    let first = rss[..mid].iter().sum::<u64>() as f64 / mid as f64;
+    let second = rss[mid..].iter().sum::<u64>() as f64 / (rss.len() - mid) as f64;
+    if first <= 0.0 {
+        return Trend::Unknown;
+    }
+    let ratio = second / first;
+    if ratio > 1.05 {
+        Trend::Rising
+    } else if ratio < 0.95 {
+        Trend::Falling
+    } else {
+        Trend::Steady
+    }
+}
+
+/// Build the consolidated summary from the buffered frames + live state.
+fn build_summary(state: &MonitorState, now_ms: u64) -> ResourceSummary {
+    let sampling = match resolve_cadence(
+        state.config,
+        state.leases.values().map(|l| l.kind).collect::<Vec<_>>(),
+    ) {
+        Some((interval, reason)) => SamplingState {
+            active: true,
+            interval_ms: Some(interval.as_millis() as u64),
+            reason,
+        },
+        None => SamplingState {
+            active: false,
+            interval_ms: None,
+            reason: "off",
+        },
+    };
+
+    let frames: Vec<&Frame> = state.frames.iter().collect();
+    let latest = frames.last();
+
+    // Total series.
+    let total_series: Vec<(u64, &MetricSample)> =
+        frames.iter().map(|f| (f.at_ms, &f.total)).collect();
+    let total = latest.map(|_| metric_summary(&total_series, now_ms));
+
+    // Group series, keyed by (kind, id).
+    type Key = (ResourceOwnerKind, Option<String>);
+    let mut series: HashMap<Key, Vec<(u64, &GroupSample)>> = HashMap::new();
+    for frame in &frames {
+        for group in &frame.groups {
+            series
+                .entry((group.kind, group.id.clone()))
+                .or_default()
+                .push((frame.at_ms, group));
+        }
+    }
+    let current: HashSet<Key> = latest
+        .map(|f| f.groups.iter().map(|g| (g.kind, g.id.clone())).collect())
+        .unwrap_or_default();
+
+    let mut groups: Vec<GroupSummary> = Vec::new();
+    for (key, appearances) in &series {
+        let last = appearances.last().expect("series entries are never empty");
+        let ended = !current.contains(key);
+        if ended && now_ms.saturating_sub(last.0) > ENDED_WINDOW_MS {
+            continue; // long gone — not even worth an "ended" row
+        }
+        let metric_appearances: Vec<(u64, &MetricSample)> = appearances
+            .iter()
+            .map(|(at, g)| (*at, &g.metrics))
+            .collect();
+        groups.push(GroupSummary {
+            kind: key.0,
+            id: key.1.clone(),
+            workspace: last.1.workspace.clone(),
+            confidence: last.1.confidence,
+            ended,
+            metrics: metric_summary(&metric_appearances, now_ms),
+        });
+    }
+    groups.sort_by(|a, b| {
+        (a.ended, kind_rank(a.kind), &a.id).cmp(&(b.ended, kind_rank(b.kind), &b.id))
+    });
+
+    ResourceSummary {
+        enabled: state.config.enabled,
+        capabilities: capabilities(),
+        sampling,
+        updated_at_ms: latest.map(|f| f.at_ms),
+        buffer_seconds: BUFFER_MAX_SECONDS as u32,
+        total,
+        groups,
+        orphans: latest.map(|f| f.orphans.clone()).unwrap_or_default(),
+        terminals_linked: state.terminals.len() as u32,
+    }
+}
+
+// --- export (manual, sanitized) ----------------------------------------------
+
+/// The manual-export document. Everything identifying is anonymized before it
+/// gets here (see [`sanitize_export`]); `fields` lists exactly what the file
+/// contains so the consent dialog can show it before anything is saved.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceExport {
+    pub schema_version: u32,
+    pub exported_at_ms: u64,
+    pub platform: &'static str,
+    pub app_version: &'static str,
+    pub capabilities: ResourceCapabilities,
+    pub sampling: SamplingState,
+    pub buffer_seconds: u32,
+    pub fields: Vec<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<MetricSummary>,
+    pub groups: Vec<GroupSummary>,
+    pub orphans: Vec<OrphanSample>,
+}
+
+/// The flat field list shown by the consent dialog (kept in sync with the
+/// export shape by the schema test below).
+const EXPORT_FIELDS: &[&str] = &[
+    "schemaVersion",
+    "exportedAtMs",
+    "platform",
+    "appVersion",
+    "capabilities",
+    "sampling",
+    "bufferSeconds",
+    "kind",
+    "id (anonymized: workspace-N / terminal-N / agent name)",
+    "workspace (anonymized: workspace-N)",
+    "confidence",
+    "ended",
+    "processes",
+    "cpuPercent / cpuAvgPercent / cpuPeakPercent",
+    "residentBytes / residentAvgBytes / residentPeakBytes",
+    "virtualBytes",
+    "ioReadBytesPerSec / ioWriteBytesPerSec",
+    "trend",
+    "pids (orphans only)",
+    "sinceMs (orphans only)",
+];
+
+/// Agent commands safe to export verbatim: the known catalog names. An
+/// explicit allow-list rather than a shape heuristic on purpose — a heuristic
+/// cannot tell `claude` from a lowercase token like `ghp_…`, and the failure
+/// mode of an out-of-date list is an anonymized label, never a leak.
+const EXPORTABLE_AGENT_IDS: &[&str] = &[
+    "claude",
+    "codex",
+    "gemini",
+    "opencode",
+    "pi",
+    "agy",
+    "goose",
+    "grok",
+    "zero",
+    "openclaude",
+    "aider",
+    "cursor-agent",
+];
+
+/// Whether an agent command may appear verbatim in the export.
+fn exportable_agent_id(id: &str) -> bool {
+    EXPORTABLE_AGENT_IDS.contains(&id)
+}
+
+/// Strip every identifying string from a summary: workspace paths and terminal
+/// ids become sequential opaque labels, agent commands survive only when they
+/// are bare catalog-style names. PIDs stay (they are the point of a process
+/// diagnostic and identify nothing outside this machine and boot).
+fn sanitize_export(summary: &ResourceSummary, now_ms: u64) -> ResourceExport {
+    /// Stable opaque label per distinct value (`workspace-1`, `terminal-2`, …).
+    fn label(map: &mut HashMap<String, String>, prefix: &str, value: &str) -> String {
+        if let Some(existing) = map.get(value) {
+            return existing.clone();
+        }
+        let next = format!("{prefix}-{}", map.len() + 1);
+        map.insert(value.to_string(), next.clone());
+        next
+    }
+
+    struct Labels {
+        workspaces: HashMap<String, String>,
+        terminals: HashMap<String, String>,
+        agents: HashMap<String, String>,
+    }
+    impl Labels {
+        fn sanitize_id(&mut self, kind: ResourceOwnerKind, id: &str) -> String {
+            match kind {
+                ResourceOwnerKind::Workspace => label(&mut self.workspaces, "workspace", id),
+                ResourceOwnerKind::Terminal => label(&mut self.terminals, "terminal", id),
+                ResourceOwnerKind::Agent => {
+                    if exportable_agent_id(id) {
+                        id.to_string()
+                    } else {
+                        label(&mut self.agents, "agent", id)
+                    }
+                }
+                _ => label(&mut self.agents, "owner", id),
+            }
+        }
+    }
+    let mut labels = Labels {
+        workspaces: HashMap::new(),
+        terminals: HashMap::new(),
+        agents: HashMap::new(),
+    };
+
+    let mut groups = Vec::with_capacity(summary.groups.len());
+    for g in &summary.groups {
+        let id = g.id.as_deref().map(|id| labels.sanitize_id(g.kind, id));
+        let workspace = g
+            .workspace
+            .as_deref()
+            .map(|ws| label(&mut labels.workspaces, "workspace", ws));
+        groups.push(GroupSummary {
+            kind: g.kind,
+            id,
+            workspace,
+            confidence: g.confidence,
+            ended: g.ended,
+            metrics: g.metrics.clone(),
+        });
+    }
+
+    let mut orphans = Vec::with_capacity(summary.orphans.len());
+    for o in &summary.orphans {
+        orphans.push(OrphanSample {
+            kind: o.kind,
+            id: labels.sanitize_id(o.kind, &o.id),
+            pids: o.pids.clone(),
+            cpu_percent: o.cpu_percent,
+            resident_bytes: o.resident_bytes,
+            since_ms: o.since_ms,
+            confidence: o.confidence,
+        });
+    }
+
+    ResourceExport {
+        schema_version: EXPORT_SCHEMA_VERSION,
+        exported_at_ms: now_ms,
+        platform: std::env::consts::OS,
+        app_version: env!("CARGO_PKG_VERSION"),
+        capabilities: summary.capabilities,
+        sampling: summary.sampling.clone(),
+        buffer_seconds: summary.buffer_seconds,
+        fields: EXPORT_FIELDS.to_vec(),
+        total: summary.total.clone(),
+        groups,
+        orphans,
+    }
+}
+
+// --- the OS collector & sampler loop -----------------------------------------
+
+/// Reads the live process table via `sysinfo`. Owns the `System` so the OS
+/// handle (and its per-process bookkeeping) exists **only while sampling** —
+/// dropping the collector is what makes "parked" cost nothing.
+pub struct Collector {
+    sys: sysinfo::System,
+    cores: usize,
+}
+
+impl Default for Collector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Collector {
+    pub fn new() -> Self {
+        Self {
+            sys: sysinfo::System::new(),
+            cores: std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(1),
+        }
+    }
+
+    /// One refresh → a [`ProcTable`]. Blocking (a full process-table walk);
+    /// call from a blocking thread.
+    pub fn collect(&mut self) -> ProcTable {
+        self.sys.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::All,
+            true,
+            sysinfo::ProcessRefreshKind::nothing()
+                .with_cpu()
+                .with_memory()
+                .with_disk_usage(),
+        );
+        let io_supported = capabilities().io;
+        let mut table = ProcTable::with_capacity(self.sys.processes().len());
+        for (pid, proc) in self.sys.processes() {
+            let start = proc.start_time();
+            let disk = proc.disk_usage();
+            table.insert(
+                pid.as_u32(),
+                ProcRow {
+                    parent: proc.parent().map(|p| p.as_u32()),
+                    // 0 = "the OS gave nothing"; absent data is never zero.
+                    start_time_secs: (start > 0).then_some(start),
+                    // Normalized to the whole machine; `ingest` nulls the first
+                    // sighting (sysinfo reports 0.0 there).
+                    cpu_percent: Some(proc.cpu_usage() / self.cores as f32),
+                    resident_bytes: proc.memory(),
+                    virtual_bytes: proc.virtual_memory(),
+                    io_read_total: io_supported.then_some(disk.total_read_bytes),
+                    io_write_total: io_supported.then_some(disk.total_written_bytes),
+                },
+            );
+        }
+        table
+    }
+
+    /// Start time (seconds since epoch) of one pid, or `None` when the process
+    /// is gone or the platform reports nothing. A one-shot, single-pid refresh.
+    pub fn probe_start_time(pid: u32) -> Option<u64> {
+        let mut sys = sysinfo::System::new();
+        let target = sysinfo::Pid::from_u32(pid);
+        sys.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::Some(&[target]),
+            false,
+            sysinfo::ProcessRefreshKind::nothing(),
+        );
+        sys.process(target)
+            .map(|p| p.start_time())
+            .filter(|s| *s > 0)
+    }
+}
+
+/// A boxed future producing one process table (lets tests inject fake tables).
+pub type TableFuture = Pin<Box<dyn Future<Output = ProcTable> + Send>>;
+
+/// The adaptive sampler loop. Parked (no timer at all) while [`ResourceMonitor::cadence`]
+/// says so; otherwise ticks at the resolved interval, re-resolving whenever the
+/// monitor signals a change. Generic over the table source and the emitter so
+/// the loop itself is testable with a fake clock.
+pub async fn run_loop<S, E>(
+    monitor: Arc<ResourceMonitor>,
+    mut sample: S,
+    mut on_park: impl FnMut(),
+    mut emit: E,
+) where
+    S: FnMut() -> TableFuture,
+    E: FnMut(&ResourceSummary),
+{
+    let desktop_pid = std::process::id();
+    loop {
+        let Some((interval, _reason)) = monitor.cadence(now_ms()) else {
+            monitor.clear_transient();
+            on_park();
+            monitor.changed().await;
+            continue;
+        };
+        tokio::select! {
+            _ = tokio::time::sleep(interval) => {}
+            _ = monitor.changed() => continue, // cadence changed — re-resolve
+        }
+        if monitor.cadence(now_ms()).is_none() {
+            continue; // raced a shutdown of the last consumer
+        }
+        let table = sample().await;
+        let summary = monitor.ingest(now_ms(), desktop_pid, table);
+        emit(&summary);
+    }
+}
+
+/// Spawn the production sampler: real `sysinfo` collection on a blocking
+/// thread, summaries emitted to the webview as `resources:summary`.
+pub fn spawn_collector(app: tauri::AppHandle, monitor: Arc<ResourceMonitor>) {
+    let slot: Arc<Mutex<Option<Collector>>> = Arc::new(Mutex::new(None));
+    let sample_slot = slot.clone();
+    let park_slot = slot;
+    tauri::async_runtime::spawn(run_loop(
+        monitor,
+        move || -> TableFuture {
+            let slot = sample_slot.clone();
+            Box::pin(async move {
+                let mut collector = slot.lock().unwrap().take().unwrap_or_default();
+                let (collector, table) = tokio::task::spawn_blocking(move || {
+                    let table = collector.collect();
+                    (collector, table)
+                })
+                .await
+                .expect("resource sample task panicked");
+                *slot.lock().unwrap() = Some(collector);
+                table
+            })
+        },
+        move || {
+            // Parked: drop the OS handle so nothing per-process is retained.
+            *park_slot.lock().unwrap() = None;
+        },
+        move |summary| {
+            let _ = app.emit("resources:summary", summary);
+        },
+    ));
+}
+
+/// Register a terminal after probing its start time (fire-and-forget from
+/// `pty_create`; the probe is a single-pid refresh on a blocking thread).
+pub async fn register_terminal_probed(
+    monitor: Arc<ResourceMonitor>,
+    pty_id: String,
+    pid: u32,
+    workspace: Option<String>,
+) {
+    let start = tokio::task::spawn_blocking(move || Collector::probe_start_time(pid))
+        .await
+        .unwrap_or(None);
+    monitor.register_terminal(&pty_id, pid, start, workspace);
+}
+
+// --- tests -------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(parent: Option<u32>, start: Option<u64>) -> ProcRow {
+        ProcRow {
+            parent,
+            start_time_secs: start,
+            cpu_percent: Some(1.0),
+            resident_bytes: 100,
+            virtual_bytes: 1000,
+            io_read_total: Some(0),
+            io_write_total: Some(0),
+        }
+    }
+
+    fn link(
+        pid: u32,
+        start: Option<u64>,
+        workspace: Option<&str>,
+        agent: Option<&str>,
+    ) -> TerminalLink {
+        TerminalLink {
+            pid,
+            start_time_secs: start,
+            workspace: workspace.map(str::to_string),
+            agent: agent.map(str::to_string),
+            recycled: false,
+        }
+    }
+
+    fn monitor_with(config: MonitorConfig) -> Arc<ResourceMonitor> {
+        ResourceMonitor::new(config)
+    }
+
+    fn enabled_config() -> MonitorConfig {
+        MonitorConfig {
+            enabled: true,
+            orphan_sweep: false,
+            sweep_secs: 20,
+        }
+    }
+
+    // --- cadence -------------------------------------------------------------
+
+    #[test]
+    fn cadence_is_parked_by_default() {
+        assert_eq!(resolve_cadence(enabled_config(), vec![]), None);
+    }
+
+    #[test]
+    fn cadence_prefers_popover_over_budget_over_sweep() {
+        let mut config = enabled_config();
+        config.orphan_sweep = true;
+        assert_eq!(
+            resolve_cadence(config, vec![ConsumerKind::Budget, ConsumerKind::Popover]),
+            Some((POPOVER_INTERVAL, "popover"))
+        );
+        assert_eq!(
+            resolve_cadence(config, vec![ConsumerKind::Budget]),
+            Some((BUDGET_INTERVAL, "budget"))
+        );
+        assert_eq!(
+            resolve_cadence(config, vec![]),
+            Some((Duration::from_secs(20), "orphanSweep"))
+        );
+    }
+
+    #[test]
+    fn cadence_clamps_the_sweep_interval() {
+        let mut config = enabled_config();
+        config.orphan_sweep = true;
+        config.sweep_secs = 5;
+        assert_eq!(
+            resolve_cadence(config, vec![]),
+            Some((Duration::from_secs(SWEEP_MIN_SECS as u64), "orphanSweep"))
+        );
+        config.sweep_secs = 300;
+        assert_eq!(
+            resolve_cadence(config, vec![]),
+            Some((Duration::from_secs(SWEEP_MAX_SECS as u64), "orphanSweep"))
+        );
+    }
+
+    #[test]
+    fn disabled_config_parks_even_with_consumers() {
+        let config = MonitorConfig {
+            enabled: false,
+            orphan_sweep: true,
+            sweep_secs: 20,
+        };
+        assert_eq!(resolve_cadence(config, vec![ConsumerKind::Popover]), None);
+    }
+
+    #[test]
+    fn expired_leases_are_pruned() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t1", ConsumerKind::Popover, 1_000);
+        assert!(monitor.cadence(2_000).is_some());
+        // Past the TTL the lease no longer holds the sampler awake.
+        assert_eq!(monitor.cadence(1_000 + LEASE_TTL_MS + 1), None);
+    }
+
+    #[test]
+    fn unsubscribe_releases_the_lease() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t1", ConsumerKind::Popover, 1_000);
+        monitor.unsubscribe("t1");
+        assert_eq!(monitor.cadence(1_001), None);
+    }
+
+    // --- attribution ---------------------------------------------------------
+
+    #[test]
+    fn shell_is_exact_and_descendants_inferred() {
+        let mut table = ProcTable::new();
+        table.insert(1, row(None, Some(10))); // desktop
+        table.insert(100, row(Some(1), Some(50))); // shell
+        table.insert(200, row(Some(100), Some(60))); // child
+        table.insert(300, row(Some(200), Some(70))); // grandchild
+        let mut links = HashMap::new();
+        links.insert(
+            "pty-1".to_string(),
+            link(100, Some(50), Some("C:\\ws"), None),
+        );
+
+        let (owners, recycled) = attribute(&table, 1, &links);
+        assert!(recycled.is_empty());
+        assert_eq!(
+            owners.get(&100),
+            Some(&OwnerRef::Terminal {
+                pty_id: "pty-1".into(),
+                workspace: Some("C:\\ws".into()),
+                confidence: AttributionConfidence::Exact,
+            })
+        );
+        for pid in [200, 300] {
+            match owners.get(&pid) {
+                Some(OwnerRef::Terminal { confidence, .. }) => {
+                    assert_eq!(*confidence, AttributionConfidence::Inferred)
+                }
+                other => panic!("pid {pid} not attributed to the terminal: {other:?}"),
+            }
+        }
+        assert_eq!(
+            owners.get(&1),
+            Some(&OwnerRef::Desktop {
+                confidence: AttributionConfidence::Exact
+            })
+        );
+    }
+
+    #[test]
+    fn detected_agent_reclassifies_the_subtree_not_the_shell() {
+        let mut table = ProcTable::new();
+        table.insert(100, row(None, Some(50)));
+        table.insert(200, row(Some(100), Some(60)));
+        let mut links = HashMap::new();
+        links.insert(
+            "pty-1".to_string(),
+            link(100, Some(50), Some("/ws"), Some("claude")),
+        );
+
+        let (owners, _) = attribute(&table, 1, &links);
+        assert!(matches!(owners.get(&100), Some(OwnerRef::Terminal { .. })));
+        assert_eq!(
+            owners.get(&200),
+            Some(&OwnerRef::Agent {
+                command: "claude".into(),
+                workspace: Some("/ws".into()),
+                confidence: AttributionConfidence::Inferred,
+            })
+        );
+    }
+
+    #[test]
+    fn recycled_pid_claims_nothing_and_is_reported() {
+        let mut table = ProcTable::new();
+        // Same pid as the link, started at a very different time: another process.
+        table.insert(100, row(None, Some(9_999)));
+        table.insert(200, row(Some(100), Some(9_999)));
+        let mut links = HashMap::new();
+        links.insert("pty-1".to_string(), link(100, Some(50), None, None));
+
+        let (owners, recycled) = attribute(&table, 1, &links);
+        assert_eq!(recycled, vec!["pty-1".to_string()]);
+        assert!(!owners.contains_key(&100));
+        assert!(!owners.contains_key(&200));
+    }
+
+    #[test]
+    fn start_time_tolerance_still_matches() {
+        let mut table = ProcTable::new();
+        table.insert(100, row(None, Some(52)));
+        let mut links = HashMap::new();
+        links.insert("pty-1".to_string(), link(100, Some(50), None, None));
+        let (owners, recycled) = attribute(&table, 1, &links);
+        assert!(recycled.is_empty());
+        assert!(matches!(
+            owners.get(&100),
+            Some(OwnerRef::Terminal {
+                confidence: AttributionConfidence::Exact,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn missing_start_time_degrades_to_inferred_not_exact() {
+        let mut table = ProcTable::new();
+        table.insert(100, row(None, None));
+        let mut links = HashMap::new();
+        links.insert("pty-1".to_string(), link(100, Some(50), None, None));
+        let (owners, recycled) = attribute(&table, 1, &links);
+        assert!(recycled.is_empty());
+        assert!(matches!(
+            owners.get(&100),
+            Some(OwnerRef::Terminal {
+                confidence: AttributionConfidence::Inferred,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn desktop_tree_excludes_claimed_terminal_subtrees() {
+        let mut table = ProcTable::new();
+        table.insert(1, row(None, Some(10))); // desktop
+        table.insert(2, row(Some(1), Some(20))); // webview helper
+        table.insert(100, row(Some(1), Some(50))); // shell (child of desktop!)
+        table.insert(200, row(Some(100), Some(60))); // shell's child
+        let mut links = HashMap::new();
+        links.insert("pty-1".to_string(), link(100, Some(50), None, None));
+
+        let (owners, _) = attribute(&table, 1, &links);
+        assert!(matches!(owners.get(&2), Some(OwnerRef::Desktop { .. })));
+        assert!(matches!(owners.get(&100), Some(OwnerRef::Terminal { .. })));
+        assert!(matches!(owners.get(&200), Some(OwnerRef::Terminal { .. })));
+    }
+
+    #[test]
+    fn unrelated_processes_are_never_classified() {
+        let mut table = ProcTable::new();
+        table.insert(1, row(None, Some(10)));
+        table.insert(9_000, row(None, Some(5))); // someone else's process
+        let (owners, _) = attribute(&table, 1, &HashMap::new());
+        assert!(!owners.contains_key(&9_000));
+    }
+
+    // --- deltas & honesty ----------------------------------------------------
+
+    #[test]
+    fn io_rate_needs_both_totals_and_a_window() {
+        assert_eq!(io_rate(None, Some(10), Some(1.0)), None);
+        assert_eq!(io_rate(Some(10), None, Some(1.0)), None);
+        assert_eq!(io_rate(Some(10), Some(30), None), None);
+        assert_eq!(io_rate(Some(10), Some(30), Some(2.0)), Some(10.0));
+    }
+
+    #[test]
+    fn first_sighting_reports_no_cpu_or_io() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t", ConsumerKind::Popover, 1_000);
+        let mut table = ProcTable::new();
+        table.insert(std::process::id(), row(None, Some(10)));
+        let summary = monitor.ingest(1_000, std::process::id(), table);
+        let total = summary.total.expect("a total exists");
+        assert_eq!(total.cpu_percent, None, "first sight must not report CPU");
+        assert_eq!(total.io_read_bytes_per_sec, None);
+        // Memory is a point-in-time read and is available immediately.
+        assert_eq!(total.resident_bytes, Some(100));
+    }
+
+    #[test]
+    fn second_tick_reports_cpu_and_io_deltas() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t", ConsumerKind::Popover, 1_000);
+        let me = std::process::id();
+        let mut t1 = ProcTable::new();
+        t1.insert(me, row(None, Some(10)));
+        monitor.ingest(1_000, me, t1);
+
+        let mut t2 = ProcTable::new();
+        let mut r = row(None, Some(10));
+        r.cpu_percent = Some(3.5);
+        r.io_read_total = Some(2_000);
+        r.io_write_total = Some(1_000);
+        t2.insert(me, r);
+        let summary = monitor.ingest(3_000, me, t2);
+        let total = summary.total.expect("a total exists");
+        assert_eq!(total.cpu_percent, Some(3.5));
+        assert_eq!(total.io_read_bytes_per_sec, Some(1_000.0)); // 2000 B over 2 s
+        assert_eq!(total.io_write_bytes_per_sec, Some(500.0));
+    }
+
+    #[test]
+    fn a_gap_invalidates_rates_but_not_memory() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t", ConsumerKind::Popover, 1_000);
+        let me = std::process::id();
+        let mut t1 = ProcTable::new();
+        t1.insert(me, row(None, Some(10)));
+        monitor.ingest(1_000, me, t1.clone());
+        monitor.ingest(3_000, me, t1.clone());
+        // Renew the lease, then a long gap (parked window) before the next tick.
+        monitor.subscribe("t", ConsumerKind::Popover, 500_000);
+        let summary = monitor.ingest(500_000, me, t1);
+        let total = summary.total.expect("a total exists");
+        assert_eq!(total.cpu_percent, None, "a gap must invalidate CPU");
+        assert_eq!(total.io_read_bytes_per_sec, None);
+        assert_eq!(total.resident_bytes, Some(100));
+    }
+
+    #[test]
+    fn identity_change_resets_deltas() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t", ConsumerKind::Popover, 1_000);
+        let me = std::process::id();
+        let mut t1 = ProcTable::new();
+        t1.insert(me, row(None, Some(10)));
+        monitor.ingest(1_000, me, t1);
+        // Same pid, different start time: a different process.
+        let mut t2 = ProcTable::new();
+        t2.insert(me, row(None, Some(999)));
+        let summary = monitor.ingest(3_000, me, t2);
+        let total = summary.total.expect("a total exists");
+        assert_eq!(total.cpu_percent, None);
+        assert_eq!(total.io_read_bytes_per_sec, None);
+    }
+
+    // --- aggregation ---------------------------------------------------------
+
+    #[test]
+    fn groups_fold_terminals_into_workspaces_and_agents_apart() {
+        let mut table = ProcTable::new();
+        table.insert(1, row(None, Some(10))); // desktop
+        table.insert(100, row(Some(1), Some(50))); // shell in ws A
+        table.insert(101, row(Some(1), Some(51))); // second shell in ws A
+        table.insert(200, row(Some(100), Some(60))); // agent process under shell 100
+        let mut links = HashMap::new();
+        links.insert(
+            "pty-1".to_string(),
+            link(100, Some(50), Some("A"), Some("codex")),
+        );
+        links.insert("pty-2".to_string(), link(101, Some(51), Some("A"), None));
+
+        let (owners, _) = attribute(&table, 1, &links);
+        let (total, groups) = aggregate(&table, &owners, &links);
+
+        assert_eq!(total.processes, 4);
+        let desktop = groups
+            .iter()
+            .find(|g| g.kind == ResourceOwnerKind::Desktop)
+            .unwrap();
+        assert_eq!(desktop.metrics.processes, 1);
+        let ws = groups
+            .iter()
+            .find(|g| g.kind == ResourceOwnerKind::Workspace && g.id.as_deref() == Some("A"))
+            .unwrap();
+        // The two shells; the agent process is its own group.
+        assert_eq!(ws.metrics.processes, 2);
+        let agent = groups
+            .iter()
+            .find(|g| g.kind == ResourceOwnerKind::Agent && g.id.as_deref() == Some("codex"))
+            .unwrap();
+        assert_eq!(agent.metrics.processes, 1);
+        assert_eq!(agent.workspace.as_deref(), Some("A"));
+        assert_eq!(agent.confidence, AttributionConfidence::Inferred);
+    }
+
+    #[test]
+    fn one_unknown_member_makes_the_group_rate_unknown() {
+        let mut table = ProcTable::new();
+        let mut fresh = row(Some(1), Some(50));
+        fresh.cpu_percent = None; // first sighting
+        table.insert(100, row(None, Some(10)));
+        table.insert(200, fresh);
+        let mut links = HashMap::new();
+        links.insert("pty-1".to_string(), link(100, Some(10), Some("A"), None));
+        // 200 is a child of 1 — irrelevant; rebuild: make 200 child of 100.
+        table.get_mut(&200).unwrap().parent = Some(100);
+
+        let (owners, _) = attribute(&table, 999, &links);
+        let (_, groups) = aggregate(&table, &owners, &links);
+        let ws = groups
+            .iter()
+            .find(|g| g.kind == ResourceOwnerKind::Workspace)
+            .unwrap();
+        assert_eq!(ws.metrics.processes, 2);
+        assert_eq!(
+            ws.metrics.cpu_percent, None,
+            "partial sums must not pose as facts"
+        );
+        assert!(ws.metrics.resident_bytes.is_some(), "memory is still known");
+    }
+
+    #[test]
+    fn recycled_link_shows_an_unknown_group_without_metrics() {
+        let table = ProcTable::new();
+        let mut links = HashMap::new();
+        let mut l = link(100, Some(50), Some("A"), None);
+        l.recycled = true;
+        links.insert("pty-1".to_string(), l);
+        let (owners, _) = attribute(&table, 1, &links);
+        let (_, groups) = aggregate(&table, &owners, &links);
+        let g = groups
+            .iter()
+            .find(|g| g.id.as_deref() == Some("pty-1"))
+            .expect("recycled link surfaces as a group");
+        assert_eq!(g.confidence, AttributionConfidence::Unknown);
+        assert_eq!(g.metrics.processes, 0);
+        assert_eq!(
+            g.metrics.resident_bytes, None,
+            "no metrics — and never zeros"
+        );
+    }
+
+    // --- orphans -------------------------------------------------------------
+
+    #[test]
+    fn surviving_members_of_a_closed_terminal_become_orphans() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t", ConsumerKind::Popover, 1_000);
+        let me = 1;
+        let mut table = ProcTable::new();
+        table.insert(me, row(None, Some(10)));
+        table.insert(100, row(Some(me), Some(50)));
+        table.insert(200, row(Some(100), Some(60)));
+        monitor.register_terminal("pty-1", 100, Some(50), Some("A".into()));
+        monitor.ingest(1_000, me, table.clone());
+
+        monitor.terminal_closed("pty-1", 2_000);
+        // Shell died, its child survived.
+        table.remove(&100);
+        let summary = monitor.ingest(3_000, me, table.clone());
+        assert_eq!(summary.orphans.len(), 1);
+        let orphan = &summary.orphans[0];
+        assert_eq!(orphan.pids, vec![200]);
+        assert_eq!(orphan.confidence, AttributionConfidence::Exact);
+        assert_eq!(orphan.since_ms, 2_000);
+
+        // Survivor ends → the orphan disappears and the link is dropped.
+        table.remove(&200);
+        let summary = monitor.ingest(5_000, me, table);
+        assert!(summary.orphans.is_empty());
+    }
+
+    #[test]
+    fn a_recycled_pid_is_not_reported_as_a_survivor() {
+        let mut closed = vec![ClosedLink {
+            kind: ResourceOwnerKind::Terminal,
+            id: "pty-1".into(),
+            members: vec![(200, Some(60))],
+            closed_at_ms: 1_000,
+        }];
+        let mut table = ProcTable::new();
+        table.insert(200, row(None, Some(9_999))); // same pid, other process
+        let orphans = check_orphans(&mut closed, &table, 2_000);
+        assert!(orphans.is_empty());
+        assert!(closed.is_empty(), "nothing left to watch");
+    }
+
+    #[test]
+    fn unverifiable_survivors_degrade_to_unknown_and_expire() {
+        let mut closed = vec![ClosedLink {
+            kind: ResourceOwnerKind::Agent,
+            id: "claude".into(),
+            members: vec![(200, None)],
+            closed_at_ms: 1_000,
+        }];
+        let mut table = ProcTable::new();
+        table.insert(200, row(None, None));
+        let orphans = check_orphans(&mut closed, &table, 2_000);
+        assert_eq!(orphans.len(), 1);
+        assert_eq!(orphans[0].confidence, AttributionConfidence::Unknown);
+        // Long after retention it stops claiming.
+        let orphans = check_orphans(
+            &mut closed,
+            &table,
+            2_000 + ORPHAN_UNVERIFIED_RETENTION_MS + 1,
+        );
+        assert!(orphans.is_empty());
+        assert!(closed.is_empty());
+    }
+
+    // --- buffer & summaries --------------------------------------------------
+
+    fn frame_at(at_ms: u64, rss: u64) -> Frame {
+        Frame {
+            at_ms,
+            total: MetricSample {
+                processes: 1,
+                cpu_percent: Some(2.0),
+                resident_bytes: Some(rss),
+                virtual_bytes: Some(10 * rss),
+                io_read_bytes_per_sec: None,
+                io_write_bytes_per_sec: None,
+            },
+            groups: vec![],
+            orphans: vec![],
+        }
+    }
+
+    #[test]
+    fn the_buffer_is_bounded_by_time_and_count() {
+        let mut frames: VecDeque<Frame> = VecDeque::new();
+        for i in 0..(BUFFER_MAX_FRAMES + 100) {
+            frames.push_back(frame_at(i as u64, 1));
+        }
+        trim_frames(&mut frames, BUFFER_MAX_FRAMES as u64 + 100);
+        assert!(frames.len() <= BUFFER_MAX_FRAMES);
+
+        let mut frames: VecDeque<Frame> = VecDeque::new();
+        frames.push_back(frame_at(0, 1));
+        frames.push_back(frame_at(BUFFER_MAX_SECONDS * 1000 + 5_000, 1));
+        trim_frames(&mut frames, BUFFER_MAX_SECONDS * 1000 + 5_000);
+        assert_eq!(frames.len(), 1, "frames older than the window are dropped");
+    }
+
+    #[test]
+    fn summary_reports_instant_average_peak_and_trend() {
+        let frames: Vec<Frame> = (0..10u64)
+            .map(|i| frame_at(i * 2_000, 100 + i * 20))
+            .collect();
+        let series: Vec<(u64, &MetricSample)> =
+            frames.iter().map(|f| (f.at_ms, &f.total)).collect();
+        let m = metric_summary(&series, 18_000);
+        assert_eq!(m.resident_bytes, Some(280)); // latest
+        assert_eq!(m.resident_peak_bytes, Some(280));
+        assert_eq!(m.cpu_percent, Some(2.0));
+        assert_eq!(m.trend, Trend::Rising);
+    }
+
+    #[test]
+    fn trend_needs_enough_points_and_detects_direction() {
+        let rising: Vec<Frame> = (0..8u64).map(|i| frame_at(i, 100 + i * 50)).collect();
+        let series: Vec<(u64, &MetricSample)> =
+            rising.iter().map(|f| (f.at_ms, &f.total)).collect();
+        assert_eq!(trend_of(&series), Trend::Rising);
+
+        let falling: Vec<Frame> = (0..8u64).map(|i| frame_at(i, 1_000 - i * 100)).collect();
+        let series: Vec<(u64, &MetricSample)> =
+            falling.iter().map(|f| (f.at_ms, &f.total)).collect();
+        assert_eq!(trend_of(&series), Trend::Falling);
+
+        let flat: Vec<Frame> = (0..8u64).map(|i| frame_at(i, 500)).collect();
+        let series: Vec<(u64, &MetricSample)> = flat.iter().map(|f| (f.at_ms, &f.total)).collect();
+        assert_eq!(trend_of(&series), Trend::Steady);
+
+        let few: Vec<Frame> = (0..3u64).map(|i| frame_at(i, 500)).collect();
+        let series: Vec<(u64, &MetricSample)> = few.iter().map(|f| (f.at_ms, &f.total)).collect();
+        assert_eq!(trend_of(&series), Trend::Unknown);
+    }
+
+    #[test]
+    fn a_vanished_group_is_reported_as_ended_then_dropped() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t", ConsumerKind::Popover, 1_000);
+        let me = 1;
+        monitor.register_terminal("pty-1", 100, Some(50), Some("A".into()));
+        let mut table = ProcTable::new();
+        table.insert(me, row(None, Some(10)));
+        table.insert(100, row(Some(me), Some(50)));
+        monitor.ingest(1_000, me, table.clone());
+
+        table.remove(&100); // shell exits
+        let summary = monitor.ingest(3_000, me, table.clone());
+        let ws = summary
+            .groups
+            .iter()
+            .find(|g| g.kind == ResourceOwnerKind::Workspace)
+            .expect("the workspace group lingers as ended");
+        assert!(ws.ended);
+        assert_eq!(ws.metrics.resident_bytes, Some(100), "last-known metrics");
+
+        // Renew the lease far in the future and tick again: past the ended
+        // window the group is gone entirely.
+        monitor.subscribe("t", ConsumerKind::Popover, 500_000);
+        let summary = monitor.ingest(3_000 + ENDED_WINDOW_MS + 10_000, me, table);
+        assert!(summary
+            .groups
+            .iter()
+            .all(|g| g.kind != ResourceOwnerKind::Workspace));
+    }
+
+    #[test]
+    fn summary_reports_sampling_state_and_link_count() {
+        let monitor = monitor_with(enabled_config());
+        let s = monitor.summary(1_000);
+        assert!(!s.sampling.active);
+        assert_eq!(s.sampling.reason, "off");
+        assert!(s.updated_at_ms.is_none());
+        assert!(s.total.is_none());
+
+        monitor.subscribe("t", ConsumerKind::Popover, 1_000);
+        monitor.register_terminal("pty-1", 100, Some(50), None);
+        let s = monitor.summary(1_001);
+        assert!(s.sampling.active);
+        assert_eq!(s.sampling.interval_ms, Some(2_000));
+        assert_eq!(s.terminals_linked, 1);
+    }
+
+    #[test]
+    fn ingest_broadcasts_to_internal_subscribers() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t", ConsumerKind::Popover, 1_000);
+        let mut rx = monitor.subscribe_events();
+        let mut table = ProcTable::new();
+        table.insert(1, row(None, Some(10)));
+        monitor.ingest(1_000, 1, table);
+        let received = rx.try_recv().expect("a summary is broadcast per frame");
+        assert_eq!(received.updated_at_ms, Some(1_000));
+    }
+
+    #[test]
+    fn apply_settings_wakes_only_on_change() {
+        let monitor = monitor_with(enabled_config());
+        let settings = crate::model::ResourceSettings {
+            enabled: true,
+            orphan_sweep: true,
+            orphan_sweep_seconds: 7, // clamped to 15
+        };
+        monitor.apply_settings(&settings);
+        assert_eq!(
+            monitor.cadence(1_000),
+            Some((Duration::from_secs(15), "orphanSweep"))
+        );
+        let settings = crate::model::ResourceSettings {
+            enabled: false,
+            orphan_sweep: true,
+            orphan_sweep_seconds: 20,
+        };
+        monitor.apply_settings(&settings);
+        assert_eq!(monitor.cadence(1_001), None);
+    }
+
+    // --- the loop ------------------------------------------------------------
+
+    #[tokio::test(start_paused = true)]
+    async fn the_loop_parks_without_consumers_and_wakes_on_subscribe() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let monitor = monitor_with(enabled_config());
+        let samples = Arc::new(AtomicUsize::new(0));
+        let samples_in_loop = samples.clone();
+        let loop_monitor = monitor.clone();
+        let handle = tokio::spawn(run_loop(
+            loop_monitor,
+            move || -> TableFuture {
+                samples_in_loop.fetch_add(1, Ordering::SeqCst);
+                Box::pin(async { ProcTable::new() })
+            },
+            || {},
+            |_| {},
+        ));
+
+        // Parked: even after a long virtual wait, nothing was sampled.
+        tokio::time::sleep(Duration::from_secs(120)).await;
+        assert_eq!(
+            samples.load(Ordering::SeqCst),
+            0,
+            "parked must sample nothing"
+        );
+
+        // A popover consumer wakes it at the fast cadence. (The lease is
+        // renewed against the real clock, which tokio's pause doesn't move.)
+        monitor.subscribe("t", ConsumerKind::Popover, now_ms());
+        tokio::time::sleep(Duration::from_secs(7)).await;
+        assert!(
+            samples.load(Ordering::SeqCst) >= 2,
+            "an active popover lease must drive samples"
+        );
+
+        handle.abort();
+    }
+
+    // --- export sanitization (the golden test) -------------------------------
+
+    /// Every JSON key the export may contain. A new field must be added here
+    /// *consciously* — that is the moment to ask whether it can leak anything.
+    const ALLOWED_EXPORT_KEYS: &[&str] = &[
+        "schemaVersion",
+        "exportedAtMs",
+        "platform",
+        "appVersion",
+        "capabilities",
+        "cpu",
+        "memory",
+        "virtualMemory",
+        "io",
+        "startTime",
+        "validated",
+        "sampling",
+        "active",
+        "intervalMs",
+        "reason",
+        "bufferSeconds",
+        "fields",
+        "total",
+        "groups",
+        "orphans",
+        "kind",
+        "id",
+        "workspace",
+        "confidence",
+        "ended",
+        "processes",
+        "cpuPercent",
+        "cpuAvgPercent",
+        "cpuPeakPercent",
+        "residentBytes",
+        "residentAvgBytes",
+        "residentPeakBytes",
+        "virtualBytes",
+        "ioReadBytesPerSec",
+        "ioWriteBytesPerSec",
+        "trend",
+        "pids",
+        "sinceMs",
+    ];
+
+    fn collect_keys(value: &serde_json::Value, keys: &mut HashSet<String>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                for (k, v) in map {
+                    keys.insert(k.clone());
+                    collect_keys(v, keys);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    collect_keys(item, keys);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// A summary poisoned with the kinds of values that must never leave the
+    /// machine: home paths, tokens, env-var spellings, file names.
+    fn hostile_summary() -> ResourceSummary {
+        let hostile_ids = [
+            "C:\\Users\\bob\\secret-project",
+            "/home/alice/.ssh/id_ed25519",
+            "/Users/carol/Documents/taxes.xlsx",
+            "ghp_abcdefghijklmnop",
+            "Bearer sk-ans-1234567890",
+            "%USERPROFILE%\\creds.json",
+            "$HOME/.config/token",
+        ];
+        let group = |kind: ResourceOwnerKind, id: &str, ws: Option<&str>| GroupSummary {
+            kind,
+            id: Some(id.to_string()),
+            workspace: ws.map(str::to_string),
+            confidence: AttributionConfidence::Exact,
+            ended: false,
+            metrics: MetricSummary {
+                processes: 1,
+                resident_bytes: Some(1),
+                trend: Trend::Unknown,
+                ..MetricSummary::default()
+            },
+        };
+        ResourceSummary {
+            enabled: true,
+            capabilities: capabilities(),
+            sampling: SamplingState {
+                active: false,
+                interval_ms: None,
+                reason: "off",
+            },
+            updated_at_ms: Some(1),
+            buffer_seconds: 600,
+            total: None,
+            groups: vec![
+                group(
+                    ResourceOwnerKind::Workspace,
+                    hostile_ids[0],
+                    Some(hostile_ids[0]),
+                ),
+                group(
+                    ResourceOwnerKind::Terminal,
+                    hostile_ids[1],
+                    Some(hostile_ids[2]),
+                ),
+                group(ResourceOwnerKind::Agent, hostile_ids[3], None),
+                group(ResourceOwnerKind::Agent, hostile_ids[4], None),
+                // A legitimate bare agent name survives verbatim.
+                group(ResourceOwnerKind::Agent, "cursor-agent", None),
+            ],
+            orphans: vec![OrphanSample {
+                kind: ResourceOwnerKind::Agent,
+                id: hostile_ids[5].to_string(),
+                pids: vec![4242],
+                cpu_percent: None,
+                resident_bytes: Some(1),
+                since_ms: 1,
+                confidence: AttributionConfidence::Unknown,
+            }],
+            terminals_linked: 1,
+        }
+    }
+
+    #[test]
+    fn export_strips_every_identifying_string() {
+        let export = sanitize_export(&hostile_summary(), 2_000);
+        let json = serde_json::to_string_pretty(&export).unwrap();
+
+        // No path shapes, no home spellings, no token prefixes — the patterns
+        // that have historically leaked from diagnostics.
+        for needle in [
+            "C:\\",
+            "C:\\\\",
+            "/home/",
+            "/Users/",
+            ".ssh",
+            "taxes",
+            "ghp_",
+            "sk-ans",
+            "Bearer",
+            "USERPROFILE",
+            "$HOME",
+            "secret",
+            "creds",
+            "id_ed25519",
+        ] {
+            assert!(!json.contains(needle), "export leaked {needle:?}:\n{json}");
+        }
+        // Anonymized labels took their place; the safe agent name survived.
+        assert!(json.contains("workspace-1"));
+        assert!(json.contains("terminal-1"));
+        assert!(json.contains("agent-1"));
+        assert!(json.contains("cursor-agent"));
+        // PIDs are allowed in an explicit diagnostic export.
+        assert!(json.contains("4242"));
+    }
+
+    #[test]
+    fn export_contains_only_allow_listed_keys() {
+        let export = sanitize_export(&hostile_summary(), 2_000);
+        let value = serde_json::to_value(&export).unwrap();
+        let mut keys = HashSet::new();
+        collect_keys(&value, &mut keys);
+        for key in &keys {
+            assert!(
+                ALLOWED_EXPORT_KEYS.contains(&key.as_str()),
+                "export gained an un-reviewed key {key:?} — add it to ALLOWED_EXPORT_KEYS only after checking it cannot leak"
+            );
+        }
+    }
+
+    #[test]
+    fn export_lists_its_fields_for_the_consent_dialog() {
+        let export = sanitize_export(&hostile_summary(), 2_000);
+        assert!(!export.fields.is_empty());
+        assert!(export.fields.iter().any(|f| f.contains("anonymized")));
+    }
+
+    #[test]
+    fn exportable_agent_ids_are_known_catalog_names_only() {
+        assert!(exportable_agent_id("claude"));
+        assert!(exportable_agent_id("cursor-agent"));
+        assert!(exportable_agent_id("agy"));
+        assert!(!exportable_agent_id(""));
+        assert!(!exportable_agent_id("C:\\tools\\agent.exe"));
+        assert!(!exportable_agent_id("/usr/bin/agent"));
+        assert!(!exportable_agent_id("my agent"));
+        // A lowercase token *shaped* like a name still isn't in the catalog —
+        // the reason this is an allow-list and not a heuristic.
+        assert!(!exportable_agent_id("ghp_abcdefghijklmnop"));
+        assert!(!exportable_agent_id("Claude")); // catalog ids are lowercase
+    }
+
+    // --- registry lifecycle --------------------------------------------------
+
+    #[test]
+    fn closing_an_unknown_terminal_is_a_noop() {
+        let monitor = monitor_with(enabled_config());
+        monitor.terminal_closed("nope", 1_000);
+        assert!(monitor.summary(1_000).orphans.is_empty());
+    }
+
+    #[test]
+    fn set_agent_on_unknown_terminal_is_a_noop() {
+        let monitor = monitor_with(enabled_config());
+        monitor.set_terminal_agent("nope", Some("claude".into()));
+        // Nothing to assert beyond "no panic"; the registry stays empty.
+        assert_eq!(monitor.summary(1_000).terminals_linked, 0);
+    }
+}

--- a/uxnandesktop/src-tauri/src/state.rs
+++ b/uxnandesktop/src-tauri/src/state.rs
@@ -92,10 +92,15 @@ pub struct AppState {
     pub mcp_prepared: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
     /// MCP config files we wrote, recorded so they're undone on exit (best-effort).
     pub mcp_written: Arc<std::sync::Mutex<Vec<crate::mcpinject::Written>>>,
+    /// Local resource observability: the PTY-link registry, the adaptive
+    /// sampler's leases and the aggregated circular buffer (`resources.rs`).
+    /// Parked (no timer, no OS handle) unless a consumer subscribes.
+    pub resources: Arc<crate::resources::ResourceMonitor>,
 }
 
 impl AppState {
     pub fn new(persistence: PersistenceManager, data: AppData) -> Self {
+        let resources = crate::resources::ResourceMonitor::new((&data.settings.resources).into());
         Self {
             data: RwLock::new(data),
             persistence,
@@ -112,6 +117,7 @@ impl AppState {
             browser_url: Arc::new(std::sync::Mutex::new(None)),
             mcp_prepared: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             mcp_written: Arc::new(std::sync::Mutex::new(Vec::new())),
+            resources,
         }
     }
 }

--- a/uxnandesktop/src-tauri/tests/resources_processes.rs
+++ b/uxnandesktop/src-tauri/tests/resources_processes.rs
@@ -1,0 +1,242 @@
+//! L3 — the resource monitor against real, spawned processes.
+//!
+//! The unit tests prove the attribution rules on synthetic tables; what they
+//! cannot prove is that the same rules hold against the OS: that `sysinfo`
+//! start times round-trip through the probe within tolerance, that a real
+//! shell's child is discovered by parent-chain walking, and that a subtree
+//! which outlives its closed owner is re-identified as an orphan and released
+//! when it ends.
+//!
+//! The processes are the test's own (a throwaway `cmd /c ping` tree on
+//! Windows, `sh -c "sleep …"` elsewhere) and are killed by pid on the way out
+//! — never by name.
+
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use uxnan_desktop_lib::resources::{
+    AttributionConfidence, Collector, ConsumerKind, MonitorConfig, ResourceMonitor,
+    ResourceOwnerKind, ResourceSummary,
+};
+
+/// Spawn a two-level tree: a shell whose child sleeps for ~30 s. Long enough
+/// that the test never races its natural end; short enough that a leak from an
+/// aborted run cleans itself up.
+fn spawn_shell_tree() -> Child {
+    if cfg!(windows) {
+        Command::new("cmd.exe")
+            .args(["/c", "ping -n 30 127.0.0.1 > NUL"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("cmd.exe should spawn")
+    } else {
+        Command::new("sh")
+            .args(["-c", "sleep 30; true"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("sh should spawn")
+    }
+}
+
+/// Kill one specific pid — only ever a pid this test created.
+fn kill_pid(pid: u32) {
+    if cfg!(windows) {
+        let _ = Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    } else {
+        let _ = Command::new("kill").args(["-9", &pid.to_string()]).status();
+    }
+}
+
+fn workspace_group(
+    summary: &ResourceSummary,
+) -> Option<&uxnan_desktop_lib::resources::GroupSummary> {
+    summary
+        .groups
+        .iter()
+        .find(|g| g.kind == ResourceOwnerKind::Workspace && !g.ended)
+}
+
+#[test]
+fn attributes_a_real_shell_tree_then_reports_its_survivor_as_an_orphan() {
+    let monitor = ResourceMonitor::new(MonitorConfig::default());
+    let mut shell = spawn_shell_tree();
+    let shell_pid = shell.id();
+
+    // The probe and the table must agree on the process's start time — that
+    // agreement is the whole identity scheme.
+    let start = Collector::probe_start_time(shell_pid);
+    monitor.register_terminal("pty-int", shell_pid, start, Some("bench-ws".into()));
+    monitor.subscribe("int-test", ConsumerKind::Popover, now());
+
+    let mut collector = Collector::new();
+    let me = std::process::id();
+
+    // Sample until the child process is visible under the shell (spawning it
+    // takes the OS a moment). The shell itself must be attributed immediately.
+    let mut summary = monitor.ingest(now(), me, collector.collect());
+    let mut child_pid: Option<u32> = None;
+    for _ in 0..40 {
+        if let Some(group) = workspace_group(&summary) {
+            if group.metrics.processes >= 2 {
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(250));
+        summary = monitor.ingest(now(), me, collector.collect());
+    }
+    {
+        let group =
+            workspace_group(&summary).expect("the registered shell forms a workspace group");
+        assert!(
+            group.metrics.processes >= 2,
+            "the shell's child never appeared under it (got {} processes)",
+            group.metrics.processes
+        );
+        // pid + start time verified for the shell, parent-chain for the child:
+        // the group's combined confidence is inferred when start times are
+        // readable, and must never claim exact for the whole subtree.
+        assert_ne!(group.confidence, AttributionConfidence::Unknown);
+        assert!(
+            group.metrics.resident_bytes.is_some(),
+            "a live group reports memory"
+        );
+    }
+
+    // Find the child's pid from the shell's process table entry (the survivor
+    // we will assert on, and the one we must clean up).
+    let table = collector.collect();
+    for (pid, row) in &table {
+        if row.parent == Some(shell_pid) {
+            child_pid = Some(*pid);
+        }
+    }
+    let child_pid = child_pid.expect("the shell has a child in the live table");
+
+    // Close the terminal (snapshotting members), then kill only the shell.
+    // The sleeping child survives its owner — the textbook orphan.
+    monitor.terminal_closed("pty-int", now());
+    let _ = shell.kill();
+    let _ = shell.wait();
+    std::thread::sleep(Duration::from_millis(500));
+
+    let mut summary = monitor.ingest(now(), me, collector.collect());
+    let mut found_orphan = false;
+    for _ in 0..20 {
+        if summary.orphans.iter().any(|o| o.pids.contains(&child_pid)) {
+            found_orphan = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+        summary = monitor.ingest(now(), me, collector.collect());
+    }
+    // On Windows, killing the `cmd` shell leaves `ping` running; on Unix,
+    // killing `sh` leaves `sleep`. Either way the child must be re-identified.
+    assert!(
+        found_orphan,
+        "the surviving child was not reported as an orphan: {:?}",
+        summary.orphans
+    );
+    let orphan = summary
+        .orphans
+        .iter()
+        .find(|o| o.pids.contains(&child_pid))
+        .unwrap();
+    assert_eq!(
+        orphan.confidence,
+        AttributionConfidence::Exact,
+        "identity is re-verified by start time, so the claim is exact"
+    );
+
+    // End the survivor: the orphan report must clear on the next sample.
+    kill_pid(child_pid);
+    std::thread::sleep(Duration::from_millis(500));
+    let mut summary = monitor.ingest(now(), me, collector.collect());
+    for _ in 0..20 {
+        if summary.orphans.iter().all(|o| !o.pids.contains(&child_pid)) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+        summary = monitor.ingest(now(), me, collector.collect());
+    }
+    assert!(
+        summary.orphans.iter().all(|o| !o.pids.contains(&child_pid)),
+        "a dead survivor must stop being reported"
+    );
+}
+
+#[test]
+fn probe_start_time_matches_the_full_table_read() {
+    let mut shell = spawn_shell_tree();
+    let pid = shell.id();
+    let probed = Collector::probe_start_time(pid);
+
+    let mut collector = Collector::new();
+    let table = collector.collect();
+    let in_table = table.get(&pid).and_then(|row| row.start_time_secs);
+
+    // Clean up before asserting so a failure never leaks the tree.
+    let _ = shell.kill();
+    let _ = shell.wait();
+
+    match (probed, in_table) {
+        (Some(a), Some(b)) => assert!(
+            a.abs_diff(b) <= 2,
+            "probe ({a}) and table ({b}) disagree beyond tolerance"
+        ),
+        // A platform that reports no start time must do so consistently.
+        (None, None) => {}
+        other => panic!("probe and table disagree on availability: {other:?}"),
+    }
+}
+
+#[test]
+fn a_terminated_process_is_no_longer_attributed() {
+    let monitor = ResourceMonitor::new(MonitorConfig::default());
+    let mut shell = spawn_shell_tree();
+    let shell_pid = shell.id();
+    let start = Collector::probe_start_time(shell_pid);
+    monitor.register_terminal("pty-gone", shell_pid, start, Some("ws".into()));
+    monitor.subscribe("int-test-2", ConsumerKind::Popover, now());
+
+    let mut collector = Collector::new();
+    let me = std::process::id();
+    let summary = monitor.ingest(now(), me, collector.collect());
+    assert!(workspace_group(&summary).is_some());
+
+    // Kill the whole tree, then sample: the live group disappears and the
+    // summary reports it as ended instead (last-known metrics, honest flag).
+    kill_pid(shell_pid);
+    let _ = shell.kill();
+    let _ = shell.wait();
+    std::thread::sleep(Duration::from_millis(500));
+
+    let mut summary = monitor.ingest(now(), me, collector.collect());
+    for _ in 0..20 {
+        if workspace_group(&summary).is_none() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+        summary = monitor.ingest(now(), me, collector.collect());
+    }
+    assert!(
+        workspace_group(&summary).is_none(),
+        "a killed tree must not stay attributed as live"
+    );
+    assert!(
+        summary
+            .groups
+            .iter()
+            .any(|g| g.kind == ResourceOwnerKind::Workspace && g.ended),
+        "the vanished group is reported as ended"
+    );
+}
+
+fn now() -> u64 {
+    uxnan_desktop_lib::resources::now_ms()
+}

--- a/uxnandesktop/src/lib/api.ts
+++ b/uxnandesktop/src/lib/api.ts
@@ -51,6 +51,9 @@ import type {
   ProviderUsage,
   QuickCommand,
   RepoData,
+  ResourceConsumerKind,
+  ResourceExport,
+  ResourceSummary,
   SavedRun,
   SavedTerminalLayout,
   TimelineEvent,
@@ -183,6 +186,31 @@ export function usageDetect(providers: UsageProvider[]): Promise<UsageProvider[]
  *  (`reset` / `nothing_to_reset` / `no_credit` / `already_redeemed`). */
 export function usageCodexRedeemReset(): Promise<string> {
   return invoke<string>("usage_codex_redeem_reset");
+}
+
+// --- Resource observability --------------------------------------------------
+
+/** The consolidated resource summary (from the buffered frames; no fresh
+ *  sample). The live feed is the `resources:summary` event while subscribed. */
+export function resourcesSummary(): Promise<ResourceSummary> {
+  return invoke<ResourceSummary>("resources_summary");
+}
+
+/** Take (or renew) a sampling lease. Leases expire on their own, so a surface
+ *  renews while open and releases on close. */
+export function resourcesSubscribe(token: string, kind: ResourceConsumerKind): Promise<void> {
+  return invoke<void>("resources_subscribe", { token, kind });
+}
+
+/** Release a sampling lease (idempotent). */
+export function resourcesUnsubscribe(token: string): Promise<void> {
+  return invoke<void>("resources_unsubscribe", { token });
+}
+
+/** The sanitized diagnostics document. Nothing is saved backend-side: the UI
+ *  shows its `fields` list for consent and writes the file itself. */
+export function resourcesExport(): Promise<ResourceExport> {
+  return invoke<ResourceExport>("resources_export");
 }
 
 /** Coordinates of the local agent hook server (null until it's listening). */

--- a/uxnandesktop/src/lib/components/BackendStatus.svelte
+++ b/uxnandesktop/src/lib/components/BackendStatus.svelte
@@ -9,8 +9,10 @@
   // Unread notifications stay passively visible as a dot on the trigger, so the
   // signal the old button carried isn't lost behind a click.
   import * as Popover from "$lib/components/ui/popover";
+  import ResourceSummary from "$lib/components/ResourceSummary.svelte";
   import { app } from "$lib/state/app.svelte";
   import { github } from "$lib/state/github.svelte";
+  import { resources } from "$lib/state/resources.svelte";
   import { cn } from "$lib/utils";
   import { text } from "$lib/design";
   import { TooltipSimple } from "$lib/components/ui/tooltip";
@@ -64,9 +66,18 @@
   let open = $state(false);
   let triggerTooltipOpen = $state(false);
 
-  /** Opening is the moment to re-read the two cheap GitHub values, so the
-   *  popover never shows a figure up to one poll interval old. */
+  // The resource section renders only while the feature is on; its sampling
+  // lease follows the popover's lifecycle (open = sample, closed = parked).
+  const showResources = $derived(resources.enabled);
+
+  /** Opening is the moment to re-read the two cheap GitHub values (so the
+   *  popover never shows a figure up to one poll interval old) and to take /
+   *  release the resource-sampling lease. */
   function onOpenChange(next: boolean): void {
+    if (showResources) {
+      if (next) void resources.open();
+      else void resources.close();
+    }
     if (!next || !showGithub) return;
     void github.refreshRateLimit();
     if (showUnread) void github.refreshNotifications();
@@ -125,6 +136,21 @@
         </span>
       </div>
     </div>
+
+    {#if showResources}
+      <ResourceSummary />
+      <button
+        type="button"
+        class="flex w-full items-center gap-1.5 border-t border-border/60 px-3 py-2 text-muted-foreground hover:text-foreground {text.meta}"
+        onclick={() => {
+          open = false;
+          app.openSettings("resources");
+        }}
+      >
+        <SettingsIcon class="size-3.5" />
+        {i18n.t("resources.settingsLink")}
+      </button>
+    {/if}
 
     {#if showGithub}
       <div class="flex flex-col gap-2 border-t border-border/60 p-3">

--- a/uxnandesktop/src/lib/components/ResourceSettings.svelte
+++ b/uxnandesktop/src/lib/components/ResourceSettings.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+  // Settings → Resources: the feature switch, the opt-in background orphan
+  // sweep, an explanation of the attribution confidences, and the manual
+  // diagnostics export. The export is consent-first: the dialog lists every
+  // field of the already-sanitized document, and only a confirmation writes a
+  // file (via the OS save dialog — nothing is ever uploaded).
+  import * as Dialog from "$lib/components/ui/dialog";
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import { Switch } from "$lib/components/ui/switch";
+  import SettingsSection from "$lib/components/SettingsSection.svelte";
+  import SettingsRow from "$lib/components/SettingsRow.svelte";
+  import { app } from "$lib/state/app.svelte";
+  import { resourcesExport, fsWriteFile } from "$lib/api";
+  import type { ResourceExport, ResourceSettings } from "$lib/types";
+  import { i18n } from "$lib/i18n";
+  import { cn } from "$lib/utils";
+  import { text } from "$lib/design";
+  import DownloadIcon from "@lucide/svelte/icons/download";
+
+  const settings = $derived(app.settings.resources ?? {});
+
+  function set(patch: Partial<ResourceSettings>): void {
+    app.settings.resources = { ...app.settings.resources, ...patch };
+    void app.persistSettings();
+  }
+
+  // --- export (consent-first) ------------------------------------------------
+
+  let exportDoc = $state<ResourceExport | null>(null);
+  let exportOpen = $state(false);
+  let exportBusy = $state(false);
+  let exportError = $state<string | null>(null);
+  let exportSaved = $state(false);
+
+  /** Fetch the sanitized document and show its field list for consent. */
+  async function beginExport(): Promise<void> {
+    exportError = null;
+    exportSaved = false;
+    exportBusy = true;
+    try {
+      exportDoc = await resourcesExport();
+      exportOpen = true;
+    } catch (e) {
+      exportError = e instanceof Error ? e.message : String(e);
+    } finally {
+      exportBusy = false;
+    }
+  }
+
+  /** Write the exact document the dialog showed, via the OS save dialog. */
+  async function confirmExport(): Promise<void> {
+    if (!exportDoc) return;
+    exportError = null;
+    exportBusy = true;
+    try {
+      const { save } = await import("@tauri-apps/plugin-dialog");
+      const stamp = new Date(exportDoc.exportedAtMs).toISOString().slice(0, 10);
+      const path = await save({
+        defaultPath: `uxnan-resources-${stamp}.json`,
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (typeof path !== "string") return; // user cancelled the OS dialog
+      await fsWriteFile(path, JSON.stringify(exportDoc, null, 2));
+      exportSaved = true;
+      exportOpen = false;
+    } catch (e) {
+      exportError = e instanceof Error ? e.message : String(e);
+    } finally {
+      exportBusy = false;
+    }
+  }
+</script>
+
+<SettingsSection
+  title={i18n.t("settings.resources")}
+  description={i18n.t("settings.resourcesDesc")}
+  bare
+>
+  <div class="space-y-6">
+    <div class="divide-y divide-border/50 rounded-xl border border-border/60 bg-muted/20 px-4 py-1">
+      <SettingsRow label={i18n.t("resources.enable")} description={i18n.t("resources.enableDesc")}>
+        {#snippet control()}
+          <Switch
+            checked={settings.enabled !== false}
+            onCheckedChange={(c) => set({ enabled: c })}
+          />
+        {/snippet}
+      </SettingsRow>
+
+      <SettingsRow
+        label={i18n.t("resources.orphanSweep")}
+        description={i18n.t("resources.orphanSweepDesc")}
+      >
+        {#snippet control()}
+          <Switch
+            checked={settings.orphanSweep === true}
+            disabled={settings.enabled === false}
+            onCheckedChange={(c) => set({ orphanSweep: c })}
+          />
+        {/snippet}
+      </SettingsRow>
+
+      <SettingsRow
+        label={i18n.t("resources.sweepInterval")}
+        description={i18n.t("resources.sweepIntervalDesc")}
+        for="resource-sweep-interval"
+      >
+        {#snippet control()}
+          <Input
+            id="resource-sweep-interval"
+            type="number"
+            class="w-20 text-right tabular-nums"
+            min={15}
+            max={30}
+            disabled={settings.enabled === false || settings.orphanSweep !== true}
+            value={settings.orphanSweepSeconds ?? 20}
+            onchange={(e) => {
+              const raw = Number((e.currentTarget as HTMLInputElement).value);
+              // The backend clamps too; clamping here keeps the field honest.
+              const clamped = Number.isFinite(raw) ? Math.min(30, Math.max(15, Math.round(raw))) : 20;
+              set({ orphanSweepSeconds: clamped });
+            }}
+          />
+        {/snippet}
+      </SettingsRow>
+    </div>
+
+    <!-- What the confidences mean — the vocabulary every row in the popover uses. -->
+    <div class="space-y-2 rounded-xl border border-border/60 bg-muted/20 px-4 py-3">
+      <span class={text.section}>{i18n.t("resources.confidenceTitle")}</span>
+      <ul class={cn("space-y-1.5", text.meta)}>
+        <li>
+          <span class="font-medium text-foreground">{i18n.t("resources.confidenceExactName")}</span>
+          — {i18n.t("resources.confidenceExact")}
+        </li>
+        <li>
+          <span class="font-medium text-foreground"
+            >{i18n.t("resources.confidenceInferredName")} (~)</span
+          >
+          — {i18n.t("resources.confidenceInferred")}
+        </li>
+        <li>
+          <span class="font-medium text-foreground"
+            >{i18n.t("resources.confidenceUnknownName")} (?)</span
+          >
+          — {i18n.t("resources.confidenceUnknown")}
+        </li>
+      </ul>
+    </div>
+
+    <div class="divide-y divide-border/50 rounded-xl border border-border/60 bg-muted/20 px-4 py-1">
+      <SettingsRow label={i18n.t("resources.export")} description={i18n.t("resources.exportDesc")}>
+        {#snippet control()}
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={exportBusy || settings.enabled === false}
+            onclick={beginExport}
+          >
+            <DownloadIcon class="size-3.5" />
+            {i18n.t("resources.exportButton")}
+          </Button>
+        {/snippet}
+      </SettingsRow>
+      {#if exportSaved}
+        <p class={cn("py-2 text-green-600 dark:text-green-400", text.meta)}>
+          {i18n.t("resources.exportSaved")}
+        </p>
+      {/if}
+      {#if exportError && !exportOpen}
+        <p class={cn("py-2 text-destructive", text.meta)}>{exportError}</p>
+      {/if}
+    </div>
+  </div>
+</SettingsSection>
+
+<Dialog.Root bind:open={exportOpen}>
+  <Dialog.Content class="sm:max-w-[480px]">
+    <Dialog.Header>
+      <Dialog.Title>{i18n.t("resources.exportTitle")}</Dialog.Title>
+      <Dialog.Description>{i18n.t("resources.exportFieldsIntro")}</Dialog.Description>
+    </Dialog.Header>
+
+    {#if exportDoc}
+      <ul
+        class={cn(
+          "max-h-56 list-disc space-y-0.5 overflow-y-auto rounded-md border border-border/50 bg-muted/20 py-2 pl-7 pr-3",
+          text.meta,
+        )}
+        data-testid="export-fields"
+      >
+        {#each exportDoc.fields as field (field)}
+          <li>{field}</li>
+        {/each}
+      </ul>
+      <p class={text.meta}>{i18n.t("resources.exportSanitizedNote")}</p>
+    {/if}
+    {#if exportError}
+      <p class={cn("text-destructive", text.meta)}>{exportError}</p>
+    {/if}
+
+    <Dialog.Footer>
+      <Button variant="ghost" onclick={() => (exportOpen = false)}>
+        {i18n.t("common.cancel")}
+      </Button>
+      <Button disabled={exportBusy || !exportDoc} onclick={confirmExport}>
+        {i18n.t("resources.exportConfirm")}
+      </Button>
+    </Dialog.Footer>
+  </Dialog.Content>
+</Dialog.Root>

--- a/uxnandesktop/src/lib/components/ResourceSettings.svelte.test.ts
+++ b/uxnandesktop/src/lib/components/ResourceSettings.svelte.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Settings → Resources, and above all its export flow: the dialog must list
+ * the document's fields BEFORE anything touches disk, cancelling must write
+ * nothing, and confirming must write exactly the document that was shown —
+ * consent-first is the feature's whole privacy story, so it gets the tests.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mount, until } from "../../test/render";
+import { app } from "$lib/state/app.svelte";
+import type { ResourceExport } from "$lib/types";
+import ResourceSettings from "./ResourceSettings.svelte";
+
+beforeEach(() => {
+  // A bits-ui modal that is still open when its test unmounts leaves
+  // `pointer-events: none` on the body, blocking every later click in the
+  // file (the same leak the app guards against at runtime). Reset it.
+  document.body.style.pointerEvents = "";
+});
+
+function exportDoc(): ResourceExport {
+  return {
+    schemaVersion: 1,
+    exportedAtMs: 1_750_000_000_000,
+    platform: "windows",
+    appVersion: "0.0.24",
+    capabilities: {
+      cpu: true,
+      memory: true,
+      virtualMemory: true,
+      io: true,
+      startTime: true,
+      validated: true,
+    },
+    sampling: { active: false, reason: "off" },
+    bufferSeconds: 600,
+    fields: ["schemaVersion", "cpuPercent / cpuAvgPercent / cpuPeakPercent", "pids (orphans only)"],
+    groups: [],
+    orphans: [],
+  };
+}
+
+/** Handlers every mount here needs; tests add their own on top. */
+function baseCommands() {
+  return {
+    update_settings: () => ({ version: 1, repos: [], settings: {}, agentCache: [] }),
+    resources_export: () => exportDoc(),
+  };
+}
+
+describe("ResourceSettings", () => {
+  it("renders the switches from the current settings", () => {
+    app.settings.resources = { enabled: true, orphanSweep: false, orphanSweepSeconds: 20 };
+    const { screen } = mount(ResourceSettings, { commands: baseCommands() });
+    const switches = screen.getAllByRole("switch");
+    expect(switches).toHaveLength(2);
+    expect(switches[0]).toBeChecked(); // resource monitor on
+    expect(switches[1]).not.toBeChecked(); // orphan sweep off (opt-in)
+  });
+
+  it("persists a toggle through the real settings command", async () => {
+    app.settings.resources = { enabled: true, orphanSweep: false, orphanSweepSeconds: 20 };
+    const { screen, backend, user } = mount(ResourceSettings, { commands: baseCommands() });
+    await user.click(screen.getAllByRole("switch")[1]);
+    await until(() => backend.called("update_settings"), { label: "settings persisted" });
+    const sent = backend.lastCallTo("update_settings")?.args.settings as {
+      resources?: { orphanSweep?: boolean };
+    };
+    expect(sent.resources?.orphanSweep).toBe(true);
+  });
+
+  it("explains the three confidence levels", () => {
+    app.settings.resources = { enabled: true };
+    const { screen } = mount(ResourceSettings, { commands: baseCommands() });
+    expect(screen.getByText("Exact")).toBeInTheDocument();
+    expect(screen.getByText(/Inferred/)).toBeInTheDocument();
+    expect(screen.getByText(/Unknown/)).toBeInTheDocument();
+  });
+
+  it("shows the export field list for consent before anything is written", async () => {
+    app.settings.resources = { enabled: true };
+    const { screen, backend, user } = mount(ResourceSettings, { commands: baseCommands() });
+    await user.click(screen.getByRole("button", { name: /Export…/ }));
+    // The dialog lists exactly the document's fields…
+    const list = await until(
+      () => document.querySelector('[data-testid="export-fields"]') !== null,
+      { label: "consent dialog" },
+    ).then(() => document.querySelector('[data-testid="export-fields"]')!);
+    expect(list.textContent).toContain("pids (orphans only)");
+    // …and nothing has touched disk yet.
+    expect(backend.called("fs_write_file")).toBe(false);
+    expect(backend.called("plugin:dialog|save")).toBe(false);
+  });
+
+  it("cancelling the consent dialog writes nothing", async () => {
+    app.settings.resources = { enabled: true };
+    const { screen, backend, user } = mount(ResourceSettings, { commands: baseCommands() });
+    await user.click(screen.getByRole("button", { name: /Export…/ }));
+    await until(() => document.querySelector('[data-testid="export-fields"]') !== null, {
+      label: "consent dialog",
+    });
+    const cancel = [...document.querySelectorAll("button")].find(
+      (b) => b.textContent?.trim() === "Cancel",
+    );
+    expect(cancel).toBeDefined();
+    await user.click(cancel!);
+    expect(backend.called("fs_write_file")).toBe(false);
+  });
+
+  it("confirming writes exactly the document that was shown", async () => {
+    app.settings.resources = { enabled: true };
+    const { screen, backend, user } = mount(ResourceSettings, {
+      commands: {
+        ...baseCommands(),
+        "plugin:dialog|save": () => "C:\\tmp\\uxnan-resources.json",
+        fs_write_file: () => undefined,
+      },
+    });
+    await user.click(screen.getByRole("button", { name: /Export…/ }));
+    await until(() => document.querySelector('[data-testid="export-fields"]') !== null, {
+      label: "consent dialog",
+    });
+    const confirm = [...document.querySelectorAll("button")].find(
+      (b) => b.textContent?.trim() === "Save file…",
+    );
+    await user.click(confirm!);
+    await until(() => backend.called("fs_write_file"), { label: "file written" });
+    const written = backend.lastCallTo("fs_write_file")?.args as { path: string; content: string };
+    expect(written.path).toContain("uxnan-resources");
+    expect(JSON.parse(written.content)).toEqual(exportDoc());
+  });
+
+  it("disables the sweep interval until the sweep itself is on", () => {
+    app.settings.resources = { enabled: true, orphanSweep: false };
+    const { screen } = mount(ResourceSettings, { commands: baseCommands() });
+    expect(screen.getByLabelText(/Check interval/)).toBeDisabled();
+  });
+});

--- a/uxnandesktop/src/lib/components/ResourceSummary.svelte
+++ b/uxnandesktop/src/lib/components/ResourceSummary.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+  // Compact resource readout for the backend popover: what uxnan + its
+  // terminals + its agents cost right now, each row carrying its attribution
+  // confidence instead of pretending precision. Fed by the `resources` store,
+  // whose lease the popover takes on open — this component renders whatever is
+  // buffered and never drives sampling itself.
+  import { i18n } from "$lib/i18n";
+  import { resources } from "$lib/state/resources.svelte";
+  import type { ResourceGroupSummary } from "$lib/types";
+  import {
+    confidenceKey,
+    groupLabel,
+    groupState,
+    orderedGroups,
+    surfaceState,
+  } from "$lib/resources/display";
+  import { formatAge, formatBytes, formatCpu } from "$lib/resources/format";
+  import { cn } from "$lib/utils";
+  import { text } from "$lib/design";
+  import { TooltipSimple } from "$lib/components/ui/tooltip";
+  import ActivityIcon from "@lucide/svelte/icons/activity";
+  import TrendingUpIcon from "@lucide/svelte/icons/trending-up";
+  import TrendingDownIcon from "@lucide/svelte/icons/trending-down";
+  import TriangleAlertIcon from "@lucide/svelte/icons/triangle-alert";
+
+  const summary = $derived(resources.summary);
+  const state = $derived(surfaceState(summary, resources.loading));
+  const groups = $derived(summary ? orderedGroups(summary) : []);
+  const total = $derived(summary?.total ?? null);
+  const orphans = $derived(summary?.orphans ?? []);
+
+  /** Confidence marker after a row label: nothing for exact, `~` inferred,
+   *  `?` unknown — each explained in its tooltip. */
+  function confidenceMark(group: ResourceGroupSummary): string {
+    if (group.confidence === "exact") return "";
+    return group.confidence === "inferred" ? "~" : "?";
+  }
+
+  function kindLabel(group: ResourceGroupSummary): string {
+    switch (group.kind) {
+      case "desktop":
+        return i18n.t("resources.kindDesktop");
+      case "workspace":
+        return groupLabel(group);
+      case "agent":
+        return groupLabel(group);
+      case "terminal":
+        return `${i18n.t("resources.kindTerminal")} ${groupLabel(group)}`;
+      default:
+        return groupLabel(group) || group.kind;
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-2 border-t border-border/60 p-3" data-testid="resource-summary">
+  <div class="flex items-center gap-1.5">
+    <ActivityIcon class="size-3.5 text-muted-foreground" />
+    <span class="text-sm font-medium text-foreground">{i18n.t("resources.title")}</span>
+    {#if summary?.sampling.active && summary.sampling.intervalMs}
+      <span class={cn("ml-auto tabular-nums", text.meta)}>
+        {i18n.t("resources.samplingEvery", { seconds: summary.sampling.intervalMs / 1000 })}
+      </span>
+    {/if}
+  </div>
+
+  {#if state === "loading"}
+    <p class={text.meta}>{i18n.t("resources.loading")}</p>
+  {:else if state === "unsupported"}
+    <p class={text.meta}>{i18n.t("resources.unsupported")}</p>
+  {:else if state === "empty"}
+    <p class={text.meta}>{i18n.t("resources.empty")}</p>
+  {:else if summary}
+    <!-- Uxnan total: instant, with average/peak context underneath. -->
+    {#if total}
+      <div class="flex items-baseline justify-between gap-2">
+        <span class={cn("font-medium text-foreground", text.body)}>
+          {i18n.t("resources.totalLabel")}
+        </span>
+        <span class={cn("shrink-0 font-medium tabular-nums text-foreground", text.body)}>
+          {formatCpu(total.cpuPercent)} · {formatBytes(total.residentBytes)}
+        </span>
+      </div>
+      <div class="flex items-center justify-between gap-2">
+        <span class={text.meta}>
+          {i18n.plural(total.processes, "resources.processesOne", "resources.processesOther")}
+        </span>
+        <span class={cn("flex items-center gap-1 tabular-nums", text.meta)}>
+          {i18n.t("resources.peak")}
+          {formatCpu(total.cpuPeakPercent)} · {formatBytes(total.residentPeakBytes)}
+          {#if total.trend === "rising"}
+            <TooltipSimple title={i18n.t("resources.trendRising")}>
+              {#snippet children(tp)}
+                <span {...tp}><TrendingUpIcon class="size-3 text-amber-500" /></span>
+              {/snippet}
+            </TooltipSimple>
+          {:else if total.trend === "falling"}
+            <TooltipSimple title={i18n.t("resources.trendFalling")}>
+              {#snippet children(tp)}
+                <span {...tp}><TrendingDownIcon class="size-3 text-muted-foreground" /></span>
+              {/snippet}
+            </TooltipSimple>
+          {/if}
+        </span>
+      </div>
+    {/if}
+
+    {#if groups.length > 0}
+      <div class="flex flex-col gap-1 border-t border-border/50 pt-2">
+        {#each groups as group (group.kind + (group.id ?? ""))}
+          {@const rowState = groupState(group)}
+          <div
+            class={cn("flex items-baseline justify-between gap-2", group.ended && "opacity-60")}
+            data-testid="resource-group"
+            data-state={rowState}
+          >
+            <span class={cn("flex min-w-0 items-baseline gap-1", text.meta)}>
+              <span class="truncate" title={group.id ?? undefined}>{kindLabel(group)}</span>
+              {#if confidenceMark(group)}
+                <TooltipSimple title={i18n.t(confidenceKey(group.confidence))}>
+                  {#snippet children(tp)}
+                    <span
+                      {...tp}
+                      class={cn(
+                        "shrink-0 cursor-help font-medium",
+                        group.confidence === "unknown" ? "text-amber-500" : "",
+                      )}>{confidenceMark(group)}</span
+                    >
+                  {/snippet}
+                </TooltipSimple>
+              {/if}
+              {#if group.ended}
+                <span class="shrink-0">· {i18n.t("resources.ended")}</span>
+              {/if}
+            </span>
+            <span
+              class={cn(
+                "shrink-0 tabular-nums",
+                text.meta,
+                rowState === "spike" && "font-medium text-amber-600 dark:text-amber-400",
+              )}
+            >
+              {#if rowState === "spike"}
+                <TooltipSimple title={i18n.t("resources.spike")}>
+                  {#snippet children(tp)}
+                    <span {...tp}>{formatCpu(group.cpuPercent)}</span>
+                  {/snippet}
+                </TooltipSimple>
+              {:else}
+                {formatCpu(group.cpuPercent)}
+              {/if}
+              · {formatBytes(group.residentBytes)}
+            </span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if orphans.length > 0}
+      <div
+        class={cn(
+          "flex flex-col gap-1 rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-1.5",
+          text.meta,
+        )}
+        data-testid="resource-orphans"
+      >
+        <span class="flex items-center gap-1.5 font-medium text-amber-600 dark:text-amber-400">
+          <TriangleAlertIcon class="size-3" />
+          {i18n.plural(orphans.length, "resources.orphansOne", "resources.orphansOther")}
+        </span>
+        {#each orphans as orphan (orphan.id + orphan.sinceMs)}
+          <span class="truncate">
+            {orphan.id} · {formatBytes(orphan.residentBytes)} ·
+            {i18n.t("resources.orphanAge", { age: formatAge(Date.now() - orphan.sinceMs) })}
+          </span>
+        {/each}
+      </div>
+    {/if}
+
+    {#if !summary.capabilities.validated}
+      <p class={text.meta}>{i18n.t("resources.bestEffort")}</p>
+    {/if}
+  {/if}
+</div>

--- a/uxnandesktop/src/lib/components/ResourceSummary.svelte.test.ts
+++ b/uxnandesktop/src/lib/components/ResourceSummary.svelte.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The popover's resource readout, state by state. What matters here is honesty
+ * under partial knowledge: loading is not empty, empty is not zero, an unknown
+ * confidence is visibly marked, a spike is highlighted only when real, an ended
+ * group is frozen rather than dropped, and a survivor gets a warning — each of
+ * these is a distinct render this file pins down.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { mountWithProviders as mount } from "../../test/render";
+import { resources } from "$lib/state/resources.svelte";
+import type { ResourceGroupSummary, ResourceSummary } from "$lib/types";
+import ResourceSummaryView from "./ResourceSummary.svelte";
+
+function group(overrides: Partial<ResourceGroupSummary> = {}): ResourceGroupSummary {
+  return {
+    kind: "workspace",
+    id: "C:\\dev\\uxnan--pets",
+    confidence: "exact",
+    ended: false,
+    processes: 2,
+    cpuPercent: 1.2,
+    cpuAvgPercent: 1.0,
+    cpuPeakPercent: 2.0,
+    residentBytes: 200 * 1024 * 1024,
+    residentAvgBytes: 190 * 1024 * 1024,
+    residentPeakBytes: 220 * 1024 * 1024,
+    virtualBytes: 900 * 1024 * 1024,
+    ioReadBytesPerSec: null,
+    ioWriteBytesPerSec: null,
+    trend: "steady",
+    ...overrides,
+  };
+}
+
+function summary(overrides: Partial<ResourceSummary> = {}): ResourceSummary {
+  return {
+    enabled: true,
+    capabilities: {
+      cpu: true,
+      memory: true,
+      virtualMemory: true,
+      io: true,
+      startTime: true,
+      validated: true,
+    },
+    sampling: { active: true, intervalMs: 2000, reason: "popover" },
+    updatedAtMs: Date.now(),
+    bufferSeconds: 600,
+    total: {
+      processes: 9,
+      cpuPercent: 4.2,
+      cpuAvgPercent: 3.9,
+      cpuPeakPercent: 12,
+      residentBytes: 800 * 1024 * 1024,
+      residentAvgBytes: 780 * 1024 * 1024,
+      residentPeakBytes: 900 * 1024 * 1024,
+      virtualBytes: 4 * 1024 * 1024 * 1024,
+      ioReadBytesPerSec: null,
+      ioWriteBytesPerSec: null,
+      trend: "steady",
+    },
+    groups: [group()],
+    orphans: [],
+    terminalsLinked: 1,
+    ...overrides,
+  };
+}
+
+/** The store is a module singleton; each test states its world explicitly. */
+function setStore(value: ResourceSummary | null, loading = false): void {
+  resources.summary = value;
+  resources.loading = loading;
+}
+
+describe("ResourceSummary", () => {
+  it("shows a loading line before the first data, never an empty zero-table", () => {
+    setStore(null, true);
+    const { screen } = mount(ResourceSummaryView);
+    expect(screen.getByText("Reading…")).toBeInTheDocument();
+  });
+
+  it("says measuring starts with the panel open when nothing was sampled yet", () => {
+    setStore(null, false);
+    const { screen } = mount(ResourceSummaryView);
+    expect(screen.getByText(/No samples yet/)).toBeInTheDocument();
+  });
+
+  it("states unsupported when the platform offers neither CPU nor memory", () => {
+    const s = summary();
+    s.capabilities = { ...s.capabilities, cpu: false, memory: false };
+    setStore(s);
+    const { screen } = mount(ResourceSummaryView);
+    expect(screen.getByText(/not available on this platform/)).toBeInTheDocument();
+  });
+
+  it("renders the total with instant CPU and memory", () => {
+    setStore(summary());
+    const { screen } = mount(ResourceSummaryView);
+    expect(screen.getByText("Uxnan (everything)")).toBeInTheDocument();
+    expect(screen.getByText(/4\.2%/)).toBeInTheDocument();
+    expect(screen.getByText(/800 MB/)).toBeInTheDocument();
+    expect(screen.getByText("9 processes")).toBeInTheDocument();
+  });
+
+  it("shows the workspace folder name, not the full path", () => {
+    setStore(summary());
+    const { screen } = mount(ResourceSummaryView);
+    expect(screen.getByText("uxnan--pets")).toBeInTheDocument();
+    expect(screen.queryByText(/C:\\dev/)).not.toBeInTheDocument();
+  });
+
+  it("marks an inferred group with ~ and an unknown one with ?", () => {
+    setStore(
+      summary({
+        groups: [
+          group({ kind: "agent", id: "claude", confidence: "inferred" }),
+          group({ kind: "terminal", id: "pty-9", confidence: "unknown", cpuPercent: null, residentBytes: null }),
+        ],
+      }),
+    );
+    const { screen } = mount(ResourceSummaryView);
+    expect(screen.getByText("~")).toBeInTheDocument();
+    expect(screen.getByText("?")).toBeInTheDocument();
+  });
+
+  it("renders an unknown group's metrics as dashes, never zeros", () => {
+    setStore(
+      summary({
+        groups: [
+          group({
+            kind: "terminal",
+            id: "pty-9",
+            confidence: "unknown",
+            processes: 0,
+            cpuPercent: null,
+            residentBytes: null,
+          }),
+        ],
+      }),
+    );
+    const { screen } = mount(ResourceSummaryView);
+    const row = screen.container.querySelector('[data-testid="resource-group"]');
+    expect(row?.textContent).toContain("—");
+    expect(row?.textContent).not.toContain("0 B");
+  });
+
+  it("highlights a spike only when the instant is far above the average", () => {
+    setStore(
+      summary({
+        groups: [group({ kind: "agent", id: "codex", cpuPercent: 22, cpuAvgPercent: 4 })],
+      }),
+    );
+    const { screen } = mount(ResourceSummaryView);
+    const row = screen.container.querySelector('[data-testid="resource-group"]');
+    expect(row?.getAttribute("data-state")).toBe("spike");
+  });
+
+  it("freezes an ended group with an explicit note instead of dropping it", () => {
+    setStore(summary({ groups: [group({ ended: true })] }));
+    const { screen } = mount(ResourceSummaryView);
+    const row = screen.container.querySelector('[data-testid="resource-group"]');
+    expect(row?.getAttribute("data-state")).toBe("ended");
+    expect(screen.getByText(/ended/)).toBeInTheDocument();
+  });
+
+  it("warns about processes that outlived their terminal", () => {
+    setStore(
+      summary({
+        orphans: [
+          {
+            kind: "agent",
+            id: "claude",
+            pids: [4242],
+            cpuPercent: 1,
+            residentBytes: 64 * 1024 * 1024,
+            sinceMs: Date.now() - 30_000,
+            confidence: "exact",
+          },
+        ],
+      }),
+    );
+    const { screen } = mount(ResourceSummaryView);
+    expect(screen.getByText("1 surviving process")).toBeInTheDocument();
+    expect(
+      screen.container.querySelector('[data-testid="resource-orphans"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("admits best-effort figures on an unvalidated platform", () => {
+    const s = summary();
+    s.capabilities = { ...s.capabilities, validated: false };
+    setStore(s);
+    const { screen } = mount(ResourceSummaryView);
+    expect(screen.getByText(/best effort/)).toBeInTheDocument();
+  });
+});

--- a/uxnandesktop/src/lib/components/Settings.svelte
+++ b/uxnandesktop/src/lib/components/Settings.svelte
@@ -58,6 +58,7 @@
   import OpenWithSettings from "./OpenWithSettings.svelte";
   import GithubSettings from "./GithubSettings.svelte";
   import PetsSettings from "./PetsSettings.svelte";
+  import ResourceSettings from "./ResourceSettings.svelte";
   import SettingsSection from "./SettingsSection.svelte";
   import SettingsRow from "./SettingsRow.svelte";
   import { TERMINAL_SCROLLBACK_PRESETS } from "$lib/terminal/scrollback";
@@ -77,6 +78,7 @@
   import BotIcon from "@lucide/svelte/icons/bot";
   import GaugeIcon from "@lucide/svelte/icons/gauge";
   import LanguagesIcon from "@lucide/svelte/icons/languages";
+  import ActivityIcon from "@lucide/svelte/icons/activity";
   import KeyboardIcon from "@lucide/svelte/icons/keyboard";
   import WebhookIcon from "@lucide/svelte/icons/webhook";
   import DownloadIcon from "@lucide/svelte/icons/download";
@@ -782,7 +784,10 @@
     },
     {
       titleKey: "settings.groupApp",
-      items: [{ id: "updates", key: "settings.updates", icon: DownloadIcon }],
+      items: [
+        { id: "resources", key: "settings.resources", icon: ActivityIcon },
+        { id: "updates", key: "settings.updates", icon: DownloadIcon },
+      ],
     },
   ] as const;
 </script>
@@ -1674,6 +1679,8 @@
           <OpenWithSettings />
         {:else if app.settingsSection === "github"}
           <GithubSettings />
+        {:else if app.settingsSection === "resources"}
+          <ResourceSettings />
         {:else}
           <div class="flex flex-col gap-6">
           <SettingsSection title={i18n.t("settings.terminal")} description={i18n.t("settings.terminalDesc")}>

--- a/uxnandesktop/src/lib/components/Terminal.svelte
+++ b/uxnandesktop/src/lib/components/Terminal.svelte
@@ -410,7 +410,16 @@
       },
       ligatures: t.ligatures,
       webLinks: app.settings.browser?.terminalLinks ?? true,
-      spec: { cwd, shell, args, runCommand, runCommandExecute, env },
+      spec: {
+        cwd,
+        shell,
+        args,
+        runCommand,
+        runCommandExecute,
+        env,
+        // Attribution only (resource monitor): the workspace this tab lives in.
+        workspace: terminals.workspaceOfTab(id),
+      },
     }));
     if (destroyed) {
       // The pane died while the instance was being built (rapid open/close or a

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -467,6 +467,60 @@ export const en = {
   "settings.updates": "Updates",
   "settings.updatesDesc":
     "Choose how Uxnan Desktop checks for, downloads and installs new versions.",
+  "settings.resources": "Resources",
+  "settings.resourcesDesc":
+    "A local, explainable readout of what Uxnan, its terminals and its agents cost in CPU and memory. Nothing is measured unless a surface is open, and nothing ever leaves this machine.",
+
+  // Resource observability (backend popover + Settings → Resources)
+  "resources.title": "Resources",
+  "resources.samplingEvery": "every {seconds} s",
+  "resources.loading": "Reading…",
+  "resources.empty": "No samples yet — measuring starts while this panel is open.",
+  "resources.unsupported": "Resource metrics are not available on this platform.",
+  "resources.totalLabel": "Uxnan (everything)",
+  "resources.processesOne": "{n} process",
+  "resources.processesOther": "{n} processes",
+  "resources.peak": "peak",
+  "resources.trendRising": "Memory has been rising over the last minutes",
+  "resources.trendFalling": "Memory has been falling over the last minutes",
+  "resources.kindDesktop": "App",
+  "resources.kindTerminal": "Terminal",
+  "resources.ended": "ended",
+  "resources.spike": "Well above its recent average",
+  "resources.orphansOne": "{n} surviving process",
+  "resources.orphansOther": "{n} surviving processes",
+  "resources.orphanAge": "outlived its terminal by {age}",
+  "resources.bestEffort":
+    "Figures on this platform are best effort (not yet validated on hardware).",
+  "resources.settingsLink": "Resource settings",
+  "resources.enable": "Resource monitor",
+  "resources.enableDesc":
+    "Show the Resources readout in the backend popover. Measuring only runs while that panel is open, so the feature costs nothing at rest.",
+  "resources.orphanSweep": "Watch for surviving processes",
+  "resources.orphanSweepDesc":
+    "Keep a slow background check running so a process that outlives its closed terminal is noticed even with no panel open. The one mode that samples unasked.",
+  "resources.sweepInterval": "Check interval (seconds)",
+  "resources.sweepIntervalDesc": "How often the background check runs (15–30 s).",
+  "resources.confidenceTitle": "How attribution is labeled",
+  "resources.confidenceExactName": "Exact",
+  "resources.confidenceExact":
+    "Verified by process id and start time against a terminal Uxnan spawned.",
+  "resources.confidenceInferredName": "Inferred",
+  "resources.confidenceInferred":
+    "Attributed through the parent chain below a verified process — solid evidence, not proof.",
+  "resources.confidenceUnknownName": "Unknown",
+  "resources.confidenceUnknown":
+    "Identity could not be verified (for example, the process id was recycled). No figures are claimed.",
+  "resources.export": "Export diagnostics",
+  "resources.exportDesc":
+    "Save a sanitized JSON snapshot of the current summary — anonymized labels, no paths, no command lines. You review the fields before anything is written.",
+  "resources.exportButton": "Export…",
+  "resources.exportTitle": "Export resource diagnostics",
+  "resources.exportFieldsIntro": "The file will contain exactly these fields:",
+  "resources.exportSanitizedNote":
+    "Workspace and terminal names are replaced with opaque labels; agent names are kept only for known catalog agents. Nothing is uploaded — you choose where the file is saved.",
+  "resources.exportConfirm": "Save file…",
+  "resources.exportSaved": "Diagnostics exported.",
   "settings.browser": "Browser",
   "settings.browserDesc":
     "A lightweight in-app browser to preview and debug what your agents build, and to open the links they create.",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -468,6 +468,60 @@ export const es: Record<MessageKey, string> = {
   "settings.updates": "Actualizaciones",
   "settings.updatesDesc":
     "Elige cómo Uxnan Desktop busca, descarga e instala nuevas versiones.",
+  "settings.resources": "Recursos",
+  "settings.resourcesDesc":
+    "Una lectura local y explicable de lo que cuestan Uxnan, sus terminales y sus agentes en CPU y memoria. No se mide nada salvo que haya una superficie abierta, y nada sale de esta máquina.",
+
+  // Observabilidad de recursos (popover del backend + Ajustes → Recursos)
+  "resources.title": "Recursos",
+  "resources.samplingEvery": "cada {seconds} s",
+  "resources.loading": "Leyendo…",
+  "resources.empty": "Aún no hay muestras: se mide mientras este panel está abierto.",
+  "resources.unsupported": "Las métricas de recursos no están disponibles en esta plataforma.",
+  "resources.totalLabel": "Uxnan (todo)",
+  "resources.processesOne": "{n} proceso",
+  "resources.processesOther": "{n} procesos",
+  "resources.peak": "pico",
+  "resources.trendRising": "La memoria ha ido subiendo en los últimos minutos",
+  "resources.trendFalling": "La memoria ha ido bajando en los últimos minutos",
+  "resources.kindDesktop": "Aplicación",
+  "resources.kindTerminal": "Terminal",
+  "resources.ended": "terminado",
+  "resources.spike": "Muy por encima de su media reciente",
+  "resources.orphansOne": "{n} proceso superviviente",
+  "resources.orphansOther": "{n} procesos supervivientes",
+  "resources.orphanAge": "sobrevivió a su terminal {age}",
+  "resources.bestEffort":
+    "En esta plataforma las cifras son aproximadas (aún sin validar en hardware).",
+  "resources.settingsLink": "Ajustes de recursos",
+  "resources.enable": "Monitor de recursos",
+  "resources.enableDesc":
+    "Muestra la lectura de Recursos en el popover del backend. Solo se mide mientras ese panel está abierto, así que la función no cuesta nada en reposo.",
+  "resources.orphanSweep": "Vigilar procesos supervivientes",
+  "resources.orphanSweepDesc":
+    "Mantén una comprobación lenta en segundo plano para detectar un proceso que sobreviva a su terminal cerrada aunque no haya ningún panel abierto. El único modo que muestrea sin pedirlo.",
+  "resources.sweepInterval": "Intervalo de comprobación (segundos)",
+  "resources.sweepIntervalDesc": "Cada cuánto se ejecuta la comprobación en segundo plano (15–30 s).",
+  "resources.confidenceTitle": "Cómo se etiqueta la atribución",
+  "resources.confidenceExactName": "Exacta",
+  "resources.confidenceExact":
+    "Verificada por id de proceso y hora de inicio contra una terminal creada por Uxnan.",
+  "resources.confidenceInferredName": "Inferida",
+  "resources.confidenceInferred":
+    "Atribuida por la cadena de procesos padre bajo un proceso verificado: evidencia sólida, no prueba.",
+  "resources.confidenceUnknownName": "Desconocida",
+  "resources.confidenceUnknown":
+    "No se pudo verificar la identidad (por ejemplo, el id de proceso fue reciclado). No se afirman cifras.",
+  "resources.export": "Exportar diagnóstico",
+  "resources.exportDesc":
+    "Guarda una instantánea JSON saneada del resumen actual: etiquetas anónimas, sin rutas, sin líneas de comandos. Revisas los campos antes de escribir nada.",
+  "resources.exportButton": "Exportar…",
+  "resources.exportTitle": "Exportar diagnóstico de recursos",
+  "resources.exportFieldsIntro": "El archivo contendrá exactamente estos campos:",
+  "resources.exportSanitizedNote":
+    "Los nombres de workspaces y terminales se sustituyen por etiquetas opacas; los nombres de agente se conservan solo para agentes conocidos del catálogo. No se sube nada: tú eliges dónde se guarda el archivo.",
+  "resources.exportConfirm": "Guardar archivo…",
+  "resources.exportSaved": "Diagnóstico exportado.",
   "settings.browser": "Navegador",
   "settings.browserDesc":
     "Un navegador ligero dentro de la app para previsualizar y depurar lo que construyen tus agentes, y abrir los enlaces que crean.",

--- a/uxnandesktop/src/lib/resources/display.test.ts
+++ b/uxnandesktop/src/lib/resources/display.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The display rules the popover rows depend on: when a row is a spike, when it
+ * is frozen as ended, when identity loss outranks everything, and what the
+ * whole surface shows before/without data. Pure, so each rule is one assert.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { ResourceGroupSummary, ResourceSummary } from "$lib/types";
+import {
+  confidenceKey,
+  groupLabel,
+  groupState,
+  orderedGroups,
+  SPIKE_FACTOR,
+  SPIKE_FLOOR_PERCENT,
+  surfaceState,
+} from "./display";
+
+function group(overrides: Partial<ResourceGroupSummary> = {}): ResourceGroupSummary {
+  return {
+    kind: "workspace",
+    id: "C:\\dev\\uxnan",
+    confidence: "exact",
+    ended: false,
+    processes: 2,
+    cpuPercent: 1,
+    cpuAvgPercent: 1,
+    cpuPeakPercent: 2,
+    residentBytes: 100,
+    residentAvgBytes: 100,
+    residentPeakBytes: 120,
+    virtualBytes: 1000,
+    ioReadBytesPerSec: null,
+    ioWriteBytesPerSec: null,
+    trend: "steady",
+    ...overrides,
+  };
+}
+
+function summary(overrides: Partial<ResourceSummary> = {}): ResourceSummary {
+  return {
+    enabled: true,
+    capabilities: {
+      cpu: true,
+      memory: true,
+      virtualMemory: true,
+      io: true,
+      startTime: true,
+      validated: true,
+    },
+    sampling: { active: true, intervalMs: 2000, reason: "popover" },
+    updatedAtMs: 1000,
+    bufferSeconds: 600,
+    groups: [],
+    orphans: [],
+    terminalsLinked: 0,
+    ...overrides,
+  };
+}
+
+describe("groupState", () => {
+  it("is ok for a quiet, attributed, live group", () => {
+    expect(groupState(group())).toBe("ok");
+  });
+
+  it("flags a spike only above the floor AND the factor", () => {
+    // Above both: instant 20% vs 4% average.
+    expect(groupState(group({ cpuPercent: 20, cpuAvgPercent: 4 }))).toBe("spike");
+    // Factor exceeded but under the floor: a 0.5% → 2% wiggle stays quiet.
+    expect(groupState(group({ cpuPercent: 2, cpuAvgPercent: 0.5 }))).toBe("ok");
+    // Floor exceeded but not the factor: busy-but-steady is not a spike.
+    expect(groupState(group({ cpuPercent: 20, cpuAvgPercent: 15 }))).toBe("ok");
+    // The exact boundary counts as a spike.
+    expect(
+      groupState(
+        group({
+          cpuPercent: SPIKE_FLOOR_PERCENT * SPIKE_FACTOR,
+          cpuAvgPercent: SPIKE_FLOOR_PERCENT,
+        }),
+      ),
+    ).toBe("spike");
+  });
+
+  it("never calls a spike on unknown CPU (absent is not zero, nor a peak)", () => {
+    expect(groupState(group({ cpuPercent: null, cpuAvgPercent: null }))).toBe("ok");
+    expect(groupState(group({ cpuPercent: 50, cpuAvgPercent: null }))).toBe("ok");
+  });
+
+  it("freezes an ended group regardless of its last figures", () => {
+    expect(groupState(group({ ended: true, cpuPercent: 90, cpuAvgPercent: 1 }))).toBe("ended");
+  });
+
+  it("identity loss outranks everything else", () => {
+    expect(
+      groupState(group({ confidence: "unknown", ended: true, cpuPercent: 90, cpuAvgPercent: 1 })),
+    ).toBe("unknown");
+  });
+});
+
+describe("surfaceState", () => {
+  it("is loading before any summary arrives", () => {
+    expect(surfaceState(null, true)).toBe("loading");
+  });
+
+  it("is empty when nothing was ever sampled and nothing is in flight", () => {
+    expect(surfaceState(null, false)).toBe("empty");
+    expect(surfaceState(summary({ updatedAtMs: undefined }), false)).toBe("empty");
+  });
+
+  it("is unsupported only when neither CPU nor memory exist", () => {
+    const caps = summary().capabilities;
+    expect(
+      surfaceState(summary({ capabilities: { ...caps, cpu: false, memory: false } }), false),
+    ).toBe("unsupported");
+    // Partial support renders the table with dashes instead of giving up.
+    expect(surfaceState(summary({ capabilities: { ...caps, cpu: false } }), false)).toBe("ready");
+  });
+
+  it("is ready once a frame exists", () => {
+    expect(surfaceState(summary(), false)).toBe("ready");
+  });
+});
+
+describe("confidenceKey", () => {
+  it("maps each confidence to its explanation key", () => {
+    expect(confidenceKey("exact")).toBe("resources.confidenceExact");
+    expect(confidenceKey("inferred")).toBe("resources.confidenceInferred");
+    expect(confidenceKey("unknown")).toBe("resources.confidenceUnknown");
+  });
+});
+
+describe("groupLabel", () => {
+  it("shortens a workspace path to its folder name (both separators)", () => {
+    expect(groupLabel(group({ kind: "workspace", id: "C:\\dev\\uxnan--pets" }))).toBe(
+      "uxnan--pets",
+    );
+    expect(groupLabel(group({ kind: "workspace", id: "/home/dev/uxnan" }))).toBe("uxnan");
+  });
+
+  it("keeps an agent command verbatim", () => {
+    expect(groupLabel(group({ kind: "agent", id: "cursor-agent" }))).toBe("cursor-agent");
+  });
+
+  it("trims a long terminal id to its tail", () => {
+    const label = groupLabel(
+      group({ kind: "terminal", id: "3f89ab00-1234-4cd9-a1b2-99887766aabb" }),
+    );
+    expect(label.length).toBeLessThanOrEqual(9);
+    expect(label.startsWith("…")).toBe(true);
+  });
+});
+
+describe("orderedGroups", () => {
+  it("puts desktop first and ended groups last, whatever the wire order", () => {
+    const s = summary({
+      groups: [
+        group({ kind: "agent", id: "claude" }),
+        group({ kind: "workspace", id: "b", ended: true }),
+        group({ kind: "desktop", id: undefined }),
+        group({ kind: "workspace", id: "a" }),
+      ],
+    });
+    const kinds = orderedGroups(s).map((g) => `${g.kind}${g.ended ? ":ended" : ""}`);
+    expect(kinds).toEqual(["desktop", "workspace", "agent", "workspace:ended"]);
+  });
+});

--- a/uxnandesktop/src/lib/resources/display.ts
+++ b/uxnandesktop/src/lib/resources/display.ts
@@ -1,0 +1,95 @@
+// Presentation logic for the resource-observability surfaces: which state a
+// group renders in, how a workspace path becomes a short label, and the i18n
+// keys explaining each attribution confidence. Pure (node test project) so the
+// spike/ended/unknown rules are provable without mounting a component.
+
+import type {
+  AttributionConfidence,
+  ResourceGroupSummary,
+  ResourceSummary,
+} from "$lib/types";
+
+/** Visual state of one group row. Ordered by urgency for tie-breaks. */
+export type ResourceGroupState = "unknown" | "spike" | "ended" | "ok";
+
+/** A CPU reading this many × the short average (and at least `SPIKE_FLOOR`)
+ *  renders as a spike. The floor keeps a 0.2% → 0.6% wiggle from shouting. */
+export const SPIKE_FACTOR = 2.5;
+export const SPIKE_FLOOR_PERCENT = 5;
+
+/** Which state a group row renders in. `unknown` (identity lost) outranks a
+ *  spike — a number we can't attribute shouldn't be dressed as a live alarm —
+ *  and `ended` freezes the row regardless of its last figures. */
+export function groupState(group: ResourceGroupSummary): ResourceGroupState {
+  if (group.confidence === "unknown") return "unknown";
+  if (group.ended) return "ended";
+  if (
+    group.cpuPercent !== null &&
+    group.cpuAvgPercent !== null &&
+    group.cpuPercent >= SPIKE_FLOOR_PERCENT &&
+    group.cpuPercent >= SPIKE_FACTOR * group.cpuAvgPercent
+  ) {
+    return "spike";
+  }
+  return "ok";
+}
+
+/** Overall surface state, driving the popover section's body. */
+export type ResourceSurfaceState = "loading" | "unsupported" | "empty" | "ready";
+
+/** What the summary surface should render. `unsupported` = the platform gives
+ *  us no CPU *and* no memory (nothing worth a table); partial support renders
+ *  `ready` with per-metric dashes instead. */
+export function surfaceState(
+  summary: ResourceSummary | null,
+  loading: boolean,
+): ResourceSurfaceState {
+  if (summary === null) return loading ? "loading" : "empty";
+  if (!summary.capabilities.cpu && !summary.capabilities.memory) return "unsupported";
+  if (summary.updatedAtMs === undefined) return loading ? "loading" : "empty";
+  return "ready";
+}
+
+/** i18n key explaining one attribution confidence (tooltip text). */
+export function confidenceKey(
+  confidence: AttributionConfidence,
+): "resources.confidenceExact" | "resources.confidenceInferred" | "resources.confidenceUnknown" {
+  switch (confidence) {
+    case "exact":
+      return "resources.confidenceExact";
+    case "inferred":
+      return "resources.confidenceInferred";
+    default:
+      return "resources.confidenceUnknown";
+  }
+}
+
+/** Short display label for a group: the workspace folder name, the agent
+ *  command, or a terminal id trimmed to its tail. Display-only — the full id
+ *  stays available for tooltips. */
+export function groupLabel(group: ResourceGroupSummary): string {
+  const id = group.id ?? "";
+  if (group.kind === "workspace") {
+    const segments = id.split(/[\\/]/).filter(Boolean);
+    return segments[segments.length - 1] ?? id;
+  }
+  if (group.kind === "terminal") {
+    return id.length > 12 ? `…${id.slice(-8)}` : id;
+  }
+  return id;
+}
+
+/** Groups in display order with the desktop row first. The backend already
+ *  sorts (kind rank, id, ended last); this is a stable safety net so the UI
+ *  never depends on wire order. */
+export function orderedGroups(summary: ResourceSummary): ResourceGroupSummary[] {
+  const rank = (g: ResourceGroupSummary): number =>
+    g.ended
+      ? 100
+      : { desktop: 0, workspace: 1, terminal: 2, agent: 3, bridge: 4, browser: 5, unknown: 6 }[
+          g.kind
+        ];
+  return [...summary.groups].sort(
+    (a, b) => rank(a) - rank(b) || (a.id ?? "").localeCompare(b.id ?? ""),
+  );
+}

--- a/uxnandesktop/src/lib/resources/format.test.ts
+++ b/uxnandesktop/src/lib/resources/format.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The one rule every formatter here must uphold: an unknown value renders as a
+ * dash, never as a zero. A "0 B" where the collector reported nothing would
+ * quietly turn honesty into a lie on every surface at once.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { formatAge, formatBytes, formatCpu, formatRate, UNKNOWN } from "./format";
+
+describe("formatBytes", () => {
+  it("renders unknown as a dash, not zero", () => {
+    expect(formatBytes(null)).toBe(UNKNOWN);
+    expect(formatBytes(undefined)).toBe(UNKNOWN);
+    expect(formatBytes(Number.NaN)).toBe(UNKNOWN);
+    expect(formatBytes(-1)).toBe(UNKNOWN);
+  });
+
+  it("renders a real zero as 0 B (measured, distinct from unknown)", () => {
+    expect(formatBytes(0)).toBe("0 B");
+  });
+
+  it("scales through the units", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(2048)).toBe("2 KB");
+    expect(formatBytes(850 * 1024 * 1024)).toBe("850 MB");
+    expect(formatBytes(1.4 * 1024 * 1024 * 1024)).toBe("1.4 GB");
+  });
+
+  it("drops the decimal once it stops carrying information", () => {
+    expect(formatBytes(812 * 1024 * 1024)).toBe("812 MB");
+    expect(formatBytes(99.4 * 1024)).toBe("99.4 KB");
+  });
+});
+
+describe("formatCpu", () => {
+  it("renders unknown as a dash and a measured idle as 0%", () => {
+    expect(formatCpu(null)).toBe(UNKNOWN);
+    expect(formatCpu(undefined)).toBe(UNKNOWN);
+    expect(formatCpu(0)).toBe("0%");
+  });
+
+  it("keeps one decimal below 10% and rounds above", () => {
+    expect(formatCpu(3.44)).toBe("3.4%");
+    expect(formatCpu(42.6)).toBe("43%");
+  });
+
+  it("clamps runaway values to 100%", () => {
+    expect(formatCpu(250)).toBe("100%");
+  });
+});
+
+describe("formatRate", () => {
+  it("appends /s to a known rate and stays a dash otherwise", () => {
+    expect(formatRate(2048)).toBe("2 KB/s");
+    expect(formatRate(null)).toBe(UNKNOWN);
+  });
+});
+
+describe("formatAge", () => {
+  it("scales seconds → minutes → hours", () => {
+    expect(formatAge(12_000)).toBe("12s");
+    expect(formatAge(3 * 60_000)).toBe("3m");
+    expect(formatAge(65 * 60_000)).toBe("1h 05m");
+  });
+
+  it("rejects nonsense", () => {
+    expect(formatAge(-5)).toBe(UNKNOWN);
+  });
+});

--- a/uxnandesktop/src/lib/resources/format.ts
+++ b/uxnandesktop/src/lib/resources/format.ts
@@ -1,0 +1,51 @@
+// Formatting for the resource-observability surfaces. Pure on purpose (node
+// test project): the rule that matters — an unknown value renders as a dash,
+// never as a zero — lives here once, for every surface.
+
+/** Placeholder for a metric the collector could not provide. */
+export const UNKNOWN = "—";
+
+/** Human bytes: `812 MB`, `1.4 GB`. `null`/`undefined` → the unknown dash. */
+export function formatBytes(bytes: number | null | undefined): string {
+  if (bytes === null || bytes === undefined || !Number.isFinite(bytes) || bytes < 0) {
+    return UNKNOWN;
+  }
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  // One decimal only when it carries information (1.4 GB yes, 812.0 MB no).
+  const rounded = value >= 100 ? Math.round(value).toString() : value.toFixed(1).replace(/\.0$/, "");
+  return `${rounded} ${units[unit]}`;
+}
+
+/** CPU percentage: `3.4%`. `null` → the unknown dash, and 0 renders as `0%`
+ *  (a real measured idle, distinct from unknown). */
+export function formatCpu(percent: number | null | undefined): string {
+  if (percent === null || percent === undefined || !Number.isFinite(percent) || percent < 0) {
+    return UNKNOWN;
+  }
+  const clamped = Math.min(percent, 100);
+  return `${clamped >= 10 ? Math.round(clamped) : Math.round(clamped * 10) / 10}%`;
+}
+
+/** I/O rate: `1.2 MB/s`. `null` → the unknown dash. */
+export function formatRate(bytesPerSec: number | null | undefined): string {
+  const bytes = formatBytes(bytesPerSec);
+  return bytes === UNKNOWN ? UNKNOWN : `${bytes}/s`;
+}
+
+/** Seconds-scale age: `12s`, `3m`, `1h 05m`. Used for orphan/staleness notes. */
+export function formatAge(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return UNKNOWN;
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  return `${hours}h ${String(mins % 60).padStart(2, "0")}m`;
+}

--- a/uxnandesktop/src/lib/state/app.svelte.ts
+++ b/uxnandesktop/src/lib/state/app.svelte.ts
@@ -77,6 +77,7 @@ export type SettingsSection =
   | "browser"
   | "openWith"
   | "github"
+  | "resources"
   | "updates";
 
 /** A pane in the inline GitHub view (opened per-project from a project card).

--- a/uxnandesktop/src/lib/state/resources.svelte.ts
+++ b/uxnandesktop/src/lib/state/resources.svelte.ts
@@ -1,0 +1,95 @@
+// Resource-observability store: holds the latest consolidated summary and
+// manages the sampling lease for the popover surface. The collector backend is
+// fully parked unless something calls `open()` — so simply not opening the
+// popover is what keeps the feature at zero cost.
+//
+// Leases are renewed on a timer while open and released on close; the backend
+// also expires them on its own, so a webview reload that never called `close()`
+// cannot pin the fast sampling cadence forever.
+
+import { listen } from "@tauri-apps/api/event";
+
+import { resourcesSubscribe, resourcesSummary, resourcesUnsubscribe } from "$lib/api";
+import type { ResourceSummary } from "$lib/types";
+import { app } from "./app.svelte";
+
+/** Renew the lease at half its backend TTL (90 s), so one missed renewal
+ *  still keeps the surface live. */
+const LEASE_RENEW_MS = 45_000;
+
+class ResourcesStore {
+  /** Latest consolidated summary (event-fed while open; `null` before). */
+  summary = $state<ResourceSummary | null>(null);
+  /** First fetch for a surface is in flight (drives the loading state). */
+  loading = $state(false);
+
+  #token: string | null = null;
+  #renewTimer: ReturnType<typeof setInterval> | null = null;
+  #unlisten: (() => void) | null = null;
+  /** Open surfaces (popover, settings preview) sharing the one lease. */
+  #opens = 0;
+
+  /** Whether the feature's surfaces should render at all. */
+  get enabled(): boolean {
+    return app.settings.resources?.enabled ?? true;
+  }
+
+  /** A surface that shows live resources opened: take the sampling lease,
+   *  subscribe to the event feed and pull the buffered summary once. */
+  async open(): Promise<void> {
+    if (!this.enabled) return;
+    this.#opens += 1;
+    if (this.#opens > 1) return; // the lease is already live
+    if (this.summary === null) this.loading = true;
+    const token = crypto.randomUUID();
+    this.#token = token;
+    try {
+      this.#unlisten = await listen<ResourceSummary>("resources:summary", (event) => {
+        this.summary = event.payload;
+        this.loading = false;
+      });
+      await resourcesSubscribe(token, "popover");
+      this.#renewTimer = setInterval(() => {
+        void resourcesSubscribe(token, "popover").catch(() => {});
+      }, LEASE_RENEW_MS);
+    } catch {
+      // No Tauri backend (plain web preview): the surface shows its empty state.
+    }
+    await this.refresh();
+  }
+
+  /** The surface closed: release the lease so the sampler parks again. */
+  async close(): Promise<void> {
+    if (this.#opens === 0) return;
+    this.#opens -= 1;
+    if (this.#opens > 0) return;
+    if (this.#renewTimer) {
+      clearInterval(this.#renewTimer);
+      this.#renewTimer = null;
+    }
+    this.#unlisten?.();
+    this.#unlisten = null;
+    const token = this.#token;
+    this.#token = null;
+    if (token) {
+      try {
+        await resourcesUnsubscribe(token);
+      } catch {
+        // The backend expires the lease on its own; nothing to recover.
+      }
+    }
+  }
+
+  /** One-shot pull of the buffered summary (no fresh sample). */
+  async refresh(): Promise<void> {
+    try {
+      this.summary = await resourcesSummary();
+    } catch {
+      // Keep the previous snapshot (or the empty state outside Tauri).
+    } finally {
+      this.loading = false;
+    }
+  }
+}
+
+export const resources = new ResourcesStore();

--- a/uxnandesktop/src/lib/terminal/instances.ts
+++ b/uxnandesktop/src/lib/terminal/instances.ts
@@ -62,6 +62,9 @@ export interface TerminalSpawnSpec {
   /** Whether `runCommand` is auto-run (Enter appended) or only pre-typed. */
   runCommandExecute?: boolean;
   env?: [string, string][];
+  /** Workspace key the tab belongs to at spawn time — only so the backend's
+   *  resource monitor can attribute the shell's cost to its workspace. */
+  workspace?: string;
 }
 
 /** Everything needed to build a fresh instance. */
@@ -285,6 +288,8 @@ export async function spawnPty(
       env: spec.env,
       cols,
       rows,
+      // "" is the global workspace — meaningless as an attribution target.
+      workspace: spec.workspace || null,
     });
     // The PTY now exists at exactly `cols`×`rows`; record that as the known
     // grid, then flush any fit that settled while the spawn was in flight so

--- a/uxnandesktop/src/lib/types.ts
+++ b/uxnandesktop/src/lib/types.ts
@@ -345,6 +345,23 @@ export interface AppSettings {
   /** Left-sidebar footer profile card (avatar, name, description); clicking it
    *  opens the Settings / GitHub sections. All fields optional. */
   profile?: SidebarProfile;
+  /** Local resource observability (backend-popover summary + Settings →
+   *  Resources). Absent = the defaults (enabled, no background sweep). */
+  resources?: ResourceSettings;
+}
+
+/** Local resource observability settings (mirror of the Rust `ResourceSettings`).
+ *  The collector samples only while a surface consumes it; the opt-in orphan
+ *  sweep is the one background mode. */
+export interface ResourceSettings {
+  /** Master switch for the feature's surfaces + data. Default true (a parked
+   *  collector costs nothing). */
+  enabled?: boolean;
+  /** Background sweep that notices orphaned processes with no UI open.
+   *  Default false — the only mode that costs anything unasked. */
+  orphanSweep?: boolean;
+  /** Sweep interval in seconds; the backend clamps it to 15–30. */
+  orphanSweepSeconds?: number;
 }
 
 /** The configurable identity card in the left sidebar's footer: an avatar, a
@@ -1049,6 +1066,116 @@ export interface AppData {
   orchestrationRuns?: SavedRun[] | null;
 }
 
+// --- Resource observability (mirror of `src-tauri/src/resources.rs`) ---------
+
+/** Who a measured aggregate belongs to. `bridge`/`browser` are reserved. */
+export type ResourceOwnerKind =
+  | "desktop"
+  | "workspace"
+  | "terminal"
+  | "agent"
+  | "bridge"
+  | "browser"
+  | "unknown";
+
+/** How sure the attribution is: `exact` = pid + start time verified,
+ *  `inferred` = parent-chain evidence, `unknown` = identity not verifiable. */
+export type AttributionConfidence = "exact" | "inferred" | "unknown";
+
+/** Direction of a group's memory over the buffered window. */
+export type ResourceTrend = "rising" | "falling" | "steady" | "unknown";
+
+/** Consumer kinds a sampling lease can carry. */
+export type ResourceConsumerKind = "popover" | "budget";
+
+/** Which metrics this build/platform can provide; `validated` = measured on
+ *  real hardware (Windows only so far — elsewhere the figures are best effort). */
+export interface ResourceCapabilities {
+  cpu: boolean;
+  memory: boolean;
+  virtualMemory: boolean;
+  io: boolean;
+  startTime: boolean;
+  validated: boolean;
+}
+
+/** Whether/why/how fast the sampler is running. */
+export interface ResourceSamplingState {
+  active: boolean;
+  intervalMs?: number;
+  reason: "popover" | "budget" | "orphanSweep" | "off";
+}
+
+/** Instant + short-average + peak + trend for one series. `null` = the metric
+ *  is unknown for that point (never rendered as zero). */
+export interface ResourceMetricSummary {
+  processes: number;
+  cpuPercent: number | null;
+  cpuAvgPercent: number | null;
+  cpuPeakPercent: number | null;
+  residentBytes: number | null;
+  residentAvgBytes: number | null;
+  residentPeakBytes: number | null;
+  virtualBytes: number | null;
+  ioReadBytesPerSec: number | null;
+  ioWriteBytesPerSec: number | null;
+  trend: ResourceTrend;
+}
+
+/** One owner group (desktop / workspace / agent / …) as the UI consumes it. */
+export interface ResourceGroupSummary extends ResourceMetricSummary {
+  kind: ResourceOwnerKind;
+  /** Workspace path, agent command or terminal id — depending on `kind`. */
+  id?: string;
+  /** The workspace an agent/terminal group belongs to, when known. */
+  workspace?: string;
+  confidence: AttributionConfidence;
+  /** The group's processes ended; metrics are its last-known figures. */
+  ended: boolean;
+}
+
+/** A subtree that outlived its closed owner and is still alive. */
+export interface ResourceOrphan {
+  kind: ResourceOwnerKind;
+  id: string;
+  pids: number[];
+  cpuPercent: number | null;
+  residentBytes: number | null;
+  sinceMs: number;
+  confidence: AttributionConfidence;
+}
+
+/** The consolidated resource document (`resources_summary` + the
+ *  `resources:summary` event payload). */
+export interface ResourceSummary {
+  enabled: boolean;
+  capabilities: ResourceCapabilities;
+  sampling: ResourceSamplingState;
+  updatedAtMs?: number;
+  bufferSeconds: number;
+  /** Everything attributed to uxnan combined; absent until a first sample. */
+  total?: ResourceMetricSummary;
+  groups: ResourceGroupSummary[];
+  orphans: ResourceOrphan[];
+  terminalsLinked: number;
+}
+
+/** The sanitized manual-export document (`resources_export`). Ids are opaque
+ *  labels; `fields` is the consent list shown before saving. */
+export interface ResourceExport {
+  schemaVersion: number;
+  exportedAtMs: number;
+  platform: string;
+  appVersion: string;
+  capabilities: ResourceCapabilities;
+  sampling: ResourceSamplingState;
+  bufferSeconds: number;
+  fields: string[];
+  total?: ResourceMetricSummary;
+  groups: ResourceGroupSummary[];
+  orphans: ResourceOrphan[];
+}
+
 /** Mirror of the Rust `CommandError` returned across the command boundary. */
 export interface CommandError {
   message: string;
@@ -1067,6 +1194,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   defaultProfileId: null,
   agentProfiles: [],
   pets: { enabled: true },
+  resources: { enabled: true, orphanSweep: false, orphanSweepSeconds: 20 },
   usageProviders: [],
   usageRefreshMinutes: 5,
   usageStatusBarEnabled: true,

--- a/uxnandesktop/src/test/ProviderHost.svelte
+++ b/uxnandesktop/src/test/ProviderHost.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  // Test-only wrapper reproducing the app-level context providers a component
+  // gets for free under `src/routes/+layout.svelte` — today just the tooltip
+  // provider (bits-ui tooltips throw without one). Keep this in sync with the
+  // layout if more app-wide providers appear.
+  import { TooltipProvider } from "$lib/components/ui/tooltip";
+  import type { Component } from "svelte";
+
+  let {
+    component,
+    props = {},
+  }: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    component: Component<any, any, any>;
+    props?: Record<string, unknown>;
+  } = $props();
+
+  const C = $derived(component);
+</script>
+
+<TooltipProvider>
+  <C {...props} />
+</TooltipProvider>

--- a/uxnandesktop/src/test/render.ts
+++ b/uxnandesktop/src/test/render.ts
@@ -16,6 +16,7 @@ import { render as tlRender, type RenderResult } from "@testing-library/svelte";
 import userEvent from "@testing-library/user-event";
 import type { Component } from "svelte";
 
+import ProviderHost from "./ProviderHost.svelte";
 import { installFakeBackend, type CommandTable, type FakeBackend } from "./tauri";
 
 /** Any Svelte 5 component, whatever its prop types. Tests pass props as a plain
@@ -51,6 +52,23 @@ export function mount(component: AnyComponent, options: MountOptions = {}): Moun
   const backend = installFakeBackend(options.commands);
   const user = userEvent.setup();
   const screen = tlRender(component, options.props ?? {}) as RenderResult<AnyComponent>;
+  return { screen, backend, user };
+}
+
+/**
+ * Like [`mount`], but under the app-level context providers a component
+ * normally inherits from the root layout (`ProviderHost.svelte`) — needed by
+ * anything rendering bits-ui tooltips, which throw without their provider.
+ */
+export function mountWithProviders(
+  component: AnyComponent,
+  options: MountOptions = {},
+): Mounted {
+  const backend = installFakeBackend(options.commands);
+  const user = userEvent.setup();
+  const screen = tlRender(ProviderHost as unknown as AnyComponent, {
+    props: { component, props: options.props ?? {} },
+  }) as RenderResult<AnyComponent>;
   return { screen, backend, user };
 }
 

--- a/uxnandesktop/tests/quality-matrix.json
+++ b/uxnandesktop/tests/quality-matrix.json
@@ -375,7 +375,31 @@
         "macos": "untested",
         "linux": "untested"
       },
-      "gaps": "R07/R08 need an operator; R10 (the 2 h soak) has never been run."
+      "gaps": "R07/R08 need an operator; R10 (the 2 h soak) has never been run; R12 (the resource monitor's own overhead) is wired but its baseline has not been captured — the harness refuses to run beside a live uxnan instance."
+    },
+    {
+      "id": "resource-observability",
+      "flow": "In-app resource monitor (attribution, sampling, export)",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L2",
+        "L3"
+      ],
+      "planned": [
+        "L4"
+      ],
+      "evidence": {
+        "L1": "src/lib/resources/format.test.ts, src/lib/resources/display.test.ts",
+        "L2": "src/lib/components/ResourceSummary.svelte.test.ts, src/lib/components/ResourceSettings.svelte.test.ts",
+        "L3": "src-tauri/src/resources.rs #[cfg(test)] (cadence, attribution, deltas, buffer, export golden tests) plus src-tauri/tests/resources_processes.rs (real spawned process trees)"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "No E2E journey opens the backend popover against the real binary yet (the suite cannot run beside a live uxnan instance, so it was not runnable while this feature was built); the popover lease -> sample -> park round trip is covered at L2/L3 instead. macOS/Linux metrics run the same portable sysinfo code but are unvalidated on hardware — the UI says 'best effort' there on purpose."
     }
   ]
 }


### PR DESCRIPTION
## What

An in-app resource monitor: CPU / memory / process attribution for the desktop process, every PTY it spawned and the agents running inside them — local only, never telemetry, never a general task manager.

- **Evidence-based attribution** (pid + start time + parent chain + the explicit link each terminal registers at spawn), with an explicit confidence on every figure: `exact` / `inferred` / `unknown`. A recycled pid voids the link instead of guessing; absent data is never reported as zero.
- **Zero cost unless consumed**: the sampler is fully parked (no timer, no OS handle) until a consumer exists — 2 s while the backend popover is open (self-expiring lease), 3 s for a reserved budget consumer, and an opt-in 15–30 s orphan sweep. History is a ~10-minute in-memory circular buffer.
- **Surfaces**: a compact *Resources* section in the status bar's backend popover (totals with peak + trend, per-workspace/per-agent rows, spike highlighting, ended groups, an amber warning for processes that outlived their closed terminal) and **Settings → Resources**.
- **Consent-first sanitized export**: the dialog lists the exact fields before writing; agent names survive only via a known-catalog allow-list; golden + schema-allow-list tests fail the build on any leak. Command lines, env, cwd and file names are never read at all.
- **Benchmark scenario R12** measures the feature's own promise (off/parked must equal the R02 baseline), wired as a one-command run with a provisional budget until a real capture happens with the app closed (tracked in `FOR-DEV.md`).

## Verification

- `npm run check`: 1482 files, 0 errors / 0 warnings
- `npm test`: 608 passed (52 files)
- `cargo test`: 429 (416 unit + 13 integration); `clippy -D warnings` + `fmt --check` clean
- New tests: 38 Rust unit + 3 Rust integration against real process trees + 24 pure-logic + 18 component
- Full EN/ES i18n; `tests/quality-matrix.json` row with real file citations

## Honest gaps (tracked in `FOR-DEV.md`)

R12 baseline capture and the popover L4 journey must run with the app closed; non-Windows metrics are labelled best-effort until validated on real hardware.