### PR TITLE
feat(desktop): resource mode — explicit efficiency presets with controlled degradation

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,65 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — resource mode: explicit efficiency presets with controlled degradation
+
+- **Three presets — `Efficient` / `Balanced` / `Performance` — govern uxnan's
+  background work** (Settings → Resources → Resource mode, `docs/resource-mode.md`).
+  A pure policy engine (`src/lib/resources/policy.ts`: `ResourceProfile`,
+  `ResourceCapabilities`, `ResolvedResourcePolicy`) resolves the preset plus
+  per-capability overrides into the values every consumer reads, so no
+  subsystem re-derives conditions from settings. **`Balanced` is the default
+  and mirrors the pre-mode constants exactly** (a policy test pins it), so
+  existing behavior does not change. The mode governs local infrastructure
+  only — never an agent's model/permissions, OS priority, or any process
+  uxnan did not spawn.
+- **Governed consumers, all hot-switchable and reversible:** the all-worktree
+  git status sweep (45 s / 15 s / 10 s) and the worktree-list reconcile poll;
+  GitHub polling (×4 on Efficient; ×0.5 floored at 30 s on Performance; `0`
+  stays manual); provider-usage refresh (×3 on Efficient); orchestration
+  concurrency (2 / 4 / 4–6); the resource monitor's history budget (180 s on
+  Efficient — a new `resources_set_policy` command feeds
+  `ResourceMonitor::set_history_seconds`, clamped 60–600 s, live in the
+  summary's `bufferSeconds`); and the pet's decorative idle one-shots (off on
+  Efficient; state changes always animate). Forced refreshes — focus, agent
+  activity, uxnan's own git actions, every manual refresh — always run.
+- **Performance's extra parallelism is evidence-gated:** the orchestration
+  engine is the first consumer of the resource monitor's `budget` lease (3 s),
+  held only while a run is active under a profile that allows extending, and
+  the 5th/6th concurrent step is granted only when a fresh summary shows
+  uxnan's own CPU is known and below 50 % — no measurement never counts as
+  capacity.
+- **Workspace auto-sleep, behind a feature flag (off by default), double-gated**
+  with the profile's level: `suggest` surfaces a toast whose action is the
+  user's confirmation; the opt-in `auto` level sleeps an idle workspace through
+  the existing sleep/wake lifecycle — except one with a working agent, which is
+  only ever *suggested*, mirroring the manual path's confirmation. Never the
+  active workspace, the Global space, an unmounted workspace, or one without a
+  last-active stamp; suggestions repeat at most every 30 min per workspace.
+- **Degradation is never silent:** surfaces whose cadence Efficient relaxes
+  show a freshness hint (sidebar projects header, right-panel GitHub tab, the
+  usage popover) whose tooltip explains the mode and whose click is a one-shot
+  **refresh now** that never changes the profile.
+- **Overrides without residue:** per-capability overrides (`null` = inherit)
+  with hard safety limits outside them, clamped on write, unknown/invalid
+  values dropped on read, a "use preset" affordance that deletes (not shadows)
+  the override, a reset-all, and a newer `schemaVersion` resolving to Balanced
+  with no overrides (the rollback posture). Persisted additively as
+  `AppSettings.resourceMode` — no schema bump.
+- **Per-preset efficiency matrix wired into the benchmark harness**
+  (`npm run bench -- --resource-profile efficient|balanced|performance`): the
+  preset is seeded into the scenario's disposable profile, recorded in the
+  result document and suffixed into file names. The actual capture must run
+  with the app closed (the harness refuses to run beside a live instance), so
+  no figures or budgets change yet — tracked in `FOR-DEV.md`.
+- Tests: 36 policy/auto-sleep unit tests (presets, the Balanced invariant,
+  residue-free normalization, headroom, every auto-sleep guard under a fake
+  clock), 8 component tests for the Settings section (accessible radio group,
+  EN/ES, keyboard selection, clamped overrides + use-preset + reset, the flag
+  gating, corrupt settings rendering as Balanced), 3 harness tests, and 5 Rust
+  tests (history clamp/trim/summary, settings defaults + round trip). Totals:
+  **655 Vitest**, **434 Rust** (421 unit + 13 integration). Full EN/ES i18n.
+
 ### Added — local resource observability: what uxnan, its terminals and its agents cost
 
 - **A demand-driven resource monitor** (`src-tauri/src/resources.rs`,

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -347,9 +347,9 @@ few declared gaps — not machinery.
       three platforms.** The flag (off by default) is the rollback lever; the
       `auto` level additionally needs live-process verification (a real dev
       server / watcher in a background workspace) on Windows, macOS and Linux
-      before the flag can even be discussed. Windows-only today, and the
-      maintainer's on-device UI review of the new Settings section + toasts is
-      still owed (UI changes need visual approval before release).
+      before the flag can even be discussed. Windows-only today. (The new
+      Settings section + freshness hints passed the maintainer's on-device
+      review on 2026-07-31.)
 - [ ] **An E2E journey for a hot preset switch.** No spec drives Settings →
       Resource mode against the real binary (same live-instance constraint as
       the popover journey above); the switch is covered at L1 (policy) + L2

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -18,7 +18,9 @@ OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
 with" external editors/IDEs**, **automations**, **pets**, **a reproducible
-resource benchmark**, **an in-app resource monitor**). 429 Rust tests (416 unit + 13 integration) + 608 frontend Vitest tests across
+resource benchmark**, **an in-app resource monitor**, **a resource mode with
+explicit efficiency presets — Efficient / Balanced / Performance — governing the
+background consumers**, `docs/resource-mode.md`). 434 Rust tests (421 unit + 13 integration) + 655 frontend Vitest tests across
 two projects — pure logic and **Svelte component tests** — plus a **real E2E suite**
 (WebdriverIO + tauri-driver: 8 journeys, 24 tests, green on Windows). macOS now ships an
 **experimental, unsigned** build (Intel + Apple Silicon; CI verifies `{ubuntu,
@@ -311,12 +313,52 @@ and platform confidence, not machinery.
       macOS's out-of-tree WebKit content process is measured for what the
       `desktop` group misses there. Until then no non-Windows figure may be
       published.
-- [ ] *(optional)* **A first consumer for the `budget` lease kind + the
-      internal event stream.** `ResourceMonitor::subscribe_events` broadcasts
-      every frame and the `budget` cadence (3 s) is implemented and tested, but
-      nothing subscribes with it yet — it is the designed hook for a future
-      resource-limits / orchestration-routing engine, kept in the contract so
-      that engine does not need a second sampler.
+- [ ] *(optional)* **A first Rust-side consumer for the internal event
+      stream.** The `budget` lease kind now has its consumer — the
+      orchestration engine's headroom check holds it while a run is active
+      under a resource profile with extended concurrency
+      (`docs/resource-mode.md`) — but `ResourceMonitor::subscribe_events`
+      (the Rust broadcast of every ingested frame) still has no backend
+      subscriber. It stays in the contract as the hook for a future
+      backend-side consumer (e.g. a Tokio-driven limits engine), so that
+      engine will not need a second sampler.
+
+## Resource mode — follow-ups ☐
+
+**The resource mode is built and tested** (`src/lib/resources/policy.ts`,
+`docs/resource-mode.md`): three presets with Balanced pinned to the pre-mode
+behavior, residue-free overrides, governed consumers (git sweeps,
+GitHub/provider polling, orchestration concurrency with headroom-gated
+extension, monitor history, pet flavour), freshness hints with manual refresh,
+and flag-gated workspace auto-sleep. What is left is measurement, soak and a
+few declared gaps — not machinery.
+
+- [ ] **Capture the per-preset efficiency matrix — must run with the app
+      closed.** The knob is wired (`npm run bench -- --resource-profile
+      efficient|balanced|performance`, seeded into the disposable profile and
+      recorded in the result document), but the harness (correctly) refuses to
+      run beside a live uxnan instance, so no preset has been measured yet.
+      Plan: R01/R04/R06/R09 per preset (R07/R08 assisted, R10 once), then
+      publish the internal table in `docs/resource-mode.md` and check the
+      acceptance bar there (Efficient improves at least one material metric
+      without breaking the core flow's latency; Balanced matches the existing
+      baseline). No figure or budget changes until those runs exist.
+- [ ] **Do NOT retire the auto-sleep feature flag until it has soaked on all
+      three platforms.** The flag (off by default) is the rollback lever; the
+      `auto` level additionally needs live-process verification (a real dev
+      server / watcher in a background workspace) on Windows, macOS and Linux
+      before the flag can even be discussed. Windows-only today, and the
+      maintainer's on-device UI review of the new Settings section + toasts is
+      still owed (UI changes need visual approval before release).
+- [ ] **An E2E journey for a hot preset switch.** No spec drives Settings →
+      Resource mode against the real binary (same live-instance constraint as
+      the popover journey above); the switch is covered at L1 (policy) + L2
+      (component) instead, per `tests/quality-matrix.json` → `resource-mode`.
+- [ ] **Ungoverned recurring work, declared:** the 1 s agent-detection tick and
+      the OSC title layer are deliberately outside the policy in v1 — pacing
+      them risks stale "needs you" states, which the mode must never cause
+      (see the inventory in `docs/resource-mode.md`). Revisit only with a
+      design that keeps attention states honest.
 
 ## Automations — follow-ups ☐
 
@@ -959,7 +1001,7 @@ go stale; these are the ones worth calling out.
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 429 Rust + 608 Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 434 Rust + 655 Vitest tests (both
   projects: pure logic and components). E2E runs in its own on-demand/nightly
   Windows workflow (`e2e-desktop.yml`), deliberately outside the required gate.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -221,6 +221,7 @@ Detailed docs live in [`docs/`](./docs/):
 [end-to-end tests](./tests/e2e/README.md) ·
 [resource benchmarks](./docs/resource-benchmarks.md) ·
 [resource monitoring (in-app)](./docs/resource-monitoring.md) ·
+[resource mode (presets & degradation)](./docs/resource-mode.md) ·
 [architecture orientation](./docs/architecture.md) ·
 [design tokens](./docs/design-tokens.md) ·
 [theming & appearance](./docs/theming.md) ·

--- a/uxnandesktop/architecture/04-technical-reference.md
+++ b/uxnandesktop/architecture/04-technical-reference.md
@@ -523,6 +523,49 @@ base de Windows y rellenar su presupuesto, pasar a `enforce` tras dos semanas de
 ejecuciones reales, ejecutar el colector Unix en hardware real, y automatizar
 R07/R08 cuando exista el driver E2E.
 
+#### Modo de recursos — ✅ Hecho (adición post-plan)
+
+Sobre el monitor de recursos en-app (`src-tauri/src/resources.rs`,
+`docs/resource-monitoring.md`) se construye un **modo de recursos** con presets
+explícitos — `Efficient` / `Balanced` / `Performance` — que gobierna el trabajo
+en segundo plano sin degradar en silencio (`docs/resource-mode.md`).
+
+- **Motor de políticas puro** (`src/lib/resources/policy.ts`:
+  `ResourceProfile`, `ResourceCapabilities`, `ResolvedResourcePolicy`): cada
+  consumidor lee la política resuelta en vez de replicar condiciones desde
+  settings. `Balanced` es el predeterminado y **replica exactamente las
+  constantes previas al modo** (un test lo fija), así que la migración no
+  cambia nada. Persistencia aditiva en `AppSettings.resourceMode`
+  (`{ profile, overrides, autoSleep, schemaVersion: 1 }`, `null` = heredar),
+  validación sin residuos (perfil desconocido → `balanced`, override
+  inválido → heredar, `schemaVersion` más nuevo → `balanced` sin overrides) y
+  límites duros de seguridad fuera de los overrides.
+- **Consumidores gobernados, en caliente y reversibles**: barrido de estado
+  Git de todos los worktrees + reconciliación de la lista, sondeo de
+  GitHub/proveedores (factores con suelo de 30 s; `0` sigue siendo manual),
+  concurrencia de orquestación (2/4/4–6), retención del historial del monitor
+  (nuevo comando `resources_set_policy` → `set_history_seconds`, 60–600 s) y
+  las animaciones decorativas de la mascota. Los refrescos forzados (foco,
+  actividad de agente, acciones git propias, todo botón manual) corren siempre.
+- **El paralelismo extra de `Performance` exige evidencia**: la orquestación es
+  el primer consumidor del *lease* `budget` del monitor (3 s), tomado solo con
+  una ejecución activa, y concede el 5.º/6.º paso solo si un resumen fresco
+  muestra CPU propia conocida y < 50 %.
+- **Auto-dormir workspaces tras doble compuerta** (nivel del preset + feature
+  flag apagado por defecto): sugerencias confirmadas por el usuario; el nivel
+  `auto` nunca duerme un workspace con agente trabajando (solo sugiere) y
+  reutiliza el ciclo sleep/wake existente de `terminals.svelte.ts`, sin
+  duplicar lifecycle.
+- **La degradación siempre se explica**: cada superficie relajada muestra un
+  indicador con «refrescar ahora» que no cambia el preset.
+- **Matriz de eficiencia por preset cableada en el banco**
+  (`--resource-profile`), pendiente de medirse con la app cerrada.
+
+Pendientes en `FOR-DEV.md` → *Resource mode — follow-ups*: capturar la matriz
+por preset (app cerrada), el soak multiplataforma del flag de auto-dormir, un
+E2E de cambio de preset y los detectores de agentes deliberadamente fuera de la
+política en v1.
+
 #### Entregable
 
 ADE MVP completo, pulido y listo para uso diario.

--- a/uxnandesktop/docs/resource-benchmarks.md
+++ b/uxnandesktop/docs/resource-benchmarks.md
@@ -42,6 +42,7 @@ modified.
 | `npm run bench:build` | build a measurable release binary (`tauri build --no-bundle`) |
 | `npm run bench -- --scenario <id>` | run one scenario |
 | `npm run bench -- --all` | every unattended scenario |
+| `npm run bench -- --resource-profile <p>` | pin a resource-mode preset (`efficient` \| `balanced` \| `performance`) for the run — the per-preset efficiency matrix ([`resource-mode.md`](resource-mode.md)); results are suffixed so presets never overwrite each other |
 | `npm run bench:report` | render `report.md` from the aggregates |
 | `npm run bench:compare` | compare the results against an approved baseline |
 

--- a/uxnandesktop/docs/resource-mode.md
+++ b/uxnandesktop/docs/resource-mode.md
@@ -1,0 +1,176 @@
+# Resource mode
+
+Uxnan can be told, explicitly, how much background work to keep running:
+**Settings → Resources → Resource mode** offers three presets — `Efficient`,
+`Balanced` (the default) and `Performance` — plus per-capability overrides.
+The mode governs **local infrastructure only**: refresh cadences, polling,
+orchestration parallelism, the resource monitor's history, the pet's idle
+motion and (behind its own flag) workspace auto-sleep. It never changes what
+an agent may do, which model it uses, OS process priorities, or any process
+Uxnan did not spawn.
+
+Two product rules shape everything below:
+
+- **`Balanced` is the pre-mode behavior, exactly.** Its values are the
+  constants the consumers shipped with, and a policy test pins them — the
+  default changes nothing.
+- **Degradation is never silent.** Every surface whose data `Efficient` makes
+  less fresh shows a hint (a quiet leaf) that explains itself and offers a
+  one-shot **refresh now** which never touches the selected profile.
+
+## The policy engine
+
+One pure module — [`src/lib/resources/policy.ts`](../src/lib/resources/policy.ts)
+— resolves `{ profile, overrides }` into the values every consumer reads
+(`ResourceProfile`, `ResourceCapabilities`, `ResolvedResourcePolicy`).
+Consumers ask the resolved policy instead of re-reading settings, so no
+subsystem replicates conditions. The reactive door is
+`src/lib/state/resourceMode.svelte.ts`; a profile switch applies **hot** and
+is fully reversible (timers restart, pacing re-reads per decision, nothing is
+woken or killed by a switch).
+
+Persistence (`AppSettings.resourceMode`, mirrored by Rust
+`ResourceModeSettings` in `model.rs` — an additive field, no schema bump):
+
+```jsonc
+{ "profile": "balanced", "overrides": { "orchestrationConcurrency": null }, "autoSleep": false, "schemaVersion": 1 }
+```
+
+`null` (or absence) means *inherit from the preset*. Validation is
+residue-free: an unknown profile resolves to `balanced`, an unknown key or
+wrong-typed/out-of-range value to *inherit* (numbers clamp into the hard
+limits), and a `schemaVersion` newer than the build understands resolves to
+`balanced` with no overrides — the rollback posture. Hard safety limits
+(`LIMITS`) sit **outside** overrides: sweeps can never go below 5 s, GitHub
+polling never below 30 s, orchestration concurrency never above 8, monitor
+history never outside 60–600 s.
+
+The backend never resolves policy. Its one consumer — the resource monitor's
+history budget — receives the already-resolved parameter over the
+`resources_set_policy` command (clamped defensively in
+`ResourceMonitor::set_history_seconds`).
+
+## What each preset does
+
+| Capability | Efficient | Balanced (default) | Performance |
+|---|---|---|---|
+| All-worktree git status sweep (`gitSweepIntervalMs`)* | every 45 s | every 15 s | every 10 s |
+| Worktree-list reconcile poll | every 10 s | every driver tick (3 s) | every driver tick (3 s) |
+| GitHub polling (× the user's interval; 0 stays manual) | ×4, long TTL | ×1 | ×0.5, floored at 30 s |
+| Provider-usage refresh (× the user's interval) | ×3 | ×1 | ×1 (quota data gains nothing from more) |
+| Orchestration concurrency (`orchestrationConcurrency`)* | 2 | 4 | 4, up to **6 with measured headroom** |
+| Resource-monitor history (`resourceHistorySeconds`)* | 180 s | 600 s | 600 s |
+| Pet idle one-shots (`petFlavour`)* | off (state changes still animate) | on | on |
+| Workspace auto-sleep (`workspaceAutoSleep`*, behind the flag) | suggest after 30 min idle | off | off |
+| Browser panel on close | destroy webview | destroy webview | destroy webview (no preloading) |
+| Watchers (fs, active-worktree git, browse) | unchanged — they follow what is visible | unchanged | unchanged |
+
+\* = user-overridable per capability (plus `autoSleepIdleMinutes`); everything
+else follows the preset. Forced refreshes — window focus, an agent state
+change, Uxnan's own git actions, every manual refresh button — always run in
+every preset.
+
+**Performance's extra parallelism is evidence-gated.** While a run is active
+and the profile allows extending, the orchestration engine holds the resource
+monitor's `budget` lease (3 s cadence) and grants the 5th/6th concurrent step
+only when the freshest summary (≤ 15 s old) shows Uxnan's own total CPU is
+known and **below 50 %**. No sample, a stale one, or an unknown CPU all mean
+the base cap — absence of a measurement is never treated as capacity.
+
+## Workspace auto-sleep (feature flag)
+
+Off by default, and double-gated: the profile's capability level (`suggest` /
+`auto`, or an override) **and** the explicit switch in Settings → Resources →
+Resource mode must both allow it. A one-minute engine
+(`src/lib/state/autoSleep.svelte.ts`) evaluates the pure planner
+(`src/lib/resources/autoSleep.ts`) and acts **only** through the existing
+sleep/wake lifecycle in `terminals.svelte.ts`:
+
+- `suggest` — a toast offers to sleep an idle workspace; the click is the
+  user's confirmation (and re-checks the blockers at that moment).
+- `auto` — sleeps an idle workspace automatically, **except** one with a
+  working agent, which gets a suggestion instead — an agent-active workspace
+  is never slept without a human click, same as the manual path.
+
+Guards, all tested under a fake clock: never the active workspace, never the
+Global scratch space, never a workspace that is already asleep, holds no live
+terminals, or was never mounted this session (it holds no processes); a
+workspace with no last-active stamp is never guessed at; suggestions repeat at
+most every 30 minutes per workspace. Sleeping preserves scrollback (the
+serialized-screen sidecar) and agent sessions resume on wake — but it does
+stop that workspace's other processes (a dev server, a watcher), which is why
+the automatic level is a second, explicit opt-in. The flag stays until the
+behavior has soaked on all three platforms; turning it off kills the whole
+feature whatever the profile says.
+
+## Background-work inventory
+
+Every recurring activity, who owns it, and how the mode governs it. Cost
+evidence points at the benchmark scenarios
+([`resource-benchmarks.md`](resource-benchmarks.md)) where one measures it.
+
+| Activity | Owner | Cadence (Balanced) | Trigger / park | Cost evidence | Governed by |
+|---|---|---|---|---|---|
+| Active-worktree git status watcher | `src-tauri/src/git.rs` (Tokio) | 3 s, focus-paused | follows `gitSetWatch`; parks with no watched path | R01/R06 | not governed — it feeds the visible Changes panel |
+| All-worktree status sweep | `projects.sweepStatuses` | ≥ 15 s (3 s driver tick in `LeftSidebar`) | skipped hidden; forced by focus / agent activity / own git actions | R06 | `gitSweepIntervalMs` |
+| Worktree-list reconcile | `projects.refreshWorktrees` | every 3 s tick | forced by `refreshNow` | R06 | `worktreeReconcileIntervalMs` |
+| GitHub context/rate-limit/badge poll | `github.startPolling` | user setting (45 s), hidden-paused; ≤ 2 badge reads per tick | armed while the app runs, `0` = manual | R08 | `githubPollFactor` (+ 30 s floor) |
+| Provider-usage poll | `usage.reschedule` | user setting (5 min), armed lazily | `0` = manual; surfaces call `ensureFresh` on open | — | `usageRefreshFactor` |
+| Orchestration engine tick | `orchestrationRun` | 700 ms **while a run is active**, parks idle | run start/stop | — | concurrency cap (2/4/4–6), not the tick |
+| Resource-monitor sampler | `src-tauri/src/resources.rs` | parked; popover 2 s / budget 3 s / opt-in orphan sweep 15–30 s | leases (TTL 90 s) | R12 | `resourceHistorySeconds`; the budget lease is the headroom feed |
+| Auto-sleep engine | `state/autoSleep.svelte.ts` | 60 s (one function call when gated off) | armed at boot, double-gated | R04 (sleeping's effect) | `workspaceAutoSleep` + flag + `autoSleepIdleMinutes` |
+| Pet renderer | `PetSprite`/`PetLayer`/`PetWindow` | frame boundaries; parks hidden; still under reduced motion | enabled + a sheet loaded | R09 | `petFlavour` (idle one-shots) |
+| Agent detection (process layer) | `agentMonitor` (1 s tick) + hook server (event-driven) | 1 s / on-event | armed at boot | R05 | **not governed (gap)** — it feeds attention states; pacing it risks stale "needs you" |
+| Filesystem watcher (active worktree) | `fswatch.rs` via `fsSetWatch` | event-driven | follows the active worktree only | — | not governed — necessary |
+| Folder-browser watcher | `browse_set_watch` | event-driven while a picker is open | parks on close | — | not governed — UI-scoped |
+| Updater check / download | `updater.start` | once per launch + on channel change; download opt-in | Settings → Updates | — | not governed |
+| Keep-awake | `power.rs` | none (a held OS request) | opt-in && agent working; 2 h cap | — | not governed — opt-in already |
+| Terminal PTYs / xterm | user-owned | — | workspace sleep/wake lifecycle | R02–R04 | auto-sleep (above); manual sleep unchanged |
+| Browser panel webview | `browser.rs` | — | destroyed on close in every preset | R07 | already minimal; no preloading in v1 |
+| Broadcast console pacing | `orchestration` store | while the console is open | open/close | — | not governed — interactive |
+
+Known gaps (tracked in [`FOR-DEV.md`](../FOR-DEV.md)): the 1 s agent-detection
+tick and the OSC title layer are not policy-governed in v1, and the Rust-side
+`ResourceMonitor::subscribe_events` broadcast still has no backend consumer.
+
+## Efficiency gates (pending measurement)
+
+The per-preset matrix is wired but **not yet measured**: the harness refuses
+to run beside a live Uxnan instance (the WebView2 user-data-folder sharing
+documented in [`resource-benchmarks.md`](resource-benchmarks.md)), so the
+capture must happen with the app closed. What will be measured, per preset
+(`--resource-profile efficient|balanced|performance`):
+
+| Scenario | Question the presets must answer |
+|---|---|
+| R01 (idle) | Efficient must not regress idle; the deltas quantify the sweep/poll relaxations |
+| R04 (sleeping workspace) | the state auto-sleep produces — its saving is auto-sleep's value |
+| R06 (large repo) | the git sweep pacing is most visible here |
+| R07 (browser), R08 (GitHub) | operator-assisted; R08 exercises the poll factors |
+| R09 (pet) | flavour off vs on under Efficient |
+| R10 (2 h soak) | the shortened monitor history + no leak under any preset |
+
+Acceptance (from the plan of record): Efficient must improve at least one
+material metric without pushing the core flow outside its latency budget, and
+`Balanced` must match the existing baseline. No number is published until the
+runs exist; budgets stay untouched.
+
+## Testing
+
+- **L1** — `src/lib/resources/policy.test.ts` (presets, the Balanced
+  invariant, normalization/clamping, headroom, effective intervals) and
+  `src/lib/resources/autoSleep.test.ts` (every guard under a fake clock).
+- **L2** — `src/lib/components/ResourceModeSection.svelte.test.ts`
+  (accessible radio group, EN/ES, persist + effects view, keyboard selection,
+  clamped overrides + "use preset" + reset, the auto-sleep flag gating, corrupt
+  settings rendering as Balanced).
+- **L3** — `src-tauri/src/resources.rs` (history clamp/trim/summary) and
+  `model.rs` (defaults, back-compat, camelCase round trip).
+- **Not covered (honest):** no E2E journey switches the preset against the
+  real binary (the suite cannot run beside the live instance this was built
+  next to), and the auto-sleep flag needs a multi-platform soak before it can
+  ever be retired. Both in `tests/quality-matrix.json` (`resource-mode`) and
+  [`FOR-DEV.md`](../FOR-DEV.md).
+
+See also [`resource-monitoring.md`](resource-monitoring.md) — the monitor the
+mode's history budget and headroom check are built on.

--- a/uxnandesktop/docs/resource-monitoring.md
+++ b/uxnandesktop/docs/resource-monitoring.md
@@ -25,7 +25,7 @@ retained OS handle (the `sysinfo` state is dropped on park). The cadences:
 |---|---|---|
 | Parked | — (nothing runs) | the default |
 | Popover open | 2 s | opening the backend popover takes a sampling lease |
-| Budget consumer | 3 s | reserved for a future limits/orchestration engine |
+| Budget consumer | 3 s | the orchestration engine's headroom check — held only while a run is active under a resource profile that allows extended concurrency ([`resource-mode.md`](resource-mode.md)) |
 | Orphan sweep | 15–30 s (default 20) | the **opt-in** background check |
 
 Leases are renewed by the frontend while its surface is open and **expire on
@@ -66,6 +66,10 @@ Per group: instant CPU (normalized to the whole machine), a ~60 s short
 average, the buffered peak, resident + virtual memory, I/O rates, and a memory
 **trend** over the buffer. History lives in an in-memory circular buffer capped
 at **10 minutes** of aggregated frames — never per-process, never persisted.
+The resource mode may shorten (never extend) that budget — 3 minutes on the
+Efficient profile, applied over `resources_set_policy` and clamped to
+60–600 s by the backend; the summary's `bufferSeconds` reports the live value
+(see [`resource-mode.md`](resource-mode.md)).
 A first sighting (or a gap after a parked window) reports CPU/I-O as unknown
 rather than a made-up number; a partially-unknown group's rate is unknown too
 (a partial sum shown as a fact would under-report).
@@ -108,10 +112,13 @@ confidence to *inferred* instead of inventing identity.
 
 ## For future consumers
 
-Every ingested frame's summary is also broadcast on an internal Rust channel
-(`ResourceMonitor::subscribe_events`), and a `budget` lease kind exists in the
-contract — that is the hook for resource-limit / orchestration-routing features
-to consume the same data without adding a second sampler.
+The `budget` lease kind now has its first real consumer: the orchestration
+engine's capacity check, which holds it while a run is active under a resource
+profile with extended concurrency and reads the summary events to decide
+whether Uxnan has CPU headroom ([`resource-mode.md`](resource-mode.md)). The
+internal Rust channel (`ResourceMonitor::subscribe_events`) still broadcasts
+every ingested frame's summary and remains the hook for a future
+backend-side consumer — nothing subscribes to it yet.
 
 ## Testing
 

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -48,9 +48,9 @@ instead of panicking, nothing written outside its own root, and a path with
 spaces and non-ASCII characters; `resources_processes.rs` (3 tests) drives the
 resource monitor against **real spawned process trees** — live attribution, the
 start-time probe agreeing with the full table read, and the orphan flow (owner
-closed, child survives, cleared when it ends). **429 backend tests** in total.
+closed, child survives, cleared when it ends). **434 backend tests** in total.
 
-The 416 unit tests cover the Serde model shape, persistence round-trip / atomicity /
+The 421 unit tests cover the Serde model shape, persistence round-trip / atomicity /
 migration / backups, git + worktree ops (including creation, opt-in branch
 cleanup on removal — local/remote/force — checking out an existing branch,
 staging, discard, hunk apply and commit against throwaway repos), the git2 fast
@@ -60,7 +60,9 @@ the updater's per-channel endpoints, the pets store (Codex-format manifest
 parsing, path-traversal refusal, and the import copy staying scoped to the
 manifest + its spritesheet), and the resource monitor (`resources.rs`: cadence
 resolution, pid+start-time attribution, CPU/I-O delta honesty, buffer bounds,
-orphan detection, and the export sanitizer's golden + schema-allow-list tests).
+orphan detection, the configurable history budget's clamp/trim, and the export
+sanitizer's golden + schema-allow-list tests), plus the resource-mode settings
+block (defaults, back-compat, camelCase round trip).
 
 ## Frontend (Svelte / TypeScript)
 
@@ -109,13 +111,17 @@ schedule + next-runs preview, the run/step display projections, the seeded
 example automations, and the prompt-variable insertion) and
 `state/statusSweepRegistry.ts` (the all-worktree status sweep's pacing +
 its request registry) and `usageCatalog.ts` (which providers are still offered
-vs merely still readable) — plus the **resource-benchmark harness** under
+vs merely still readable) and `resources/policy.ts` (the resource-mode policy
+engine: presets with Balanced pinned to the pre-mode constants, residue-free
+normalization/clamping, headroom gating and the effective poll intervals) and
+`resources/autoSleep.ts` (every auto-sleep guard under a fake clock) — plus
+the **resource-benchmark harness** under
 `scripts/resources/lib/` (process-tree attribution own/managed/external, the
 result schema and its validation messages, percentile / CPU-rate / soak-slope
 maths, absolute budgets and the regression policy, the redaction gate, the
 scenario table, the pre-flight checks that mark a run invalid, the Unix collector's awk parser and the git fixture's determinism) — and the **test fixtures**
 under `tests/fixtures/` (the fake `gh`, the PATH shim, the disposable and legacy
-profiles) and the **quality matrix** check. **608 tests** across both projects,
+profiles) and the **quality matrix** check. **655 tests** across both projects,
 config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)

--- a/uxnandesktop/scripts/resources/lib/profile.mjs
+++ b/uxnandesktop/scripts/resources/lib/profile.mjs
@@ -85,6 +85,24 @@ export function settings(overrides = {}) {
   };
 }
 
+/** The resource-mode profiles a run may pin (`ResourceModeSettings` in
+ *  `src-tauri/src/model.rs`). Mirrors the app's own set. */
+export const RESOURCE_PROFILES = ["efficient", "balanced", "performance"];
+
+/**
+ * A `resourceMode` settings block pinning one resource profile — the knob the
+ * per-preset efficiency matrix runs with (`--resource-profile`). No overrides
+ * and no auto-sleep flag: a measurement of a preset must measure the preset.
+ */
+export function resourceModeSettings(profile) {
+  if (!RESOURCE_PROFILES.includes(profile)) {
+    throw new Error(
+      `unknown resource profile ${JSON.stringify(profile)} (use ${RESOURCE_PROFILES.join(" | ")})`,
+    );
+  }
+  return { profile, overrides: {}, autoSleep: false, schemaVersion: 1 };
+}
+
 /** One terminal tab descriptor (`SavedTab`, kind `terminal`). */
 export function terminalTab({ title = "shell", cwd, asleep = false, shell, args, sid } = {}) {
   const d = defaultShell();

--- a/uxnandesktop/scripts/resources/lib/scenarios.test.mjs
+++ b/uxnandesktop/scripts/resources/lib/scenarios.test.mjs
@@ -7,6 +7,8 @@ import { autoScenarioIds, getScenario, SCENARIOS } from "./scenarios.mjs";
 import { isShell } from "./tree.mjs";
 import {
   liveTerminalCount,
+  RESOURCE_PROFILES,
+  resourceModeSettings,
   STATE_SCHEMA_VERSION,
   terminalGrid,
   terminalTab,
@@ -169,6 +171,31 @@ describe("profile seeding", () => {
     expect(settings.pets.enabled).toBe(false);
     // Installing hook configs would write outside the scenario's own directory.
     expect(settings.autoInstallHooks).toBe(false);
+  });
+
+  it("pins a resource-mode preset with no overrides and no auto-sleep", () => {
+    // A measurement of a preset must measure the preset — nothing layered on.
+    for (const profile of RESOURCE_PROFILES) {
+      expect(resourceModeSettings(profile)).toEqual({
+        profile,
+        overrides: {},
+        autoSleep: false,
+        schemaVersion: 1,
+      });
+    }
+  });
+
+  it("rejects an unknown resource profile with the list of known ones", () => {
+    expect(() => resourceModeSettings("turbo")).toThrow(/unknown resource profile "turbo"/);
+  });
+
+  it("seeds a pinned resource profile into the state document", () => {
+    const dir = writeProfile(path.join(TMP, "profile-mode"), {
+      settingsOverrides: { resourceMode: resourceModeSettings("efficient") },
+    });
+    const { settings } = JSON.parse(fs.readFileSync(path.join(dir, "state.json"), "utf8"));
+    expect(settings.resourceMode.profile).toBe("efficient");
+    expect(settings.resourceMode.schemaVersion).toBe(1);
   });
 
   it("builds a balanced grid, so four terminals are four regions", () => {

--- a/uxnandesktop/scripts/resources/run.mjs
+++ b/uxnandesktop/scripts/resources/run.mjs
@@ -23,7 +23,11 @@ import { fileURLToPath } from "node:url";
 import { findBinary, launchApp } from "./lib/app.mjs";
 import { Sampler, sleep, snapshotPids } from "./lib/sampler.mjs";
 import { readPlatform } from "./lib/platform.mjs";
-import { liveTerminalCount, writeProfile } from "./lib/profile.mjs";
+import {
+  liveTerminalCount,
+  resourceModeSettings,
+  writeProfile,
+} from "./lib/profile.mjs";
 import { autoScenarioIds, getScenario, SCENARIOS } from "./lib/scenarios.mjs";
 import { aggregateRepeats, newRun, summarizeRun, validateRun } from "./lib/schema.mjs";
 import { classifyTree, findOrphans } from "./lib/tree.mjs";
@@ -52,6 +56,7 @@ function parseArgs(argv) {
     stabilize: null,
     interval: null,
     variant: null,
+    resourceProfile: null,
     out: path.join(DESKTOP_ROOT, ".resource-results"),
     binary: null,
     buildProfile: "release",
@@ -69,6 +74,7 @@ function parseArgs(argv) {
       case "--stabilize": args.stabilize = Number(next()); break;
       case "--interval": args.interval = Number(next()); break;
       case "--variant": args.variant = next(); break;
+      case "--resource-profile": args.resourceProfile = next(); break;
       case "--out": args.out = path.resolve(next()); break;
       case "--binary": args.binary = path.resolve(next()); break;
       case "--profile": args.buildProfile = next(); break;
@@ -98,6 +104,11 @@ Options
   --stabilize <s>     override the discarded warm-up window
   --interval <ms>     sampling interval (default 1000)
   --variant <name>    scenario variant (R09: off | layer | overlay; R12: off | parked | sweep)
+  --resource-profile <name>
+                      pin a resource-mode preset for the run
+                      (efficient | balanced | performance; default: the app's
+                      own default, balanced — the per-preset efficiency matrix
+                      runs each scenario once per profile)
   --out <dir>         results directory (default .resource-results)
   --binary <path>     app binary to measure (default: the release build)
   --profile <name>    build profile recorded in the result (default release)
@@ -149,7 +160,9 @@ function startHttpFixture({ weight = "light" }) {
 // --- one repetition ---------------------------------------------------------
 
 async function runOnce({ scenario, rep, args, platform, commit, binary, fixtures, outDir }) {
-  const label = `${scenario.id}${args.variant ? `-${args.variant}` : ""}-r${rep + 1}`;
+  const label = `${scenario.id}${args.variant ? `-${args.variant}` : ""}${
+    args.resourceProfile ? `-${args.resourceProfile}` : ""
+  }-r${rep + 1}`;
   const workDir = path.join(outDir, "work", label);
   // Only ever inside our own output directory — the harness must not be able to
   // delete anything a mistyped flag could point it at.
@@ -160,6 +173,15 @@ async function runOnce({ scenario, rep, args, platform, commit, binary, fixtures
   const dataDir = path.join(workDir, "data");
 
   const prepared = scenario.prepare({ fixtures, variant: args.variant, workDir });
+  if (args.resourceProfile) {
+    // Pin the requested resource-mode preset in the seeded profile — the knob
+    // the per-preset efficiency matrix turns. Scenarios themselves never set
+    // `resourceMode`, so this cannot clobber a scenario's own overrides.
+    prepared.settingsOverrides = {
+      ...(prepared.settingsOverrides ?? {}),
+      resourceMode: resourceModeSettings(args.resourceProfile),
+    };
+  }
   writeProfile(dataDir, prepared);
   const expectedShells = liveTerminalCount(prepared.layout);
 
@@ -174,6 +196,7 @@ async function runOnce({ scenario, rep, args, platform, commit, binary, fixtures
     configuration: {
       buildProfile: args.buildProfile,
       variant: args.variant ?? null,
+      resourceProfile: args.resourceProfile ?? null,
       durationS,
       stabilizeS,
       intervalMs,
@@ -328,7 +351,9 @@ async function runScenario(scenario, args, ctx) {
   const budget = loadBudget(ctx.platform.os, args.out);
   const verdict = combineVerdicts(evaluateBudget(aggregate, budget));
   aggregate.verdict = verdict.status;
-  const name = `${scenario.id}${args.variant ? `-${args.variant}` : ""}`;
+  const name = `${scenario.id}${args.variant ? `-${args.variant}` : ""}${
+    args.resourceProfile ? `-${args.resourceProfile}` : ""
+  }`;
   writeResult(path.join(args.out, "aggregates", `${name}.json`), aggregate);
   return { aggregate, scenario, verdict };
 }
@@ -377,6 +402,10 @@ async function main() {
     process.stdout.write(usage());
     return 0;
   }
+
+  // Validate an explicit resource profile up front, so a typo fails before any
+  // fixture is built or the app is launched.
+  if (args.resourceProfile) resourceModeSettings(args.resourceProfile);
 
   const ids = args.all ? autoScenarioIds() : [args.scenario];
   const scenarios = ids.map(getScenario);

--- a/uxnandesktop/src-tauri/src/commands.rs
+++ b/uxnandesktop/src-tauri/src/commands.rs
@@ -75,6 +75,22 @@ pub async fn resources_unsubscribe(
     Ok(())
 }
 
+/// Apply the frontend-resolved resource-mode parameters the monitor consumes —
+/// today just the history budget (seconds of aggregated frames retained). The
+/// policy engine (`src/lib/resources/policy.ts`) is the single place presets
+/// and overrides resolve; the backend receives only the resulting parameter
+/// and clamps it defensively (see `ResourceMonitor::set_history_seconds`).
+#[tauri::command]
+pub async fn resources_set_policy(
+    state: State<'_, AppState>,
+    history_seconds: u32,
+) -> Result<(), CommandError> {
+    state
+        .resources
+        .set_history_seconds(history_seconds, crate::resources::now_ms());
+    Ok(())
+}
+
 /// The sanitized diagnostics document for a manual export. The frontend shows
 /// its `fields` list in a consent dialog and writes this exact document only
 /// after the user confirms — nothing is saved here.

--- a/uxnandesktop/src-tauri/src/lib.rs
+++ b/uxnandesktop/src-tauri/src/lib.rs
@@ -301,6 +301,7 @@ pub fn run() {
             commands::resources_summary,
             commands::resources_subscribe,
             commands::resources_unsubscribe,
+            commands::resources_set_policy,
             commands::resources_export,
             commands::usage_read,
             commands::usage_detect,

--- a/uxnandesktop/src-tauri/src/model.rs
+++ b/uxnandesktop/src-tauri/src/model.rs
@@ -511,6 +511,13 @@ pub struct AppSettings {
     /// unchanged (the additive-field migration path every settings struct uses).
     #[serde(default)]
     pub resources: ResourceSettings,
+    /// Resource mode (Settings → Resources → Resource mode): the explicit
+    /// efficiency/degradation profile plus per-capability overrides. All fields
+    /// default (profile `balanced` = the pre-mode behavior), so older state
+    /// loads unchanged. Semantic validation lives in the frontend policy engine
+    /// (`src/lib/resources/policy.ts`); this struct only keeps the shape.
+    #[serde(default)]
+    pub resource_mode: ResourceModeSettings,
 }
 
 /// Local resource observability (CPU / memory / process attribution for uxnan,
@@ -552,6 +559,59 @@ impl Default for ResourceSettings {
             enabled: true,
             orphan_sweep: false,
             orphan_sweep_seconds: default_orphan_sweep_seconds(),
+        }
+    }
+}
+
+/// Resource mode: the explicit `efficient` / `balanced` / `performance`
+/// profile governing background work (git sweeps, GitHub/provider polling,
+/// orchestration concurrency, the resource monitor's history, the pet's idle
+/// motion, workspace auto-sleep), with per-capability `overrides`.
+///
+/// Deliberately loose here: `profile` is a plain string and override values
+/// are opaque JSON, because the **frontend policy engine**
+/// (`src/lib/resources/policy.ts`) is the single validator — an unknown
+/// profile resolves to `balanced` and an invalid override to "inherit" there,
+/// so the backend never re-derives (and never disagrees about) the semantics.
+/// The one backend consumer (the resource monitor's history budget) receives
+/// its already-resolved parameter over `resources_set_policy`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceModeSettings {
+    /// Selected profile. Default `balanced` — the pre-mode behavior.
+    #[serde(default = "default_resource_profile")]
+    pub profile: String,
+    /// Per-capability overrides; `null` (or absence) = inherit from the
+    /// preset. Unknown keys are dropped by the frontend on read, so stale keys
+    /// self-heal instead of accumulating.
+    #[serde(default)]
+    pub overrides: std::collections::HashMap<String, serde_json::Value>,
+    /// Feature flag for workspace auto-sleep. Off by default; the profile's
+    /// auto-sleep capability only applies while this is on, so turning it off
+    /// kills the behavior whatever the profile says (the rollback lever).
+    #[serde(default)]
+    pub auto_sleep: bool,
+    /// Schema version of this block. The frontend treats a version newer than
+    /// it knows as `balanced` with no overrides (rollback safety).
+    #[serde(default = "default_resource_mode_schema_version")]
+    pub schema_version: u32,
+}
+
+fn default_resource_profile() -> String {
+    "balanced".to_string()
+}
+
+fn default_resource_mode_schema_version() -> u32 {
+    1
+}
+
+impl Default for ResourceModeSettings {
+    fn default() -> Self {
+        Self {
+            profile: default_resource_profile(),
+            overrides: std::collections::HashMap::new(),
+            auto_sleep: false,
+            schema_version: default_resource_mode_schema_version(),
         }
     }
 }
@@ -1076,6 +1136,7 @@ impl Default for AppSettings {
             open_with: OpenWithSettings::default(),
             profile: None,
             resources: ResourceSettings::default(),
+            resource_mode: ResourceModeSettings::default(),
         }
     }
 }
@@ -1577,6 +1638,46 @@ mod tests {
         assert!(json.contains("openWith"));
         let back: AppSettings = serde_json::from_str(&json).unwrap();
         assert_eq!(back.open_with, settings.open_with);
+    }
+
+    #[test]
+    fn resource_mode_defaults_to_balanced_with_no_overrides() {
+        let settings = AppSettings::default();
+        assert_eq!(settings.resource_mode.profile, "balanced");
+        assert!(settings.resource_mode.overrides.is_empty());
+        assert!(!settings.resource_mode.auto_sleep);
+        assert_eq!(settings.resource_mode.schema_version, 1);
+    }
+
+    #[test]
+    fn settings_deserialize_without_resource_mode_defaults_balanced() {
+        // State persisted before the resource mode existed must still load and
+        // land on the profile that changes nothing.
+        let json = r#"{"theme":"system","leftSidebarWidth":280,"rightSidebarWidth":350,
+            "leftSidebarOpen":true,"rightSidebarOpen":true}"#;
+        let settings: AppSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(settings.resource_mode, ResourceModeSettings::default());
+    }
+
+    #[test]
+    fn resource_mode_round_trips_camel_case_with_opaque_overrides() {
+        let mut cfg = ResourceModeSettings {
+            profile: "efficient".into(),
+            auto_sleep: true,
+            ..Default::default()
+        };
+        // Overrides are opaque JSON here (the frontend policy engine validates
+        // them); the backend must round-trip them byte-for-byte, nulls included.
+        cfg.overrides
+            .insert("orchestrationConcurrency".into(), serde_json::json!(2));
+        cfg.overrides
+            .insert("gitSweepIntervalMs".into(), serde_json::Value::Null);
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(json.contains("autoSleep"));
+        assert!(json.contains("schemaVersion"));
+        assert!(!json.contains("auto_sleep"));
+        let back: ResourceModeSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
     }
 
     #[test]

--- a/uxnandesktop/src-tauri/src/resources.rs
+++ b/uxnandesktop/src-tauri/src/resources.rs
@@ -1245,7 +1245,9 @@ fn build_summary(state: &MonitorState, now_ms: u64) -> ResourceSummary {
         capabilities: capabilities(),
         sampling,
         updated_at_ms: latest.map(|f| f.at_ms),
-        buffer_seconds: state.history_secs.clamp(BUFFER_MIN_SECONDS, BUFFER_MAX_SECONDS) as u32,
+        buffer_seconds: state
+            .history_secs
+            .clamp(BUFFER_MIN_SECONDS, BUFFER_MAX_SECONDS) as u32,
         total,
         groups,
         orphans: latest.map(|f| f.orphans.clone()).unwrap_or_default(),

--- a/uxnandesktop/src-tauri/src/resources.rs
+++ b/uxnandesktop/src-tauri/src/resources.rs
@@ -44,8 +44,13 @@ pub const BUDGET_INTERVAL: Duration = Duration::from_secs(3);
 /// Allowed band for the opt-in background orphan sweep (seconds).
 pub const SWEEP_MIN_SECS: u32 = 15;
 pub const SWEEP_MAX_SECS: u32 = 30;
-/// How much aggregated history the circular buffer retains (seconds).
+/// How much aggregated history the circular buffer retains at most (seconds).
+/// Also the default; the resource mode may shorten it (never extend it) via
+/// [`ResourceMonitor::set_history_seconds`].
 const BUFFER_MAX_SECONDS: u64 = 600;
+/// Floor for the configurable history budget (seconds) — shorter than this the
+/// short-average/trend windows stop meaning anything.
+const BUFFER_MIN_SECONDS: u64 = 60;
 /// Hard frame-count cap for the buffer (safety net alongside the time cap).
 const BUFFER_MAX_FRAMES: usize = 640;
 /// Window for the "short average" statistics (ms).
@@ -371,6 +376,11 @@ struct PrevSeen {
 #[derive(Debug, Default)]
 struct MonitorState {
     config: MonitorConfig,
+    /// History budget (seconds) the buffer retains — [`BUFFER_MAX_SECONDS`] by
+    /// default, shortened by the resource mode's resolved policy
+    /// ([`ResourceMonitor::set_history_seconds`]). Always kept within
+    /// [`BUFFER_MIN_SECONDS`]..=[`BUFFER_MAX_SECONDS`] by construction.
+    history_secs: u64,
     terminals: HashMap<String, TerminalLink>,
     closed: Vec<ClosedLink>,
     leases: HashMap<String, Lease>,
@@ -421,11 +431,25 @@ impl ResourceMonitor {
         Arc::new(Self {
             state: Mutex::new(MonitorState {
                 config,
+                history_secs: BUFFER_MAX_SECONDS,
                 ..MonitorState::default()
             }),
             notify: Notify::new(),
             events,
         })
+    }
+
+    /// Apply the resource mode's resolved history budget (how much aggregated
+    /// history the buffer retains). Clamped to
+    /// [`BUFFER_MIN_SECONDS`]..=[`BUFFER_MAX_SECONDS`] — the mode may shorten
+    /// the buffer, never grow it past the observability contract. A shortened
+    /// budget trims immediately, so memory is released even while parked.
+    pub fn set_history_seconds(&self, secs: u32, now_ms: u64) {
+        let clamped = (secs as u64).clamp(BUFFER_MIN_SECONDS, BUFFER_MAX_SECONDS);
+        let mut state = self.state.lock().unwrap();
+        state.history_secs = clamped;
+        let history_secs = state.history_secs;
+        trim_frames(&mut state.frames, now_ms, history_secs);
     }
 
     /// Apply new settings; wakes the sampler only when the config changed.
@@ -653,7 +677,8 @@ impl ResourceMonitor {
             groups,
             orphans,
         });
-        trim_frames(&mut state.frames, now_ms);
+        let history_secs = state.history_secs;
+        trim_frames(&mut state.frames, now_ms, history_secs);
         state.last_frame_at_ms = Some(now_ms);
         state.last_interval_ms = interval_ms;
 
@@ -1061,8 +1086,9 @@ fn check_orphans(
 }
 
 /// Drop frames past the time window and the hard count cap.
-fn trim_frames(frames: &mut VecDeque<Frame>, now_ms: u64) {
-    let horizon = now_ms.saturating_sub(BUFFER_MAX_SECONDS * 1000);
+fn trim_frames(frames: &mut VecDeque<Frame>, now_ms: u64, history_secs: u64) {
+    let budget = history_secs.clamp(BUFFER_MIN_SECONDS, BUFFER_MAX_SECONDS);
+    let horizon = now_ms.saturating_sub(budget * 1000);
     while frames.front().map(|f| f.at_ms < horizon).unwrap_or(false) {
         frames.pop_front();
     }
@@ -1219,7 +1245,7 @@ fn build_summary(state: &MonitorState, now_ms: u64) -> ResourceSummary {
         capabilities: capabilities(),
         sampling,
         updated_at_ms: latest.map(|f| f.at_ms),
-        buffer_seconds: BUFFER_MAX_SECONDS as u32,
+        buffer_seconds: state.history_secs.clamp(BUFFER_MIN_SECONDS, BUFFER_MAX_SECONDS) as u32,
         total,
         groups,
         orphans: latest.map(|f| f.orphans.clone()).unwrap_or_default(),
@@ -2056,14 +2082,65 @@ mod tests {
         for i in 0..(BUFFER_MAX_FRAMES + 100) {
             frames.push_back(frame_at(i as u64, 1));
         }
-        trim_frames(&mut frames, BUFFER_MAX_FRAMES as u64 + 100);
+        trim_frames(
+            &mut frames,
+            BUFFER_MAX_FRAMES as u64 + 100,
+            BUFFER_MAX_SECONDS,
+        );
         assert!(frames.len() <= BUFFER_MAX_FRAMES);
 
         let mut frames: VecDeque<Frame> = VecDeque::new();
         frames.push_back(frame_at(0, 1));
         frames.push_back(frame_at(BUFFER_MAX_SECONDS * 1000 + 5_000, 1));
-        trim_frames(&mut frames, BUFFER_MAX_SECONDS * 1000 + 5_000);
+        trim_frames(
+            &mut frames,
+            BUFFER_MAX_SECONDS * 1000 + 5_000,
+            BUFFER_MAX_SECONDS,
+        );
         assert_eq!(frames.len(), 1, "frames older than the window are dropped");
+    }
+
+    #[test]
+    fn a_shorter_history_budget_trims_sooner_and_is_clamped() {
+        // A 180 s budget drops a frame 10 min old that the default would keep.
+        let now = BUFFER_MAX_SECONDS * 1000;
+        let mut frames: VecDeque<Frame> = VecDeque::new();
+        frames.push_back(frame_at(now - 400_000, 1)); // ~6.7 min old
+        frames.push_back(frame_at(now - 60_000, 1));
+        trim_frames(&mut frames, now, 180);
+        assert_eq!(frames.len(), 1, "the shortened window drops older frames");
+
+        // Below the floor the budget clamps up — a 1 s budget must not wipe
+        // everything the 60 s floor would keep.
+        let mut frames: VecDeque<Frame> = VecDeque::new();
+        frames.push_back(frame_at(now - 30_000, 1));
+        trim_frames(&mut frames, now, 1);
+        assert_eq!(frames.len(), 1, "the floor keeps a 30 s old frame");
+    }
+
+    #[test]
+    fn set_history_seconds_clamps_trims_and_reports_in_the_summary() {
+        let monitor = monitor_with(enabled_config());
+        monitor.subscribe("t", ConsumerKind::Popover, 0);
+        // Two frames 5 minutes apart; the default budget keeps both.
+        let table_a: ProcTable = HashMap::from([(1, row(None, Some(10)))]);
+        monitor.ingest(0, 1, table_a);
+        let table_b: ProcTable = HashMap::from([(1, row(None, Some(10)))]);
+        monitor.ingest(300_000, 1, table_b);
+        assert_eq!(monitor.summary(300_000).buffer_seconds, 600);
+
+        // Shortening to 180 s trims the older frame immediately (even parked)
+        // and the summary reports the live budget.
+        monitor.set_history_seconds(180, 300_000);
+        let summary = monitor.summary(300_000);
+        assert_eq!(summary.buffer_seconds, 180);
+        assert_eq!(summary.updated_at_ms, Some(300_000));
+
+        // Out-of-range values clamp instead of applying.
+        monitor.set_history_seconds(1, 300_000);
+        assert_eq!(monitor.summary(300_000).buffer_seconds, 60);
+        monitor.set_history_seconds(10_000, 300_000);
+        assert_eq!(monitor.summary(300_000).buffer_seconds, 600);
     }
 
     #[test]

--- a/uxnandesktop/src/lib/api.ts
+++ b/uxnandesktop/src/lib/api.ts
@@ -207,6 +207,12 @@ export function resourcesUnsubscribe(token: string): Promise<void> {
   return invoke<void>("resources_unsubscribe", { token });
 }
 
+/** Apply the resource mode's resolved parameters the monitor consumes (today
+ *  just the history budget in seconds; the backend clamps defensively). */
+export function resourcesSetPolicy(historySeconds: number): Promise<void> {
+  return invoke<void>("resources_set_policy", { historySeconds });
+}
+
 /** The sanitized diagnostics document. Nothing is saved backend-side: the UI
  *  shows its `fields` list for consent and writes the file itself. */
 export function resourcesExport(): Promise<ResourceExport> {

--- a/uxnandesktop/src/lib/components/FreshnessHint.svelte
+++ b/uxnandesktop/src/lib/components/FreshnessHint.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  // The "this data is less fresh because of the resource mode" indicator: a
+  // quiet leaf that explains itself in a tooltip and, when clicked, refreshes
+  // right now — without touching the selected profile. Callers render it only
+  // while their surface's cadence is actually relaxed
+  // (`resourceMode.freshness`), so its mere presence is the honest signal.
+  import { Button } from "$lib/components/ui/button";
+  import { TooltipSimple } from "$lib/components/ui/tooltip";
+  import { cn } from "$lib/utils";
+  import LeafIcon from "@lucide/svelte/icons/leaf";
+
+  let {
+    label,
+    onrefresh,
+    class: className = "",
+  }: {
+    /** Localized explanation + call to action (the tooltip and aria-label). */
+    label: string;
+    /** The one-shot manual refresh. */
+    onrefresh: () => void;
+    class?: string;
+  } = $props();
+</script>
+
+<TooltipSimple title={label}>
+  {#snippet children(tp)}
+    <Button
+      {...tp}
+      variant="ghost"
+      size="icon"
+      class={cn("size-6", className)}
+      aria-label={label}
+      onclick={onrefresh}
+    >
+      <LeafIcon class="size-3.5 text-muted-foreground" />
+    </Button>
+  {/snippet}
+</TooltipSimple>

--- a/uxnandesktop/src/lib/components/GithubPanel.svelte
+++ b/uxnandesktop/src/lib/components/GithubPanel.svelte
@@ -9,6 +9,7 @@
   import { github } from "$lib/state/github.svelte";
   import { projects } from "$lib/state/projects.svelte";
   import { app } from "$lib/state/app.svelte";
+  import { resourceMode } from "$lib/state/resourceMode.svelte";
   import { i18n } from "$lib/i18n";
   import { cn } from "$lib/utils";
   import { iconButton, text, surface } from "$lib/design";
@@ -25,6 +26,7 @@
   import { Button } from "$lib/components/ui/button";
   import { TooltipSimple } from "$lib/components/ui/tooltip";
   import CreatePrForm from "./CreatePrForm.svelte";
+  import FreshnessHint from "./FreshnessHint.svelte";
   import GithubWorktreeDialog from "./GithubWorktreeDialog.svelte";
   import GitPullRequestIcon from "@lucide/svelte/icons/git-pull-request";
   import ExternalLinkIcon from "@lucide/svelte/icons/external-link";
@@ -196,6 +198,9 @@
           </Button>
         {/snippet}
       </TooltipSimple>
+      {#if resourceMode.freshness.github}
+        <FreshnessHint label={i18n.t("resourceMode.freshness.github")} onrefresh={refreshAll} />
+      {/if}
       <TooltipSimple title={i18n.t("github.panel.refreshTip")}>
         {#snippet children(props)}
           <Button

--- a/uxnandesktop/src/lib/components/LeftSidebar.svelte
+++ b/uxnandesktop/src/lib/components/LeftSidebar.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
   import { app } from "$lib/state/app.svelte";
   import { projects } from "$lib/state/projects.svelte";
+  import { resourceMode } from "$lib/state/resourceMode.svelte";
   import { Button } from "$lib/components/ui/button";
   import * as DropdownMenu from "$lib/components/ui/dropdown-menu";
   import ProjectCard from "./ProjectCard.svelte";
   import WorktreeRow from "./WorktreeRow.svelte";
   import KeyChord from "./KeyChord.svelte";
+  import FreshnessHint from "./FreshnessHint.svelte";
   import SidebarProfile from "./SidebarProfile.svelte";
   import { createStableOrder } from "$lib/state/sidebarOrder.svelte";
   import { createDragReorder } from "$lib/state/dragReorder.svelte";
@@ -178,6 +180,12 @@
       {i18n.t("sidebar.projects")}
       <span class="text-muted-foreground/60">({projects.filteredRepos.length})</span>
     </span>
+    {#if resourceMode.freshness.git}
+      <FreshnessHint
+        label={i18n.t("resourceMode.freshness.git")}
+        onrefresh={() => projects.refreshNow()}
+      />
+    {/if}
     <TooltipSimple title={`${i18n.t("sidebar.addProject")} (${addChord})`}>
       {#snippet children(props)}
         <Button

--- a/uxnandesktop/src/lib/components/LeftSidebar.svelte
+++ b/uxnandesktop/src/lib/components/LeftSidebar.svelte
@@ -69,7 +69,8 @@
     const timer = setInterval(() => {
       void projects.refreshWorktrees();
       // …and keep every card's badges honest, not just the active worktree's:
-      // the sweep rate-limits itself (see `SWEEP_MS`) and skips a hidden window.
+      // both calls pace themselves from the resource-mode policy (see
+      // `resourceMode.policy.capabilities`) and the sweep skips a hidden window.
       void projects.sweepStatuses();
     }, 3000);
     // Coming back to the window is the moment the indicators are most likely

--- a/uxnandesktop/src/lib/components/PetLayer.svelte
+++ b/uxnandesktop/src/lib/components/PetLayer.svelte
@@ -24,6 +24,7 @@
   import { emitTo, listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { app } from "$lib/state/app.svelte";
   import { pets } from "$lib/state/pets.svelte";
+  import { resourceMode } from "$lib/state/resourceMode.svelte";
   import { petFocusMain, petWindowHide, petWindowShow } from "$lib/api";
   import { animationFor, type PetState } from "$lib/pets/status";
   import { i18n } from "$lib/i18n";
@@ -252,6 +253,9 @@
       sheet: s,
       size,
       animate: settings.animate !== false,
+      // Efficient mode drops the decorative idle one-shots (fewer wakeups);
+      // state changes still animate, so no information is lost.
+      flavour: resourceMode.policy.capabilities.petFlavour,
       clickToFocus: settings.clickToFocus !== false,
     });
   }
@@ -295,7 +299,7 @@
 
   $effect(() => {
     if (!overlayOn || !pet || !sheet) return;
-    const snapshot = JSON.stringify([pet && $state.snapshot(pet), sheet, size, settings.animate, settings.clickToFocus]);
+    const snapshot = JSON.stringify([pet && $state.snapshot(pet), sheet, size, settings.animate, settings.clickToFocus, resourceMode.policy.capabilities.petFlavour]);
     if (snapshot === sentConfig) return;
     sentConfig = snapshot;
     sendConfig();
@@ -377,6 +381,7 @@
           animation={animationFor(instance.state)}
           {size}
           animate={settings.animate !== false}
+          flavour={resourceMode.policy.capabilities.petFlavour}
           override={dragging
             ? (carryAnim ?? (dragPose === null ? DRAG_ANIMATION : null))
             : reaction}

--- a/uxnandesktop/src/lib/components/PetWindow.svelte
+++ b/uxnandesktop/src/lib/components/PetWindow.svelte
@@ -47,6 +47,9 @@
     sheet: string;
     size: number;
     animate: boolean;
+    /** Decorative idle one-shots (dropped by the Efficient resource profile).
+     *  Optional so a main window from an older build still renders. */
+    flavour?: boolean;
     clickToFocus: boolean;
   }
   /** The live state, pushed whenever the most urgent agent report changes.
@@ -295,6 +298,7 @@
         animation={animationFor(live.state)}
         size={config.size}
         animate={config.animate}
+        flavour={config.flavour !== false}
         override={dragging
           ? (carryAnim ?? (dragPose === null ? DRAG_ANIMATION : null))
           : reaction}

--- a/uxnandesktop/src/lib/components/ResourceModeSection.svelte
+++ b/uxnandesktop/src/lib/components/ResourceModeSection.svelte
@@ -1,0 +1,461 @@
+<script lang="ts">
+  // Settings → Resources → Resource mode: the preset picker (with an honest
+  // per-preset effects view), the workspace auto-sleep feature flag, and the
+  // advanced per-capability overrides with "use preset" / reset.
+  //
+  // Everything shown is derived from the RESOLVED policy, so the effects list
+  // always states what will actually happen — overrides included, each marked.
+  import { Button } from "$lib/components/ui/button";
+  import { Input } from "$lib/components/ui/input";
+  import { Switch } from "$lib/components/ui/switch";
+  import * as Select from "$lib/components/ui/select";
+  import * as Collapsible from "$lib/components/ui/collapsible";
+  import SettingsSection from "$lib/components/SettingsSection.svelte";
+  import SettingsRow from "$lib/components/SettingsRow.svelte";
+  import { TooltipSimple } from "$lib/components/ui/tooltip";
+  import { resourceMode } from "$lib/state/resourceMode.svelte";
+  import {
+    AUTO_SLEEP_LEVELS,
+    LIMITS,
+    RESOURCE_PROFILES,
+    type OverridableKey,
+    type ResourceProfile,
+    type WorkspaceAutoSleepLevel,
+  } from "$lib/resources/policy";
+  import { i18n } from "$lib/i18n";
+  import { cn } from "$lib/utils";
+  import { icon, text } from "$lib/design";
+  import LeafIcon from "@lucide/svelte/icons/leaf";
+  import ScaleIcon from "@lucide/svelte/icons/scale";
+  import GaugeIcon from "@lucide/svelte/icons/gauge";
+  import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
+  import RotateCcwIcon from "@lucide/svelte/icons/rotate-ccw";
+
+  const policy = $derived(resourceMode.policy);
+  const caps = $derived(policy.capabilities);
+  const overridden = $derived(new Set(policy.overridden));
+
+  const PROFILE_ICONS = { efficient: LeafIcon, balanced: ScaleIcon, performance: GaugeIcon };
+
+  function profileName(p: ResourceProfile): string {
+    return i18n.t(`resourceMode.profile.${p}`);
+  }
+  function profileDesc(p: ResourceProfile): string {
+    return i18n.t(`resourceMode.profile.${p}Desc`);
+  }
+
+  // Roving radio group: the checked card is the tab stop, arrows move + select.
+  function onGroupKeydown(e: KeyboardEvent): void {
+    const delta =
+      e.key === "ArrowRight" || e.key === "ArrowDown"
+        ? 1
+        : e.key === "ArrowLeft" || e.key === "ArrowUp"
+          ? -1
+          : 0;
+    if (delta === 0) return;
+    e.preventDefault();
+    const at = RESOURCE_PROFILES.indexOf(policy.profile);
+    const next =
+      RESOURCE_PROFILES[(at + delta + RESOURCE_PROFILES.length) % RESOURCE_PROFILES.length];
+    resourceMode.setProfile(next);
+    // Follow the selection with focus, radio-group style.
+    queueMicrotask(() => {
+      const el = document.querySelector<HTMLElement>(`[data-resource-profile="${next}"]`);
+      el?.focus();
+    });
+  }
+
+  /** One line of the effects view. */
+  interface EffectLine {
+    key: OverridableKey | "reconcile" | "github" | "usage";
+    label: string;
+    value: string;
+    overridden: boolean;
+  }
+
+  function autoSleepValue(level: WorkspaceAutoSleepLevel, minutes: number): string {
+    const base =
+      level === "off"
+        ? i18n.t("resourceMode.effect.autoSleepOff")
+        : level === "suggest"
+          ? i18n.t("resourceMode.effect.autoSleepSuggest", { minutes })
+          : i18n.t("resourceMode.effect.autoSleepAuto", { minutes });
+    if (level !== "off" && !policy.autoSleepEnabled) {
+      return `${base} ${i18n.t("resourceMode.effect.autoSleepFlagOff")}`;
+    }
+    return base;
+  }
+
+  const effects = $derived.by((): EffectLine[] => [
+    {
+      key: "gitSweepIntervalMs",
+      label: i18n.t("resourceMode.effect.gitSweep"),
+      value: i18n.t("resourceMode.effect.everySeconds", {
+        seconds: Math.round(caps.gitSweepIntervalMs / 1000),
+      }),
+      overridden: overridden.has("gitSweepIntervalMs"),
+    },
+    {
+      key: "reconcile",
+      label: i18n.t("resourceMode.effect.reconcile"),
+      // 0 = every driver tick (3 s) — the pre-mode behavior.
+      value: i18n.t("resourceMode.effect.everySeconds", {
+        seconds: Math.max(3, Math.round(caps.worktreeReconcileIntervalMs / 1000)),
+      }),
+      overridden: false,
+    },
+    {
+      key: "github",
+      label: i18n.t("resourceMode.effect.github"),
+      value:
+        caps.githubPollFactor > 1
+          ? i18n.t("resourceMode.effect.intervalRelaxed", { factor: caps.githubPollFactor })
+          : caps.githubPollFactor < 1
+            ? i18n.t("resourceMode.effect.intervalFresher")
+            : i18n.t("resourceMode.effect.intervalNormal"),
+      overridden: false,
+    },
+    {
+      key: "usage",
+      label: i18n.t("resourceMode.effect.usage"),
+      value:
+        caps.usageRefreshFactor > 1
+          ? i18n.t("resourceMode.effect.intervalRelaxed", { factor: caps.usageRefreshFactor })
+          : i18n.t("resourceMode.effect.intervalNormal"),
+      overridden: false,
+    },
+    {
+      key: "orchestrationConcurrency",
+      label: i18n.t("resourceMode.effect.orchestration"),
+      value:
+        caps.orchestrationExtendedConcurrency !== null
+          ? i18n.t("resourceMode.effect.orchestrationExtended", {
+              n: caps.orchestrationConcurrency,
+              max: caps.orchestrationExtendedConcurrency,
+            })
+          : i18n.t("resourceMode.effect.orchestrationSteps", {
+              n: caps.orchestrationConcurrency,
+            }),
+      overridden: overridden.has("orchestrationConcurrency"),
+    },
+    {
+      key: "resourceHistorySeconds",
+      label: i18n.t("resourceMode.effect.history"),
+      value: i18n.t("resourceMode.effect.historyMinutes", {
+        minutes: Math.round(caps.resourceHistorySeconds / 60),
+      }),
+      overridden: overridden.has("resourceHistorySeconds"),
+    },
+    {
+      key: "petFlavour",
+      label: i18n.t("resourceMode.effect.pet"),
+      value: caps.petFlavour
+        ? i18n.t("resourceMode.effect.petNormal")
+        : i18n.t("resourceMode.effect.petReduced"),
+      overridden: overridden.has("petFlavour"),
+    },
+    {
+      key: "workspaceAutoSleep",
+      label: i18n.t("resourceMode.effect.autoSleep"),
+      value: autoSleepValue(caps.workspaceAutoSleep, caps.autoSleepIdleMinutes),
+      overridden:
+        overridden.has("workspaceAutoSleep") || overridden.has("autoSleepIdleMinutes"),
+    },
+  ]);
+
+  let advancedOpen = $state(false);
+
+  /** Clamp + set a numeric override from an input's change event. */
+  function setNumber(
+    key: "gitSweepIntervalMs" | "orchestrationConcurrency" | "resourceHistorySeconds" | "autoSleepIdleMinutes",
+    raw: string,
+    scale = 1,
+  ): void {
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return;
+    const bounds = LIMITS[key];
+    const value = Math.min(bounds.max, Math.max(bounds.min, Math.round(n * scale)));
+    resourceMode.setOverride(key, value);
+  }
+
+  const autoSleepLevelLabel = $derived(i18n.t(`resourceMode.level.${caps.workspaceAutoSleep}`));
+</script>
+
+<SettingsSection title={i18n.t("resourceMode.title")} description={i18n.t("resourceMode.desc")} bare>
+  <div class="space-y-6">
+    <!-- Preset picker: three selectable cards behaving as one radio group. -->
+    <div
+      role="radiogroup"
+      aria-label={i18n.t("resourceMode.profileGroup")}
+      class="grid gap-2 md:grid-cols-3"
+    >
+      {#each RESOURCE_PROFILES as p (p)}
+        {@const Icon = PROFILE_ICONS[p]}
+        {@const checked = policy.profile === p}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={checked}
+          tabindex={checked ? 0 : -1}
+          data-resource-profile={p}
+          onkeydown={onGroupKeydown}
+          class={cn(
+            "flex flex-col items-start gap-1.5 rounded-xl border p-3.5 text-left transition-colors",
+            "focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
+            checked
+              ? "border-foreground/25 bg-[var(--ux-sidebar-accent)]"
+              : "border-border/50 bg-muted/20 hover:bg-accent/50",
+          )}
+          onclick={() => resourceMode.setProfile(p)}
+        >
+          <span class="flex items-center gap-2">
+            <Icon class={cn(icon.button, checked ? "text-foreground" : "text-muted-foreground")} />
+            <span class={cn(text.bodyStrong, !checked && "text-muted-foreground")}>
+              {profileName(p)}
+            </span>
+          </span>
+          <span class="text-[12px] leading-5 text-muted-foreground">{profileDesc(p)}</span>
+        </button>
+      {/each}
+    </div>
+
+    <!-- Effects view: what the SELECTED profile (with overrides) actually does. -->
+    <div class="space-y-2 rounded-xl border border-border/60 bg-muted/20 px-4 py-3">
+      <span class={text.section}>{i18n.t("resourceMode.effectsTitle")}</span>
+      <ul class="space-y-1.5">
+        {#each effects as line (line.key)}
+          <li class={cn("flex items-baseline justify-between gap-4", text.meta)}>
+            <span class="min-w-0 truncate">{line.label}</span>
+            <span class="shrink-0 text-right font-medium text-foreground/80">
+              {line.value}
+              {#if line.overridden}
+                <span
+                  class="ml-1 rounded bg-muted px-1 py-px text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  {i18n.t("resourceMode.overriddenBadge")}
+                </span>
+              {/if}
+            </span>
+          </li>
+        {/each}
+      </ul>
+    </div>
+
+    <!-- Workspace auto-sleep feature flag (the capability level lives in the
+         preset / its advanced override; this switch gates everything). -->
+    <div class="divide-y divide-border/50 rounded-xl border border-border/60 bg-muted/20 px-4 py-1">
+      <SettingsRow
+        label={i18n.t("resourceMode.autoSleepFlag")}
+        description={i18n.t("resourceMode.autoSleepFlagDesc")}
+      >
+        {#snippet control()}
+          <Switch
+            checked={policy.autoSleepEnabled}
+            aria-label={i18n.t("resourceMode.autoSleepFlag")}
+            onCheckedChange={(c) => resourceMode.setAutoSleepFlag(c)}
+          />
+        {/snippet}
+      </SettingsRow>
+    </div>
+
+    <!-- Advanced overrides -->
+    <Collapsible.Root bind:open={advancedOpen}>
+      <Collapsible.Trigger
+        class={cn(
+          "flex w-full items-center gap-2 rounded-md px-1 py-1.5 text-left",
+          "text-[13px] font-medium text-muted-foreground transition-colors hover:text-foreground",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        )}
+      >
+        <ChevronDownIcon
+          class={cn("size-3.5 transition-transform", !advancedOpen && "-rotate-90")}
+        />
+        {i18n.t("resourceMode.advanced")}
+      </Collapsible.Trigger>
+      <Collapsible.Content>
+        <div class="mt-2 space-y-3">
+          <p class={text.meta}>{i18n.t("resourceMode.advancedDesc")}</p>
+          <div
+            class="divide-y divide-border/50 rounded-xl border border-border/60 bg-muted/20 px-4 py-1"
+          >
+            <SettingsRow
+              label={i18n.t("resourceMode.override.gitSweep")}
+              description={i18n.t("resourceMode.override.gitSweepDesc")}
+              for="rm-git-sweep"
+            >
+              {#snippet control()}
+                <span class="flex items-center gap-1.5">
+                  {@render usePreset("gitSweepIntervalMs")}
+                  <Input
+                    id="rm-git-sweep"
+                    type="number"
+                    class="w-20 text-right tabular-nums"
+                    min={LIMITS.gitSweepIntervalMs.min / 1000}
+                    max={LIMITS.gitSweepIntervalMs.max / 1000}
+                    value={Math.round(caps.gitSweepIntervalMs / 1000)}
+                    onchange={(e) =>
+                      setNumber(
+                        "gitSweepIntervalMs",
+                        (e.currentTarget as HTMLInputElement).value,
+                        1000,
+                      )}
+                  />
+                </span>
+              {/snippet}
+            </SettingsRow>
+
+            <SettingsRow
+              label={i18n.t("resourceMode.override.concurrency")}
+              description={i18n.t("resourceMode.override.concurrencyDesc")}
+              for="rm-concurrency"
+            >
+              {#snippet control()}
+                <span class="flex items-center gap-1.5">
+                  {@render usePreset("orchestrationConcurrency")}
+                  <Input
+                    id="rm-concurrency"
+                    type="number"
+                    class="w-20 text-right tabular-nums"
+                    min={LIMITS.orchestrationConcurrency.min}
+                    max={LIMITS.orchestrationConcurrency.max}
+                    value={caps.orchestrationConcurrency}
+                    onchange={(e) =>
+                      setNumber(
+                        "orchestrationConcurrency",
+                        (e.currentTarget as HTMLInputElement).value,
+                      )}
+                  />
+                </span>
+              {/snippet}
+            </SettingsRow>
+
+            <SettingsRow
+              label={i18n.t("resourceMode.override.history")}
+              description={i18n.t("resourceMode.override.historyDesc")}
+              for="rm-history"
+            >
+              {#snippet control()}
+                <span class="flex items-center gap-1.5">
+                  {@render usePreset("resourceHistorySeconds")}
+                  <Input
+                    id="rm-history"
+                    type="number"
+                    class="w-20 text-right tabular-nums"
+                    min={LIMITS.resourceHistorySeconds.min}
+                    max={LIMITS.resourceHistorySeconds.max}
+                    value={caps.resourceHistorySeconds}
+                    onchange={(e) =>
+                      setNumber(
+                        "resourceHistorySeconds",
+                        (e.currentTarget as HTMLInputElement).value,
+                      )}
+                  />
+                </span>
+              {/snippet}
+            </SettingsRow>
+
+            <SettingsRow
+              label={i18n.t("resourceMode.override.pet")}
+              description={i18n.t("resourceMode.override.petDesc")}
+            >
+              {#snippet control()}
+                <span class="flex items-center gap-1.5">
+                  {@render usePreset("petFlavour")}
+                  <Switch
+                    checked={caps.petFlavour}
+                    aria-label={i18n.t("resourceMode.override.pet")}
+                    onCheckedChange={(c) => resourceMode.setOverride("petFlavour", c)}
+                  />
+                </span>
+              {/snippet}
+            </SettingsRow>
+
+            <SettingsRow
+              label={i18n.t("resourceMode.override.autoSleepLevel")}
+              description={i18n.t("resourceMode.override.autoSleepLevelDesc")}
+            >
+              {#snippet control()}
+                <span class="flex items-center gap-1.5">
+                  {@render usePreset("workspaceAutoSleep")}
+                  <Select.Root
+                    type="single"
+                    value={caps.workspaceAutoSleep}
+                    onValueChange={(v) =>
+                      resourceMode.setOverride(
+                        "workspaceAutoSleep",
+                        v as WorkspaceAutoSleepLevel,
+                      )}
+                  >
+                    <Select.Trigger class="h-8 w-36 text-xs" disabled={!policy.autoSleepEnabled}>
+                      {autoSleepLevelLabel}
+                    </Select.Trigger>
+                    <Select.Content>
+                      {#each AUTO_SLEEP_LEVELS as level (level)}
+                        <Select.Item value={level} label={i18n.t(`resourceMode.level.${level}`)}>
+                          {i18n.t(`resourceMode.level.${level}`)}
+                        </Select.Item>
+                      {/each}
+                    </Select.Content>
+                  </Select.Root>
+                </span>
+              {/snippet}
+            </SettingsRow>
+
+            <SettingsRow
+              label={i18n.t("resourceMode.override.idle")}
+              description={i18n.t("resourceMode.override.idleDesc")}
+              for="rm-idle"
+            >
+              {#snippet control()}
+                <span class="flex items-center gap-1.5">
+                  {@render usePreset("autoSleepIdleMinutes")}
+                  <Input
+                    id="rm-idle"
+                    type="number"
+                    class="w-20 text-right tabular-nums"
+                    min={LIMITS.autoSleepIdleMinutes.min}
+                    max={LIMITS.autoSleepIdleMinutes.max}
+                    disabled={!policy.autoSleepEnabled}
+                    value={caps.autoSleepIdleMinutes}
+                    onchange={(e) =>
+                      setNumber(
+                        "autoSleepIdleMinutes",
+                        (e.currentTarget as HTMLInputElement).value,
+                      )}
+                  />
+                </span>
+              {/snippet}
+            </SettingsRow>
+          </div>
+
+          {#if policy.overridden.length > 0}
+            <Button variant="outline" size="sm" onclick={() => resourceMode.resetOverrides()}>
+              <RotateCcwIcon class="size-3.5" />
+              {i18n.t("resourceMode.reset")}
+            </Button>
+          {/if}
+        </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  </div>
+</SettingsSection>
+
+<!-- The "use preset" affordance shown beside an overridden control. -->
+{#snippet usePreset(key: OverridableKey)}
+  {#if overridden.has(key)}
+    <TooltipSimple title={i18n.t("resourceMode.usePreset")}>
+      {#snippet children(tp)}
+        <Button
+          {...tp}
+          variant="ghost"
+          size="icon-sm"
+          class="size-6"
+          aria-label={i18n.t("resourceMode.usePreset")}
+          onclick={() => resourceMode.clearOverride(key)}
+        >
+          <RotateCcwIcon class="size-3" />
+        </Button>
+      {/snippet}
+    </TooltipSimple>
+  {/if}
+{/snippet}

--- a/uxnandesktop/src/lib/components/ResourceModeSection.svelte.test.ts
+++ b/uxnandesktop/src/lib/components/ResourceModeSection.svelte.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Settings → Resources → Resource mode. What matters here: the preset picker
+ * is a real radio group (accessible names, keyboard selection), the effects
+ * view states what the RESOLVED policy will do (overrides included, marked),
+ * overrides persist normalized and "use preset" / reset truly remove them, and
+ * the whole surface is localized (EN/ES).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mountWithProviders, until } from "../../test/render";
+import { app } from "$lib/state/app.svelte";
+import ResourceModeSection from "./ResourceModeSection.svelte";
+
+function baseCommands() {
+  return {
+    update_settings: () => ({ version: 1, repos: [], settings: {}, agentCache: [] }),
+  };
+}
+
+/** The settings snapshot of the last persist call. */
+function lastSent(backend: { lastCallTo(cmd: string): { args: Record<string, unknown> } | undefined }) {
+  return (lastCallArgs(backend)?.settings ?? {}) as {
+    resourceMode?: {
+      profile?: string;
+      overrides?: Record<string, unknown>;
+      autoSleep?: boolean;
+      schemaVersion?: number;
+    };
+  };
+}
+function lastCallArgs(backend: {
+  lastCallTo(cmd: string): { args: Record<string, unknown> } | undefined;
+}) {
+  return backend.lastCallTo("update_settings")?.args as
+    | { settings: Record<string, unknown> }
+    | undefined;
+}
+
+beforeEach(() => {
+  document.body.style.pointerEvents = "";
+  app.settings.language = "en";
+  app.settings.resourceMode = { profile: "balanced", overrides: {}, autoSleep: false, schemaVersion: 1 };
+});
+
+describe("ResourceModeSection", () => {
+  it("renders the three presets as an accessible radio group (EN)", () => {
+    const { screen } = mountWithProviders(ResourceModeSection, { commands: baseCommands() });
+    const group = screen.getByRole("radiogroup", { name: "Resource profile" });
+    expect(group).toBeInTheDocument();
+    const radios = screen.getAllByRole("radio");
+    expect(radios).toHaveLength(3);
+    expect(screen.getByRole("radio", { name: /Balanced/ })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: /Efficient/ })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("renders localized in Spanish", () => {
+    app.settings.language = "es";
+    const { screen } = mountWithProviders(ResourceModeSection, { commands: baseCommands() });
+    expect(screen.getByRole("radio", { name: /Equilibrado/ })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Eficiente/ })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /Rendimiento/ })).toBeInTheDocument();
+    expect(screen.getByText("Qué hace este preset")).toBeInTheDocument();
+  });
+
+  it("selecting a preset persists it and updates the effects view", async () => {
+    const { screen, backend, user } = mountWithProviders(ResourceModeSection, {
+      commands: baseCommands(),
+    });
+    // Balanced first: the sweep line shows the pre-mode 15 s.
+    expect(screen.getByText("every 15 s")).toBeInTheDocument();
+    await user.click(screen.getByRole("radio", { name: /Efficient/ }));
+    await until(() => backend.called("update_settings"), { label: "profile persisted" });
+    expect(lastSent(backend).resourceMode?.profile).toBe("efficient");
+    // The effects view now states Efficient's relaxed cadence.
+    expect(screen.getByText("every 45 s")).toBeInTheDocument();
+  });
+
+  it("arrow keys move and select within the radio group", async () => {
+    const { screen, backend, user } = mountWithProviders(ResourceModeSection, {
+      commands: baseCommands(),
+    });
+    const balanced = screen.getByRole("radio", { name: /Balanced/ });
+    balanced.focus();
+    await user.keyboard("{ArrowRight}");
+    await until(() => backend.called("update_settings"), { label: "keyboard selection persisted" });
+    expect(lastSent(backend).resourceMode?.profile).toBe("performance");
+  });
+
+  it("a numeric override persists clamped, is badged, and 'use preset' removes it", async () => {
+    const { screen, backend, user } = mountWithProviders(ResourceModeSection, {
+      commands: baseCommands(),
+    });
+    await user.click(screen.getByRole("button", { name: "Advanced overrides" }));
+    const input = await screen.findByLabelText(/Git sweep interval/);
+    await user.clear(input);
+    await user.type(input, "2");
+    (input as HTMLInputElement).dispatchEvent(new Event("change", { bubbles: true }));
+    await until(() => backend.called("update_settings"), { label: "override persisted" });
+    // 2 s is below the hard floor -> clamped to 5 s (5000 ms), never stored raw.
+    expect(lastSent(backend).resourceMode?.overrides?.gitSweepIntervalMs).toBe(5_000);
+    // The effects view marks the capability as overridden…
+    expect(screen.getByText("overridden")).toBeInTheDocument();
+    // …and "use preset" removes the override entirely (no residue).
+    await user.click(screen.getAllByRole("button", { name: "Use preset" })[0]);
+    await until(
+      () => lastSent(backend).resourceMode?.overrides?.gitSweepIntervalMs === undefined,
+      { label: "override cleared" },
+    );
+    expect(lastSent(backend).resourceMode?.overrides).toEqual({});
+  });
+
+  it("reset clears every override at once", async () => {
+    app.settings.resourceMode = {
+      profile: "balanced",
+      overrides: { orchestrationConcurrency: 2, petFlavour: false },
+      autoSleep: false,
+      schemaVersion: 1,
+    };
+    const { screen, backend, user } = mountWithProviders(ResourceModeSection, {
+      commands: baseCommands(),
+    });
+    await user.click(screen.getByRole("button", { name: "Advanced overrides" }));
+    await user.click(screen.getByRole("button", { name: /Reset all overrides/ }));
+    await until(() => backend.called("update_settings"), { label: "reset persisted" });
+    expect(lastSent(backend).resourceMode?.overrides).toEqual({});
+    expect(lastSent(backend).resourceMode?.profile).toBe("balanced");
+  });
+
+  it("the auto-sleep feature flag persists and gates its level controls", async () => {
+    const { screen, backend, user } = mountWithProviders(ResourceModeSection, {
+      commands: baseCommands(),
+    });
+    await user.click(screen.getByRole("button", { name: "Advanced overrides" }));
+    // Flag off: the idle-threshold override is disabled.
+    expect(screen.getByLabelText(/Auto-sleep idle threshold/)).toBeDisabled();
+    await user.click(screen.getByRole("switch", { name: /Workspace auto-sleep/ }));
+    await until(() => backend.called("update_settings"), { label: "flag persisted" });
+    expect(lastSent(backend).resourceMode?.autoSleep).toBe(true);
+    expect(screen.getByLabelText(/Auto-sleep idle threshold/)).toBeEnabled();
+  });
+
+  it("a corrupt persisted document renders as Balanced with nothing overridden", () => {
+    app.settings.resourceMode = {
+      profile: "turbo",
+      overrides: { nonsense: 12, gitSweepIntervalMs: "fast" },
+      schemaVersion: 1,
+    } as never;
+    const { screen } = mountWithProviders(ResourceModeSection, { commands: baseCommands() });
+    expect(screen.getByRole("radio", { name: /Balanced/ })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.queryByText("overridden")).not.toBeInTheDocument();
+  });
+});

--- a/uxnandesktop/src/lib/components/Settings.svelte
+++ b/uxnandesktop/src/lib/components/Settings.svelte
@@ -59,6 +59,7 @@
   import GithubSettings from "./GithubSettings.svelte";
   import PetsSettings from "./PetsSettings.svelte";
   import ResourceSettings from "./ResourceSettings.svelte";
+  import ResourceModeSection from "./ResourceModeSection.svelte";
   import SettingsSection from "./SettingsSection.svelte";
   import SettingsRow from "./SettingsRow.svelte";
   import { TERMINAL_SCROLLBACK_PRESETS } from "$lib/terminal/scrollback";
@@ -1680,7 +1681,10 @@
         {:else if app.settingsSection === "github"}
           <GithubSettings />
         {:else if app.settingsSection === "resources"}
-          <ResourceSettings />
+          <div class="flex flex-col gap-10">
+            <ResourceModeSection />
+            <ResourceSettings />
+          </div>
         {:else}
           <div class="flex flex-col gap-6">
           <SettingsSection title={i18n.t("settings.terminal")} description={i18n.t("settings.terminalDesc")}>

--- a/uxnandesktop/src/lib/components/UsageStatusButton.svelte
+++ b/uxnandesktop/src/lib/components/UsageStatusButton.svelte
@@ -8,6 +8,8 @@
   import { TooltipSimple } from "$lib/components/ui/tooltip";
   import { app } from "$lib/state/app.svelte";
   import { usage } from "$lib/state/usage.svelte";
+  import { resourceMode } from "$lib/state/resourceMode.svelte";
+  import FreshnessHint from "./FreshnessHint.svelte";
   import { cn } from "$lib/utils";
   import { text } from "$lib/design";
   import { i18n } from "$lib/i18n";
@@ -101,20 +103,28 @@
           <div class="text-sm font-medium leading-tight text-foreground">{i18n.t("providers.usageTitle")}</div>
           <div class={text.meta}>{i18n.t("providers.usedCaption")}</div>
         </div>
-        <TooltipSimple bind:open={refreshTooltipOpen} title={i18n.t("providers.refreshNow")}>
-          {#snippet children(tp)}
-            <Button
-              {...tp}
-              variant="ghost"
-              size="icon-sm"
-              disabled={usage.loading}
-              aria-label={i18n.t("providers.refreshNow")}
-              onclick={() => void usage.refresh()}
-            >
-              <RefreshCwIcon class={cn("size-3.5", usage.loading && "animate-spin")} />
-            </Button>
-          {/snippet}
-        </TooltipSimple>
+        <span class="flex items-center gap-0.5">
+          {#if resourceMode.freshness.usage}
+            <FreshnessHint
+              label={i18n.t("resourceMode.freshness.usage")}
+              onrefresh={() => void usage.refresh()}
+            />
+          {/if}
+          <TooltipSimple bind:open={refreshTooltipOpen} title={i18n.t("providers.refreshNow")}>
+            {#snippet children(tp)}
+              <Button
+                {...tp}
+                variant="ghost"
+                size="icon-sm"
+                disabled={usage.loading}
+                aria-label={i18n.t("providers.refreshNow")}
+                onclick={() => void usage.refresh()}
+              >
+                <RefreshCwIcon class={cn("size-3.5", usage.loading && "animate-spin")} />
+              </Button>
+            {/snippet}
+          </TooltipSimple>
+        </span>
       </div>
 
       <div class="scrollbar-sleek flex max-h-80 flex-col divide-y divide-border/50 overflow-y-auto px-3">

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -523,6 +523,75 @@ export const en = {
   "resources.exportSaved": "Diagnostics exported.",
 
   // Resource mode (Settings → Resources → Resource mode)
+  "resourceMode.title": "Resource mode",
+  "resourceMode.desc":
+    "Choose how much background work Uxnan keeps running. A preset governs local infrastructure only — refresh cadences, polling, parallelism, animation — never what your agents can do or which model they use.",
+  "resourceMode.profileGroup": "Resource profile",
+  "resourceMode.profile.efficient": "Efficient",
+  "resourceMode.profile.efficientDesc":
+    "Less background work and memory. Some data refreshes less often — every relaxed surface says so and offers a manual refresh.",
+  "resourceMode.profile.balanced": "Balanced",
+  "resourceMode.profile.balancedDesc": "The default: exactly the behavior Uxnan has always had.",
+  "resourceMode.profile.performance": "Performance",
+  "resourceMode.profile.performanceDesc":
+    "Fresher data, and extra parallelism only while Uxnan measures real headroom. Never aggressive.",
+  "resourceMode.effectsTitle": "What this preset does",
+  "resourceMode.overriddenBadge": "overridden",
+  "resourceMode.effect.gitSweep": "Git status sweep (background worktrees)",
+  "resourceMode.effect.reconcile": "Worktree list check",
+  "resourceMode.effect.everySeconds": "every {seconds} s",
+  "resourceMode.effect.github": "GitHub polling",
+  "resourceMode.effect.usage": "Provider usage refresh",
+  "resourceMode.effect.intervalNormal": "your configured interval",
+  "resourceMode.effect.intervalRelaxed": "{factor}× your configured interval",
+  "resourceMode.effect.intervalFresher": "up to 2× as often (never under 30 s)",
+  "resourceMode.effect.orchestration": "Orchestration parallelism",
+  "resourceMode.effect.orchestrationSteps": "{n} steps at once",
+  "resourceMode.effect.orchestrationExtended": "{n} steps at once ({max} with measured headroom)",
+  "resourceMode.effect.history": "Resource monitor history",
+  "resourceMode.effect.historyMinutes": "{minutes} min",
+  "resourceMode.effect.pet": "Pet idle animations",
+  "resourceMode.effect.petNormal": "normal",
+  "resourceMode.effect.petReduced": "reduced (state changes still play)",
+  "resourceMode.effect.autoSleep": "Workspace auto-sleep",
+  "resourceMode.effect.autoSleepOff": "off",
+  "resourceMode.effect.autoSleepSuggest": "suggest after {minutes} min idle",
+  "resourceMode.effect.autoSleepAuto": "sleep after {minutes} min idle",
+  "resourceMode.effect.autoSleepFlagOff": "(switch below is off)",
+  "resourceMode.autoSleepFlag": "Workspace auto-sleep",
+  "resourceMode.autoSleepFlagDesc":
+    "Experimental. Lets Uxnan suggest — or, at the automatic level, perform — sleeping workspaces that have been idle. Sleeping stops that workspace's processes (scrollback and agent sessions are kept and resume on wake). A workspace with a working agent is only ever suggested, never slept without your confirmation.",
+  "resourceMode.advanced": "Advanced overrides",
+  "resourceMode.advancedDesc":
+    "Pin one capability while everything else follows the preset. “Use preset” removes the override — nothing lingers.",
+  "resourceMode.usePreset": "Use preset",
+  "resourceMode.reset": "Reset all overrides",
+  "resourceMode.override.gitSweep": "Git sweep interval (seconds)",
+  "resourceMode.override.gitSweepDesc":
+    "How often background worktrees' status badges refresh (5–600 s). Focus, agent activity and your own git actions always refresh immediately.",
+  "resourceMode.override.concurrency": "Orchestration parallelism",
+  "resourceMode.override.concurrencyDesc": "Steps one run may execute at once (1–8).",
+  "resourceMode.override.history": "Monitor history (seconds)",
+  "resourceMode.override.historyDesc":
+    "How much resource history the monitor's in-memory buffer keeps (60–600 s).",
+  "resourceMode.override.pet": "Pet idle animations",
+  "resourceMode.override.petDesc":
+    "Decorative one-shots between state changes. State changes always animate.",
+  "resourceMode.override.autoSleepLevel": "Auto-sleep level",
+  "resourceMode.override.autoSleepLevelDesc":
+    "What auto-sleep may do while its switch above is on.",
+  "resourceMode.level.off": "Off",
+  "resourceMode.level.suggest": "Suggest",
+  "resourceMode.level.auto": "Automatic",
+  "resourceMode.override.idle": "Auto-sleep idle threshold (minutes)",
+  "resourceMode.override.idleDesc":
+    "How long a workspace must be inactive before auto-sleep considers it (5–480 min).",
+  "resourceMode.freshness.git":
+    "Resource mode: worktree statuses refresh less often. Click to refresh now.",
+  "resourceMode.freshness.github":
+    "Resource mode: GitHub data refreshes less often. Click to refresh now.",
+  "resourceMode.freshness.usage":
+    "Resource mode: usage data refreshes less often. Click to refresh now.",
   "resourceMode.autoSleep.suggestToast":
     "“{name}” has been inactive for a while — sleep its terminals to free resources?",
   "resourceMode.autoSleep.suggestAction": "Sleep",

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -521,6 +521,14 @@ export const en = {
     "Workspace and terminal names are replaced with opaque labels; agent names are kept only for known catalog agents. Nothing is uploaded — you choose where the file is saved.",
   "resources.exportConfirm": "Save file…",
   "resources.exportSaved": "Diagnostics exported.",
+
+  // Resource mode (Settings → Resources → Resource mode)
+  "resourceMode.autoSleep.suggestToast":
+    "“{name}” has been inactive for a while — sleep its terminals to free resources?",
+  "resourceMode.autoSleep.suggestAction": "Sleep",
+  "resourceMode.autoSleep.sleptToast":
+    "“{name}” was put to sleep to free resources. Opening it wakes it again.",
+  "resourceMode.autoSleep.blockedToast": "An agent is still working there — leaving it awake.",
   "settings.browser": "Browser",
   "settings.browserDesc":
     "A lightweight in-app browser to preview and debug what your agents build, and to open the links they create.",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -524,6 +524,76 @@ export const es: Record<MessageKey, string> = {
   "resources.exportSaved": "Diagnóstico exportado.",
 
   // Modo de recursos (Ajustes → Recursos → Modo de recursos)
+  "resourceMode.title": "Modo de recursos",
+  "resourceMode.desc":
+    "Elige cuánto trabajo en segundo plano mantiene Uxnan. Un preset gobierna solo infraestructura local (cadencias de refresco, sondeos, paralelismo, animación), nunca lo que pueden hacer tus agentes ni qué modelo usan.",
+  "resourceMode.profileGroup": "Perfil de recursos",
+  "resourceMode.profile.efficient": "Eficiente",
+  "resourceMode.profile.efficientDesc":
+    "Menos trabajo en segundo plano y menos memoria. Algunos datos se refrescan menos: cada superficie relajada lo indica y ofrece un refresco manual.",
+  "resourceMode.profile.balanced": "Equilibrado",
+  "resourceMode.profile.balancedDesc":
+    "El predeterminado: exactamente el comportamiento de siempre de Uxnan.",
+  "resourceMode.profile.performance": "Rendimiento",
+  "resourceMode.profile.performanceDesc":
+    "Datos más frescos y paralelismo extra solo mientras Uxnan mide margen real. Nunca agresivo.",
+  "resourceMode.effectsTitle": "Qué hace este preset",
+  "resourceMode.overriddenBadge": "modificado",
+  "resourceMode.effect.gitSweep": "Barrido de estado Git (worktrees en segundo plano)",
+  "resourceMode.effect.reconcile": "Comprobación de la lista de worktrees",
+  "resourceMode.effect.everySeconds": "cada {seconds} s",
+  "resourceMode.effect.github": "Sondeo de GitHub",
+  "resourceMode.effect.usage": "Refresco de uso de proveedores",
+  "resourceMode.effect.intervalNormal": "tu intervalo configurado",
+  "resourceMode.effect.intervalRelaxed": "{factor}× tu intervalo configurado",
+  "resourceMode.effect.intervalFresher": "hasta 2× más a menudo (nunca por debajo de 30 s)",
+  "resourceMode.effect.orchestration": "Paralelismo de orquestación",
+  "resourceMode.effect.orchestrationSteps": "{n} pasos a la vez",
+  "resourceMode.effect.orchestrationExtended": "{n} pasos a la vez ({max} con margen medido)",
+  "resourceMode.effect.history": "Historial del monitor de recursos",
+  "resourceMode.effect.historyMinutes": "{minutes} min",
+  "resourceMode.effect.pet": "Animaciones de reposo de la mascota",
+  "resourceMode.effect.petNormal": "normales",
+  "resourceMode.effect.petReduced": "reducidas (los cambios de estado se siguen animando)",
+  "resourceMode.effect.autoSleep": "Auto-dormir workspaces",
+  "resourceMode.effect.autoSleepOff": "apagado",
+  "resourceMode.effect.autoSleepSuggest": "sugerir tras {minutes} min inactivo",
+  "resourceMode.effect.autoSleepAuto": "dormir tras {minutes} min inactivo",
+  "resourceMode.effect.autoSleepFlagOff": "(el interruptor de abajo está apagado)",
+  "resourceMode.autoSleepFlag": "Auto-dormir workspaces",
+  "resourceMode.autoSleepFlagDesc":
+    "Experimental. Permite que Uxnan sugiera —o, en el nivel automático, realice— dormir workspaces inactivos. Dormir detiene los procesos de ese workspace (el scrollback y las sesiones de agente se conservan y se reanudan al despertar). Un workspace con un agente trabajando solo recibe una sugerencia: nunca se duerme sin tu confirmación.",
+  "resourceMode.advanced": "Ajustes finos (overrides)",
+  "resourceMode.advancedDesc":
+    "Fija una capacidad mientras el resto sigue al preset. “Usar preset” elimina el override, sin dejar restos.",
+  "resourceMode.usePreset": "Usar preset",
+  "resourceMode.reset": "Restablecer todos los overrides",
+  "resourceMode.override.gitSweep": "Intervalo del barrido Git (segundos)",
+  "resourceMode.override.gitSweepDesc":
+    "Cada cuánto se refrescan los indicadores de estado de los worktrees en segundo plano (5–600 s). El foco, la actividad de agentes y tus propias acciones git siempre refrescan al momento.",
+  "resourceMode.override.concurrency": "Paralelismo de orquestación",
+  "resourceMode.override.concurrencyDesc": "Pasos que una ejecución puede lanzar a la vez (1–8).",
+  "resourceMode.override.history": "Historial del monitor (segundos)",
+  "resourceMode.override.historyDesc":
+    "Cuánto historial de recursos conserva el buffer en memoria del monitor (60–600 s).",
+  "resourceMode.override.pet": "Animaciones de reposo de la mascota",
+  "resourceMode.override.petDesc":
+    "Gestos decorativos entre cambios de estado. Los cambios de estado siempre se animan.",
+  "resourceMode.override.autoSleepLevel": "Nivel de auto-dormir",
+  "resourceMode.override.autoSleepLevelDesc":
+    "Qué puede hacer auto-dormir mientras su interruptor de arriba está encendido.",
+  "resourceMode.level.off": "Apagado",
+  "resourceMode.level.suggest": "Sugerir",
+  "resourceMode.level.auto": "Automático",
+  "resourceMode.override.idle": "Umbral de inactividad de auto-dormir (minutos)",
+  "resourceMode.override.idleDesc":
+    "Cuánto debe llevar inactivo un workspace antes de que auto-dormir lo considere (5–480 min).",
+  "resourceMode.freshness.git":
+    "Modo de recursos: los estados de los worktrees se refrescan menos a menudo. Haz clic para refrescar ahora.",
+  "resourceMode.freshness.github":
+    "Modo de recursos: los datos de GitHub se refrescan menos a menudo. Haz clic para refrescar ahora.",
+  "resourceMode.freshness.usage":
+    "Modo de recursos: los datos de uso se refrescan menos a menudo. Haz clic para refrescar ahora.",
   "resourceMode.autoSleep.suggestToast":
     "“{name}” lleva un rato inactivo. ¿Dormir sus terminales para liberar recursos?",
   "resourceMode.autoSleep.suggestAction": "Dormir",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -522,6 +522,14 @@ export const es: Record<MessageKey, string> = {
     "Los nombres de workspaces y terminales se sustituyen por etiquetas opacas; los nombres de agente se conservan solo para agentes conocidos del catálogo. No se sube nada: tú eliges dónde se guarda el archivo.",
   "resources.exportConfirm": "Guardar archivo…",
   "resources.exportSaved": "Diagnóstico exportado.",
+
+  // Modo de recursos (Ajustes → Recursos → Modo de recursos)
+  "resourceMode.autoSleep.suggestToast":
+    "“{name}” lleva un rato inactivo. ¿Dormir sus terminales para liberar recursos?",
+  "resourceMode.autoSleep.suggestAction": "Dormir",
+  "resourceMode.autoSleep.sleptToast":
+    "“{name}” se durmió para liberar recursos. Al abrirlo se despierta de nuevo.",
+  "resourceMode.autoSleep.blockedToast": "Un agente sigue trabajando ahí; se deja despierto.",
   "settings.browser": "Navegador",
   "settings.browserDesc":
     "Un navegador ligero dentro de la app para previsualizar y depurar lo que construyen tus agentes, y abrir los enlaces que crean.",

--- a/uxnandesktop/src/lib/resources/autoSleep.test.ts
+++ b/uxnandesktop/src/lib/resources/autoSleep.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Auto-sleep planner. The guards ARE the feature: a working agent is never
+ * slept automatically, unknown recency is never guessed at, the active and
+ * Global workspaces are untouchable, and everything is double-gated behind the
+ * feature flag. Time is an explicit input, so every rule runs under a fake
+ * clock.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  planAutoSleep,
+  SUGGEST_COOLDOWN_MS,
+  type AutoSleepCandidate,
+  type AutoSleepInput,
+} from "./autoSleep";
+
+const NOW = 10_000_000;
+const HOUR = 60 * 60 * 1000;
+
+function candidate(overrides: Partial<AutoSleepCandidate> = {}): AutoSleepCandidate {
+  return {
+    key: "C:/work/repo",
+    liveTerminals: 2,
+    asleep: false,
+    blockers: 0,
+    lastActiveMs: NOW - HOUR,
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<AutoSleepInput> = {}): AutoSleepInput {
+  return {
+    level: "auto",
+    flagEnabled: true,
+    activeKey: "C:/work/active",
+    globalKey: "",
+    nowMs: NOW,
+    idleMinutes: 30,
+    candidates: [candidate()],
+    lastPromptMs: {},
+    ...overrides,
+  };
+}
+
+describe("planAutoSleep", () => {
+  it("sleeps an idle, blocker-free workspace at level auto", () => {
+    expect(planAutoSleep(input())).toEqual([{ key: "C:/work/repo", action: "sleep" }]);
+  });
+
+  it("does nothing when the feature flag is off, whatever the level", () => {
+    expect(planAutoSleep(input({ flagEnabled: false }))).toEqual([]);
+  });
+
+  it("does nothing at level off, whatever the flag", () => {
+    expect(planAutoSleep(input({ level: "off" }))).toEqual([]);
+  });
+
+  it("only suggests at level suggest", () => {
+    expect(planAutoSleep(input({ level: "suggest" }))).toEqual([
+      { key: "C:/work/repo", action: "suggest" },
+    ]);
+  });
+
+  it("NEVER auto-sleeps a workspace with a working agent — it suggests instead", () => {
+    expect(planAutoSleep(input({ candidates: [candidate({ blockers: 1 })] }))).toEqual([
+      { key: "C:/work/repo", action: "suggest" },
+    ]);
+  });
+
+  it("skips the active workspace and the Global scratch space", () => {
+    expect(
+      planAutoSleep(
+        input({
+          candidates: [candidate({ key: "C:/work/active" }), candidate({ key: "" })],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("skips asleep workspaces and workspaces with no live terminals", () => {
+    expect(
+      planAutoSleep(
+        input({
+          candidates: [candidate({ asleep: true }), candidate({ key: "x", liveTerminals: 0 })],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("never acts on a workspace whose recency is unknown", () => {
+    expect(planAutoSleep(input({ candidates: [candidate({ lastActiveMs: null })] }))).toEqual([]);
+  });
+
+  it("respects the idle threshold against the fake clock", () => {
+    const justUnder = candidate({ lastActiveMs: NOW - 30 * 60_000 + 1 });
+    expect(planAutoSleep(input({ candidates: [justUnder] }))).toEqual([]);
+    const exactly = candidate({ lastActiveMs: NOW - 30 * 60_000 });
+    expect(planAutoSleep(input({ candidates: [exactly] }))).toHaveLength(1);
+  });
+
+  it("honors a longer idle threshold from the policy", () => {
+    const idleOneHour = candidate({ lastActiveMs: NOW - HOUR });
+    expect(planAutoSleep(input({ idleMinutes: 120, candidates: [idleOneHour] }))).toEqual([]);
+  });
+
+  it("suggestions respect the per-workspace cooldown; sleeps do not need one", () => {
+    const prompted = { "C:/work/repo": NOW - 1000 };
+    expect(
+      planAutoSleep(input({ level: "suggest", lastPromptMs: prompted })),
+    ).toEqual([]);
+    // After the cooldown the suggestion returns.
+    const later = input({
+      level: "suggest",
+      nowMs: NOW + SUGGEST_COOLDOWN_MS,
+      lastPromptMs: { "C:/work/repo": NOW },
+    });
+    expect(planAutoSleep(later)).toHaveLength(1);
+    // A blocker-free auto sleep is unaffected by the prompt history.
+    expect(planAutoSleep(input({ lastPromptMs: prompted }))).toHaveLength(1);
+  });
+
+  it("handles several workspaces independently", () => {
+    const decisions = planAutoSleep(
+      input({
+        candidates: [
+          candidate({ key: "a" }),
+          candidate({ key: "b", blockers: 2 }),
+          candidate({ key: "c", lastActiveMs: NOW - 60_000 }),
+        ],
+      }),
+    );
+    expect(decisions).toEqual([
+      { key: "a", action: "sleep" },
+      { key: "b", action: "suggest" },
+    ]);
+  });
+
+  it("never mutates its input", () => {
+    const lastPromptMs = {};
+    const candidates = [candidate()];
+    planAutoSleep(input({ candidates, lastPromptMs }));
+    expect(lastPromptMs).toEqual({});
+    expect(candidates[0].asleep).toBe(false);
+  });
+});

--- a/uxnandesktop/src/lib/resources/autoSleep.ts
+++ b/uxnandesktop/src/lib/resources/autoSleep.ts
@@ -1,0 +1,94 @@
+// Workspace auto-sleep planner — pure TS, no Svelte imports, no timers.
+//
+// Decides, from a snapshot of the workspace world, which inactive workspaces
+// the auto-sleep engine should act on and how. The engine
+// (`state/autoSleep.svelte.ts`) gathers the snapshot on a slow tick and
+// executes the plan; keeping the decision pure is what makes the guards
+// testable under a fake clock.
+//
+// The guards are the feature's contract, not niceties:
+//
+// - **Everything is double-gated**: the profile's capability level AND the
+//   explicit feature flag must both allow it, so the flag alone can kill the
+//   whole behavior on rollback.
+// - **A workspace with a working agent is NEVER slept automatically.** It gets
+//   a *suggestion* at most (the notice the user acts on), even at level
+//   `auto` — sleeping kills processes, and a mid-turn agent needs an explicit
+//   OK, same as the manual path.
+// - **Only evidence counts as idleness.** No last-active stamp → no action;
+//   guessing recency is how work gets lost.
+// - **The active workspace and the Global scratch space are untouchable**, as
+//   is anything already asleep or holding no terminals.
+
+import type { WorkspaceAutoSleepLevel } from "./policy";
+
+/** One workspace as the engine snapshots it. */
+export interface AutoSleepCandidate {
+  /** Workspace key (a worktree path, or "" for Global). */
+  key: string;
+  /** Live (not asleep) terminal tabs in the workspace. */
+  liveTerminals: number;
+  /** Whether every terminal tab is already asleep. */
+  asleep: boolean;
+  /** Agent tabs currently working (the sleep blockers). */
+  blockers: number;
+  /** When the workspace was last active (epoch ms), or `null` if unknown. */
+  lastActiveMs: number | null;
+}
+
+export interface AutoSleepDecision {
+  key: string;
+  /** `sleep` = put it to sleep now (level `auto`, no blockers);
+   *  `suggest` = surface a suggestion the user confirms. */
+  action: "sleep" | "suggest";
+}
+
+/** How long after prompting about a workspace we stay quiet about it, so a
+ *  dismissed suggestion doesn't nag every tick. */
+export const SUGGEST_COOLDOWN_MS = 30 * 60 * 1000;
+
+export interface AutoSleepInput {
+  /** The resolved capability level (from the policy). */
+  level: WorkspaceAutoSleepLevel;
+  /** The explicit feature flag (Settings → Resources → Resource mode). */
+  flagEnabled: boolean;
+  /** The currently active workspace key (never acted on). */
+  activeKey: string;
+  /** The Global scratch workspace key (never acted on). */
+  globalKey: string;
+  nowMs: number;
+  /** Inactivity threshold from the policy. */
+  idleMinutes: number;
+  candidates: AutoSleepCandidate[];
+  /** Per-workspace timestamp of the last suggestion shown (epoch ms). */
+  lastPromptMs: Record<string, number>;
+  /** Override the suggestion cooldown (tests). */
+  promptCooldownMs?: number;
+}
+
+/** Compute what to do this tick. Deterministic; never mutates its input. */
+export function planAutoSleep(input: AutoSleepInput): AutoSleepDecision[] {
+  if (!input.flagEnabled || input.level === "off") return [];
+  const cooldown = input.promptCooldownMs ?? SUGGEST_COOLDOWN_MS;
+  const idleMs = input.idleMinutes * 60_000;
+  const out: AutoSleepDecision[] = [];
+
+  for (const c of input.candidates) {
+    if (c.key === input.activeKey || c.key === input.globalKey) continue;
+    if (c.asleep || c.liveTerminals === 0) continue;
+    if (c.lastActiveMs === null) continue; // unknown recency: never guess
+    if (input.nowMs - c.lastActiveMs < idleMs) continue;
+
+    // A working agent downgrades even `auto` to a suggestion — the notice the
+    // user confirms — and suggestions respect the per-workspace cooldown.
+    const mustAsk = input.level === "suggest" || c.blockers > 0;
+    if (mustAsk) {
+      const last = input.lastPromptMs[c.key];
+      if (last !== undefined && input.nowMs - last < cooldown) continue;
+      out.push({ key: c.key, action: "suggest" });
+    } else {
+      out.push({ key: c.key, action: "sleep" });
+    }
+  }
+  return out;
+}

--- a/uxnandesktop/src/lib/resources/policy.test.ts
+++ b/uxnandesktop/src/lib/resources/policy.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Resource-mode policy engine. The two invariants that matter most:
+ * `balanced` must equal the pre-mode constants (the default changes nothing),
+ * and normalization must leave no residue — corrupt or hostile persisted
+ * values always collapse to a clean document instead of reaching a consumer.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  effectiveGithubPollSeconds,
+  effectiveOrchestrationConcurrency,
+  effectiveUsageRefreshMinutes,
+  freshnessRelaxations,
+  HEADROOM_CPU_LIMIT_PERCENT,
+  HEADROOM_MAX_AGE_MS,
+  LIMITS,
+  normalizeResourceMode,
+  orchestrationHeadroom,
+  OVERRIDABLE_KEYS,
+  PRESETS,
+  RESOURCE_MODE_SCHEMA_VERSION,
+  resolveFromSettings,
+  resolvePolicy,
+  type ResolvedResourcePolicy,
+} from "./policy";
+import type { ResourceSummary } from "$lib/types";
+
+const policyFor = (raw: unknown): ResolvedResourcePolicy => resolveFromSettings(raw);
+
+describe("presets", () => {
+  it("balanced mirrors the pre-mode constants exactly", () => {
+    // These literals are the constants the consumers shipped with before the
+    // mode existed (SWEEP_MS, the every-tick reconcile, 1x polls,
+    // MAX_CONCURRENCY, the monitor's 10-minute buffer). If one of these fails,
+    // the default profile changed behavior — which it must never do silently.
+    expect(PRESETS.balanced).toEqual({
+      gitSweepIntervalMs: 15_000,
+      worktreeReconcileIntervalMs: 0,
+      githubPollFactor: 1,
+      usageRefreshFactor: 1,
+      orchestrationConcurrency: 4,
+      orchestrationExtendedConcurrency: null,
+      resourceHistorySeconds: 600,
+      petFlavour: true,
+      workspaceAutoSleep: "off",
+      autoSleepIdleMinutes: 30,
+    });
+  });
+
+  it("efficient reduces background work on every governed capability", () => {
+    const e = PRESETS.efficient;
+    const b = PRESETS.balanced;
+    expect(e.gitSweepIntervalMs).toBeGreaterThan(b.gitSweepIntervalMs);
+    expect(e.worktreeReconcileIntervalMs).toBeGreaterThan(b.worktreeReconcileIntervalMs);
+    expect(e.githubPollFactor).toBeGreaterThan(b.githubPollFactor);
+    expect(e.usageRefreshFactor).toBeGreaterThan(b.usageRefreshFactor);
+    expect(e.orchestrationConcurrency).toBeLessThan(b.orchestrationConcurrency);
+    expect(e.resourceHistorySeconds).toBeLessThan(b.resourceHistorySeconds);
+    expect(e.petFlavour).toBe(false);
+    expect(e.workspaceAutoSleep).toBe("suggest");
+  });
+
+  it("performance is fresher but never aggressive, and only extends concurrency", () => {
+    const p = PRESETS.performance;
+    const b = PRESETS.balanced;
+    expect(p.gitSweepIntervalMs).toBeLessThan(b.gitSweepIntervalMs);
+    expect(p.gitSweepIntervalMs).toBeGreaterThanOrEqual(LIMITS.gitSweepIntervalMs.min);
+    // The base concurrency stays at balanced; only the headroom-gated ceiling grows.
+    expect(p.orchestrationConcurrency).toBe(b.orchestrationConcurrency);
+    expect(p.orchestrationExtendedConcurrency).toBeGreaterThan(b.orchestrationConcurrency);
+    // Auto-sleep and history stay at the balanced posture.
+    expect(p.workspaceAutoSleep).toBe("off");
+    expect(p.resourceHistorySeconds).toBe(b.resourceHistorySeconds);
+  });
+
+  it("every preset respects the hard limits", () => {
+    for (const preset of Object.values(PRESETS)) {
+      expect(preset.gitSweepIntervalMs).toBeGreaterThanOrEqual(LIMITS.gitSweepIntervalMs.min);
+      expect(preset.gitSweepIntervalMs).toBeLessThanOrEqual(LIMITS.gitSweepIntervalMs.max);
+      expect(preset.orchestrationConcurrency).toBeGreaterThanOrEqual(
+        LIMITS.orchestrationConcurrency.min,
+      );
+      expect(preset.orchestrationConcurrency).toBeLessThanOrEqual(
+        LIMITS.orchestrationConcurrency.max,
+      );
+      expect(preset.resourceHistorySeconds).toBeGreaterThanOrEqual(
+        LIMITS.resourceHistorySeconds.min,
+      );
+      expect(preset.resourceHistorySeconds).toBeLessThanOrEqual(LIMITS.resourceHistorySeconds.max);
+    }
+  });
+});
+
+describe("normalizeResourceMode", () => {
+  it("defaults to balanced with no overrides for absent settings", () => {
+    for (const raw of [undefined, null, "efficient", 42, ["efficient"], true]) {
+      expect(normalizeResourceMode(raw)).toEqual({
+        profile: "balanced",
+        overrides: {},
+        autoSleep: false,
+        schemaVersion: RESOURCE_MODE_SCHEMA_VERSION,
+      });
+    }
+  });
+
+  it("accepts each known profile and rejects unknown ones", () => {
+    expect(normalizeResourceMode({ profile: "efficient" }).profile).toBe("efficient");
+    expect(normalizeResourceMode({ profile: "performance" }).profile).toBe("performance");
+    expect(normalizeResourceMode({ profile: "turbo" }).profile).toBe("balanced");
+    expect(normalizeResourceMode({ profile: 3 }).profile).toBe("balanced");
+  });
+
+  it("keeps valid overrides, clamped into the hard limits", () => {
+    const mode = normalizeResourceMode({
+      profile: "efficient",
+      overrides: {
+        gitSweepIntervalMs: 1, // below the floor -> clamped up
+        orchestrationConcurrency: 99, // above the ceiling -> clamped down
+        resourceHistorySeconds: 240.7, // rounded
+        petFlavour: true,
+        workspaceAutoSleep: "auto",
+        autoSleepIdleMinutes: 60,
+      },
+    });
+    expect(mode.overrides).toEqual({
+      gitSweepIntervalMs: LIMITS.gitSweepIntervalMs.min,
+      orchestrationConcurrency: LIMITS.orchestrationConcurrency.max,
+      resourceHistorySeconds: 241,
+      petFlavour: true,
+      workspaceAutoSleep: "auto",
+      autoSleepIdleMinutes: 60,
+    });
+  });
+
+  it("drops null (= inherit), unknown keys and wrong-typed values without residue", () => {
+    const mode = normalizeResourceMode({
+      profile: "balanced",
+      overrides: {
+        gitSweepIntervalMs: null, // explicit inherit
+        orchestrationConcurrency: "many", // wrong type
+        resourceHistorySeconds: Number.NaN, // not finite
+        workspaceAutoSleep: "sometimes", // not a level
+        petFlavour: 1, // wrong type
+        turboBoost: true, // unknown capability
+        githubPollFactor: 0, // a real capability, but not overridable
+      },
+    });
+    expect(mode.overrides).toEqual({});
+  });
+
+  it("treats a newer schema version as balanced with no overrides (rollback safety)", () => {
+    const mode = normalizeResourceMode({
+      profile: "efficient",
+      overrides: { orchestrationConcurrency: 2 },
+      autoSleep: true,
+      schemaVersion: RESOURCE_MODE_SCHEMA_VERSION + 1,
+    });
+    expect(mode).toEqual({
+      profile: "balanced",
+      overrides: {},
+      autoSleep: false,
+      schemaVersion: RESOURCE_MODE_SCHEMA_VERSION,
+    });
+  });
+
+  it("parses a document without a schema version as v1", () => {
+    const mode = normalizeResourceMode({ profile: "efficient", autoSleep: true });
+    expect(mode.profile).toBe("efficient");
+    expect(mode.autoSleep).toBe(true);
+  });
+
+  it("only a literal true enables the auto-sleep flag", () => {
+    expect(normalizeResourceMode({ autoSleep: true }).autoSleep).toBe(true);
+    for (const v of [1, "true", {}, [], false, null]) {
+      expect(normalizeResourceMode({ autoSleep: v }).autoSleep).toBe(false);
+    }
+  });
+});
+
+describe("resolvePolicy", () => {
+  it("resolves a bare profile to its preset with nothing overridden", () => {
+    const policy = policyFor({ profile: "efficient" });
+    expect(policy.profile).toBe("efficient");
+    expect(policy.capabilities).toEqual(PRESETS.efficient);
+    expect(policy.overridden).toEqual([]);
+  });
+
+  it("applies overrides on top of the preset and reports them", () => {
+    const policy = policyFor({
+      profile: "efficient",
+      overrides: { orchestrationConcurrency: 3, petFlavour: true },
+    });
+    expect(policy.capabilities.orchestrationConcurrency).toBe(3);
+    expect(policy.capabilities.petFlavour).toBe(true);
+    // Everything else still follows the preset.
+    expect(policy.capabilities.gitSweepIntervalMs).toBe(PRESETS.efficient.gitSweepIntervalMs);
+    expect(policy.overridden.sort()).toEqual(["orchestrationConcurrency", "petFlavour"]);
+  });
+
+  it("clearing an override returns exactly to the preset (no residue)", () => {
+    const withOverride = policyFor({
+      profile: "balanced",
+      overrides: { gitSweepIntervalMs: 60_000 },
+    });
+    expect(withOverride.capabilities.gitSweepIntervalMs).toBe(60_000);
+    const cleared = policyFor({ profile: "balanced", overrides: { gitSweepIntervalMs: null } });
+    expect(cleared.capabilities).toEqual(PRESETS.balanced);
+    expect(cleared.overridden).toEqual([]);
+  });
+
+  it("resolvePolicy never mutates the preset table", () => {
+    resolvePolicy({
+      profile: "balanced",
+      overrides: { orchestrationConcurrency: 1 },
+      autoSleep: false,
+      schemaVersion: RESOURCE_MODE_SCHEMA_VERSION,
+    });
+    expect(PRESETS.balanced.orchestrationConcurrency).toBe(4);
+  });
+
+  it("every overridable key is a real capability", () => {
+    for (const key of OVERRIDABLE_KEYS) {
+      expect(PRESETS.balanced[key]).toBeDefined();
+    }
+  });
+});
+
+describe("effective poll intervals", () => {
+  it("scales the GitHub interval by profile, keeping 0 = manual", () => {
+    expect(effectiveGithubPollSeconds(policyFor({ profile: "balanced" }), 45)).toBe(45);
+    expect(effectiveGithubPollSeconds(policyFor({ profile: "efficient" }), 45)).toBe(180);
+    expect(effectiveGithubPollSeconds(policyFor({ profile: "performance" }), 45)).toBe(30);
+    expect(effectiveGithubPollSeconds(policyFor({ profile: "efficient" }), 0)).toBe(0);
+  });
+
+  it("never lets performance push GitHub below the hard floor", () => {
+    expect(effectiveGithubPollSeconds(policyFor({ profile: "performance" }), 31)).toBe(
+      LIMITS.githubPollFloorSeconds,
+    );
+  });
+
+  it("scales the usage refresh by profile with its own floor", () => {
+    expect(effectiveUsageRefreshMinutes(policyFor({ profile: "balanced" }), 5)).toBe(5);
+    expect(effectiveUsageRefreshMinutes(policyFor({ profile: "efficient" }), 5)).toBe(15);
+    expect(effectiveUsageRefreshMinutes(policyFor({ profile: "efficient" }), 0)).toBe(0);
+  });
+});
+
+describe("orchestration headroom", () => {
+  const summaryWith = (updatedAtMs: number | undefined, cpu: number | null): ResourceSummary => ({
+    enabled: true,
+    capabilities: {
+      cpu: true,
+      memory: true,
+      virtualMemory: true,
+      io: true,
+      startTime: true,
+      validated: true,
+    },
+    sampling: { active: true, intervalMs: 3000, reason: "budget" },
+    ...(updatedAtMs !== undefined ? { updatedAtMs } : {}),
+    bufferSeconds: 600,
+    total: {
+      processes: 4,
+      cpuPercent: cpu,
+      cpuAvgPercent: cpu,
+      cpuPeakPercent: cpu,
+      residentBytes: 1,
+      residentAvgBytes: 1,
+      residentPeakBytes: 1,
+      virtualBytes: 1,
+      ioReadBytesPerSec: null,
+      ioWriteBytesPerSec: null,
+      trend: "steady",
+    },
+    groups: [],
+    orphans: [],
+    terminalsLinked: 0,
+  });
+
+  it("grants headroom only on a fresh summary with a known, low CPU", () => {
+    const now = 1_000_000;
+    expect(orchestrationHeadroom(summaryWith(now - 3000, 10), now)).toBe(true);
+    expect(orchestrationHeadroom(summaryWith(now - 3000, HEADROOM_CPU_LIMIT_PERCENT), now)).toBe(
+      false,
+    );
+    expect(orchestrationHeadroom(summaryWith(now - HEADROOM_MAX_AGE_MS - 1, 10), now)).toBe(false);
+    expect(orchestrationHeadroom(summaryWith(now - 3000, null), now)).toBe(false);
+    expect(orchestrationHeadroom(summaryWith(undefined, 10), now)).toBe(false);
+    expect(orchestrationHeadroom(null, now)).toBe(false);
+  });
+
+  it("extends concurrency only under headroom, and only where the preset allows it", () => {
+    const perf = policyFor({ profile: "performance" });
+    expect(effectiveOrchestrationConcurrency(perf, true)).toBe(6);
+    expect(effectiveOrchestrationConcurrency(perf, false)).toBe(4);
+    const balanced = policyFor({ profile: "balanced" });
+    expect(effectiveOrchestrationConcurrency(balanced, true)).toBe(4);
+    const efficient = policyFor({ profile: "efficient" });
+    expect(effectiveOrchestrationConcurrency(efficient, true)).toBe(2);
+  });
+});
+
+describe("freshness relaxations", () => {
+  it("efficient relaxes git, GitHub and usage; balanced and performance relax nothing", () => {
+    expect(freshnessRelaxations(policyFor({ profile: "efficient" }))).toEqual({
+      git: true,
+      github: true,
+      usage: true,
+    });
+    expect(freshnessRelaxations(policyFor({ profile: "balanced" }))).toEqual({
+      git: false,
+      github: false,
+      usage: false,
+    });
+    expect(freshnessRelaxations(policyFor({ profile: "performance" }))).toEqual({
+      git: false,
+      github: false,
+      usage: false,
+    });
+  });
+
+  it("an override that slows the sweep flags the git surface even on balanced", () => {
+    const policy = policyFor({ profile: "balanced", overrides: { gitSweepIntervalMs: 60_000 } });
+    expect(freshnessRelaxations(policy).git).toBe(true);
+  });
+});

--- a/uxnandesktop/src/lib/resources/policy.ts
+++ b/uxnandesktop/src/lib/resources/policy.ts
@@ -1,0 +1,334 @@
+// Resource-mode policy engine — pure TS, no Svelte imports, no Tauri.
+//
+// One place answers "how much background work may run right now?": every
+// consumer (git status sweeps, GitHub/provider polling, orchestration
+// concurrency, the resource monitor's history, the pet, workspace auto-sleep)
+// asks the resolved policy instead of reading settings and re-deriving its own
+// conditions. Three explicit presets (`efficient` / `balanced` / `performance`)
+// plus per-capability overrides, persisted as
+// `{ profile, overrides, autoSleep, schemaVersion }` in `AppSettings`
+// (`resourceMode`, mirrored by Rust `ResourceModeSettings` in `model.rs`).
+//
+// Ground rules, mirrored by the tests:
+//
+// - **`balanced` IS the pre-mode behavior.** Its values are the constants the
+//   consumers used before the mode existed, so the default changes nothing.
+// - **Validation never leaves residue.** An unknown profile, an unknown
+//   override key, a wrong-typed or out-of-range value — each normalizes away
+//   (profile → balanced, override → inherit) instead of surviving to bite a
+//   consumer. `null` means "inherit from the preset".
+// - **Hard safety limits sit outside overrides.** No override can push a
+//   cadence below its floor or a cap above its ceiling (`LIMITS`).
+// - **The mode only governs local infrastructure.** Nothing here touches agent
+//   models, permissions, OS priority or processes uxnan did not spawn.
+
+import type { ResourceModeSettings, ResourceSummary } from "$lib/types";
+
+/** The selectable presets, least- to most-eager. */
+export const RESOURCE_PROFILES = ["efficient", "balanced", "performance"] as const;
+export type ResourceProfile = (typeof RESOURCE_PROFILES)[number];
+
+/** What the auto-sleep capability may do (always additionally gated by the
+ *  `autoSleep` feature flag — see [`NormalizedResourceMode`]). */
+export const AUTO_SLEEP_LEVELS = ["off", "suggest", "auto"] as const;
+export type WorkspaceAutoSleepLevel = (typeof AUTO_SLEEP_LEVELS)[number];
+
+/** Everything a preset governs, resolved to concrete values. */
+export interface ResourceCapabilities {
+  /** Minimum gap between unforced all-worktree git status sweeps (ms). Forced
+   *  sweeps (focus, agent activity, our own git actions) always run. */
+  gitSweepIntervalMs: number;
+  /** Minimum gap between worktree-list reconcile polls (ms). `0` = every
+   *  driver tick (the pre-mode behavior). */
+  worktreeReconcileIntervalMs: number;
+  /** Multiplier over the user's GitHub poll interval (Settings → GitHub).
+   *  `> 1` relaxes, `< 1` tightens — never below the hard floor. */
+  githubPollFactor: number;
+  /** Multiplier over the user's provider-usage refresh interval. */
+  usageRefreshFactor: number;
+  /** Steps one orchestration run may execute concurrently. */
+  orchestrationConcurrency: number;
+  /** Extra concurrency ceiling used **only while measured headroom exists**
+   *  (see [`orchestrationHeadroom`]); `null` = never extend. */
+  orchestrationExtendedConcurrency: number | null;
+  /** How much aggregated history the resource monitor's buffer retains (s). */
+  resourceHistorySeconds: number;
+  /** Whether the pet plays decorative idle one-shots (state changes always
+   *  render — reducing flavour never hides information). */
+  petFlavour: boolean;
+  /** What auto-sleep may do once its feature flag is on. */
+  workspaceAutoSleep: WorkspaceAutoSleepLevel;
+  /** How long a workspace must be inactive before auto-sleep considers it. */
+  autoSleepIdleMinutes: number;
+}
+
+/** The capability keys a user may override per-capability (Settings →
+ *  Resources → Resource mode → Advanced). Everything else follows the preset. */
+export const OVERRIDABLE_KEYS = [
+  "gitSweepIntervalMs",
+  "orchestrationConcurrency",
+  "resourceHistorySeconds",
+  "petFlavour",
+  "workspaceAutoSleep",
+  "autoSleepIdleMinutes",
+] as const;
+export type OverridableKey = (typeof OVERRIDABLE_KEYS)[number];
+export type ResourceOverrides = Partial<Pick<ResourceCapabilities, OverridableKey>>;
+
+/** Hard safety bounds (never overridable): a cadence can never be pushed into
+ *  a busy loop, a cap never past what the machinery tolerates. */
+export const LIMITS = {
+  gitSweepIntervalMs: { min: 5_000, max: 600_000 },
+  orchestrationConcurrency: { min: 1, max: 8 },
+  resourceHistorySeconds: { min: 60, max: 600 },
+  autoSleepIdleMinutes: { min: 5, max: 480 },
+  /** Effective GitHub poll floor (s) — "more frequent" must never mean
+   *  hammering the API. `0` (manual only) is always respected. */
+  githubPollFloorSeconds: 30,
+  /** Effective provider-usage refresh floor (min); `0` stays manual. */
+  usageRefreshFloorMinutes: 1,
+} as const;
+
+/** The three presets. `balanced` mirrors the constants the consumers shipped
+ *  with before the mode existed (15 s sweep, every-tick reconcile, 1× polls,
+ *  4 concurrent steps, 10 min history, flavour on, no auto-sleep). */
+export const PRESETS: Record<ResourceProfile, ResourceCapabilities> = {
+  efficient: {
+    gitSweepIntervalMs: 45_000,
+    worktreeReconcileIntervalMs: 10_000,
+    githubPollFactor: 4,
+    usageRefreshFactor: 3,
+    orchestrationConcurrency: 2,
+    orchestrationExtendedConcurrency: null,
+    resourceHistorySeconds: 180,
+    petFlavour: false,
+    workspaceAutoSleep: "suggest",
+    autoSleepIdleMinutes: 30,
+  },
+  balanced: {
+    gitSweepIntervalMs: 15_000,
+    worktreeReconcileIntervalMs: 0,
+    githubPollFactor: 1,
+    usageRefreshFactor: 1,
+    orchestrationConcurrency: 4,
+    orchestrationExtendedConcurrency: null,
+    resourceHistorySeconds: 600,
+    petFlavour: true,
+    workspaceAutoSleep: "off",
+    autoSleepIdleMinutes: 30,
+  },
+  performance: {
+    gitSweepIntervalMs: 10_000,
+    worktreeReconcileIntervalMs: 0,
+    githubPollFactor: 0.5,
+    usageRefreshFactor: 1,
+    orchestrationConcurrency: 4,
+    // "Fresher / more parallel" is allowed only against measured headroom —
+    // the budget-lease summary must show uxnan itself has CPU to spare.
+    orchestrationExtendedConcurrency: 6,
+    resourceHistorySeconds: 600,
+    petFlavour: true,
+    workspaceAutoSleep: "off",
+    autoSleepIdleMinutes: 30,
+  },
+};
+
+/** The current persisted schema version. */
+export const RESOURCE_MODE_SCHEMA_VERSION = 1;
+
+/** A validated, residue-free view of the persisted settings. */
+export interface NormalizedResourceMode {
+  profile: ResourceProfile;
+  overrides: ResourceOverrides;
+  autoSleep: boolean;
+  schemaVersion: typeof RESOURCE_MODE_SCHEMA_VERSION;
+}
+
+/** The resolved policy consumers read: the preset merged with the valid
+ *  overrides, plus which keys were actually overridden (for the UI). */
+export interface ResolvedResourcePolicy {
+  profile: ResourceProfile;
+  capabilities: ResourceCapabilities;
+  overridden: OverridableKey[];
+  /** Whether the auto-sleep feature flag is on (the capability level still
+   *  decides what, if anything, runs). */
+  autoSleepEnabled: boolean;
+}
+
+function isProfile(value: unknown): value is ResourceProfile {
+  return typeof value === "string" && (RESOURCE_PROFILES as readonly string[]).includes(value);
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+/** Validate one override value for one capability. Returns the clamped value,
+ *  or `undefined` when the value is invalid (→ inherit). */
+function normalizeOverride(key: OverridableKey, value: unknown): ResourceOverrides[OverridableKey] {
+  switch (key) {
+    case "gitSweepIntervalMs":
+    case "resourceHistorySeconds":
+    case "autoSleepIdleMinutes":
+    case "orchestrationConcurrency": {
+      if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+      const bounds = LIMITS[key];
+      return clamp(Math.round(value), bounds.min, bounds.max);
+    }
+    case "petFlavour":
+      return typeof value === "boolean" ? value : undefined;
+    case "workspaceAutoSleep":
+      return typeof value === "string" &&
+        (AUTO_SLEEP_LEVELS as readonly string[]).includes(value)
+        ? (value as WorkspaceAutoSleepLevel)
+        : undefined;
+  }
+}
+
+/**
+ * Normalize whatever was persisted into a clean v1 document.
+ *
+ * - not an object (corrupt / absent) → Balanced with no overrides;
+ * - a schema version from a **newer** build (> 1) → Balanced with no overrides,
+ *   because applying overrides whose meaning this build cannot know is exactly
+ *   the residue the rollback path must not leave;
+ * - unknown profile → `balanced`; unknown/invalid/`null` overrides → inherit.
+ */
+export function normalizeResourceMode(raw: unknown): NormalizedResourceMode {
+  const fallback: NormalizedResourceMode = {
+    profile: "balanced",
+    overrides: {},
+    autoSleep: false,
+    schemaVersion: RESOURCE_MODE_SCHEMA_VERSION,
+  };
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return fallback;
+  const doc = raw as ResourceModeSettings;
+  if (
+    typeof doc.schemaVersion === "number" &&
+    Number.isInteger(doc.schemaVersion) &&
+    doc.schemaVersion > RESOURCE_MODE_SCHEMA_VERSION
+  ) {
+    return fallback;
+  }
+
+  const overrides: ResourceOverrides = {};
+  if (doc.overrides !== null && typeof doc.overrides === "object" && !Array.isArray(doc.overrides)) {
+    for (const key of OVERRIDABLE_KEYS) {
+      const value = (doc.overrides as Record<string, unknown>)[key];
+      if (value === undefined || value === null) continue; // inherit
+      const normalized = normalizeOverride(key, value);
+      if (normalized !== undefined) {
+        (overrides as Record<string, unknown>)[key] = normalized;
+      }
+    }
+  }
+
+  return {
+    profile: isProfile(doc.profile) ? doc.profile : "balanced",
+    overrides,
+    autoSleep: doc.autoSleep === true,
+    schemaVersion: RESOURCE_MODE_SCHEMA_VERSION,
+  };
+}
+
+/** Resolve the policy: preset values, then the (already-clamped) overrides. */
+export function resolvePolicy(mode: NormalizedResourceMode): ResolvedResourcePolicy {
+  const capabilities: ResourceCapabilities = { ...PRESETS[mode.profile] };
+  const overridden: OverridableKey[] = [];
+  for (const key of OVERRIDABLE_KEYS) {
+    const value = mode.overrides[key];
+    if (value === undefined) continue;
+    (capabilities as unknown as Record<string, unknown>)[key] = value;
+    overridden.push(key);
+  }
+  return {
+    profile: mode.profile,
+    capabilities,
+    overridden,
+    autoSleepEnabled: mode.autoSleep,
+  };
+}
+
+/** One-step convenience for stores: persisted blob → resolved policy. */
+export function resolveFromSettings(raw: unknown): ResolvedResourcePolicy {
+  return resolvePolicy(normalizeResourceMode(raw));
+}
+
+// --- consumer helpers ---------------------------------------------------------
+
+/** Effective GitHub poll interval (s) from the user's configured one. `0`
+ *  (manual only) is always respected; anything else is scaled by the profile
+ *  and floored so "more frequent" can never turn aggressive. */
+export function effectiveGithubPollSeconds(
+  policy: ResolvedResourcePolicy,
+  configuredSeconds: number,
+): number {
+  if (configuredSeconds <= 0) return 0;
+  return Math.max(
+    LIMITS.githubPollFloorSeconds,
+    Math.round(configuredSeconds * policy.capabilities.githubPollFactor),
+  );
+}
+
+/** Effective provider-usage refresh interval (min). `0` stays manual-only. */
+export function effectiveUsageRefreshMinutes(
+  policy: ResolvedResourcePolicy,
+  configuredMinutes: number,
+): number {
+  if (configuredMinutes <= 0) return 0;
+  return Math.max(
+    LIMITS.usageRefreshFloorMinutes,
+    Math.round(configuredMinutes * policy.capabilities.usageRefreshFactor),
+  );
+}
+
+/** A summary older than this is no evidence of headroom. Comfortably above the
+ *  budget lease's 3 s cadence, well below "the sampler parked long ago". */
+export const HEADROOM_MAX_AGE_MS = 15_000;
+/** uxnan's own measured CPU (whole-machine %) above which no extra
+ *  parallelism is granted. */
+export const HEADROOM_CPU_LIMIT_PERCENT = 50;
+
+/**
+ * Whether the extended orchestration concurrency may apply right now.
+ *
+ * Evidence-based on purpose: it needs a **fresh** summary (the budget lease
+ * must actually be sampling) whose uxnan-total CPU is known and below the
+ * limit. No summary, a stale one, or an unknown CPU all answer `false` — the
+ * absence of a measurement is never treated as capacity.
+ */
+export function orchestrationHeadroom(summary: ResourceSummary | null, nowMs: number): boolean {
+  if (!summary || summary.updatedAtMs === undefined) return false;
+  if (nowMs - summary.updatedAtMs > HEADROOM_MAX_AGE_MS) return false;
+  const cpu = summary.total?.cpuPercent;
+  if (cpu === null || cpu === undefined) return false;
+  return cpu < HEADROOM_CPU_LIMIT_PERCENT;
+}
+
+/** The per-tick orchestration concurrency cap: the base, or the extended
+ *  ceiling while measured headroom exists. */
+export function effectiveOrchestrationConcurrency(
+  policy: ResolvedResourcePolicy,
+  headroom: boolean,
+): number {
+  const base = policy.capabilities.orchestrationConcurrency;
+  const extended = policy.capabilities.orchestrationExtendedConcurrency;
+  if (extended === null || !headroom) return base;
+  return Math.max(base, Math.min(extended, LIMITS.orchestrationConcurrency.max));
+}
+
+/** Which surfaces are showing less-fresh data than Balanced would — each such
+ *  surface owes the user an indicator plus a manual "refresh now" action. */
+export interface FreshnessRelaxations {
+  git: boolean;
+  github: boolean;
+  usage: boolean;
+}
+
+export function freshnessRelaxations(policy: ResolvedResourcePolicy): FreshnessRelaxations {
+  const balanced = PRESETS.balanced;
+  return {
+    git: policy.capabilities.gitSweepIntervalMs > balanced.gitSweepIntervalMs,
+    github: policy.capabilities.githubPollFactor > balanced.githubPollFactor,
+    usage: policy.capabilities.usageRefreshFactor > balanced.usageRefreshFactor,
+  };
+}

--- a/uxnandesktop/src/lib/state/autoSleep.svelte.ts
+++ b/uxnandesktop/src/lib/state/autoSleep.svelte.ts
@@ -1,0 +1,122 @@
+// Workspace auto-sleep engine — the slow tick that executes the pure planner
+// (`$lib/resources/autoSleep`) against the live workspace world.
+//
+// Double-gated: the resource profile must allow it (capability `suggest` or
+// `auto`) AND the explicit feature flag must be on (Settings → Resources →
+// Resource mode). The tick itself is one cheap function call per minute while
+// gated off, so arming the engine at boot costs nothing.
+//
+// Execution reuses the existing sleep/wake lifecycle in `terminals.svelte.ts` —
+// this module never kills a process itself:
+// - `sleep` decisions re-check the blockers at execution time (an agent may
+//   have started since the snapshot) and downgrade to a suggestion if any
+//   appeared — an agent-active workspace is never slept without a human click;
+// - `suggest` decisions surface a toast whose action performs the same
+//   `sleepWorkspace` a row-menu click would (with a last-moment blocker check).
+
+import {
+  planAutoSleep,
+  type AutoSleepCandidate,
+} from "$lib/resources/autoSleep";
+import { i18n } from "$lib/i18n";
+import { toast } from "$lib/toast";
+import { app } from "./app.svelte";
+import { resourceMode } from "./resourceMode.svelte";
+import { terminals, GLOBAL_WORKSPACE } from "./terminals.svelte";
+
+/** How often the engine evaluates the world. Slow on purpose: idleness is
+ *  measured in tens of minutes, so a minute of latency is invisible. */
+const TICK_MS = 60_000;
+
+class AutoSleepStore {
+  #timer: ReturnType<typeof setInterval> | null = null;
+  /** Per-workspace timestamp of the last suggestion (the planner's cooldown). */
+  #lastPromptMs: Record<string, number> = {};
+
+  /** Arm the engine (idempotent). Returns a stop function. */
+  start(): () => void {
+    if (this.#timer) return () => this.stop();
+    this.#timer = setInterval(() => this.tick(), TICK_MS);
+    return () => this.stop();
+  }
+
+  stop(): void {
+    if (this.#timer) {
+      clearInterval(this.#timer);
+      this.#timer = null;
+    }
+  }
+
+  /** Snapshot the workspace world for the planner. Only workspaces mounted
+   *  this session are candidates — an unmounted (restored, never activated)
+   *  workspace holds no processes, so sleeping it would save nothing and
+   *  disturb its restore semantics. */
+  #candidates(): AutoSleepCandidate[] {
+    const lastActive = app.settings.workspaceLastActive ?? {};
+    return terminals.mountedWorkspaceKeys.map((key) => ({
+      key,
+      liveTerminals: terminals.liveTerminalCount(key),
+      asleep: terminals.isWorkspaceAsleep(key),
+      blockers: terminals.sleepBlockers(key).length,
+      lastActiveMs: lastActive[key] ?? null,
+    }));
+  }
+
+  /** One evaluation pass (also directly callable from tests). */
+  tick(now = Date.now()): void {
+    const policy = resourceMode.policy;
+    const decisions = planAutoSleep({
+      level: policy.capabilities.workspaceAutoSleep,
+      flagEnabled: policy.autoSleepEnabled,
+      activeKey: terminals.activeWorkspace,
+      globalKey: GLOBAL_WORKSPACE,
+      nowMs: now,
+      idleMinutes: policy.capabilities.autoSleepIdleMinutes,
+      candidates: this.#candidates(),
+      lastPromptMs: this.#lastPromptMs,
+    });
+    for (const d of decisions) {
+      if (d.action === "sleep") this.#sleep(d.key, now);
+      else this.#suggest(d.key, now);
+    }
+  }
+
+  /** Execute an auto sleep — with a last-moment blocker re-check, so an agent
+   *  that started between the snapshot and now downgrades to a suggestion. */
+  #sleep(key: string, now: number): void {
+    if (terminals.sleepBlockers(key).length > 0) {
+      this.#suggest(key, now);
+      return;
+    }
+    void terminals.sleepWorkspace(key).then(() => {
+      toast(i18n.t("resourceMode.autoSleep.sleptToast", { name: workspaceLabel(key) }));
+    });
+  }
+
+  /** Surface a suggestion whose action is the user's explicit confirmation. */
+  #suggest(key: string, now: number): void {
+    this.#lastPromptMs[key] = now;
+    toast(i18n.t("resourceMode.autoSleep.suggestToast", { name: workspaceLabel(key) }), {
+      action: {
+        label: i18n.t("resourceMode.autoSleep.suggestAction"),
+        onClick: () => {
+          // The user just confirmed — but an agent that went to work since the
+          // toast appeared still wins (same guard as the row-menu sleep).
+          if (terminals.sleepBlockers(key).length > 0) {
+            toast.warning(i18n.t("resourceMode.autoSleep.blockedToast"));
+            return;
+          }
+          void terminals.sleepWorkspace(key);
+        },
+      },
+    });
+  }
+}
+
+/** The workspace folder name (workspace keys are worktree paths). */
+function workspaceLabel(key: string): string {
+  return key.replace(/[\\/]+$/, "").split(/[\\/]/).pop() ?? key;
+}
+
+/** Singleton auto-sleep engine, armed from the root layout. */
+export const autoSleep = new AutoSleepStore();

--- a/uxnandesktop/src/lib/state/github.svelte.ts
+++ b/uxnandesktop/src/lib/state/github.svelte.ts
@@ -22,6 +22,8 @@ import type {
 } from "$lib/types";
 import { app, type GithubSection } from "./app.svelte";
 import { projects } from "./projects.svelte";
+import { resourceMode } from "./resourceMode.svelte";
+import { effectiveGithubPollSeconds } from "$lib/resources/policy";
 import { samePath, canonicalFor } from "$lib/pathid";
 
 /** How many non-active worktrees may have their PR badge re-read per poll tick.
@@ -250,7 +252,12 @@ class GithubStore {
 
   /** Start polling the active worktree's context (+ rate limit / notifications)
    *  on the configured interval, paused when the window is hidden. Returns a
-   *  cleanup. Safe to call repeatedly (restarts the timer). */
+   *  cleanup. Safe to call repeatedly (restarts the timer).
+   *
+   *  The user's interval is scaled by the resource-mode policy (1× on
+   *  Balanced, relaxed on Efficient, tighter — floored — on Performance);
+   *  `0` stays manual-only whatever the profile. The caller's effect also
+   *  depends on the policy, so a profile switch restarts the timer. */
   startPolling(): () => void {
     this.stopPolling();
     const tick = () => {
@@ -261,7 +268,10 @@ class GithubStore {
       if (app.settings.github?.notificationsEnabled) void this.refreshNotifications();
       this.refreshOtherWorktreeBadges();
     };
-    const seconds = Math.max(0, app.settings.github?.pollSeconds ?? 45);
+    const seconds = effectiveGithubPollSeconds(
+      resourceMode.policy,
+      Math.max(0, app.settings.github?.pollSeconds ?? 45),
+    );
     if (seconds > 0) this.#timer = setInterval(tick, seconds * 1000);
     return () => this.stopPolling();
   }

--- a/uxnandesktop/src/lib/state/orchestrationRun.svelte.ts
+++ b/uxnandesktop/src/lib/state/orchestrationRun.svelte.ts
@@ -21,6 +21,12 @@ import { terminals } from "./terminals.svelte";
 import { agentStatus } from "./agentStatus.svelte";
 import { orchestration } from "./orchestration.svelte";
 import { app } from "./app.svelte";
+import { resourceMode } from "./resourceMode.svelte";
+import { resources } from "./resources.svelte";
+import {
+  effectiveOrchestrationConcurrency,
+  orchestrationHeadroom,
+} from "$lib/resources/policy";
 import { notify } from "$lib/notify";
 import { i18n } from "$lib/i18n";
 import type { OrchestratorAgent } from "$lib/orchestration";
@@ -59,8 +65,10 @@ const TICK_MS = 700;
  *  grace, to reduce false "done" on a slow-to-start agent. */
 const PICKUP_GRACE_MS = 6000;
 
-/** Max steps a single run runs concurrently (backpressure across the DAG). */
-const MAX_CONCURRENCY = 4;
+// Max steps a single run runs concurrently (backpressure across the DAG) comes
+// from the resource-mode policy: 4 on Balanced (the pre-mode constant), 2 on
+// Efficient, and on Performance up to 6 — but only while the resource monitor
+// measures real headroom (see `effectiveConcurrency` below).
 
 /** How long an interactive step waits for its (busy) target agent to free up
  *  before it is force-dispatched anyway. Backpressure is a courtesy, not a gate —
@@ -392,6 +400,35 @@ class OrchestrationRunStore {
       clearInterval(this.timer);
       this.timer = undefined;
     }
+    this.syncBudgetLease(false);
+  }
+
+  /** Whether this engine currently holds the resource monitor's budget lease. */
+  private budgetLeaseHeld = false;
+
+  /** Hold the monitor's `budget` lease exactly while extended concurrency is
+   *  reachable (Performance profile + an active run): the headroom check needs
+   *  fresh samples, and holding the lease any longer would keep the sampler
+   *  running for a question nobody is asking. Idempotent per direction. */
+  private syncBudgetLease(wanted: boolean): void {
+    if (wanted === this.budgetLeaseHeld) return;
+    this.budgetLeaseHeld = wanted;
+    if (wanted) void resources.acquireBudget();
+    else void resources.releaseBudget();
+  }
+
+  /** The per-tick concurrency cap from the resource-mode policy. The extended
+   *  (Performance) ceiling applies only against measured headroom — a fresh
+   *  budget-lease summary whose uxnan-total CPU is known and low; no evidence
+   *  means the base cap. */
+  private effectiveConcurrency(now: number): number {
+    const policy = resourceMode.policy;
+    const extendable = policy.capabilities.orchestrationExtendedConcurrency !== null;
+    this.syncBudgetLease(extendable && this.activeRuns.length > 0);
+    return effectiveOrchestrationConcurrency(
+      policy,
+      extendable && orchestrationHeadroom(resources.summary, now),
+    );
   }
 
   /** One scheduler pass over every active run: promote → detect completion →
@@ -401,6 +438,7 @@ class OrchestrationRunStore {
     let changed = false;
     const now = Date.now();
     const agents = this.liveAgents;
+    const concurrency = this.effectiveConcurrency(now);
 
     for (const run of this.runs) {
       if (run.status !== "running" && run.status !== "paused") continue;
@@ -437,7 +475,7 @@ class OrchestrationRunStore {
             .map((s) => s.target.tabId)
             .filter((id): id is string => !!id),
         );
-        let budget = MAX_CONCURRENCY - runningCount;
+        let budget = concurrency - runningCount;
         for (const s of run.steps) {
           if (budget <= 0) break;
           if (s.status !== "ready" && s.status !== "blocked") continue;

--- a/uxnandesktop/src/lib/state/projects.svelte.ts
+++ b/uxnandesktop/src/lib/state/projects.svelte.ts
@@ -54,6 +54,7 @@ import {
   type SortMeta,
   type StatusLane,
 } from "$lib/sidebar-sort";
+import { resourceMode } from "$lib/state/resourceMode.svelte";
 import { toast, toastError } from "$lib/toast";
 import { i18n } from "$lib/i18n";
 
@@ -62,10 +63,11 @@ const msg = (e: unknown) =>
     ? String((e as { message: unknown }).message)
     : String(e);
 
-/** How often the background sweep re-reads every worktree's git status. Git is
- *  local and `worktree_status` is one `git2` walk, but this runs for every known
- *  worktree, so it's paced well below the 3 s single-worktree watcher. */
-const SWEEP_MS = 15_000;
+// The background sweep's pacing (how often every worktree's git status is
+// re-read) and the worktree-list reconcile's pacing both come from the resource
+// mode policy (`resourceMode.policy.capabilities` — 15 s / every driver tick on
+// Balanced, relaxed on Efficient, tighter on Performance). Forced refreshes
+// (focus, agent activity, our own git actions, the freshness hint) always run.
 
 const baseName = (p: string) =>
   p.replace(/[\\/]+$/, "").split(/[\\/]/).pop() ?? p;
@@ -450,6 +452,8 @@ class ProjectsStore {
     await app.persistSettings();
   }
   private worktreeRefreshInFlight = false;
+  /** When the last worktree-list reconcile pass started (policy pacing). */
+  #lastReconcile = 0;
   /** Single-flight + rate-limit state for the all-worktree status sweep. */
   #sweepInFlight = false;
   #lastSweep = 0;
@@ -508,9 +512,23 @@ class ProjectsStore {
    * filesystem event, so the sidebar uses a small polling pass. Only changed
    * lists are assigned, which keeps the sort settle window and row rendering
    * stable while still making externally-created worktrees appear promptly.
+   *
+   * Paced by the resource mode: on Balanced/Performance the policy interval is
+   * 0 (every driver tick — the pre-mode behavior); Efficient stretches it.
+   * `force` (a manual "refresh now") always runs.
    */
-  async refreshWorktrees(): Promise<void> {
+  async refreshWorktrees(force = false): Promise<void> {
     if (this.worktreeRefreshInFlight) return;
+    const proceed = shouldSweep({
+      inFlight: false, // the in-flight guard above already covers overlap
+      force,
+      hidden: false, // structural changes matter even unfocused (agent CLIs)
+      now: Date.now(),
+      lastSweep: this.#lastReconcile,
+      intervalMs: resourceMode.policy.capabilities.worktreeReconcileIntervalMs,
+    });
+    if (!proceed) return;
+    this.#lastReconcile = Date.now();
     this.worktreeRefreshInFlight = true;
     try {
       await Promise.all(
@@ -611,9 +629,10 @@ class ProjectsStore {
    *  disappeared. An agent working from another folder — or from the parent repo
    *  — left its target worktree's card showing nothing until you clicked it.
    *
-   *  Rate-limited to `SWEEP_MS`, skipped while the window is hidden, and
-   *  single-flight. `force` (agent activity, window focus, a git action of ours)
-   *  runs it now instead of waiting for the interval. */
+   *  Rate-limited to the resource-mode policy's sweep interval (15 s on
+   *  Balanced), skipped while the window is hidden, and single-flight. `force`
+   *  (agent activity, window focus, a git action of ours) runs it now instead
+   *  of waiting for the interval. */
   async sweepStatuses(force = false): Promise<void> {
     const proceed = shouldSweep({
       inFlight: this.#sweepInFlight,
@@ -621,7 +640,7 @@ class ProjectsStore {
       hidden: typeof document !== "undefined" && document.hidden,
       now: Date.now(),
       lastSweep: this.#lastSweep,
-      intervalMs: SWEEP_MS,
+      intervalMs: resourceMode.policy.capabilities.gitSweepIntervalMs,
     });
     if (!proceed) return;
     const paths = this.allWorktreePaths();
@@ -640,6 +659,14 @@ class ProjectsStore {
    *  the window regaining focus, and our own git actions. */
   requestStatusSweep(): void {
     void this.sweepStatuses(true);
+  }
+
+  /** Manual "refresh now" (the freshness hint's action): re-read the worktree
+   *  lists AND every status badge immediately. A one-shot that bypasses the
+   *  policy pacing without touching the selected profile. */
+  refreshNow(): void {
+    void this.refreshWorktrees(true);
+    this.requestStatusSweep();
   }
 
   /** Take the paths whose status changed since the last drain (the GitHub poll

--- a/uxnandesktop/src/lib/state/resourceMode.svelte.ts
+++ b/uxnandesktop/src/lib/state/resourceMode.svelte.ts
@@ -1,0 +1,86 @@
+// Resource-mode store — the one reactive door to the policy engine.
+//
+// Consumers (git sweeps, GitHub/provider polling, orchestration, pets,
+// auto-sleep) read `resourceMode.policy` and react when it changes; the
+// Settings UI writes through the setters, which persist only **normalized**
+// documents — junk never reaches disk, and "use preset" really deletes the
+// override instead of writing a shadow copy of the preset value.
+//
+// All logic lives in the pure `$lib/resources/policy` module; this file is
+// deliberately just the reactive glue plus persistence.
+
+import {
+  freshnessRelaxations,
+  normalizeResourceMode,
+  resolvePolicy,
+  type FreshnessRelaxations,
+  type NormalizedResourceMode,
+  type OverridableKey,
+  type ResolvedResourcePolicy,
+  type ResourceOverrides,
+  type ResourceProfile,
+} from "$lib/resources/policy";
+import { app } from "./app.svelte";
+
+class ResourceModeStore {
+  /** The validated view of whatever is persisted (junk normalizes away). */
+  get mode(): NormalizedResourceMode {
+    return normalizeResourceMode(app.settings.resourceMode);
+  }
+
+  /** The resolved policy every consumer reads. */
+  get policy(): ResolvedResourcePolicy {
+    return resolvePolicy(this.mode);
+  }
+
+  /** Which surfaces are less fresh than Balanced (drives the hints + their
+   *  manual "refresh now" actions). */
+  get freshness(): FreshnessRelaxations {
+    return freshnessRelaxations(this.policy);
+  }
+
+  /** Persist a normalized document (the only writer of `resourceMode`). */
+  #write(next: NormalizedResourceMode): void {
+    app.settings.resourceMode = {
+      profile: next.profile,
+      overrides: { ...next.overrides },
+      autoSleep: next.autoSleep,
+      schemaVersion: next.schemaVersion,
+    };
+    void app.persistSettings();
+  }
+
+  /** Switch preset. Overrides are kept — they are the user's explicit
+   *  per-capability choices, which the UI reports as "overridden". */
+  setProfile(profile: ResourceProfile): void {
+    this.#write({ ...this.mode, profile });
+  }
+
+  /** Set one capability override (already-validated values only reach disk). */
+  setOverride<K extends OverridableKey>(key: K, value: ResourceOverrides[K]): void {
+    const mode = this.mode;
+    this.#write({ ...mode, overrides: { ...mode.overrides, [key]: value } });
+  }
+
+  /** Back to "use preset" for one capability — the override is deleted, not
+   *  overwritten, so nothing lingers. */
+  clearOverride(key: OverridableKey): void {
+    const mode = this.mode;
+    const overrides = { ...mode.overrides };
+    delete overrides[key];
+    this.#write({ ...mode, overrides });
+  }
+
+  /** Reset every override (the profile itself stays). */
+  resetOverrides(): void {
+    this.#write({ ...this.mode, overrides: {} });
+  }
+
+  /** Toggle the workspace auto-sleep feature flag. */
+  setAutoSleepFlag(enabled: boolean): void {
+    this.#write({ ...this.mode, autoSleep: enabled });
+  }
+}
+
+/** Singleton resource-mode store shared across the app. */
+export const resourceMode = new ResourceModeStore();

--- a/uxnandesktop/src/lib/state/resources.svelte.ts
+++ b/uxnandesktop/src/lib/state/resources.svelte.ts
@@ -1,83 +1,164 @@
 // Resource-observability store: holds the latest consolidated summary and
-// manages the sampling lease for the popover surface. The collector backend is
-// fully parked unless something calls `open()` — so simply not opening the
-// popover is what keeps the feature at zero cost.
+// manages the sampling leases. The collector backend is fully parked unless
+// something takes a lease — so simply not opening a surface is what keeps the
+// feature at zero cost.
 //
-// Leases are renewed on a timer while open and released on close; the backend
-// also expires them on its own, so a webview reload that never called `close()`
-// cannot pin the fast sampling cadence forever.
+// Two lease kinds share this store (and one event listener):
+// - `popover` — a UI surface is open (the backend popover, the Settings
+//   preview). Fast cadence, held while the surface is visible.
+// - `budget` — a background consumer needs periodic samples: today the
+//   orchestration engine's headroom check while the Performance profile allows
+//   extended concurrency (see `orchestrationRun.svelte.ts`). Medium cadence.
+//
+// Leases are renewed on a timer while held and released on close; the backend
+// also expires them on its own, so a webview reload that never released cannot
+// pin the sampling cadence forever.
 
 import { listen } from "@tauri-apps/api/event";
 
 import { resourcesSubscribe, resourcesSummary, resourcesUnsubscribe } from "$lib/api";
-import type { ResourceSummary } from "$lib/types";
+import type { ResourceConsumerKind, ResourceSummary } from "$lib/types";
 import { app } from "./app.svelte";
 
-/** Renew the lease at half its backend TTL (90 s), so one missed renewal
- *  still keeps the surface live. */
+/** Renew a lease at half its backend TTL (90 s), so one missed renewal
+ *  still keeps the consumer live. */
 const LEASE_RENEW_MS = 45_000;
 
+/** One held lease: its token, its renew timer. */
+interface HeldLease {
+  token: string;
+  renew: ReturnType<typeof setInterval>;
+}
+
 class ResourcesStore {
-  /** Latest consolidated summary (event-fed while open; `null` before). */
+  /** Latest consolidated summary (event-fed while any lease is held; `null`
+   *  before the first read). */
   summary = $state<ResourceSummary | null>(null);
   /** First fetch for a surface is in flight (drives the loading state). */
   loading = $state(false);
 
-  #token: string | null = null;
-  #renewTimer: ReturnType<typeof setInterval> | null = null;
   #unlisten: (() => void) | null = null;
-  /** Open surfaces (popover, settings preview) sharing the one lease. */
+  /** How many holders (surfaces + budget consumers) need the event feed. */
+  #listenerRefs = 0;
+  /** Open UI surfaces (popover, settings preview) sharing one popover lease. */
   #opens = 0;
+  #popover: HeldLease | null = null;
+  /** Background budget consumers sharing one budget lease. */
+  #budgetRefs = 0;
+  #budget: HeldLease | null = null;
 
   /** Whether the feature's surfaces should render at all. */
   get enabled(): boolean {
     return app.settings.resources?.enabled ?? true;
   }
 
-  /** A surface that shows live resources opened: take the sampling lease,
+  /** Attach the shared `resources:summary` listener (ref-counted). */
+  async #retainListener(): Promise<void> {
+    this.#listenerRefs += 1;
+    if (this.#listenerRefs > 1 || this.#unlisten) return;
+    try {
+      this.#unlisten = await listen<ResourceSummary>("resources:summary", (event) => {
+        this.summary = event.payload;
+        this.loading = false;
+      });
+      // A holder may have released while `listen` was in flight.
+      if (this.#listenerRefs === 0) {
+        this.#unlisten();
+        this.#unlisten = null;
+      }
+    } catch {
+      // No Tauri event bus (plain web preview): surfaces show the empty state.
+    }
+  }
+
+  #releaseListener(): void {
+    if (this.#listenerRefs === 0) return;
+    this.#listenerRefs -= 1;
+    if (this.#listenerRefs === 0) {
+      this.#unlisten?.();
+      this.#unlisten = null;
+    }
+  }
+
+  /** Take one lease of `kind` and keep renewing it. */
+  async #acquire(kind: ResourceConsumerKind): Promise<HeldLease | null> {
+    const token = crypto.randomUUID();
+    try {
+      await resourcesSubscribe(token, kind);
+    } catch {
+      return null; // no backend (web preview)
+    }
+    const renew = setInterval(() => {
+      void resourcesSubscribe(token, kind).catch(() => {});
+    }, LEASE_RENEW_MS);
+    return { token, renew };
+  }
+
+  /** Release a held lease (idempotent; the backend also expires it). */
+  async #release(lease: HeldLease | null): Promise<void> {
+    if (!lease) return;
+    clearInterval(lease.renew);
+    try {
+      await resourcesUnsubscribe(lease.token);
+    } catch {
+      // The backend expires the lease on its own; nothing to recover.
+    }
+  }
+
+  /** A surface that shows live resources opened: take the popover lease,
    *  subscribe to the event feed and pull the buffered summary once. */
   async open(): Promise<void> {
     if (!this.enabled) return;
     this.#opens += 1;
     if (this.#opens > 1) return; // the lease is already live
     if (this.summary === null) this.loading = true;
-    const token = crypto.randomUUID();
-    this.#token = token;
-    try {
-      this.#unlisten = await listen<ResourceSummary>("resources:summary", (event) => {
-        this.summary = event.payload;
-        this.loading = false;
-      });
-      await resourcesSubscribe(token, "popover");
-      this.#renewTimer = setInterval(() => {
-        void resourcesSubscribe(token, "popover").catch(() => {});
-      }, LEASE_RENEW_MS);
-    } catch {
-      // No Tauri backend (plain web preview): the surface shows its empty state.
-    }
+    await this.#retainListener();
+    this.#popover = await this.#acquire("popover");
     await this.refresh();
   }
 
-  /** The surface closed: release the lease so the sampler parks again. */
+  /** The surface closed: release the lease so the sampler can park again. */
   async close(): Promise<void> {
     if (this.#opens === 0) return;
     this.#opens -= 1;
     if (this.#opens > 0) return;
-    if (this.#renewTimer) {
-      clearInterval(this.#renewTimer);
-      this.#renewTimer = null;
+    this.#releaseListener();
+    const lease = this.#popover;
+    this.#popover = null;
+    await this.#release(lease);
+  }
+
+  /** A background consumer (the orchestration headroom check) needs periodic
+   *  samples: take the shared `budget` lease. Ref-counted and idempotent per
+   *  holder pair (`acquireBudget`/`releaseBudget`). */
+  async acquireBudget(): Promise<void> {
+    if (!this.enabled) return;
+    this.#budgetRefs += 1;
+    if (this.#budgetRefs > 1) return;
+    await this.#retainListener();
+    this.#budget = await this.#acquire("budget");
+    // A ref may have released while the subscribe was in flight.
+    if (this.#budgetRefs === 0) {
+      const lease = this.#budget;
+      this.#budget = null;
+      await this.#release(lease);
     }
-    this.#unlisten?.();
-    this.#unlisten = null;
-    const token = this.#token;
-    this.#token = null;
-    if (token) {
-      try {
-        await resourcesUnsubscribe(token);
-      } catch {
-        // The backend expires the lease on its own; nothing to recover.
-      }
-    }
+  }
+
+  /** Release one budget hold; the lease goes with the last one. */
+  async releaseBudget(): Promise<void> {
+    if (this.#budgetRefs === 0) return;
+    this.#budgetRefs -= 1;
+    if (this.#budgetRefs > 0) return;
+    this.#releaseListener();
+    const lease = this.#budget;
+    this.#budget = null;
+    await this.#release(lease);
+  }
+
+  /** Whether a budget hold is currently active (for tests/inspection). */
+  get budgetHeld(): boolean {
+    return this.#budgetRefs > 0;
   }
 
   /** One-shot pull of the buffered summary (no fresh sample). */

--- a/uxnandesktop/src/lib/state/terminals.svelte.ts
+++ b/uxnandesktop/src/lib/state/terminals.svelte.ts
@@ -576,6 +576,18 @@ class TerminalStore {
     return count;
   }
 
+  /** Number of *awake* terminal tabs in a workspace — the ones whose PTY a
+   *  sleep would actually stop (feeds the auto-sleep candidate snapshot). */
+  liveTerminalCount(key: string): number {
+    const tree = this.workspaces[key];
+    if (!tree) return 0;
+    let count = 0;
+    for (const tab of allTabs(tree)) {
+      if (tab.kind === "terminal" && !tab.asleep) count += 1;
+    }
+    return count;
+  }
+
   /** Switch the visible workspace (creating an empty entry if unknown).
    *  Switching INTO an asleep workspace wakes it — activation is the wake
    *  gesture. (Sleeping the already-active workspace shows its panes asleep;

--- a/uxnandesktop/src/lib/state/usage.svelte.ts
+++ b/uxnandesktop/src/lib/state/usage.svelte.ts
@@ -4,8 +4,10 @@
 // is a no-op when the list is empty, so an idle feature costs nothing.
 
 import { usageRead } from "$lib/api";
+import { effectiveUsageRefreshMinutes } from "$lib/resources/policy";
 import type { ProviderUsage, UsageProvider } from "$lib/types";
 import { app } from "./app.svelte";
+import { resourceMode } from "./resourceMode.svelte";
 
 class UsageStore {
   /** Latest snapshot per activated provider. */
@@ -56,23 +58,33 @@ class UsageStore {
     }
   }
 
-  /** Refresh when the current data is older than the configured interval (or
+  /** The effective refresh interval (min): the configured one scaled by the
+   *  resource-mode policy (1× on Balanced, longer on Efficient); `0` stays
+   *  manual-only whatever the profile. */
+  #effectiveMinutes(): number {
+    return effectiveUsageRefreshMinutes(
+      resourceMode.policy,
+      app.settings.usageRefreshMinutes ?? 5,
+    );
+  }
+
+  /** Refresh when the current data is older than the effective interval (or
    *  never fetched). Called when a surface that shows usage opens. */
   async ensureFresh(): Promise<void> {
-    const mins = app.settings.usageRefreshMinutes ?? 5;
+    const mins = this.#effectiveMinutes();
     const maxAge = mins > 0 ? mins * 60_000 : Number.POSITIVE_INFINITY;
     if (Date.now() - this.lastRefresh > maxAge) await this.refresh();
   }
 
-  /** (Re)start the background poll to match the configured interval + active
-   *  set. Call after the providers list or interval changes. `0` minutes (manual
-   *  only) or an empty active set stops polling. */
+  /** (Re)start the background poll to match the effective interval + active
+   *  set. Call after the providers list, the interval or the resource profile
+   *  changes. `0` minutes (manual only) or an empty active set stops polling. */
   reschedule(): void {
     if (this.#timer) {
       clearInterval(this.#timer);
       this.#timer = null;
     }
-    const mins = app.settings.usageRefreshMinutes ?? 5;
+    const mins = this.#effectiveMinutes();
     if (mins <= 0 || this.active().length === 0) return;
     this.#timer = setInterval(() => void this.refresh(), mins * 60_000);
   }

--- a/uxnandesktop/src/lib/types.ts
+++ b/uxnandesktop/src/lib/types.ts
@@ -348,6 +348,25 @@ export interface AppSettings {
   /** Local resource observability (backend-popover summary + Settings →
    *  Resources). Absent = the defaults (enabled, no background sweep). */
   resources?: ResourceSettings;
+  /** Resource mode: the explicit efficiency/degradation profile plus
+   *  per-capability overrides. Absent = `balanced` (the pre-mode behavior).
+   *  Validated and resolved by `$lib/resources/policy`. */
+  resourceMode?: ResourceModeSettings;
+}
+
+/** Resource-mode settings (mirror of the Rust `ResourceModeSettings`). Every
+ *  field is optional so a partially-written blob still reads cleanly; the
+ *  policy engine (`$lib/resources/policy`) normalizes whatever is here —
+ *  unknown profiles fall back to `balanced`, invalid overrides to inherit. */
+export interface ResourceModeSettings {
+  /** `"efficient" | "balanced" | "performance"` (validated on read). */
+  profile?: string;
+  /** Per-capability overrides; `null`/absent = inherit from the preset. */
+  overrides?: Record<string, unknown>;
+  /** Feature flag for workspace auto-sleep. Off by default; the profile's
+   *  auto-sleep capability only applies while this is on. */
+  autoSleep?: boolean;
+  schemaVersion?: number;
 }
 
 /** Local resource observability settings (mirror of the Rust `ResourceSettings`).
@@ -1195,6 +1214,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   agentProfiles: [],
   pets: { enabled: true },
   resources: { enabled: true, orphanSweep: false, orphanSweepSeconds: 20 },
+  resourceMode: { profile: "balanced", overrides: {}, autoSleep: false, schemaVersion: 1 },
   usageProviders: [],
   usageRefreshMinutes: 5,
   usageStatusBarEnabled: true,

--- a/uxnandesktop/src/routes/+layout.svelte
+++ b/uxnandesktop/src/routes/+layout.svelte
@@ -10,7 +10,9 @@
   import { anyAgentWorking } from "$lib/state/agentDisplay";
   import { unread } from "$lib/state/unread.svelte";
   import { pets } from "$lib/state/pets.svelte";
-  import { setPreventSleep } from "$lib/api";
+  import { autoSleep } from "$lib/state/autoSleep.svelte";
+  import { resourceMode } from "$lib/state/resourceMode.svelte";
+  import { setPreventSleep, resourcesSetPolicy } from "$lib/api";
   import { installPointerLockGuard } from "$lib/utils/pointerLock";
   import { TooltipProvider } from "$lib/components/ui/tooltip";
   import PetWindow from "$lib/components/PetWindow.svelte";
@@ -107,6 +109,24 @@
     if (petWindow) return;
     const active = app.settings.preventSleep === true && anyAgentWorking();
     void setPreventSleep(active).catch(() => {});
+  });
+
+  // Resource mode → backend: push the resolved history budget to the resource
+  // monitor (its one backend-side parameter). Re-runs on a profile/override
+  // change, so switching presets applies hot and reversibly.
+  $effect(() => {
+    if (petWindow) return;
+    if (app.backend !== "ready") return;
+    const seconds = resourceMode.policy.capabilities.resourceHistorySeconds;
+    void resourcesSetPolicy(seconds).catch(() => {});
+  });
+
+  // Workspace auto-sleep engine: one cheap evaluation per minute, gated inside
+  // by the profile's capability AND the explicit feature flag — armed here so
+  // enabling the flag needs no restart.
+  $effect(() => {
+    if (petWindow) return;
+    return autoSleep.start();
   });
 </script>
 

--- a/uxnandesktop/src/routes/+page.svelte
+++ b/uxnandesktop/src/routes/+page.svelte
@@ -8,6 +8,8 @@
   import { git } from "$lib/state/git.svelte";
   import { github } from "$lib/state/github.svelte";
   import { openWith } from "$lib/state/openWith.svelte";
+  import { resourceMode } from "$lib/state/resourceMode.svelte";
+  import { usage } from "$lib/state/usage.svelte";
   import { fsSetWatch } from "$lib/api";
   import { i18n } from "$lib/i18n";
   import { matchAction } from "$lib/keybindings";
@@ -175,9 +177,24 @@
     void github.loadContext(projects.activeWorktreePath);
   });
   $effect(() => {
-    // Restart the poll when the interval setting changes; cleanup stops it.
+    // Restart the poll when the interval setting or the resource-mode policy
+    // changes; cleanup stops it.
     void app.settings.github?.pollSeconds;
+    void resourceMode.policy.capabilities.githubPollFactor;
     return github.startPolling();
+  });
+
+  // Re-arm the provider-usage poll when the resource profile changes its
+  // factor. Skipped on the first run on purpose: the background usage poll is
+  // armed lazily (from the Providers settings pane), and a boot-time reschedule
+  // here would change that pre-mode behavior.
+  let usageFactorSeen: number | null = null;
+  $effect(() => {
+    const factor = resourceMode.policy.capabilities.usageRefreshFactor;
+    untrack(() => {
+      if (usageFactorSeen !== null && usageFactorSeen !== factor) usage.reschedule();
+      usageFactorSeen = factor;
+    });
   });
 
   // Detect installed external editors once, so the "Open with" menus are ready

--- a/uxnandesktop/tests/quality-matrix.json
+++ b/uxnandesktop/tests/quality-matrix.json
@@ -400,6 +400,31 @@
         "linux": "untested"
       },
       "gaps": "No E2E journey opens the backend popover against the real binary yet (the suite cannot run beside a live uxnan instance, so it was not runnable while this feature was built); the popover lease -> sample -> park round trip is covered at L2/L3 instead. macOS/Linux metrics run the same portable sysinfo code but are unvalidated on hardware — the UI says 'best effort' there on purpose."
+    },
+    {
+      "id": "resource-mode",
+      "flow": "Resource mode (presets, overrides, governed consumers, auto-sleep)",
+      "owner": "desktop",
+      "covered": [
+        "L1",
+        "L2",
+        "L3"
+      ],
+      "planned": [
+        "L4",
+        "L5"
+      ],
+      "evidence": {
+        "L1": "src/lib/resources/policy.test.ts, src/lib/resources/autoSleep.test.ts, scripts/resources/lib/scenarios.test.mjs",
+        "L2": "src/lib/components/ResourceModeSection.svelte.test.ts",
+        "L3": "src-tauri/src/resources.rs #[cfg(test)] (the history budget's clamp/trim/summary), src-tauri/src/model.rs #[cfg(test)] (resource-mode settings defaults + round trip)"
+      },
+      "platforms": {
+        "windows": "verified",
+        "macos": "untested",
+        "linux": "untested"
+      },
+      "gaps": "No E2E journey switches the preset against the real binary (the same live-instance constraint as the popover journey), and the per-preset efficiency matrix (--resource-profile) is wired but unmeasured for the same reason — it must run with the app closed. Workspace auto-sleep's automatic level needs a multi-platform soak with real live processes before its feature flag can ever be retired (L5), and the maintainer's on-device review of the new Settings section is still owed."
     }
   ]
 }


### PR DESCRIPTION
## What

Builds on the resource monitor (#133): explicit `Efficient` / `Balanced` / `Performance` presets that govern uxnan's background work without silently degrading anything.

- **A pure policy engine** (`src/lib/resources/policy.ts`): presets + per-capability overrides (`null` = inherit), hard safety floors outside overrides, corrupt settings normalize to Balanced with no residue. **Balanced replicates the pre-mode constants exactly — a test pins it**, so migration changes nothing.
- **Governed consumers**: the active-worktree Git sweep and all-worktree reconcile, GitHub polling (floor 30 s; 0 = manual in Efficient), provider-usage refresh, the resource monitor's history retention (hot-trimmed), orchestration concurrency, and the pet's decorative one-shots — each through the resolved policy, none reading raw settings.
- **Performance earns its parallelism**: the orchestration tick may extend 4 → 6 only with measured headroom — the monitor's `budget` lease (its first real consumer), a fresh summary ≤ 15 s old and own-CPU < 50 %. No evidence, no extra concurrency.
- **Auto-sleep is suggest-first and double-opt-in** (feature flag, off by default): a workspace with a working agent is never slept automatically; only evidence counts as idleness; the active workspace and Global are untouchable. Reuses the existing sleep/wake lifecycle — nothing duplicated.
- **Explainable in the UI**: Settings → Resource mode (preset picker with a real effects view derived from the *resolved* policy, override badges, "Use preset" reset) plus freshness hints with a "refresh now" action wherever data may be older because of the mode.
- **Per-preset benchmarking**: `npm run bench -- --resource-profile <preset>` seeds the preset into the disposable profile and stamps it into the results, ready for the efficiency matrix (captured with the app closed; tracked in `FOR-DEV.md`).

## Verification

- `npm run check`: 1492 files, 0 errors / 0 warnings
- `npm test`: 655 passed (55 files)
- `cargo test`: 434; `clippy -D warnings` + `fmt --check` clean
- New: 23 policy + 13 auto-sleep + 3 harness + 8 component tests; full EN/ES i18n; `tests/quality-matrix.json` row
- The new Settings UI passed the maintainer's on-device review (2026-07-31)

## Honest gaps (tracked in `FOR-DEV.md`)

The per-preset efficiency matrix must run with the app closed; the auto-sleep flag stays until a three-platform soak; the hot preset-switch E2E journey shares the live-instance constraint.