### PR TITLE
test(desktop): a platform support matrix that cannot exceed its evidence

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -41,8 +41,28 @@ jobs:
   verify:
     uses: ./.github/workflows/verify-desktop.yml
 
+  # Refuse to build a release whose announced platform state exceeds the
+  # recorded evidence (uxnandesktop/tests/platform-support.json — see
+  # uxnandesktop/docs/platform-support.md). Pure Node, no install step: the
+  # same rule also runs in the required `npm test` gate on every PR, so this is
+  # the belt to that suspender on the tagged commit itself.
+  platform-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Announced platform states must not exceed the evidence
+        run: node uxnandesktop/scripts/platform-support.mjs gate
+
   build:
-    needs: verify
+    needs: [verify, platform-gate]
     strategy:
       fail-fast: false # a failing mac leg must not drop the win/linux artifacts
       matrix:

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,73 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Added — a platform support matrix: honest per-platform states, evidence-gated releases
+
+- **A machine-readable platform matrix** (`tests/platform-support.json`): every
+  platform×feature pair records one of six escalating levels — `code-only`,
+  `builds`, `smoke`, `validated`, `signed`, `release-ready` — with the evidence
+  that demonstrates it (date, commit, hardware, tester). "Supported" is never
+  said without a level, and a green CI build is never promoted to `smoke`: a
+  build proves the artifact compiles, not that anyone ran it. Current announced
+  states: **Windows 11 x64 `smoke`** (E2E suite green locally, an approved
+  11-scenario resource baseline, the maintainer's installed daily-driver build
+  self-updating on both channels — several features individually `validated`),
+  **macOS (both architectures) and Linux `builds`** (CI compiles + runs the
+  full suites on their runners; no run on real hardware has ever been
+  recorded, and the matrix says so instead of implying otherwise).
+- **The matrix cannot quietly lie** (`tests/platform-support.test.mjs`, in the
+  required `npm test` gate): only the six levels exist; every cell cites
+  evidence and every cited file must exist; `smoke`+ requires date, sha,
+  hardware and tester; a platform's announced level can never exceed its
+  weakest core feature; `signed`+ requires a signing-evidence block; and the
+  human-readable page must agree with the source about every announced level.
+- **Release gate** (`scripts/platform-support.mjs`): `gate` exits non-zero when
+  an announced state exceeds the evidence — wired into `release-desktop.yml`
+  as a job the installers depend on — and `checklist` renders each platform's
+  release checklist (minimum versions, install/upgrade cycles, the exact
+  manual steps that advance it) from the source, so no hand-kept table can
+  contradict it.
+- **`docs/platform-support.md`** — the human-readable view: level definitions,
+  the summary and feature×platform tables, where CI ends and hardware begins,
+  a negative-scenario coverage table (unwritable data dir, corrupt state,
+  occupied ports, missing CLIs/`caffeinate`/`systemd-inhibit`, hostile
+  updates, channel crossing, unplugged monitors, old webviews, Gatekeeper/
+  SmartScreen), and the full OS-specific code inventory mapping every
+  `#[cfg]`/platform branch to its test or its checklist item. Linked from the
+  README, `build.md`, `install-macos.md` and `testing.md`.
+- **Updater failure & rollback path documented** (`docs/updates.md`): a corrupt
+  manifest fails `check()`, a wrong-key or tampered artifact fails minisign
+  verification *inside download* (nothing is ever staged), a stale staged
+  download is refused at install, and a manual rollback path exists via the
+  previous release's installers — plus the **key/certificate procedure**
+  (creation, rotation — including the signed hop that re-keys installed apps —
+  and storage rules that keep every secret out of the repo).
+
+### Added — platform-sensitive negative tests
+
+- **Keep-awake state machine under test** (`src-tauri/src/power.rs`): the
+  worker loop is now generic over the inhibitor, so a fake records that a
+  duplicate request is never re-applied, the 2 h auto-release cap fires on a
+  stuck `working`, and dropping the handle releases before exit. A host-OS
+  test also toggles the **real** inhibitor once, so each CI runner exercises
+  its own branch (`SetThreadExecutionState` / `caffeinate` /
+  `systemd-inhibit`) — previously this module had no tests at all.
+- **Pet placement is monitor-aware and provably so** (`src-tauri/src/commands.rs`):
+  the visibility test and the fallback resting corner are pure functions now —
+  a saved position on an unplugged display is rejected (including the
+  zero-monitors race), partial overlap counts as visible, and the fallback
+  corner is asserted to land on the monitor that produced it, on scaled and
+  offset monitors too.
+- **Persistence fails cleanly when the disk fights back**
+  (`src-tauri/src/persistence.rs`): saving into a data dir obstructed by a
+  plain file errors without panicking or clobbering, and a corrupt
+  `state.json` errors at load (the rotating backups are the recovery path).
+- **Frontend OS detection under test** (`src/lib/platform.ts` +
+  `platform.test.ts`): the user-agent parsing behind the untested-platform
+  badge and every per-OS frontend default now takes an injectable agent string
+  and answers `other` instead of guessing.
+- Totals: **397 Rust** (387 unit + 10 integration) and **570 Vitest** tests.
+
 ### Added — a test pyramid: component tests, backend integration, and real end-to-end
 
 - **Five layers, each doing what the one below cannot** (`docs/testing.md`): L0

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -18,12 +18,16 @@ OSC/process layers, settings/themes/i18n, multi-agent orchestration,
 **in-app auto-updater**, **browser-control MCP for agents**, **orchestration run
 engine**, **user quick commands**, **GitHub integration (`gh`-backed)**, **"Open
 with" external editors/IDEs**, **automations**, **pets**, **a reproducible
-resource benchmark**). 388 Rust tests (378 unit + 10 integration) + 565 frontend Vitest tests across
+resource benchmark**). 397 Rust tests (387 unit + 10 integration) + 570 frontend Vitest tests across
 two projects — pure logic and **Svelte component tests** — plus a **real E2E suite**
 (WebdriverIO + tauri-driver: 8 journeys, 24 tests, green on Windows). macOS now ships an
 **experimental, unsigned** build (Intel + Apple Silicon; CI verifies `{ubuntu,
 windows, macOS}`, release gate stays `{ubuntu, windows}`) but is **not yet validated
-on real hardware**. **Phase 6 (embedded bridge / mobile pairing) is NOT started.**
+on real hardware**. **Every platform claim now lives in the platform support
+matrix** (`tests/platform-support.json` + `docs/platform-support.md`, checked by
+the suite and gating releases): Windows announces `smoke`, macOS (both arches)
+and Linux announce `builds`. **Phase 6 (embedded bridge / mobile pairing) is NOT
+started.**
 
 **Built (DONE), in detail:**
 
@@ -894,14 +898,39 @@ go stale; these are the ones worth calling out.
 
 ## Platform validation
 
+**The record is the platform support matrix** — `tests/platform-support.json`
+(machine-readable: level + date + sha + hardware + tester per platform×feature,
+verified by `tests/platform-support.test.mjs` in the required suite) rendered in
+`docs/platform-support.md`, with per-platform release checklists generated from
+it (`node scripts/platform-support.mjs checklist`) and a release gate
+(`… gate`, wired into `release-desktop.yml`) that refuses to build installers
+when an announced state exceeds the evidence. Announced today: **Windows
+`smoke`** (several features `validated`), **macOS aarch64/x64 and Linux
+`builds`**. Everything below advances a cell in that matrix; record the run
+(date, sha, hardware, tester) when it happens.
+
 - [ ] **macOS** — an **experimental, unsigned** build now ships (two ad-hoc-signed
       DMGs, Intel + Apple Silicon; `docs/install-macos.md`), CI compiles + tests it on
-      both arch runners, and the Finder/Dock `PATH` gap is fixed (`path_env.rs`).
+      an Apple Silicon runner, and the Finder/Dock `PATH` gap is fixed (`path_env.rs`).
       Still **not validated on real hardware** by the maintainer — needs a smoke test
       of launch, agent/`gh`/editor detection, notifications, keep-awake and a
-      self-update on both architectures.
-- [ ] **keep-awake** is implemented for macOS/Linux but **untested** there
-      (`power.rs`); Windows works.
+      self-update on both architectures (the x86_64 binary has never executed
+      anywhere). Full checklist: `matrix → checklists.macos-aarch64 / macos-x64`.
+- [ ] **Linux** — full suites green on `ubuntu-latest` and installers ship, but
+      no human has installed/launched any of them; the systemd user timer, keep-awake,
+      the pet overlay under a compositor, and the first-ever Linux E2E run
+      (`tauri-driver` supports it) are all unexecuted. Full checklist:
+      `matrix → checklists.linux-x64`.
+- [ ] **Windows to `validated`** — what blocks the announced level from rising:
+      two recorded install→upgrade→uninstall cycles (config preserved, no
+      leftovers — cannot run on the dev machine while its live instance is the
+      thing being tested), the wake-fidelity check, R07/R08/R10, and one recorded
+      hostile-update run against a staging channel. Full checklist:
+      `matrix → checklists.windows-x64`.
+- [ ] **keep-awake** is implemented for macOS/Linux and its state machine +
+      spawn/kill path are now unit-tested (each CI runner toggles its own real
+      inhibitor once), but **whether the machine actually stays awake** is
+      untested there (`power.rs`); Windows works.
 - [ ] **Update UI (pinned sonner toast + in-Settings download/install) — visual +
       functional validation pending.** The former top banner is now a pinned
       sonner toast (`UpdateToast.svelte` + `updateToast.svelte.ts`) and the
@@ -918,12 +947,14 @@ go stale; these are the ones worth calling out.
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 388 Rust + 565 Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 397 Rust + 570 Vitest tests (both
   projects: pure logic and components). E2E runs in its own on-demand/nightly
   Windows workflow (`e2e-desktop.yml`), deliberately outside the required gate.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →
   draft GitHub Release, **and signs the updater artifacts** when the signing secrets
-  are set. Builds Windows + Linux + **experimental unsigned macOS** (two ad-hoc-signed
+  are set. The build now also depends on the **platform-support gate**
+  (`node scripts/platform-support.mjs gate`): a release whose announced platform
+  state exceeds the matrix's evidence fails before any installer is built. Builds Windows + Linux + **experimental unsigned macOS** (two ad-hoc-signed
   DMGs, both built on Apple Silicon `macos-14` with the Intel `x86_64` DMG
   **cross-compiled**, `fail-fast: false`). Windows and macOS ship without OS
   code-signing (SmartScreen / Gatekeeper warnings).

--- a/uxnandesktop/FOR-HUMAN.md
+++ b/uxnandesktop/FOR-HUMAN.md
@@ -48,7 +48,13 @@ only this checklist and the inline `FOR-HUMAN:` markers describing what's needed
         cert is the *optional* upgrade to a warning-free, notarized install.
       - **Linux** — optional GPG for `.deb`/`.rpm` (spec §5.1).
 
-      **Unrelated to the updater key** (free, already configured).
+      **Unrelated to the updater key** (free, already configured). The
+      creation / rotation / storage procedure for both kinds of secret — and
+      why none of them ever enters the repo — is documented in
+      `docs/updates.md` → *Keys & certificates*. When a certificate lands,
+      record its fingerprint/expiry in the platform matrix's `signing` block
+      (`tests/platform-support.json`) — announcing `signed` without it fails
+      the suite and the release gate.
 
 ## Deferred until later phases (no action needed yet)
 

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -190,9 +190,12 @@ flowchart TB
 
 Uxnan Desktop is cross-platform by construction — Tauri 2 targets Windows, macOS
 and Linux — but **all current testing has been carried out directly on Windows**.
+The full state is recorded honestly, per platform and per feature, in the
+[platform support matrix](docs/platform-support.md) (machine-readable source in
+`tests/platform-support.json`, checked by the test suite and gating releases).
 
-- **Windows** — actively developed and tested; this is the validated platform
-  today.
+- **Windows** — actively developed and tested; this is the exercised platform
+  today (matrix level: `smoke`, with several features at `validated`).
 - **Linux** — expected to work and built in CI, but not yet exercised end-to-end
   by the maintainer. If you run it on Linux, your feedback and recommendations are
   genuinely welcome; please open an issue or a discussion so the experience can be
@@ -217,6 +220,7 @@ Detailed docs live in [`docs/`](./docs/):
 [development & running in debug](./docs/development.md) ·
 [release builds & packaging](./docs/build.md) ·
 [installing on macOS (experimental)](./docs/install-macos.md) ·
+[platform support matrix](./docs/platform-support.md) ·
 [testing & verification](./docs/testing.md) ·
 [end-to-end tests](./tests/e2e/README.md) ·
 [resource benchmarks](./docs/resource-benchmarks.md) ·

--- a/uxnandesktop/docs/build.md
+++ b/uxnandesktop/docs/build.md
@@ -7,6 +7,13 @@
 How to compile Uxnan Desktop for distribution. For day-to-day debug runs see
 [`development.md`](development.md).
 
+> **A build is not a validation.** What each platform has actually demonstrated
+> — `code-only` / `builds` / `smoke` / `validated` / `signed` / `release-ready`,
+> with evidence — is recorded in the
+> [platform support matrix](platform-support.md). Today: Windows `smoke`
+> (exercised daily, E2E + resource baseline), macOS and Linux `builds` (CI
+> compiles and tests them; no run on real hardware has been recorded).
+
 ## Build a release bundle
 
 ```bash

--- a/uxnandesktop/docs/install-macos.md
+++ b/uxnandesktop/docs/install-macos.md
@@ -10,6 +10,13 @@
 > [build it yourself](build.md) on your own Mac (a self-built app runs with no
 > prompt), and **issues / PRs that improve these installers — or help
 > non-technical users — are very welcome.**
+>
+> Where macOS stands overall — `builds` in the
+> [platform support matrix](platform-support.md): CI compiles the app and runs
+> the full test suites on an Apple Silicon runner, but **no one has recorded a
+> run on real Apple hardware yet**. The remaining steps (this walkthrough,
+> notifications, keep-awake, self-update, the automations LaunchAgent) are that
+> matrix's macOS checklist.
 
 ## Pick the right download
 

--- a/uxnandesktop/docs/platform-support.md
+++ b/uxnandesktop/docs/platform-support.md
@@ -1,0 +1,181 @@
+# Platform support matrix
+
+![Windows](https://img.shields.io/badge/Windows_11_x64-smoke-brightgreen?style=for-the-badge&logo=windows&logoColor=white)
+![macOS](https://img.shields.io/badge/macOS-builds-orange?style=for-the-badge&logo=apple&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-builds-orange?style=for-the-badge&logo=linux&logoColor=black)
+
+What each platform has actually demonstrated, with the evidence that
+demonstrates it. **"Supported" is never used without a level, and a level is
+never claimed without evidence.**
+
+The source of truth is machine-readable:
+[`../tests/platform-support.json`](../tests/platform-support.json) — every
+platform×feature cell records a level, a date, a commit, the hardware and the
+tester. This page is the human-readable view of that file, and the two cannot
+drift apart quietly: [`../tests/platform-support.test.mjs`](../tests/platform-support.test.mjs)
+runs in the required `npm test` gate and fails when a citation points at
+nothing, a claimed run has no date/sha/hardware/tester, or this page disagrees
+with the source about an announced level. The release workflow additionally runs
+`node scripts/platform-support.mjs gate` before building installers, so a
+release cannot announce a state that exceeds the recorded evidence.
+
+## The levels
+
+Escalating; each presumes the previous. These are the only six words the
+project uses for platform state:
+
+| Level | Meaning |
+|---|---|
+| `code-only` | Pure/unit tests exist; the OS-specific interaction has never executed on that platform. |
+| `builds` | The platform artifact compiles green (and, where a CI runner exists, the automated suites pass on it). The feature has not been exercised as a running app there. |
+| `smoke` | The app was installed/run on the platform and the flow was walked at least once, with the run recorded (date, sha, hardware, tester). |
+| `validated` | The full suite/walkthrough passed and resources were measured (an approved baseline). |
+| `signed` | Artifacts carry a valid OS code-signing identity. |
+| `release-ready` | Install/upgrade/uninstall + rollback approved on real hardware, configuration preserved, no leftovers. |
+
+A green CI build is **never** promoted to `smoke` — a build proves the artifact
+compiles, not that anyone ran it. And evidence ages: when a platform's recorded
+evidence no longer describes the current release line (a major dependency bump,
+a rewritten subsystem, or evidence older than ~6 months), the claim is
+**degraded** back to what current evidence supports, not defended.
+
+## Summary (updated 2026-07-31)
+
+| Platform | Minimum version | Announced level | Why not higher |
+|---|---|---|---|
+| `windows-x64` — Windows 11 x64 | Windows 10 + WebView2 Evergreen | `smoke` | `validated` blocked by: unscripted install/upgrade/uninstall cycle, wake-fidelity checked only by hand, R07/R08/R10 unmeasured. `signed` needs the paid Authenticode cert (`FOR-HUMAN.md`). |
+| `macos-aarch64` — macOS Apple Silicon | macOS 11.0 | `builds` | Experimental ad-hoc-signed DMG; CI compiles + runs the full suites on `macos-14`, but the app has never been launched on real Apple hardware. |
+| `macos-x64` — macOS Intel | macOS 11.0 | `builds` | Cross-compiled on an Apple Silicon runner; the x86_64 binary has never executed anywhere, not even its test suite. |
+| `linux-x64` — Ubuntu LTS reference | WebKitGTK 4.1 distro (Ubuntu 22.04+) | `builds` | Full suites pass on `ubuntu-latest` and installers ship, but no human has installed or launched any of them; the E2E driver supports Linux and has never been run. |
+
+WSL2 is a **repository environment inside Windows**, not a GUI platform — it
+appears as the `wsl` feature row on `windows-x64` (currently `code-only`).
+
+Per-platform release checklists are generated from the source, never
+hand-kept:
+
+```bash
+node scripts/platform-support.mjs checklist            # all platforms
+node scripts/platform-support.mjs checklist linux-x64  # one platform
+node scripts/platform-support.mjs gate                 # what the release runs
+```
+
+## Feature × platform
+
+The full per-cell evidence (date, sha, hardware, tester, gaps) lives in the
+JSON; this table is the level at a glance.
+
+| Feature | windows-x64 | macos-aarch64 | macos-x64 | linux-x64 |
+|---|---|---|---|---|
+| Clean first launch | `validated` | `builds` | `builds` | `builds` |
+| Install / upgrade / uninstall | `smoke` | `builds` | `builds` | `builds` |
+| Terminals, splits, keyboard | `validated` | `builds` | `builds` | `builds` |
+| Sleep/wake + scrollback | `smoke` | `builds` | `builds` | `builds` |
+| Git, worktrees, review | `validated` | `builds` | `builds` | `builds` |
+| Agent launch + hooks | `smoke` | `builds` | `builds` | `builds` |
+| Integrated browser + DevTools | `smoke` | `builds` | `builds` | `builds` |
+| Pet companion (layer/overlay) | `smoke` | `builds` | `builds` | `builds` |
+| Keep-awake | `smoke` | `code-only` | `code-only` | `code-only` |
+| Automations + OS scheduler | `validated` | `code-only` | `code-only` | `code-only` |
+| In-app updater | `smoke` | `builds` | `builds` | `builds` |
+| Paths with spaces / non-ASCII | `code-only` | `code-only` | `code-only` | `code-only` |
+| Shutdown with agents / persistence | `smoke` | `builds` | `builds` | `builds` |
+| Resource footprint (R00–R11) | `validated` | `code-only` | `code-only` | `code-only` |
+| WSL repositories | `code-only` | — | — | — |
+
+Key Windows evidence anchors: the E2E suite (8 journeys, 24 tests) green
+locally on 2026-07-30 (`docs/testing.md`); the approved resource baseline
+(11 scenarios, `scripts/resources/baselines/windows/`, commit `54d935e8`,
+2026-07-30); the maintainer's installed daily-driver build self-updating on
+both channels each release. Key macOS/Linux evidence anchors: the
+`ci-desktop.yml` verify legs (compile + full Rust/Vitest suites on
+`ubuntu-latest` and `macos-14`) and the installers shipped in
+`desktop-stable-v0.0.24` (2026-07-29, `039866bb`).
+
+## Where CI ends and hardware begins
+
+CI already gives every platform what a runner can give it:
+
+- **Build + test per OS** — `verify-desktop.yml` compiles and runs the full
+  Rust + Vitest suites on `{ubuntu-latest, windows-latest, macos-14}` for every
+  PR (`ci-desktop.yml`), and `release-desktop.yml` bundles installers for all
+  four targets on tags.
+- **Smoke on a runner** — the E2E suite (`e2e-desktop.yml`) runs the real
+  release binary on `windows-latest`, on demand and nightly. `tauri-driver`
+  supports Linux (WebKitWebDriver) but the harness — driver fetch, preflight,
+  teardown — is Windows-specific today and has never executed on Linux; wiring
+  a Linux leg without being able to run it once would be exactly the
+  speculative platform code this matrix exists to prevent, so it stays on the
+  `linux-x64` checklist. `tauri-driver` does not support macOS at all.
+- **Everything past that needs hardware** — the maintainer has Windows
+  hardware only, which is precisely why macOS and Linux sit at `builds`: their
+  remaining items (Gatekeeper walkthrough, LaunchAgent/systemd registration,
+  keep-awake, self-update, resource collection) are recorded as per-platform
+  checklists in the JSON, ready for whoever first holds the hardware.
+
+## Negative scenarios
+
+Where each hostile condition is handled, and what covers it:
+
+| Scenario | Behavior | Coverage |
+|---|---|---|
+| Data dir not writable / obstructed | `PersistenceManager::save` returns an error instead of panicking; a relative `UXNAN_DATA_DIR` is refused and the platform default used | `src-tauri/src/persistence.rs` tests (save into a file-obstructed dir), `src-tauri/src/datadir.rs` tests |
+| Corrupt/truncated state on disk | Load errors (or degrades) instead of panicking; 5 rotating backups retain the previous good copy | `src-tauri/src/persistence.rs` (corrupt-load test, backup ring), `src-tauri/tests/automations_store.rs` (truncated file) |
+| Forced close during a write | Write-rename atomicity: the previous good copy survives an interrupted write | `src-tauri/src/persistence.rs` (no temp file left behind); design in the module header |
+| Hook port occupied | Impossible by design: the hook server binds an ephemeral `127.0.0.1:0` port; if binding fails the app runs without precise hook reporting | `src-tauri/src/hooks.rs` (bind at :0; error path documented in `spawn`) |
+| Missing agent CLI / `gh` / editor | Detection reports not-installed and the UI degrades (install state in Settings; GitHub view says it needs `gh`) | `src-tauri/src/which.rs`, `src-tauri/src/agentcli.rs`, `src-tauri/src/editors.rs` tests; fake-`gh` fixtures (`tests/fixtures/`) |
+| Missing `caffeinate` / `systemd-inhibit` | Spawn failure is a silent no-op (keep-awake simply doesn't hold) | `src-tauri/src/power.rs` (spawn is `.ok()`); efficacy on the checklist — never executed on real macOS/Linux hardware |
+| Scheduler unavailable / registration fails | `SchedulerStatus::Failed` carries the OS's own message; the automation stays runnable in-app (honest degradation) | `src-tauri/src/automations/oscheduler/mod.rs` tests (support probe, Failed serde); real-OS registration on the mac/linux checklists |
+| Corrupt update manifest / bad signature | `tauri-plugin-updater` verifies the minisign signature against the bundled pubkey and refuses; the installed version keeps running (`docs/updates.md` → failure & rollback) | Plugin-owned verification; per-channel endpoints + stale-staged guard in `src-tauri/src/updater.rs`; a recorded hostile-artifact run is on the `windows-x64` checklist |
+| Channel crossing (stable↔nightly) | The tag is the channel; CI rejects a release whose pre-release flag disagrees | `src/lib/desktop-release-tag.test.ts`, `.github/workflows/release-desktop-manifest.yml` |
+| Monitor unplugged with the pet off-screen | A saved position not on any live monitor falls back to resting near the primary's bottom-right corner | `src-tauri/src/commands.rs` (pure placement helpers + tests) |
+| Old / missing webview runtime | Windows: WebView2 Evergreen updates itself; Linux: WebKitGTK is a package dependency of the .deb/.rpm (AppImage assumes the host's); macOS: WKWebView ships with the OS (min 11.0) | Environment property — on each platform's checklist, not testable from code |
+| Gatekeeper / SmartScreen | Documented, expected warnings while unsigned (`docs/install-macos.md`; SmartScreen on Windows) | Removed only by the paid certificates (`FOR-HUMAN.md`) |
+| Notification permission denied | Notifications simply do not appear; no functional loss | On each platform's smoke checklist |
+
+## OS-specific code inventory
+
+The per-OS branches in the codebase, and what covers each. Anything marked
+*checklist* is covered by a manual item in the JSON, not by an automated test —
+adding OS-specific fixes without a reproduced failure is out of bounds, so
+uncovered branches get evidence before they get changes.
+
+### Backend (Rust)
+
+| Area | Branches | Automated coverage | Uncovered → where tracked |
+|---|---|---|---|
+| `power.rs` (keep-awake) | Windows `SetThreadExecutionState`; macOS `caffeinate -i`; Linux `systemd-inhibit`; no-op elsewhere | Worker state machine (flip-on-change, auto-release cap, release-on-drop) unit-tested against a fake inhibitor; a host-OS test toggles the real inhibitor once on each CI runner | Real sleep prevention on macOS/Linux hardware → checklists |
+| `wsl.rs` + `git.rs` WSL routing | UNC parse/translate (pure); `cfg!(windows)` routing through `wsl.exe -d`; case-insensitive path compare | Parse/round-trip fully tested (7 tests) | Live routing (`git.rs:133/851`) has no automated run → `wsl` feature row (`code-only`) + L5 checklist row 9 |
+| `winproc.rs` | `CREATE_NO_WINDOW` on spawned commands (Windows) | Command identity test; the flag itself is opaque to assertions | Behavior visible only by eye (no flashing consoles) — daily use |
+| `automations/oscheduler/` | Dispatch per OS; Task Scheduler XML; LaunchAgent plist; systemd user units | All three document builders fully unit-tested on every platform (hostile text included); support probe + `Failed` serde tested; Windows has an `#[ignore]`d round-trip against the real scheduler | Real registration on macOS (`launchctl`) and Linux (`systemctl --user`) never executed → checklists |
+| `automations/store.rs` / `graph.rs` | Per-OS data dir bases; `cmd /C` vs `sh -c` for shell steps | Store integration suite (12 tests, incl. non-ASCII paths); graph logic (10 tests) | Shell-step branch runs only on its host OS |
+| `updater.rs` | No OS branches in code; Windows `installMode: passive` + MSI numeric-version constraint in config | Per-channel endpoints tested; stale-staged guard code-reviewed; channel parsing tested (`desktop-release-tag`) | Signed round trip is L5 by nature → checklists |
+| `editors.rs`, `fonts.rs`, `agentcli.rs`, `agent_hooks.rs`, `hooks.rs`, `browse.rs`, `zero.rs`, `codex_trust.rs`, `which.rs` | Home-dir/`PATHEXT`/`%VAR%` expansion, per-OS probe paths, `.cmd` vs `.sh` reporters, `chmod 0755/0600` on Unix, `WSLENV` injection, 8.3 short paths | Host-OS halves covered by their module suites (each runs on all three CI runners); Windows-gated cases in `editors.rs` | `fonts.rs` enumeration (3 per-OS impls) has no tests — output feeds a font picker, degrades to empty list; macOS-only branches execute on the `macos-14` leg only |
+| `path_env.rs` (macOS Finder PATH) | macOS-only enrichment; no-op elsewhere | Merge/dedupe logic + the off-macOS no-op tested | The macOS ON-branch (login-shell probe) needs real hardware → mac checklist (agent/`gh` detection item) |
+| `pty.rs`, `model.rs` | Default shell per OS (PowerShell / zsh / bash), profile seeds | Lifecycle + seed tests run per-OS on each runner | Interactive behavior per OS → smoke checklists |
+| `main.rs`, `Cargo.toml`, `tauri.conf.json`, `capabilities/` | `windows_subsystem`, `windows-sys` deps, `macOSPrivateApi`, ad-hoc signing identity, bundle targets, per-window capabilities (no platform filters) | Config is exercised by every build; capabilities audit is a standing FOR-DEV item | — |
+
+### Frontend (TS/Svelte)
+
+| Area | Branches | Coverage |
+|---|---|---|
+| `platform.ts` | User-agent OS detection; the status-bar "untested platform" badge for macOS/Linux | Unit-tested (`platform.test.ts`) |
+| `keybindings.ts`, `Terminal.svelte`, dialogs | `isMac` modifier mapping (⌘ vs Ctrl), chord rendering | Untested — behavior is visible on first keypress; verified as part of each platform's smoke checklist |
+| `shell.ts`, `terminalTemplates.ts` | Per-shell quoting (PowerShell/cmd/POSIX), per-OS profile templates | Quoting fully tested; templates are data |
+| `windowsJunctionGuard.ts` | Windows-only Redirection-Guard detection | Pure detector fully tested; the OS gate is a one-line guard |
+| `pathid.ts` | Case-insensitive path identity (Windows semantics applied everywhere, deliberately) | Tested, including UNC/WSL spellings |
+
+## Updating the matrix
+
+1. Ran something on real hardware? Record it in
+   `tests/platform-support.json` — level, ISO date, commit sha, hardware
+   description, tester — and cite the artifact (a baseline file, a suite, a
+   release) in `evidence`.
+2. Keep this page's summary table in step (the test fails if they disagree).
+3. Never raise `announced` past the weakest core feature cell — the gate
+   refuses the release if you do.
+4. When evidence stops describing the current code (rewrite, major bump, age),
+   degrade the cell and say why in `gaps`.
+5. Signing evidence (`signed` and above) additionally needs a `signing` block
+   on the platform entry — certificates themselves live outside the repo, only
+   their fingerprint/procedure references belong here (`FOR-HUMAN.md`).

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -45,15 +45,24 @@ keeps them integration tests rather than unit tests with a longer path —
 `automations_store.rs` (10 tests) drives the store against a real `TempDir`:
 round-trip across a process boundary, seed-once, a truncated file degrading
 instead of panicking, nothing written outside its own root, and a path with
-spaces and non-ASCII characters. **388 backend tests** in total.
+spaces and non-ASCII characters. **397 backend tests** in total (387 unit + 10
+integration; one more — the Windows Task Scheduler round-trip — is `#[ignore]`d
+and run by hand).
 
-The 378 unit tests cover the Serde model shape, persistence round-trip / atomicity /
-migration / backups, git + worktree ops (including creation, opt-in branch
+The 387 unit tests cover the Serde model shape, persistence round-trip / atomicity /
+migration / backups (including a corrupt state file and an obstructed data
+directory failing cleanly instead of panicking), git + worktree ops (including
+creation, opt-in branch
 cleanup on removal — local/remote/force — checking out an existing branch,
 staging, discard, hunk apply and commit against throwaway repos), the git2 fast
 path, the PTY lifecycle,
 the agent hook server, the integrated-browser scheme gate, process detection,
-the updater's per-channel endpoints, and the pets store (Codex-format manifest
+the updater's per-channel endpoints, the keep-awake state machine (fake
+inhibitor: flip-on-change, the auto-release cap, release-on-drop — plus one
+host-OS test that toggles the real inhibitor, so each CI runner exercises its
+own platform branch), the pet overlay's monitor-aware placement (an unplugged
+display's saved position rejected, the fallback corner provably on-screen), and
+the pets store (Codex-format manifest
 parsing, path-traversal refusal, and the import copy staying scoped to the
 manifest + its spritesheet).
 
@@ -104,14 +113,19 @@ schedule + next-runs preview, the run/step display projections, the seeded
 example automations, and the prompt-variable insertion) and
 `state/statusSweepRegistry.ts` (the all-worktree status sweep's pacing +
 its request registry) and `usageCatalog.ts` (which providers are still offered
-vs merely still readable) — plus the **resource-benchmark harness** under
+vs merely still readable) and `platform.ts` (user-agent OS detection behind the
+untested-platform badge and every per-OS frontend default) — plus the
+**resource-benchmark harness** under
 `scripts/resources/lib/` (process-tree attribution own/managed/external, the
 result schema and its validation messages, percentile / CPU-rate / soak-slope
 maths, absolute budgets and the regression policy, the redaction gate, the
 scenario table, the pre-flight checks that mark a run invalid, the Unix collector's awk parser and the git fixture's determinism) — and the **test fixtures**
 under `tests/fixtures/` (the fake `gh`, the PATH shim, the disposable and legacy
-profiles) and the **quality matrix** check. **565 tests** across both projects,
-config in `vitest.config.ts` / `vitest.dom.config.ts`.
+profiles) and the **quality matrix** check and the **platform support matrix**
+check (`tests/platform-support.test.mjs` — every platform claim backed by
+evidence that exists, and the announced level gated to it; see
+[`platform-support.md`](platform-support.md)). **570 tests** across both
+projects, config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)
 
@@ -253,6 +267,16 @@ machine — an unrecorded manual check is indistinguishable from one nobody did.
 
 **Never in the required CI job.** These need credentials, cost money, or mutate
 somebody's real data.
+
+**Platform claims have their own machine-readable record**: what each
+platform×feature pair has demonstrated (with date, sha, hardware, tester) lives
+in [`../tests/platform-support.json`](../tests/platform-support.json), checked
+by `tests/platform-support.test.mjs` and summarised in
+[`platform-support.md`](platform-support.md). The per-platform release
+checklists are **generated from it** (`node scripts/platform-support.mjs
+checklist`), and the release workflow refuses a build whose announced platform
+state exceeds the evidence (`… gate`). The table below is the cross-cutting
+manual list; recording one of its platform runs means updating that matrix.
 
 | # | Check | Why it cannot be automated here | Last verified |
 |---|---|---|---|

--- a/uxnandesktop/docs/updates.md
+++ b/uxnandesktop/docs/updates.md
@@ -145,6 +145,85 @@ Then:
 > A tag with the wrong shape is rejected before installers are built. A manually
 > altered GitHub pre-release flag is rejected before the updater manifest changes.
 
+## Failure & rollback path
+
+What happens when an update is hostile or broken, and why the installed version
+survives every case:
+
+- **Corrupt / unparseable manifest** — `updater_check` (the plugin's `check()`)
+  fails to parse `latest.json` and returns an error; the UI reports it and the
+  app keeps running the installed version. A manifest **missing its `signature`
+  field** is rejected at deserialization for the same outcome.
+- **Invalid or wrong-key signature** — the plugin verifies the minisign
+  signature against `plugins.updater.pubkey` **inside `download`, before the
+  bytes are ever returned** (tauri-plugin-updater `verify_signature`). A
+  tampered installer or a signature made with any other key fails there:
+  nothing is staged, nothing is installed.
+- **Stale staged download** — if a newer release appears between download and
+  install, `updater_install` compares versions, refuses the stale bytes, and
+  asks for a fresh download (`src-tauri/src/updater.rs`).
+- **Channel switched by the user** — the endpoint is rebuilt from the selected
+  channel at runtime; the next check runs against the other channel's manifest,
+  which still has to carry a valid signature. CI prevents a release from ever
+  *feeding* the wrong channel (tag ↔ pre-release validation in
+  `release-desktop-manifest.yml`).
+- **An installed update misbehaves anyway** — every previous release keeps its
+  installers on GitHub Releases: roll back by installing the previous version's
+  installer by hand. The app's data directory is not touched by
+  install/uninstall, so configuration survives the round trip. (The updater
+  compares the numeric base version, so after a manual rollback it will offer
+  the newer version again — decline or stay on it deliberately.)
+
+None of these paths can leave the app without a working version: verification
+happens before staging, staging before install, and the installer only replaces
+the binary after the artifact passed its signature check.
+
+> Exercising the hostile cases end to end (a tampered `latest.json`, a
+> wrong-key `.sig`) needs a staging channel and a deliberately-bad artifact —
+> that is a recorded checklist item in the
+> [platform support matrix](platform-support.md), not something CI can safely
+> fabricate.
+
+## Keys & certificates: creation, rotation, storage
+
+Two unrelated secrets exist. Neither ever enters the repository — only their
+public halves do.
+
+**1. The updater minisign keypair (free, already configured).**
+
+- *Creation:* `npx tauri signer generate -w <keyfile>` (see “First-time setup”
+  above). Public key → `tauri.conf.json` (safe to commit); private key +
+  password → the `TAURI_SIGNING_PRIVATE_KEY` / `…_PASSWORD` GitHub Actions
+  secrets.
+- *Storage:* the private key lives **only** in the maintainer's password
+  manager and in the repo's Actions secrets. Never in the repo, never in logs,
+  never on a build machine's disk outside CI's secret store.
+- *Rotation:* generate a new keypair; put the new pubkey in `tauri.conf.json`
+  and ship **one release signed with the old key** carrying the new pubkey
+  (installed apps verify against their *bundled* pubkey, so an immediate key
+  swap would strand them). Once that release is the installed base, switch the
+  Actions secrets to the new private key. A **lost** private key is the same
+  operation minus the graceful hop: users on old builds must reinstall by hand
+  (their updater can no longer verify anything newer), which is why the key and
+  its password are backed up in the password manager.
+
+**2. OS code-signing identities (paid, optional, not configured).**
+
+- *What:* Windows Authenticode certificate; Apple Developer ID + notarization;
+  optional GPG for Linux packages. These remove the SmartScreen/Gatekeeper
+  warnings; the updater works without them. Tracked in
+  [`../FOR-HUMAN.md`](../FOR-HUMAN.md).
+- *Creation:* purchased/issued by the respective CA or Apple — a human-only
+  step (identity verification, payment).
+- *Storage:* as GitHub Actions secrets consumed by `release-desktop.yml`
+  (certificate + password), plus the vendor's own escrow (Apple ID / CA
+  account). Never committed, never echoed in workflow logs.
+- *Rotation / expiry:* certificates expire on the CA's schedule; renew through
+  the vendor, replace the Actions secrets, and record the new
+  fingerprint/expiry in the platform matrix's `signing` block when `signed` is
+  first announced. Timestamped Authenticode signatures keep already-shipped
+  installers valid after expiry.
+
 ## Without the signing key
 
 Everything degrades cleanly: builds still produce installers (just no

--- a/uxnandesktop/scripts/platform-support.mjs
+++ b/uxnandesktop/scripts/platform-support.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * Read `tests/platform-support.json` — the machine-readable source for every
+ * platform claim — and answer two questions from it:
+ *
+ *   node scripts/platform-support.mjs checklist [platform]
+ *     Render the release checklist for one platform (or all of them): the
+ *     announced level, the evidence gaps, and the recorded manual steps that
+ *     advance it. Generated from the source so no hand-kept table can
+ *     contradict it.
+ *
+ *   node scripts/platform-support.mjs gate
+ *     Exit non-zero if any platform announces a state its evidence does not
+ *     support. Run by the release workflow before installers are built, and by
+ *     `tests/platform-support.test.mjs` on every PR. Pure Node, no deps — the
+ *     release job can run it before `npm ci`.
+ *
+ * The structural shape of the file (levels, required fields, citations) is
+ * verified by the test; the gate re-checks only the claims-vs-evidence rule so
+ * a stale checkout can never publish an overstated platform.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MATRIX_PATH = path.join(HERE, "..", "tests", "platform-support.json");
+
+/** The escalating levels; index = strength. */
+export const LEVELS = ["code-only", "builds", "smoke", "validated", "signed", "release-ready"];
+
+/** Position of a level in the ladder; -1 for an unknown level (which the
+ *  structural test rejects — the gate treats it as "no evidence"). */
+export function levelIndex(level) {
+  return LEVELS.indexOf(level);
+}
+
+/** The strongest level a platform may announce: the weakest of its core
+ *  feature cells. A platform missing a core row supports nothing. */
+export function maxAnnouncable(matrix, platformId) {
+  let weakest = LEVELS.length - 1;
+  for (const featureId of matrix.coreFeatures) {
+    const feature = matrix.features.find((f) => f.id === featureId);
+    const cell = feature?.status?.[platformId];
+    if (!cell) return -1;
+    weakest = Math.min(weakest, levelIndex(cell.level));
+  }
+  return weakest;
+}
+
+/**
+ * Every claims-vs-evidence violation in the matrix, as human-readable strings.
+ * Empty means the announced states are honest.
+ */
+export function gate(matrix) {
+  const problems = [];
+  for (const [id, platform] of Object.entries(matrix.platforms)) {
+    const announced = levelIndex(platform.announced);
+    if (announced < 0) {
+      problems.push(`${id}: announces unknown level '${platform.announced}'`);
+      continue;
+    }
+    const supported = maxAnnouncable(matrix, id);
+    if (supported < 0) {
+      problems.push(`${id}: has no cell for at least one core feature`);
+      continue;
+    }
+    if (announced > supported) {
+      problems.push(
+        `${id}: announces '${platform.announced}' but its weakest core feature only demonstrates '${LEVELS[supported]}'`,
+      );
+    }
+    if (announced >= levelIndex("signed") && !platform.signing) {
+      problems.push(`${id}: announces '${platform.announced}' with no signing evidence block`);
+    }
+  }
+  return problems;
+}
+
+/** Render one platform's release checklist from the source. */
+export function renderChecklist(matrix, platformId) {
+  const platform = matrix.platforms[platformId];
+  if (!platform) return `unknown platform '${platformId}'`;
+  const lines = [];
+  lines.push(`${platform.name} (${platformId})`);
+  lines.push(`  announced level : ${platform.announced}`);
+  lines.push(`  minimum version : ${platform.minimum}`);
+  if (platform.notes) lines.push(`  notes           : ${platform.notes}`);
+  lines.push("  core feature evidence:");
+  for (const featureId of matrix.coreFeatures) {
+    const feature = matrix.features.find((f) => f.id === featureId);
+    const cell = feature?.status?.[platformId];
+    if (!cell) {
+      lines.push(`    - ${featureId}: MISSING`);
+      continue;
+    }
+    lines.push(`    - ${featureId}: ${cell.level} (${cell.date ?? "no date"}, ${cell.sha ?? "no sha"})`);
+    if (cell.gaps) lines.push(`        gap: ${cell.gaps}`);
+  }
+  const list = matrix.checklists?.[platformId] ?? [];
+  if (list.length > 0) {
+    lines.push("  to advance:");
+    for (const item of list) {
+      lines.push(`    [ ] (${item.advancesTo}) ${item.item}`);
+    }
+  } else if (platform.announced !== "release-ready") {
+    lines.push("  to advance: NO CHECKLIST RECORDED — that is a matrix bug.");
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const matrix = JSON.parse(fs.readFileSync(MATRIX_PATH, "utf8"));
+  const [, , command, arg] = process.argv;
+
+  if (command === "gate") {
+    const problems = gate(matrix);
+    if (problems.length > 0) {
+      for (const p of problems) console.error(`platform-support gate: ${p}`);
+      console.error(
+        "Refusing: an announced platform state exceeds its recorded evidence. " +
+          "Either add the evidence to tests/platform-support.json or degrade the announced level.",
+      );
+      process.exit(1);
+    }
+    console.log(
+      `platform-support gate: ${Object.keys(matrix.platforms).length} platform(s) announce no more than their evidence (updated ${matrix.updated}).`,
+    );
+    return;
+  }
+
+  if (command === "checklist") {
+    const ids = arg ? [arg] : Object.keys(matrix.platforms);
+    console.log(ids.map((id) => renderChecklist(matrix, id)).join("\n\n"));
+    return;
+  }
+
+  console.error("Usage: node scripts/platform-support.mjs <gate | checklist [platform]>");
+  process.exit(2);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/uxnandesktop/src-tauri/src/commands.rs
+++ b/uxnandesktop/src-tauri/src/commands.rs
@@ -158,6 +158,41 @@ pub async fn pets_delete(app: AppHandle, id: String) -> Result<(), CommandError>
 /// Label of the desktop pet overlay window (also the capability's scope).
 pub const PET_WINDOW_LABEL: &str = "pet";
 
+/// A monitor's rectangle in physical px: `(position, size)`.
+type MonitorRect = ((i32, i32), (u32, u32));
+
+/// Whether a window of `size` at `pos` (both physical px) would be visible on
+/// any of the given monitor rects.
+///
+/// Pure half of the pet-window placement, split out so the unplugged-monitor
+/// case is testable: a saved position that no longer intersects a live monitor
+/// must be rejected, or the pet comes back stranded off-screen.
+fn rect_on_any_monitor(pos: (i32, i32), size: (i32, i32), monitors: &[MonitorRect]) -> bool {
+    monitors.iter().any(|((mx, my), (mw, mh))| {
+        pos.0 + size.0 > *mx
+            && pos.0 < mx + *mw as i32
+            && pos.1 + size.1 > *my
+            && pos.1 < my + *mh as i32
+    })
+}
+
+/// The fallback resting spot: above a monitor's bottom-right corner, with an
+/// extra vertical margin that keeps the pet clear of a conventionally-placed
+/// taskbar (the monitor API reports full bounds, not the work area).
+fn resting_corner(
+    monitor_pos: (i32, i32),
+    monitor_size: (u32, u32),
+    scale: f64,
+    size: (i32, i32),
+) -> (i32, i32) {
+    let margin = (24.0 * scale) as i32;
+    let taskbar = (48.0 * scale) as i32;
+    (
+        monitor_pos.0 + monitor_size.0 as i32 - size.0 - margin,
+        monitor_pos.1 + monitor_size.1 as i32 - size.1 - margin - taskbar,
+    )
+}
+
 /// Show the desktop pet window, creating it on first use.
 ///
 /// `width`/`height` are logical px (the sprite box plus a little padding);
@@ -221,32 +256,30 @@ pub async fn pet_window_show(
         _ => None,
     };
     let on_screen = |p: &PhysicalPosition<i32>| {
-        app.available_monitors()
+        let monitors: Vec<MonitorRect> = app
+            .available_monitors()
             .ok()
             .into_iter()
             .flatten()
-            .any(|m| {
+            .map(|m| {
                 let mp = m.position();
                 let ms = m.size();
-                p.x + w > mp.x
-                    && p.x < mp.x + ms.width as i32
-                    && p.y + h > mp.y
-                    && p.y < mp.y + ms.height as i32
+                ((mp.x, mp.y), (ms.width, ms.height))
             })
+            .collect();
+        rect_on_any_monitor((p.x, p.y), (w, h), &monitors)
     };
     let pos = saved.filter(on_screen).or_else(|| {
         let m = app.primary_monitor().ok().flatten()?;
         let mp = m.position();
         let ms = m.size();
-        // Rest above the bottom-right corner; the extra vertical margin keeps
-        // the pet clear of a conventionally-placed taskbar (the monitor API
-        // reports full bounds, not the work area).
-        let margin = (24.0 * m.scale_factor()) as i32;
-        let taskbar = (48.0 * m.scale_factor()) as i32;
-        Some(PhysicalPosition::new(
-            mp.x + ms.width as i32 - w - margin,
-            mp.y + ms.height as i32 - h - margin - taskbar,
-        ))
+        let (x, y) = resting_corner(
+            (mp.x, mp.y),
+            (ms.width, ms.height),
+            m.scale_factor(),
+            (w, h),
+        );
+        Some(PhysicalPosition::new(x, y))
     });
     if let Some(pos) = pos {
         let _ = win.set_position(pos);
@@ -2422,9 +2455,53 @@ pub async fn github_ai_draft_pr(
 #[cfg(test)]
 mod tests {
     use super::{
-        bracketed_paste, fs_path_exists, pty_submit_payload, read_term_buffers, reorder_by_ids,
-        term_buffers_path,
+        bracketed_paste, fs_path_exists, pty_submit_payload, read_term_buffers,
+        rect_on_any_monitor, reorder_by_ids, resting_corner, term_buffers_path,
     };
+
+    #[test]
+    fn a_pet_position_on_an_unplugged_monitor_is_rejected() {
+        // One live 1920×1080 monitor at the origin; the saved spot belonged to a
+        // second display that is gone. The placement must fall back rather than
+        // strand the pet off-screen.
+        let monitors = [((0, 0), (1920_u32, 1080_u32))];
+        assert!(!rect_on_any_monitor((2200, 300), (200, 200), &monitors));
+        // No monitors at all (headless race while displays reconfigure): reject.
+        assert!(!rect_on_any_monitor((100, 100), (200, 200), &[]));
+    }
+
+    #[test]
+    fn a_pet_position_partly_on_a_live_monitor_is_kept() {
+        let monitors = [
+            ((0, 0), (1920_u32, 1080_u32)),
+            ((1920, 0), (1280_u32, 1024_u32)),
+        ];
+        assert!(rect_on_any_monitor((100, 100), (200, 200), &monitors));
+        // Half off the left edge still counts — some of the pet is visible.
+        assert!(rect_on_any_monitor((-100, 100), (200, 200), &monitors));
+        // On the secondary monitor.
+        assert!(rect_on_any_monitor((2000, 200), (200, 200), &monitors));
+        // Fully past every edge does not.
+        assert!(!rect_on_any_monitor((3300, 100), (200, 200), &monitors));
+    }
+
+    #[test]
+    fn the_fallback_resting_corner_lands_on_the_monitor() {
+        // The fallback must itself pass the visibility test, or the rescue path
+        // would re-strand the pet it just rescued — including on a scaled display
+        // and on a monitor that does not sit at the origin.
+        for (mpos, msize, scale) in [
+            ((0, 0), (1920_u32, 1080_u32), 1.0),
+            ((1920, 240), (2560_u32, 1440_u32), 1.5),
+        ] {
+            let size = (160, 176);
+            let corner = resting_corner(mpos, msize, scale, size);
+            assert!(
+                rect_on_any_monitor(corner, size, &[(mpos, msize)]),
+                "resting corner {corner:?} is off the monitor at {mpos:?} {msize:?} (scale {scale})"
+            );
+        }
+    }
 
     #[tokio::test]
     async fn term_buffers_sidecar_round_trips_and_tolerates_corruption() {

--- a/uxnandesktop/src-tauri/src/persistence.rs
+++ b/uxnandesktop/src-tauri/src/persistence.rs
@@ -209,6 +209,30 @@ mod tests {
     }
 
     #[test]
+    fn save_into_an_obstructed_data_dir_errors_instead_of_panicking() {
+        // The "AppData not writable" case: the data directory cannot be created
+        // because a plain file sits where it should be. The save must surface an
+        // error (the UI reports it) — never panic, never write elsewhere.
+        let dir = tempfile::tempdir().unwrap();
+        let obstruction = dir.path().join("not-a-dir");
+        std::fs::write(&obstruction, b"in the way").unwrap();
+        let mgr = PersistenceManager::new(&obstruction);
+        assert!(mgr.save(&AppData::default()).is_err());
+        // The obstruction is untouched — nothing was clobbered trying.
+        assert_eq!(std::fs::read(&obstruction).unwrap(), b"in the way");
+    }
+
+    #[test]
+    fn load_of_a_corrupt_state_file_errors_instead_of_panicking() {
+        // A forced close mid-write can't corrupt state.json (write-rename), but a
+        // disk-level mangling still can. The load must fail cleanly; the rotating
+        // backups are the recovery path.
+        let (dir, mgr) = temp_manager();
+        std::fs::write(dir.path().join(STATE_FILE), b"{ definitely not json").unwrap();
+        assert!(mgr.load().is_err());
+    }
+
+    #[test]
     fn migrate_accepts_missing_version() {
         let value = serde_json::json!({
             "repos": [],

--- a/uxnandesktop/src-tauri/src/power.rs
+++ b/uxnandesktop/src-tauri/src/power.rs
@@ -52,16 +52,29 @@ impl Default for SleepBlocker {
     }
 }
 
-/// Worker loop: owns the platform [`Inhibitor`] so any thread-affine request
-/// (Windows) and any child inhibitor process (macOS/Linux) stay on one thread.
-/// Blocks for commands; while a request is active it instead waits up to
-/// [`AUTO_RELEASE`] and then releases on timeout.
+/// What the worker drives: the platform [`Inhibitor`] in the app, a recorder in
+/// the state-machine tests (the OS calls themselves are covered by the host-OS
+/// test below — each CI runner exercises its own branch).
+trait Inhibit {
+    fn apply(&mut self, keep_awake: bool);
+}
+
+/// Worker loop entry: owns the platform [`Inhibitor`] so any thread-affine
+/// request (Windows) and any child inhibitor process (macOS/Linux) stay on one
+/// thread.
 fn worker(rx: mpsc::Receiver<bool>) {
+    worker_loop(rx, Inhibitor::new(), AUTO_RELEASE);
+}
+
+/// The state machine, generic over the inhibitor so it is testable: blocks for
+/// commands; while a request is active it instead waits up to `auto_release`
+/// and then releases on timeout. Applies a change only when the desired state
+/// actually flips.
+fn worker_loop<I: Inhibit>(rx: mpsc::Receiver<bool>, mut inhibitor: I, auto_release: Duration) {
     let mut active = false;
-    let mut inhibitor = Inhibitor::new();
     loop {
         let next = if active {
-            rx.recv_timeout(AUTO_RELEASE)
+            rx.recv_timeout(auto_release)
         } else {
             rx.recv().map_err(|_| RecvTimeoutError::Disconnected)
         };
@@ -69,17 +82,17 @@ fn worker(rx: mpsc::Receiver<bool>) {
             Ok(want) => {
                 if want != active {
                     active = want;
-                    inhibitor.set(active);
+                    inhibitor.apply(active);
                 }
             }
             // Auto-release safety cap: drop the request even if still "working".
             Err(RecvTimeoutError::Timeout) => {
                 active = false;
-                inhibitor.set(false);
+                inhibitor.apply(false);
             }
             // Handle dropped: release and exit.
             Err(RecvTimeoutError::Disconnected) => {
-                inhibitor.set(false);
+                inhibitor.apply(false);
                 break;
             }
         }
@@ -94,7 +107,11 @@ impl Inhibitor {
     fn new() -> Self {
         Self
     }
-    fn set(&mut self, keep_awake: bool) {
+}
+
+#[cfg(windows)]
+impl Inhibit for Inhibitor {
+    fn apply(&mut self, keep_awake: bool) {
         use windows_sys::Win32::System::Power::{
             SetThreadExecutionState, ES_CONTINUOUS, ES_SYSTEM_REQUIRED,
         };
@@ -125,7 +142,11 @@ impl Inhibitor {
     fn new() -> Self {
         Self { child: None }
     }
-    fn set(&mut self, keep_awake: bool) {
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+impl Inhibit for Inhibitor {
+    fn apply(&mut self, keep_awake: bool) {
         if keep_awake {
             if self.child.is_none() {
                 self.child = spawn_inhibitor();
@@ -174,5 +195,99 @@ impl Inhibitor {
     fn new() -> Self {
         Self
     }
-    fn set(&mut self, _keep_awake: bool) {}
+}
+
+#[cfg(not(any(windows, target_os = "macos", target_os = "linux")))]
+impl Inhibit for Inhibitor {
+    fn apply(&mut self, _keep_awake: bool) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// Records every state the worker applies, standing in for the OS.
+    struct Recorder(Arc<Mutex<Vec<bool>>>);
+
+    impl Inhibit for Recorder {
+        fn apply(&mut self, keep_awake: bool) {
+            self.0.lock().unwrap().push(keep_awake);
+        }
+    }
+
+    fn spawn_loop(
+        auto_release: Duration,
+    ) -> (Sender<bool>, Arc<Mutex<Vec<bool>>>, thread::JoinHandle<()>) {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let recorder = Recorder(log.clone());
+        let (tx, rx) = mpsc::channel::<bool>();
+        let handle = thread::spawn(move || worker_loop(rx, recorder, auto_release));
+        (tx, log, handle)
+    }
+
+    fn wait_until(log: &Arc<Mutex<Vec<bool>>>, expected: &[bool]) -> bool {
+        // Poll on an observable state rather than sleeping a fixed time — the
+        // worker applies commands asynchronously.
+        for _ in 0..200 {
+            if log.lock().unwrap().as_slice() == expected {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(5));
+        }
+        false
+    }
+
+    #[test]
+    fn applies_only_real_state_changes() {
+        let (tx, log, handle) = spawn_loop(Duration::from_secs(60));
+        tx.send(true).unwrap();
+        tx.send(true).unwrap(); // duplicate: must not re-apply
+        tx.send(false).unwrap();
+        assert!(
+            wait_until(&log, &[true, false]),
+            "got {:?}",
+            log.lock().unwrap()
+        );
+        drop(tx); // exit path releases once more, unconditionally
+        handle.join().unwrap();
+        assert_eq!(log.lock().unwrap().as_slice(), &[true, false, false]);
+    }
+
+    #[test]
+    fn a_stuck_working_state_auto_releases_after_the_cap() {
+        let (tx, log, handle) = spawn_loop(Duration::from_millis(30));
+        tx.send(true).unwrap();
+        // No further message: the cap alone must release the request.
+        assert!(
+            wait_until(&log, &[true, false]),
+            "got {:?}",
+            log.lock().unwrap()
+        );
+        drop(tx);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn dropping_the_handle_releases_and_ends_the_worker() {
+        let (tx, log, handle) = spawn_loop(Duration::from_secs(60));
+        tx.send(true).unwrap();
+        assert!(wait_until(&log, &[true]), "got {:?}", log.lock().unwrap());
+        drop(tx);
+        handle.join().unwrap(); // the loop exited…
+        assert_eq!(log.lock().unwrap().last(), Some(&false)); // …after releasing
+    }
+
+    #[test]
+    fn the_real_inhibitor_toggles_on_this_host() {
+        // Executes the platform branch of whichever OS runs the suite — each CI
+        // runner covers its own: `SetThreadExecutionState` on Windows, a spawned
+        // `caffeinate` on macOS, `systemd-inhibit` on Linux (a silent no-op when
+        // the helper is absent). Proves the call/spawn/kill path holds together;
+        // whether the machine truly stays awake is hardware evidence and lives
+        // on the platform checklist (tests/platform-support.json).
+        let mut inhibitor = Inhibitor::new();
+        inhibitor.apply(true);
+        inhibitor.apply(false);
+    }
 }

--- a/uxnandesktop/src/lib/platform.test.ts
+++ b/uxnandesktop/src/lib/platform.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { currentOS, osLabel } from "./platform";
+
+// The status bar's "untested platform" badge and the per-OS defaults (agent
+// launch shell, dialog filters, junction guard) all hang off this detection —
+// misreading a user agent silently gives a Mac user Windows behavior.
+
+describe("currentOS", () => {
+  it("recognises the three desktop webview user agents", () => {
+    expect(
+      currentOS(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36 Edg/120",
+      ),
+    ).toBe("windows");
+    expect(
+      currentOS("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)"),
+    ).toBe("macos");
+    expect(
+      currentOS("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)"),
+    ).toBe("linux");
+  });
+
+  it("answers 'other' for an empty or unknown agent instead of guessing", () => {
+    expect(currentOS("")).toBe("other");
+    expect(currentOS("SomethingEmbedded/1.0")).toBe("other");
+  });
+});
+
+describe("osLabel", () => {
+  it("names each OS for the untested-platform notice", () => {
+    expect(osLabel("windows")).toBe("Windows");
+    expect(osLabel("macos")).toBe("macOS");
+    expect(osLabel("linux")).toBe("Linux");
+    expect(osLabel("other")).toBe("this platform");
+  });
+});

--- a/uxnandesktop/src/lib/platform.ts
+++ b/uxnandesktop/src/lib/platform.ts
@@ -4,12 +4,11 @@
 
 export type OS = "windows" | "macos" | "linux" | "other";
 
-export function currentOS(): OS {
-  if (typeof navigator === "undefined") return "other";
-  const ua = navigator.userAgent;
-  if (/Windows/i.test(ua)) return "windows";
-  if (/Mac/i.test(ua)) return "macos";
-  if (/Linux|X11/i.test(ua)) return "linux";
+export function currentOS(ua?: string): OS {
+  const agent = ua ?? (typeof navigator === "undefined" ? "" : navigator.userAgent);
+  if (/Windows/i.test(agent)) return "windows";
+  if (/Mac/i.test(agent)) return "macos";
+  if (/Linux|X11/i.test(agent)) return "linux";
   return "other";
 }
 

--- a/uxnandesktop/tests/platform-support.json
+++ b/uxnandesktop/tests/platform-support.json
@@ -1,0 +1,743 @@
+{
+  "$comment": [
+    "The platform support matrix: what each platform×feature pair has actually",
+    "demonstrated, with the evidence that demonstrates it. 'Supported' is never",
+    "used without a level, and a level is never claimed without evidence —",
+    "`platform-support.test.mjs` checks this file against the repository and",
+    "`scripts/platform-support.mjs gate` refuses a release whose announced state",
+    "exceeds it.",
+    "",
+    "Levels (ordered; each one presumes the previous):",
+    "  code-only     — pure/unit tests exist; the OS-specific interaction has",
+    "                  never executed on that platform.",
+    "  builds        — the platform artifact compiles green (and, where a CI",
+    "                  runner exists, the automated suites pass on it); the",
+    "                  feature has not been exercised as a running app there.",
+    "  smoke         — the app was installed/run on the platform and the flow",
+    "                  was walked at least once, with the run recorded.",
+    "  validated     — the full suite/walkthrough passed and, for the platform",
+    "                  claim, resources were measured (an approved baseline).",
+    "  signed        — artifacts carry a valid OS code-signing identity.",
+    "  release-ready — install/upgrade/uninstall + rollback approved on real",
+    "                  hardware, with configuration preserved and no leftovers.",
+    "",
+    "Rules enforced by the test: every cell cites evidence; smoke and above also",
+    "record date, sha, hardware and tester; a platform's `announced` level never",
+    "exceeds the weakest of its core feature cells; `signed`/`release-ready`",
+    "additionally require a `signing` evidence block on the platform. A claim",
+    "whose evidence has expired (see `docs/platform-support.md`) is degraded, not",
+    "defended."
+  ],
+  "version": 1,
+  "updated": "2026-07-31",
+  "levels": [
+    "code-only",
+    "builds",
+    "smoke",
+    "validated",
+    "signed",
+    "release-ready"
+  ],
+  "platforms": {
+    "windows-x64": {
+      "name": "Windows 11 x64",
+      "minimum": "Windows 10 with the WebView2 Evergreen runtime; exercised on Windows 11",
+      "announced": "smoke",
+      "notes": "The maintainer's daily platform: installed NSIS build in daily use, E2E suite green locally, approved resource baseline. `validated` is blocked by the unscripted install/upgrade/uninstall cycle, the manual-only wake-fidelity check and the unmeasured R07/R08/R10 scenarios; `signed` needs the paid Authenticode certificate (FOR-HUMAN.md)."
+    },
+    "macos-aarch64": {
+      "name": "macOS (Apple Silicon)",
+      "minimum": "macOS 11.0 (src-tauri/tauri.conf.json bundle.macOS.minimumSystemVersion)",
+      "announced": "builds",
+      "notes": "Experimental, ad-hoc-signed DMG. CI compiles the app and runs the full Rust + Vitest suites on a macos-14 runner, but the app has never been launched on real Apple hardware — docs/install-macos.md says so to users. No macOS resource baseline exists."
+    },
+    "macos-x64": {
+      "name": "macOS (Intel)",
+      "minimum": "macOS 11.0 (src-tauri/tauri.conf.json bundle.macOS.minimumSystemVersion)",
+      "announced": "builds",
+      "notes": "The Intel DMG is cross-compiled on an Apple Silicon runner (.github/workflows/release-desktop.yml); the x86_64 binary has never executed anywhere — not even its test suite. Everything macos-aarch64 still owes, this owes too, plus first execution."
+    },
+    "linux-x64": {
+      "name": "Linux x64 (Ubuntu LTS reference)",
+      "minimum": "A distribution with WebKitGTK 4.1 (Ubuntu 22.04 LTS or newer is the reference); other distributions are best-effort until there is evidence",
+      "announced": "builds",
+      "notes": "CI runs the full suites on ubuntu-latest and the release ships .deb/.AppImage/.rpm, but no human has installed or launched any of them. tauri-driver supports Linux (WebKitWebDriver), and has never been run here — the E2E harness does not claim a platform nobody executed on."
+    }
+  },
+  "coreFeatures": [
+    "clean-start",
+    "install-cycle",
+    "terminals",
+    "sleep-wake",
+    "git-worktrees",
+    "agent-hooks",
+    "updater",
+    "shutdown"
+  ],
+  "features": [
+    {
+      "id": "clean-start",
+      "name": "Clean first launch (empty profile)",
+      "status": {
+        "windows-x64": {
+          "level": "validated",
+          "date": "2026-07-30",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB, WebView2 150.0.4078.105 (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "E2E launch journey green (tests/e2e/specs/launch.e2e.mjs, suite recorded in docs/testing.md, 2026-07-30); cold-process cost measured and approved (scripts/resources/baselines/windows/R00.json, 54d935e8, 2026-07-30)."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "verify leg green on macos-14 — compile + full Rust/Vitest suites (.github/workflows/ci-desktop.yml run 30608531497); aarch64 DMG shipped in desktop-stable-v0.0.24 (2026-07-29, 039866bb). Never launched on real Apple hardware."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "x86_64 DMG cross-compiled and shipped in desktop-stable-v0.0.24 (.github/workflows/release-desktop.yml); the Intel binary has never executed anywhere."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "verify leg green on ubuntu-latest (.github/workflows/ci-desktop.yml run 30608531497); .deb/.AppImage/.rpm shipped in desktop-stable-v0.0.24 (2026-07-29, 039866bb). Never installed or launched by a person."
+        }
+      }
+    },
+    {
+      "id": "install-cycle",
+      "name": "Install / upgrade / uninstall",
+      "status": {
+        "windows-x64": {
+          "level": "smoke",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "The NSIS build is installed and in daily use on the maintainer's machine, upgraded through the in-app updater on every stable/nightly release since 0.0.10 (FOR-DEV.md, CI/CD — release). No scripted cycle: configuration preservation, uninstall cleanliness and leftover processes/scheduler tasks are unrecorded.",
+          "gaps": "Two recorded install→upgrade→uninstall cycles (previous stable → current) with config-preservation and no-leftovers checks are still owed; see the checklist."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner",
+          "tester": "ci",
+          "evidence": "Ad-hoc-signed DMG published (desktop-stable-v0.0.24); the Gatekeeper walkthrough exists as instructions (docs/install-macos.md) but has never been executed on real hardware."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "x86_64 DMG published (desktop-stable-v0.0.24); never opened on an Intel Mac."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": ".deb/.AppImage/.rpm published (desktop-stable-v0.0.24); no install of any of the three has been recorded."
+        }
+      }
+    },
+    {
+      "id": "terminals",
+      "name": "Terminals, splits, tabs and the keyboard protocol",
+      "status": {
+        "windows-x64": {
+          "level": "validated",
+          "date": "2026-07-30",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "E2E terminal journey — two panes in a split, a real shell behind each (tests/e2e/specs/terminal.e2e.mjs, 2026-07-30); PTY lifecycle unit tests (src-tauri/src/pty.rs); terminal cost measured and approved (scripts/resources/baselines/windows/R02.json, scripts/resources/baselines/windows/R03.json, 54d935e8)."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "portable-pty tests run green on the macos-14 verify leg (.github/workflows/ci-desktop.yml run 30608531497); no interactive terminal has ever been opened on real Apple hardware."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Compiles into the shipped x86_64 DMG (desktop-stable-v0.0.24); never executed."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "portable-pty tests run green on the ubuntu verify leg (.github/workflows/ci-desktop.yml run 30608531497); no interactive terminal opened on a real desktop."
+        }
+      }
+    },
+    {
+      "id": "sleep-wake",
+      "name": "Workspace sleep/wake with scrollback restore",
+      "status": {
+        "windows-x64": {
+          "level": "smoke",
+          "date": "2026-07-30",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "E2E sleeping-workspace journey proves a slept workspace spawns no shells (tests/e2e/specs/sleep-wake.e2e.mjs, 2026-07-30); the asleep cost is measured and approved (scripts/resources/baselines/windows/R04.json, 54d935e8).",
+          "gaps": "Wake fidelity — that the replayed scrollback matches what was captured — is still only checked by hand (tests/quality-matrix.json, sleep-wake row)."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "Scrollback/serialize logic tested on the macos-14 verify leg (.github/workflows/ci-desktop.yml run 30608531497); the flow has never run as an app there."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Compiles into the shipped x86_64 DMG (desktop-stable-v0.0.24); never executed."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "Same suites green on ubuntu-latest (.github/workflows/ci-desktop.yml run 30608531497); the flow has never run as an app there."
+        }
+      }
+    },
+    {
+      "id": "git-worktrees",
+      "name": "Git, worktrees and review",
+      "status": {
+        "windows-x64": {
+          "level": "validated",
+          "date": "2026-07-30",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "E2E worktree journey — a real repository recognised, listed and read (tests/e2e/specs/worktree.e2e.mjs, 2026-07-30); git/worktree/staging suites against throwaway repos (src-tauri/src/git.rs, src-tauri/src/gitfast.rs); watcher + sweep cost on a large dirty checkout measured and approved (scripts/resources/baselines/windows/R06.json, 54d935e8)."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "The full git/gitfast suites run green on the macos-14 verify leg (.github/workflows/ci-desktop.yml run 30608531497); never exercised as a running app on Apple hardware."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Compiles into the shipped x86_64 DMG (desktop-stable-v0.0.24); never executed."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "The full git/gitfast suites run green on ubuntu-latest (.github/workflows/ci-desktop.yml run 30608531497); never exercised as a running app there."
+        }
+      }
+    },
+    {
+      "id": "agent-hooks",
+      "name": "Agent launch, hook reporting and state",
+      "status": {
+        "windows-x64": {
+          "level": "smoke",
+          "date": "2026-07-30",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "E2E agent journey — the agent runs under a shell, the endpoint file is written, an untokened report is refused, a valid one reaches the sidebar state (tests/e2e/specs/agent.e2e.mjs, 2026-07-30); hook-server suites (src-tauri/src/hooks.rs, src-tauri/src/agent_hooks.rs); agent-working cost measured and approved (scripts/resources/baselines/windows/R05.json, 54d935e8). Real CLIs report daily on the maintainer's machine.",
+          "gaps": "The fixture agent's own reporter never reaches the hook server (unresolved — FOR-DEV.md, test pyramid follow-ups); per-CLI reporter correctness is L5 by nature."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "Hook-server and reporter-install suites green on the macos-14 verify leg (.github/workflows/ci-desktop.yml run 30608531497); no real agent has reported from Apple hardware, and Finder-launch PATH enrichment (src-tauri/src/path_env.rs) is untested there."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Compiles into the shipped x86_64 DMG (desktop-stable-v0.0.24); never executed."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "Hook-server suites green on ubuntu-latest (.github/workflows/ci-desktop.yml run 30608531497); no real agent has reported from a Linux desktop."
+        }
+      }
+    },
+    {
+      "id": "browser",
+      "name": "Integrated browser and DevTools",
+      "status": {
+        "windows-x64": {
+          "level": "smoke",
+          "date": "2026-07-30",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "E2E browser journey opens a loopback page in the docked second window — the suite's only multi-window coverage (tests/e2e/specs/browser.e2e.mjs, 2026-07-30); scheme gate unit-tested (src-tauri/src/browser.rs).",
+          "gaps": "R07 (browser cost) still needs an operator; DevTools and real-site browsing are on the manual checklist (docs/testing.md, L5 row 11)."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "browser.rs suites green on the macos-14 verify leg (.github/workflows/ci-desktop.yml run 30608531497); the docked-window glue has never been seen on macOS."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Compiles into the shipped x86_64 DMG (desktop-stable-v0.0.24); never executed."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "browser.rs suites green on ubuntu-latest (.github/workflows/ci-desktop.yml run 30608531497); the docked-window glue has never been seen on a Linux desktop."
+        }
+      }
+    },
+    {
+      "id": "pet-overlay",
+      "name": "Pet companion (layer and desktop overlay)",
+      "status": {
+        "windows-x64": {
+          "level": "smoke",
+          "date": "2026-07-30",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "All three pet variants — off, layer and the separate overlay window — launched and measured under the approved baseline (scripts/resources/baselines/windows/R09-off.json, scripts/resources/baselines/windows/R09-layer.json, scripts/resources/baselines/windows/R09-overlay.json, 54d935e8, 2026-07-30); pure pet logic unit-tested (src/lib/pets/).",
+          "gaps": "No automated journey drives the overlay (multi-window E2E is unproven); drag/click/monitor behavior is manual (docs/testing.md, L5 row 10)."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "pets.rs suites green on the macos-14 verify leg (.github/workflows/ci-desktop.yml run 30608531497); the transparent always-on-top overlay window has never been created on macOS."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Compiles into the shipped x86_64 DMG (desktop-stable-v0.0.24); never executed."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "pets.rs suites green on ubuntu-latest (.github/workflows/ci-desktop.yml run 30608531497); a transparent always-on-top window on Linux depends on the compositor and has never been tried."
+        }
+      }
+    },
+    {
+      "id": "keep-awake",
+      "name": "Keep-awake (opt-in)",
+      "status": {
+        "windows-x64": {
+          "level": "smoke",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "SetThreadExecutionState path in daily use and recorded working on Windows (FOR-DEV.md, Platform validation); state-machine logic unit-tested (src-tauri/src/power.rs)."
+        },
+        "macos-aarch64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "The caffeinate branch compiles on the macos-14 verify leg; the keep-awake state machine is unit-tested and a host-OS test toggles the real inhibitor per runner (src-tauri/src/power.rs). Whether a Mac actually stays awake has never been verified on physical hardware."
+        },
+        "macos-x64": {
+          "level": "code-only",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Compiles into the shipped x86_64 DMG (src-tauri/src/power.rs); never executed."
+        },
+        "linux-x64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "The systemd-inhibit branch compiles on ubuntu-latest; the keep-awake state machine is unit-tested and a host-OS test toggles the real inhibitor per runner (src-tauri/src/power.rs). A real inhibitor lock on a Linux desktop session has never been observed (CI runners have no logind session for it)."
+        }
+      }
+    },
+    {
+      "id": "automations",
+      "name": "Automations: headless runner + OS scheduler with the app closed",
+      "status": {
+        "windows-x64": {
+          "level": "validated",
+          "date": "2026-07-26",
+          "sha": "039866bb",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "Verified live end to end with the app closed — a real Task Scheduler task fired the headless runner driving a multi-agent graph (FOR-DEV.md, Status; CHANGELOG 0.0.23/0.0.24); store integration suite (src-tauri/tests/automations_store.rs); an ignored round-trip test against the real Task Scheduler exists (src-tauri/src/automations/, cargo test -- --ignored windows_round_trip)."
+        },
+        "macos-aarch64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "The LaunchAgent plist is produced by pure functions tested on every platform (src-tauri/src/automations/), but launchctl registration has never executed on a real Mac (FOR-DEV.md, Automations follow-ups)."
+        },
+        "macos-x64": {
+          "level": "code-only",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Same plist generators compiled into the x86_64 DMG (src-tauri/src/automations/); never executed."
+        },
+        "linux-x64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "The systemd user units are produced by pure functions tested on every platform (src-tauri/src/automations/), but systemctl --user registration has never executed on a real Linux session (FOR-DEV.md, Automations follow-ups)."
+        }
+      }
+    },
+    {
+      "id": "updater",
+      "name": "In-app updater (channels, signature, staged install)",
+      "status": {
+        "windows-x64": {
+          "level": "smoke",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "Signed (minisign) self-updates verified by the maintainer on both channels on each release since 0.0.10 (FOR-DEV.md, CI/CD — release); per-channel endpoints unit-tested (src-tauri/src/updater.rs); channel/tag crossing rejected by test (src/lib/desktop-release-tag.test.ts) and by CI (.github/workflows/release-desktop-manifest.yml).",
+          "gaps": "The failure paths that need a hostile artifact — corrupt manifest, wrong-key signature — are exercised by the plugin's own verification, not by a recorded local run; see docs/updates.md (failure & rollback) and the checklist."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner",
+          "tester": "ci",
+          "evidence": "Updater artifacts (.app.tar.gz + .sig) built and published per release (desktop-stable-v0.0.24); a real self-update on macOS has never been observed (docs/install-macos.md calls the path experimental)."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "x64 updater artifacts built and published per release (desktop-stable-v0.0.24); never exercised."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "AppImage/deb updater artifacts + .sig built and published per release (desktop-stable-v0.0.24); a real self-update on a Linux desktop has never been observed."
+        }
+      }
+    },
+    {
+      "id": "hardened-paths",
+      "name": "Paths with spaces and non-ASCII characters",
+      "status": {
+        "windows-x64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64 (local + windows-latest runner)",
+          "tester": "ci",
+          "evidence": "The automations store round-trips a root with spaces and non-ASCII characters (src-tauri/tests/automations_store.rs); git suites run against temp dirs. No full-app walkthrough over a Unicode profile/worktree path has been recorded on any platform."
+        },
+        "macos-aarch64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "Same suites green on macos-14 (.github/workflows/ci-desktop.yml run 30608531497); no app-level pass."
+        },
+        "macos-x64": {
+          "level": "code-only",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Compiled into the shipped DMG (desktop-stable-v0.0.24); never executed."
+        },
+        "linux-x64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "Same suites green on ubuntu-latest (.github/workflows/ci-desktop.yml run 30608531497); no app-level pass."
+        }
+      }
+    },
+    {
+      "id": "shutdown",
+      "name": "Shutdown with live agents; persistence under interruption",
+      "status": {
+        "windows-x64": {
+          "level": "smoke",
+          "date": "2026-07-30",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "The E2E agent journey closes the app and proves nothing outlives it (tests/e2e/specs/agent.e2e.mjs, 2026-07-30); atomic persistence with rotating backups and a truncated file degrading instead of panicking is suite-covered (src-tauri/src/persistence.rs, src-tauri/tests/automations_store.rs).",
+          "gaps": "A literal kill-during-write of the running app is not automated; the atomic-write + backup design is the defense, exercised at the file layer."
+        },
+        "macos-aarch64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "Persistence suites green on the macos-14 verify leg (.github/workflows/ci-desktop.yml run 30608531497); the app-level close path has never run on Apple hardware."
+        },
+        "macos-x64": {
+          "level": "builds",
+          "date": "2026-07-29",
+          "sha": "039866bb",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Compiles into the shipped x86_64 DMG (desktop-stable-v0.0.24); never executed."
+        },
+        "linux-x64": {
+          "level": "builds",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "Persistence suites green on ubuntu-latest (.github/workflows/ci-desktop.yml run 30608531497); the app-level close path has never run on a Linux desktop."
+        }
+      }
+    },
+    {
+      "id": "resources",
+      "name": "Resource footprint (R00–R11)",
+      "status": {
+        "windows-x64": {
+          "level": "validated",
+          "date": "2026-07-30",
+          "sha": "54d935e8",
+          "hardware": "Windows 11 Pro 10.0.26200 x64, i7-13620H, 16 GB, WebView2 150.0.4078.105 (hostId 2b9d89e1cf9f)",
+          "tester": "maintainer",
+          "evidence": "Approved baseline: eleven scenarios, five release-build repetitions each (scripts/resources/baselines/windows/, scripts/resources/baselines/README.md).",
+          "gaps": "R07/R08 need an operator and R10 (the 2 h soak) has never run; the budget gate is warn-only (FOR-DEV.md, Resource benchmarks follow-ups)."
+        },
+        "macos-aarch64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (Apple Silicon)",
+          "tester": "ci",
+          "evidence": "The Unix collector is implemented and its parser unit-tested (scripts/resources/collectors/, scripts/resources/lib/), but it has never executed on macOS; budgets stay empty and no figure may be published (scripts/resources/baselines/README.md)."
+        },
+        "macos-x64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted macos-14 runner (cross-compiling to x86_64)",
+          "tester": "ci",
+          "evidence": "Same collector, same status (scripts/resources/collectors/); never executed."
+        },
+        "linux-x64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "GitHub-hosted ubuntu-latest runner",
+          "tester": "ci",
+          "evidence": "Same collector, same status (scripts/resources/collectors/); never executed on a Linux desktop."
+        }
+      }
+    },
+    {
+      "id": "wsl",
+      "name": "WSL repositories (Windows-hosted)",
+      "status": {
+        "windows-x64": {
+          "level": "code-only",
+          "date": "2026-07-31",
+          "sha": "5d05643b",
+          "hardware": "Windows 11 Pro 10.0.26200 x64 (local + windows-latest runner)",
+          "tester": "ci",
+          "evidence": "wsl.exe path routing is unit-tested (src-tauri/src/wsl.rs); no recorded walkthrough opens a \\\\wsl.localhost repository, creates a worktree in it and runs an agent (docs/testing.md, L5 row 9; tests/quality-matrix.json, project-worktree row)."
+        }
+      }
+    }
+  ],
+  "checklists": {
+    "windows-x64": [
+      {
+        "id": "win-install-cycle",
+        "advancesTo": "validated",
+        "item": "Record two full install→upgrade→uninstall cycles (previous stable → current, stable and nightly): configuration preserved, no leftover processes, no orphaned scheduler tasks, uninstall leaves no app files behind."
+      },
+      {
+        "id": "win-wake-fidelity",
+        "advancesTo": "validated",
+        "item": "Wake a slept workspace and confirm the replayed scrollback matches what was captured (R04 assisted checklist)."
+      },
+      {
+        "id": "win-resources-operator",
+        "advancesTo": "validated",
+        "item": "Capture R07 and R08 with an operator and run R10 (the 2 h soak) once; promote the aggregates."
+      },
+      {
+        "id": "win-updater-negative",
+        "advancesTo": "validated",
+        "item": "Exercise the updater failure path once against a staging channel: a tampered latest.json and a wrong-key .sig must both be refused and leave the installed version running (docs/updates.md, failure & rollback)."
+      },
+      {
+        "id": "win-authenticode",
+        "advancesTo": "signed",
+        "item": "Obtain and configure the Windows Authenticode certificate (FOR-HUMAN.md); verify SmartScreen accepts a signed installer."
+      },
+      {
+        "id": "win-release-ready",
+        "advancesTo": "release-ready",
+        "item": "On clean hardware (not the development machine): install, upgrade from the previous stable, roll back by reinstalling it, and uninstall — configuration preserved at every step."
+      }
+    ],
+    "macos-aarch64": [
+      {
+        "id": "mac-first-smoke",
+        "advancesTo": "smoke",
+        "item": "On real Apple Silicon hardware: install the DMG via the documented Gatekeeper walkthrough (docs/install-macos.md), launch, open a terminal, add a project, and confirm agent/gh/editor detection finds Homebrew-installed CLIs from a Finder launch."
+      },
+      {
+        "id": "mac-feature-smoke",
+        "advancesTo": "smoke",
+        "item": "Walk the platform-sensitive features once: notifications, keep-awake (a caffeinate process appears and disappears), the pet overlay window, the integrated browser, sleep/wake of a workspace."
+      },
+      {
+        "id": "mac-scheduler",
+        "advancesTo": "validated",
+        "item": "Register an automation, quit the app, and confirm the LaunchAgent fires the headless runner; then remove it and confirm launchctl is clean."
+      },
+      {
+        "id": "mac-self-update",
+        "advancesTo": "validated",
+        "item": "Apply a real self-update on both channels and confirm Gatekeeper does not re-quarantine it; record two install/upgrade cycles."
+      },
+      {
+        "id": "mac-resources",
+        "advancesTo": "validated",
+        "item": "Run the Unix resource collector for R00–R06/R09/R11 on the machine, define the macOS `own` bucket (WebKit's content process lives outside the app tree), and promote a baseline."
+      },
+      {
+        "id": "mac-signing",
+        "advancesTo": "signed",
+        "item": "Apple Developer ID + notarization (FOR-HUMAN.md); verify a notarized build opens with no Gatekeeper prompt."
+      }
+    ],
+    "macos-x64": [
+      {
+        "id": "macx64-first-run",
+        "advancesTo": "smoke",
+        "item": "Execute the cross-compiled x86_64 DMG on a real Intel Mac at all — it has never run anywhere; then repeat the macos-aarch64 checklist there."
+      }
+    ],
+    "linux-x64": [
+      {
+        "id": "linux-first-smoke",
+        "advancesTo": "smoke",
+        "item": "On Ubuntu LTS (or the reference distribution): install the .deb and the AppImage, launch under X11 and under Wayland, open a terminal, add a project."
+      },
+      {
+        "id": "linux-feature-smoke",
+        "advancesTo": "smoke",
+        "item": "Walk the platform-sensitive features once: notifications, keep-awake (systemd-inhibit held and released), the pet overlay (compositor-dependent), the integrated browser (WebKitGTK), sleep/wake."
+      },
+      {
+        "id": "linux-scheduler",
+        "advancesTo": "validated",
+        "item": "Register an automation, quit the app, and confirm the systemd user timer fires the headless runner; then remove it and confirm systemctl --user is clean. Also verify honest degradation on a system without systemd."
+      },
+      {
+        "id": "linux-e2e",
+        "advancesTo": "validated",
+        "item": "Run the E2E suite via tauri-driver + WebKitWebDriver for the first time (supported by the driver, never executed); record the result before claiming the layer."
+      },
+      {
+        "id": "linux-self-update",
+        "advancesTo": "validated",
+        "item": "Apply a real self-update (AppImage path) on both channels; record two install/upgrade cycles, including the .deb upgrade path."
+      },
+      {
+        "id": "linux-resources",
+        "advancesTo": "validated",
+        "item": "Run the Unix resource collector for R00–R06/R09/R11 and promote a baseline."
+      },
+      {
+        "id": "linux-signing",
+        "advancesTo": "signed",
+        "item": "Optional GPG signing for .deb/.rpm (FOR-HUMAN.md)."
+      }
+    ]
+  }
+}

--- a/uxnandesktop/tests/platform-support.test.mjs
+++ b/uxnandesktop/tests/platform-support.test.mjs
@@ -1,0 +1,189 @@
+/**
+ * The platform matrix has to be true, not aspirational.
+ *
+ * `platform-support.json` is the machine-readable source for every platform
+ * claim the project makes — the levels, the evidence, the checklists and the
+ * `announced` state per platform. Left as prose it would drift within a release;
+ * as data it can be read back against the repository, the same posture as
+ * `quality-matrix.test.mjs`.
+ *
+ * What is enforced here:
+ *   - only the six agreed levels exist, in their escalating order;
+ *   - every cell cites evidence, and every file a citation names exists;
+ *   - `smoke` and above additionally record date, sha, hardware and tester —
+ *     an unrecorded manual check is indistinguishable from one nobody did;
+ *   - a platform's `announced` level never exceeds the weakest of its core
+ *     feature cells (announcing more than the evidence is the failure mode this
+ *     whole file exists to prevent);
+ *   - `signed` / `release-ready` require a signing evidence block;
+ *   - a platform still below `release-ready` has a checklist saying how to
+ *     advance, and the doc (`docs/platform-support.md`) states each platform's
+ *     announced level verbatim, so the human-readable table cannot quietly
+ *     disagree with the source.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { gate, levelIndex, renderChecklist } from "../scripts/platform-support.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DESKTOP_ROOT = path.resolve(HERE, "..");
+const REPO_ROOT = path.resolve(DESKTOP_ROOT, "..");
+const matrix = JSON.parse(fs.readFileSync(path.join(HERE, "platform-support.json"), "utf8"));
+
+const LEVELS = ["code-only", "builds", "smoke", "validated", "signed", "release-ready"];
+
+/** Every repo path a piece of evidence mentions, split out of its prose.
+ *  `.github/…` lives at the repository root; everything else under the
+ *  desktop root — same citation style as the quality matrix. */
+function citedPaths(evidence) {
+  return String(evidence)
+    .split(/[,;\s]+/)
+    .map((token) => token.replace(/[(),;]/g, "").replace(/\.+$/, ""))
+    .filter((token) => /^(src|scripts|tests|src-tauri|docs|\.github)\//.test(token));
+}
+
+function citationResolves(cited) {
+  const root = cited.startsWith(".github/") ? REPO_ROOT : DESKTOP_ROOT;
+  const full = path.join(root, cited);
+  if (!cited.includes("*")) return fs.existsSync(full);
+  const dir = path.dirname(full);
+  if (!fs.existsSync(dir)) return false;
+  const pattern = new RegExp(
+    `^${path
+      .basename(cited)
+      .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+      .replace(/\*/g, ".*")}$`,
+  );
+  const walk = (root_) =>
+    fs.readdirSync(root_, { withFileTypes: true }).some((entry) => {
+      if (entry.isDirectory()) return walk(path.join(root_, entry.name));
+      return pattern.test(entry.name);
+    });
+  return walk(dir);
+}
+
+const platformIds = Object.keys(matrix.platforms);
+
+describe("the platform support matrix", () => {
+  it("declares exactly the agreed levels, in order", () => {
+    expect(matrix.levels).toEqual(LEVELS);
+  });
+
+  it("gives every platform a name, a minimum version and an announced level", () => {
+    for (const [id, platform] of Object.entries(matrix.platforms)) {
+      expect(platform.name, `${id} has no name`).toBeTruthy();
+      expect(platform.minimum, `${id} has no minimum version`).toBeTruthy();
+      expect(LEVELS, `${id} announces an unknown level`).toContain(platform.announced);
+    }
+  });
+
+  it("keeps every feature cell on a known platform and a known level", () => {
+    const ids = new Set();
+    for (const feature of matrix.features) {
+      expect(feature.id, "a feature has no id").toBeTruthy();
+      expect(ids.has(feature.id), `duplicate feature id ${feature.id}`).toBe(false);
+      ids.add(feature.id);
+      for (const [platform, cell] of Object.entries(feature.status)) {
+        expect(platformIds, `${feature.id} cites unknown platform ${platform}`).toContain(platform);
+        expect(LEVELS, `${feature.id}/${platform} has an unknown level`).toContain(cell.level);
+      }
+    }
+    for (const core of matrix.coreFeatures) {
+      expect(ids.has(core), `core feature ${core} has no row`).toBe(true);
+    }
+  });
+
+  it("backs every cell with evidence, and every citation with a file that exists", () => {
+    const missing = [];
+    for (const feature of matrix.features) {
+      for (const [platform, cell] of Object.entries(feature.status)) {
+        if (!cell.evidence) {
+          missing.push(`${feature.id}/${platform}: no evidence`);
+          continue;
+        }
+        for (const cited of citedPaths(cell.evidence)) {
+          if (!citationResolves(cited)) {
+            missing.push(`${feature.id}/${platform}: ${cited} matches nothing in the repo`);
+          }
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("records date, sha, hardware and tester wherever a run is claimed", () => {
+    // `builds` needs a date + sha (a CI run or release is identifiable);
+    // `smoke` and above also need the machine and the person.
+    const missing = [];
+    for (const feature of matrix.features) {
+      for (const [platform, cell] of Object.entries(feature.status)) {
+        if (levelIndex(cell.level) >= levelIndex("builds")) {
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(cell.date ?? "")) {
+            missing.push(`${feature.id}/${platform}: no ISO date`);
+          }
+          if (!/^[0-9a-f]{7,40}$/.test(cell.sha ?? "")) {
+            missing.push(`${feature.id}/${platform}: no commit sha`);
+          }
+        }
+        if (levelIndex(cell.level) >= levelIndex("smoke")) {
+          if (!cell.hardware) missing.push(`${feature.id}/${platform}: no hardware`);
+          if (!cell.tester) missing.push(`${feature.id}/${platform}: no tester`);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it("never announces more than the weakest core feature demonstrates", () => {
+    // The release gate proper — also enforced by `scripts/platform-support.mjs
+    // gate` in the release workflow; failing here catches it on every PR.
+    expect(gate(matrix)).toEqual([]);
+  });
+
+  it("requires signing evidence before `signed` is ever announced", () => {
+    for (const [id, platform] of Object.entries(matrix.platforms)) {
+      if (levelIndex(platform.announced) >= levelIndex("signed")) {
+        expect(platform.signing, `${id} announces ${platform.announced} with no signing block`).toBeTruthy();
+      }
+    }
+  });
+
+  it("gives every platform below release-ready a checklist that advances it", () => {
+    for (const [id, platform] of Object.entries(matrix.platforms)) {
+      if (platform.announced === "release-ready") continue;
+      const list = matrix.checklists?.[id] ?? [];
+      expect(list.length, `${id} is ${platform.announced} but has no checklist`).toBeGreaterThan(0);
+      for (const item of list) {
+        expect(LEVELS, `${id}/${item.id} advances to an unknown level`).toContain(item.advancesTo);
+        expect(
+          levelIndex(item.advancesTo) > levelIndex(platform.announced),
+          `${id}/${item.id} advances to ${item.advancesTo}, which ${id} already announces`,
+        ).toBe(true);
+      }
+      // The checklist renderer must be able to produce the release checklist
+      // from this source alone (no hand-kept twin to contradict it).
+      const rendered = renderChecklist(matrix, id);
+      expect(rendered).toContain(platform.announced);
+      for (const item of list) expect(rendered).toContain(item.item);
+    }
+  });
+
+  it("agrees with the human-readable doc about every announced level", () => {
+    const doc = fs.readFileSync(path.join(DESKTOP_ROOT, "docs", "platform-support.md"), "utf8");
+    for (const [id, platform] of Object.entries(matrix.platforms)) {
+      const row = new RegExp(`\\|\\s*\`${id}\`[^\\n]*\`${platform.announced}\``);
+      expect(
+        row.test(doc),
+        `docs/platform-support.md has no summary row stating ${id} = ${platform.announced}`,
+      ).toBe(true);
+    }
+    expect(
+      doc.includes(matrix.updated),
+      "docs/platform-support.md does not carry the matrix's updated date",
+    ).toBe(true);
+  });
+});

--- a/uxnandesktop/tests/quality-matrix.json
+++ b/uxnandesktop/tests/quality-matrix.json
@@ -358,6 +358,26 @@
       "gaps": "A signed-artifact round trip is L5 by nature."
     },
     {
+      "id": "platform-claims",
+      "flow": "Platform claims and the release gate",
+      "owner": "desktop",
+      "covered": [
+        "L1"
+      ],
+      "planned": [
+        "L5"
+      ],
+      "evidence": {
+        "L1": "tests/platform-support.test.mjs (the matrix checked against the repo + the announced-level gate), scripts/platform-support.mjs (the release-workflow gate)"
+      },
+      "platforms": {
+        "windows": "gate in the required suite",
+        "macos": "gate in the required suite",
+        "linux": "gate in the required suite"
+      },
+      "gaps": "The L5 half is the per-platform manual checklists inside tests/platform-support.json — macOS/Linux hardware is not available, which is exactly what the matrix records."
+    },
+    {
       "id": "resource-footprint",
       "flow": "Resource footprint",
       "owner": "desktop",


### PR DESCRIPTION
## What

Turns "supported" from a word into a recorded, gated state. Every platform×feature pair now carries one of six escalating levels — `code-only`, `builds`, `smoke`, `validated`, `signed`, `release-ready` — with the evidence (date, commit, hardware, tester) that demonstrates it.

- **Machine-readable source of truth** (`tests/platform-support.json`) + the human-readable `docs/platform-support.md`, and they cannot drift apart: `tests/platform-support.test.mjs` runs in the required `npm test` gate — every cited evidence file must exist, `smoke`+ requires run metadata, a platform's announced level can never exceed its weakest core feature, and the doc must agree with the source.
- **Release gate**: `scripts/platform-support.mjs gate` refuses a release whose announced state exceeds the evidence — wired into `release-desktop.yml` as a job the installers depend on. `checklist` renders each platform's path forward from the same source.
- **Current honest states**: Windows 11 x64 **`smoke`** (E2E suite green locally, approved 11-scenario resource baseline, the maintainer's installed daily-driver build); macOS (both arches) and Linux **`builds`** — CI compiles and runs the full suites on their runners, but no run on real hardware has ever been recorded, and the matrix says so.
- **Platform-sensitive negative tests**: the keep-awake state machine (previously untested) under a fake inhibitor + one host-OS toggle per CI runner; monitor-aware pet placement (unplugged display, zero-monitors race, scaled/offset monitors); persistence failing cleanly on an obstructed data dir and a corrupt state file; injectable user-agent OS detection.
- **Updater failure & rollback path + key/certificate procedure** documented in `docs/updates.md` (verified against the updater plugin's source: a tampered artifact fails signature verification inside download; nothing is ever staged).
- Full OS-specific code inventory (every `#[cfg]`/platform branch → its test or its checklist item) as a doc appendix.

## Verification (merged tree, local run)

- `npm run check`: 1493 files, 0 errors / 0 warnings
- `npm test`: 667 passed (including the new matrix + negative tests)
- `cargo test`: 443 (430 unit + 13 integration); `clippy -D warnings` + `fmt --check` clean
- Windows bundles built as `builds` evidence (MSI + NSIS, hashes recorded); nothing was installed over the running instance

## Honest gaps (tracked in the matrix + `FOR-DEV.md` / `FOR-HUMAN.md`)

macOS/Linux physical validation awaits hardware (checklists ready); Windows `validated` is blocked by the unscripted install/upgrade/uninstall cycle; `signed` needs the paid certificates.