### PR TITLE
ci(desktop): retire the E2E nightly, with the measured reason it never passed

### DIFF
--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -3,12 +3,36 @@ name: E2E — Desktop (uxnandesktop)
 # The end-to-end layer: a real release binary, a real WebView2, real IPC.
 # Documented in `uxnandesktop/tests/e2e/README.md`.
 #
-# On demand and nightly, never on a PR — and deliberately **not yet required**.
-# It needs a release build (minutes), a WebDriver matched to the runner's
-# WebView2, and a machine with no other uxnan running. Making it blocking before
-# it has a track record on this runner is how a gate earns a reputation for
-# false failures and gets switched off; the plan is to require it once it has run
-# green for a fortnight (tracked in `uxnandesktop/FOR-DEV.md`).
+# **On demand only — this suite does not pass on a GitHub-hosted runner, and the
+# schedule was removed rather than left failing every night.** E2E is a local
+# layer today (`npm run test:e2e`, green on Windows); this workflow stays so the
+# next attempt costs a dispatch instead of a rebuild.
+#
+# What four failed runs plus `npm run test:e2e:diagnose` established, so nobody
+# pays for it twice:
+#
+#   * every spec dies in `session not created: DevToolsActivePort file doesn't
+#     exist`, before any assertion — the WebDriver attach, not the app;
+#   * NOT the app: `resource-benchmarks.yml` is green on this same image, and the
+#     diagnosis sees the webview come up under automation too (6 processes:
+#     browser, gpu, renderer, utilities);
+#   * NOT the driver pairing: `setup-driver.mjs` fetches the matching driver here
+#     as it does locally;
+#   * NOT the runtime version: forcing the runner to 151.0.4129.59 — byte for
+#     byte what the green local machine runs — changed nothing;
+#   * NOT `webviewOptions.userDataFolder`: it made no difference, and locally
+#     `DevToolsActivePort` is absent from that folder on a *passing* run anyway.
+#
+# What it IS: the browser process comes up with **no `--remote-debugging-port`**
+# and none of msedgedriver's other switches, so nothing was ever listening —
+# `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` is dropped on this runner while the
+# same variable is honoured locally. The env-var channel itself works (the
+# webview does pick up msedgedriver's `--user-data-dir`), so it is the additional
+# *arguments* specifically. A machine policy is the open lead — the steps below
+# print the Edge/WebView2 policy keys, which are empty on the machine where this
+# passes; the other path is the app passing the switch itself through wry's
+# `additional_browser_args` rather than the environment. Both in
+# `uxnandesktop/FOR-DEV.md`.
 #
 # Windows only. `tauri-driver` supports Linux and does not support macOS, and
 # neither has been exercised here — this workflow does not claim a platform
@@ -21,9 +45,6 @@ on:
         description: "Spec file filter (empty runs them all)"
         required: false
         default: ""
-  schedule:
-    # 03:40 UTC, off the hour so it does not queue behind everyone else's cron.
-    - cron: "40 3 * * *"
 
 concurrency:
   group: e2e-desktop
@@ -82,15 +103,16 @@ jobs:
       # bootstrapper installs the current version, and the driver step below
       # re-reads the registry, so the pairing stays matched with nothing pinned.
       # If a green run proves this was not the cause, this step comes out again.
-      # Never fatal: provisioning that fails leaves the image's runtime in place
-      # and the run still reports what it found, which is the whole point.
+      # This was the runtime hypothesis, and it is **disproved**: with the
+      # `edgeupdate` service started the bootstrapper does work (150.0.4078.105 →
+      # 151.0.4129.59, the exact version the suite passes on locally) and the
+      # attach failed exactly as before. The step stays anyway, for two reasons:
+      # a retry should not be confounded by a stale runtime, and its policy dump
+      # is the live evidence for the open lead — those keys are empty on the
+      # machine where this suite is green.
       #
-      # The first attempt at this was a silent no-op — the bootstrapper returned
-      # in 0.7 s with no exit code and the version did not move — so the step now
-      # reports the state of the update path it depends on (the `edgeupdate`
-      # service and the EdgeUpdate policies, both commonly disabled on CI images)
-      # before trying. A no-op that says why is worth a cycle; one that says
-      # nothing costs one.
+      # Never fatal: provisioning that fails leaves the image's runtime in place
+      # and the run still reports what it found.
       - name: Update the WebView2 Runtime
         shell: pwsh
         run: |
@@ -100,12 +122,22 @@ jobs:
 
           Get-Service -Name 'edgeupdate*' -EA SilentlyContinue |
             ForEach-Object { "service {0}: {1} ({2})" -f $_.Name, $_.Status, $_.StartType }
-          $policy = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\EdgeUpdate' -EA SilentlyContinue
-          if ($policy) {
-            $policy.PSObject.Properties |
-              Where-Object { $_.Name -notlike 'PS*' } |
-              ForEach-Object { "policy {0} = {1}" -f $_.Name, $_.Value }
-          } else { "policy: none set" }
+          # Every policy that could plausibly strip a switch from the browser
+          # command line. All three are empty on the machine where the suite
+          # passes, which is why a value here would be the answer.
+          foreach ($path in @(
+            'HKLM:\SOFTWARE\Policies\Microsoft\EdgeUpdate',
+            'HKLM:\SOFTWARE\Policies\Microsoft\Edge',
+            'HKLM:\SOFTWARE\Policies\Microsoft\EdgeWebView',
+            'HKLM:\SOFTWARE\Policies\Microsoft\Windows\WebView2'
+          )) {
+            $policy = Get-ItemProperty -Path $path -EA SilentlyContinue
+            if ($policy) {
+              $policy.PSObject.Properties |
+                Where-Object { $_.Name -notlike 'PS*' } |
+                ForEach-Object { "policy {0}\{1} = {2}" -f (Split-Path $path -Leaf), $_.Name, $_.Value }
+            } else { "policy {0}: none set" -f (Split-Path $path -Leaf) }
+          }
 
           try {
             # The updater is a service on this box; the bootstrapper cannot move

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -88,14 +88,30 @@ jobs:
             npm run test:e2e
           fi
 
+      # After the suite, never before it: the diagnosis launches the app, which
+      # creates the webview's user-data folder — and "a runner that has never
+      # launched this app" is one of the differences it exists to measure. It
+      # cannot fail the job; it explains one.
+      - name: Diagnose the WebDriver attach
+        if: always()
+        continue-on-error: true
+        run: npm run test:e2e:diagnose
+
       # Evidence, not noise: a screenshot and the page source per failed test,
-      # plus the driver log. The suite writes nothing else, and the profile it
-      # used is a temp directory that never leaves the runner.
+      # plus the driver logs and the diagnosis report. The suite writes nothing
+      # else, and the profile it used is a temp directory that never leaves the
+      # runner.
+      #
+      # `include-hidden-files` is not optional here: the directory is
+      # `.artifacts`, and upload-artifact skips dot-paths by default — every run
+      # so far uploaded nothing and logged "No files were found", which is why
+      # four failed nightlies left no evidence to read.
       - name: Upload failure artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: e2e-artifacts-windows
           path: uxnandesktop/tests/e2e/.artifacts/
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -71,6 +71,38 @@ jobs:
       - name: Build a release binary with its frontend embedded
         run: npm run bench:build
 
+      # The runner image ships WebView2 150.0.4078.105, and that runtime is the
+      # last standing suspect for a failure the diagnosis narrowed to one step:
+      # the app launches and creates its webview there (the resource benchmarks
+      # see `msedgewebview2.exe` in the tree), but it never opens the
+      # remote-debugging port, so no session can be created. The same code, the
+      # same binary and the same experiment on WebView2 151 answer in 611 ms.
+      #
+      # So the runtime is updated rather than accepted: the Evergreen
+      # bootstrapper installs the current version, and the driver step below
+      # re-reads the registry, so the pairing stays matched with nothing pinned.
+      # If a green run proves this was not the cause, this step comes out again.
+      # Never fatal: provisioning that fails leaves the image's runtime in place
+      # and the run still reports what it found, which is the whole point.
+      - name: Update the WebView2 Runtime
+        shell: pwsh
+        run: |
+          $key = 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'
+          $version = { (Get-ItemProperty -Path $key -EA SilentlyContinue).pv }
+          "before: $(& $version)"
+          try {
+            $exe = Join-Path $env:RUNNER_TEMP 'MicrosoftEdgeWebview2Setup.exe'
+            # The Evergreen bootstrapper is the supported way to move the runtime
+            # forward, and a no-op on a machine that is already current.
+            Invoke-WebRequest -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile $exe
+            & $exe '/silent' '/install'
+            if ($LASTEXITCODE -ne 0) { "installer exited $LASTEXITCODE — staying on the image's runtime" }
+          } catch {
+            "could not update the runtime ($($_.Exception.Message)) — staying on the image's"
+          }
+          "after:  $(& $version)"
+          $global:LASTEXITCODE = 0
+
       # Reads the runner's installed WebView2 version and fetches the matching
       # driver. Not pinned in a file on purpose — the runner image updates its
       # runtime, and a pinned version would break on their schedule.

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -84,19 +84,41 @@ jobs:
       # If a green run proves this was not the cause, this step comes out again.
       # Never fatal: provisioning that fails leaves the image's runtime in place
       # and the run still reports what it found, which is the whole point.
+      #
+      # The first attempt at this was a silent no-op — the bootstrapper returned
+      # in 0.7 s with no exit code and the version did not move — so the step now
+      # reports the state of the update path it depends on (the `edgeupdate`
+      # service and the EdgeUpdate policies, both commonly disabled on CI images)
+      # before trying. A no-op that says why is worth a cycle; one that says
+      # nothing costs one.
       - name: Update the WebView2 Runtime
         shell: pwsh
         run: |
           $key = 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}'
           $version = { (Get-ItemProperty -Path $key -EA SilentlyContinue).pv }
           "before: $(& $version)"
+
+          Get-Service -Name 'edgeupdate*' -EA SilentlyContinue |
+            ForEach-Object { "service {0}: {1} ({2})" -f $_.Name, $_.Status, $_.StartType }
+          $policy = Get-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\EdgeUpdate' -EA SilentlyContinue
+          if ($policy) {
+            $policy.PSObject.Properties |
+              Where-Object { $_.Name -notlike 'PS*' } |
+              ForEach-Object { "policy {0} = {1}" -f $_.Name, $_.Value }
+          } else { "policy: none set" }
+
           try {
+            # The updater is a service on this box; the bootstrapper cannot move
+            # anything while it is disabled, which is how the first attempt
+            # "succeeded" without changing the version.
+            Get-Service -Name 'edgeupdate' -EA SilentlyContinue |
+              Set-Service -StartupType Manual -EA SilentlyContinue
+            Start-Service -Name 'edgeupdate' -EA SilentlyContinue
+
             $exe = Join-Path $env:RUNNER_TEMP 'MicrosoftEdgeWebview2Setup.exe'
-            # The Evergreen bootstrapper is the supported way to move the runtime
-            # forward, and a no-op on a machine that is already current.
             Invoke-WebRequest -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile $exe
-            & $exe '/silent' '/install'
-            if ($LASTEXITCODE -ne 0) { "installer exited $LASTEXITCODE — staying on the image's runtime" }
+            & $exe '/silent' '/install' | Out-Null
+            "installer exit code: '$LASTEXITCODE'"
           } catch {
             "could not update the runtime ($($_.Exception.Message)) — staying on the image's"
           }

--- a/.github/workflows/verify-desktop.yml
+++ b/.github/workflows/verify-desktop.yml
@@ -73,8 +73,10 @@ jobs:
       # mounting and wiring failures that unit tests structurally cannot.
       #
       # End-to-end (L4) is deliberately NOT here: it needs a release binary, a
-      # version-matched WebDriver and a machine with no other uxnan running. It
-      # runs on demand and nightly in `e2e-desktop.yml`.
+      # version-matched WebDriver and a machine with no other uxnan running — and
+      # it does not pass on a hosted runner at all (the attach never gets a
+      # debugging port; the evidence is in `e2e-desktop.yml`'s header). It is a
+      # local layer, kept dispatch-only there.
       - name: Frontend unit + component tests (Vitest)
         run: npm test
 

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -76,7 +76,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   installs the current runtime and `setup-driver.mjs` re-reads the registry
   afterwards, keeping the driver matched with nothing pinned. The step cannot
   fail the job: a failed update leaves the image's runtime and the run still
-  reports what it found.
+  reports what it found — as the first attempt did, returning in 0.7 s without
+  moving the version, so the step now also reports the `edgeupdate` service and
+  policy state it depends on.
+- **The diagnosis now samples the app's process tree while the attach is in
+  flight**, which is what separates three failures that look identical from
+  outside: no webview process at all (the automation switches prevent it), a
+  webview whose command line never received `--remote-debugging-port` (the
+  runtime dropped it), or one that was asked for the port and refused to listen.
+  Each points at a different fix.
 
 ## [0.0.26] - 2026-08-03
 

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -49,6 +49,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   budget is carried to the next tick instead of being dropped (the projects store
   hands each change over exactly once, so nothing re-announced it).
 
+### Changed — E2E is a local layer, and the nightly that never passed is retired
+
+- **`e2e-desktop.yml` no longer runs on a schedule.** It never passed on a
+  GitHub-hosted runner — every run, all 9 specs dying in `session not created:
+  DevToolsActivePort file doesn't exist` before any assertion — and a permanently
+  red nightly only teaches people to ignore CI mail. The workflow stays,
+  dispatch-only, so the next attempt costs a dispatch rather than a rebuild.
+  Measured cause: on the runner the browser process comes up with **no
+  `--remote-debugging-port`**, so nothing is ever listening;
+  `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` is dropped there and honoured locally,
+  while the env-var channel itself works (the webview does take msedgedriver's
+  `--user-data-dir`). Ruled out with evidence: the driver pairing, the app and
+  its graphics environment, the runtime version (the runner was forced to the
+  same 151.0.4129.59 the suite passes on) and `webviewOptions.userDataFolder`.
+  The docs that claimed a nightly or runner smoke — `docs/testing.md`,
+  `docs/platform-support.md`, `architecture/04-technical-reference.md`,
+  `verify-desktop.yml` — now say what actually happens; the two remaining leads
+  are in `FOR-DEV.md`.
+
 ### Fixed — the nightly E2E failure can finally be read
 
 - **The E2E workflow uploaded no evidence at all.** Its artifact step pointed at

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -49,6 +49,26 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   budget is carried to the next tick instead of being dropped (the projects store
   hands each change over exactly once, so nothing re-announced it).
 
+### Fixed — the nightly E2E failure can finally be read
+
+- **The E2E workflow uploaded no evidence at all.** Its artifact step pointed at
+  `tests/e2e/.artifacts/`, and `upload-artifact` skips dot-paths unless
+  `include-hidden-files` is set — so all four failed nightlies logged "No files
+  were found" and threw away the driver log they existed to preserve. The
+  screenshots, page sources, driver logs and the report below now leave the
+  runner.
+- **`npm run test:e2e:diagnose` explains a session that never starts.** Every
+  scheduled run so far died in `session not created: DevToolsActivePort file
+  doesn't exist` — the WebDriver attach, not the app, which the resource
+  benchmarks prove launches on that same runner with a full WebView2 process
+  tree. The new `tests/e2e/diagnose-session.mjs` measures the two things that
+  failure leaves open: whether the app exposes a remote-debugging endpoint at
+  all, and whether `msedgedriver` accepts a session when the capabilities carry
+  the webview's real `userDataFolder` (verbose driver logs included). It runs
+  after the suite on CI, cannot fail the job, and refuses to run beside another
+  uxnan — arming its name-based reaper only once that guard has passed, so it
+  can never take down an app you had open.
+
 ## [0.0.26] - 2026-08-03
 
 ### Added — the app now records its own failures

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -68,6 +68,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   after the suite on CI, cannot fail the job, and refuses to run beside another
   uxnan — arming its name-based reaper only once that guard has passed, so it
   can never take down an app you had open.
+- **The E2E workflow now updates the runner's WebView2 Runtime before testing.**
+  Run side by side, the diagnosis put the failure in one place: the app launches
+  and creates its webview on the runner, but never opens the remote-debugging
+  port — where the same binary and the same experiment answer in 611 ms on
+  WebView2 151. The image ships 150.0.4078.105, so the Evergreen bootstrapper
+  installs the current runtime and `setup-driver.mjs` re-reads the registry
+  afterwards, keeping the driver matched with nothing pinned. The step cannot
+  fail the job: a failed update leaves the image's runtime and the run still
+  reports what it found.
 
 ## [0.0.26] - 2026-08-03
 

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -1032,9 +1032,37 @@ go stale; these are the ones worth calling out.
         on that machine, and does a session succeed when the capabilities carry
         the webview's real `userDataFolder`.
 
-      Next: read the first diagnosis artifact and act on its verdict. Iterating
-      still costs a push-per-attempt CI cycle (~35 min, dominated by the release
-      build).
+      **What the first diagnosis (2026-08-04) measured**, runner against this
+      machine, same experiment, the release binary that ran the suite green:
+
+      | | local (green) | runner (red) |
+      |---|---|---|
+      | remote-debugging endpoint | answers in **611 ms** | never, at 90 s |
+      | session, capabilities as sent today | created in **956 ms** | refused at 60 s |
+      | session + `webviewOptions.userDataFolder` | created in 748 ms | refused at 60 s |
+      | WebView2 / msedgedriver | 151.0.4129.59 | 150.0.4078.105 |
+
+      - **`userDataFolder` is not the fix** — it changed nothing on the runner,
+        and locally `DevToolsActivePort` is **not** in that folder either while
+        sessions still start in under a second. `msedgedriver` finds the port
+        another way; that folder was never the problem.
+      - **Not slowness.** 611 ms against silence at 90 s is a hard failure.
+      - **The app is not the problem, and neither is the graphics environment**:
+        WebView2 starts on the runner (the benchmarks see `msedgewebview2.exe`
+        in the tree with real RSS). What never comes up is the *debugging port*
+        — a selective failure of the automation layer.
+      - **Last suspect standing: the runtime version.** The image ships WebView2
+        150.0.4078.105; the machine where all of this is green runs 151. The
+        workflow now installs the current Evergreen runtime before the suite —
+        with `setup-driver.mjs` re-reading the registry afterwards, so the
+        pairing stays matched and nothing is pinned.
+
+      Next: if that run is green, the provisioning step stays and this item is
+      down to the fortnight of track record. If it is still red, the open
+      question is whether `msedgewebview2.exe` spawns *at all* under the
+      automation switches (it does under a plain launch) — capture the tree from
+      inside the diagnosis. Iterating costs a push-per-attempt CI cycle (~35 min,
+      dominated by the release build).
 - [ ] **Multi-window journeys are unproven** with this driver — the pet overlay
       and the browser panel are both separate windows. Find out before promising
       coverage for either.

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -1003,79 +1003,61 @@ go stale; these are the ones worth calling out.
       has the old shapes (missing `isGit`, no terminal profiles, tabs without a
       `kind`, a truncated file) and nothing consumes them yet — so the migration
       path is covered in Rust but never end to end.
-- [ ] **Make E2E a required gate** once `e2e-desktop.yml` has run green for a
-      fortnight. Blocking before it has a track record on that runner is how a
-      gate earns a reputation for false failures. **It has never been green on
-      CI**: the four scheduled runs so far (2026-08-01 … 2026-08-04) failed
-      identically — all 9 specs dying in `Failed to create a session` before a
-      single assertion — while the same suite runs green locally.
+- [ ] **E2E on a hosted runner: measured, unresolved, and no longer on a
+      schedule.** `e2e-desktop.yml` never passed on `windows-latest` — four
+      nightlies plus three diagnostic dispatches (2026-08-01 … 08-04), all 9
+      specs dying in `session not created: DevToolsActivePort file doesn't exist`
+      before any assertion, while the same suite is green locally. The cron is
+      **removed** (dispatch-only): a permanently red nightly teaches people to
+      ignore CI mail. **E2E is a local layer today**, and the required gate stays
+      out of reach until a runner can attach at all.
 
-      What the logs have since settled, so nobody re-investigates it:
-
-      - **Not the driver pairing**, the standing first suspect, now ruled out.
-        `test:e2e:setup` resolves and fetches the matching driver on the runner
-        too (`fetching WebDriver 150.0.4078.105… ready`), and a mismatch fails
-        with an explicit "only supports version" message. The real error is
-        `session not created: DevToolsActivePort file doesn't exist`, which is
-        about the **attach**, not the versions.
-      - **Not the app.** `resource-benchmarks.yml` is green on the same runner
-        image on the same nights, launching the same release binary and
-        recording a full WebView2 process tree (R01: ~425 MB own RSS, ~513 MB
-        managed). The app runs there; only the automation attach fails.
-      - **The failures left no evidence**, which is part of why this stalled:
-        the upload step pointed at `.artifacts/`, and upload-artifact skips
-        dot-paths unless `include-hidden-files` is set — so every run logged
-        "No files were found" and discarded the driver log. Fixed, together with
-        `npm run test:e2e:diagnose` (`tests/e2e/diagnose-session.mjs`), which now
-        runs after the suite on CI and answers the two questions the failure
-        leaves open, with data: does the app expose a remote-debugging endpoint
-        on that machine, and does a session succeed when the capabilities carry
-        the webview's real `userDataFolder`.
-
-      **What the first diagnosis (2026-08-04) measured**, runner against this
-      machine, same experiment, the release binary that ran the suite green:
+      **The cause, measured** (`npm run test:e2e:diagnose`, both sides, same
+      release binary): on the runner the browser process comes up with **no
+      `--remote-debugging-port`** and none of msedgedriver's other switches, so
+      nothing was ever listening. `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` is
+      dropped there and honoured here. The env-var channel itself is fine — the
+      webview does pick up msedgedriver's `--user-data-dir`
+      (`C:\Windows\SystemTemp\scoped_dir…`) — so it is the additional
+      *arguments* specifically.
 
       | | local (green) | runner (red) |
       |---|---|---|
-      | remote-debugging endpoint | answers in **611 ms** | never, at 90 s |
-      | session, capabilities as sent today | created in **956 ms** | refused at 60 s |
-      | session + `webviewOptions.userDataFolder` | created in 748 ms | refused at 60 s |
-      | WebView2 / msedgedriver | 151.0.4129.59 | 150.0.4078.105 |
+      | remote-debugging endpoint | **611 ms** | never, at 90 s |
+      | session, capabilities as sent | **956 ms** | refused at 60 s |
+      | session + `webviewOptions.userDataFolder` | 748 ms | refused at 60 s |
+      | webview processes under automation | — | **6** (browser, gpu, renderer, …) |
+      | of those carrying `--remote-debugging-port` | — | **0** |
 
-      - **`userDataFolder` is not the fix** — it changed nothing on the runner,
-        and locally `DevToolsActivePort` is **not** in that folder either while
-        sessions still start in under a second. `msedgedriver` finds the port
-        another way; that folder was never the problem.
-      - **Not slowness.** 611 ms against silence at 90 s is a hard failure.
-      - **The app is not the problem, and neither is the graphics environment**:
-        WebView2 starts on the runner (the benchmarks see `msedgewebview2.exe`
-        in the tree with real RSS). What never comes up is the *debugging port*
-        — a selective failure of the automation layer.
-      - **Last suspect standing: the runtime version.** The image ships WebView2
-        150.0.4078.105; the machine where all of this is green runs 151. The
-        workflow now installs the current Evergreen runtime before the suite —
-        with `setup-driver.mjs` re-reading the registry afterwards, so the
-        pairing stays matched and nothing is pinned.
+      Ruled out, with the evidence, so none of it is re-investigated:
 
-      **The runtime update did not take (2026-08-04, second run).** The Evergreen
-      bootstrapper returned in 0.7 s with an empty exit code and the version did
-      not move (`before` and `after` both 150.0.4078.105), so the runtime
-      hypothesis is still **untested** — not confirmed, not ruled out. The step
-      now reports the update path it depends on (the `edgeupdate` service and the
-      EdgeUpdate policies, commonly disabled on CI images) and tries to start it
-      first; if the image will not budge, forcing a fixed-version runtime through
-      `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` is the way that does not need the
-      updater at all.
+      - **The driver pairing.** `setup-driver.mjs` fetches the matching driver on
+        the runner as it does locally, and a mismatch says so explicitly.
+      - **The app, and the graphics environment.** `resource-benchmarks.yml` is
+        green on the same image, and the diagnosis sees the webview come up
+        under automation too — 6 processes, renderer and GPU included.
+      - **The runtime version.** With the `edgeupdate` service started (it ships
+        `Stopped`, which is why the first attempt was a silent no-op) the
+        bootstrapper does work: the runner ran 151.0.4129.59, byte for byte what
+        the green machine runs, and failed identically.
+      - **`webviewOptions.userDataFolder`.** No difference — and locally
+        `DevToolsActivePort` is absent from that folder on a *passing* run, so it
+        was never the mechanism.
 
-      Next, and the reason the following cycle is worth spending: the diagnosis
-      now samples the app's **process tree** while the attach is in flight, which
-      separates three failures that look identical from outside — no webview
-      process at all (the switches prevent it), a webview whose command line
-      lacks `--remote-debugging-port` (the runtime dropped what
-      `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` asked for), or a webview that was
-      asked and refused to listen (the machine, not the arguments). Each points
-      at a different fix. Iterating costs a push-per-attempt CI cycle (~35 min,
-      dominated by the release build).
+      Two leads, if CI E2E is ever worth another attempt:
+
+      1. **A machine policy stripping the switch.** `HKLM\SOFTWARE\Policies\
+         Microsoft\{Edge,EdgeWebView,EdgeUpdate}` and `…\Windows\WebView2` are
+         **empty** on the machine where the suite passes; the workflow now dumps
+         all four, so one dispatch answers it.
+      2. **Stop routing the switch through the environment.** The app could pass
+         it itself via wry's `additional_browser_args` / Tauri's
+         `additionalBrowserArgs` when a `TAURI_WEBVIEW_AUTOMATION` build asks for
+         it. That is a change to the shipped binary for testability's sake, so it
+         needs a deliberate decision, not a drive-by patch.
+
+      Each attempt costs a push-per-dispatch CI cycle (~35 min, dominated by the
+      release build).
 - [ ] **Multi-window journeys are unproven** with this driver — the pet overlay
       and the browser panel are both separate windows. Find out before promising
       coverage for either.
@@ -1138,8 +1120,10 @@ when an announced state exceeds the evidence. Announced today: **Windows
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
   keeps the default `{ubuntu, windows}`. 488 Rust + 764 Vitest tests (both
-  projects: pure logic and components). E2E runs in its own on-demand/nightly
-  Windows workflow (`e2e-desktop.yml`), deliberately outside the required gate.
+  projects: pure logic and components). E2E has its own **dispatch-only** Windows
+  workflow (`e2e-desktop.yml`), outside the required gate — and it does not pass
+  on a hosted runner at all: E2E is a local layer, for the measured reason in the
+  open item above.
 - ✅ **`release-desktop.yml`** — `tauri-action` bundles on a `desktop-*-v*` tag →
   draft GitHub Release, **and signs the updater artifacts** when the signing secrets
   are set. The build now also depends on the **platform-support gate**

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -1057,11 +1057,24 @@ go stale; these are the ones worth calling out.
         with `setup-driver.mjs` re-reading the registry afterwards, so the
         pairing stays matched and nothing is pinned.
 
-      Next: if that run is green, the provisioning step stays and this item is
-      down to the fortnight of track record. If it is still red, the open
-      question is whether `msedgewebview2.exe` spawns *at all* under the
-      automation switches (it does under a plain launch) — capture the tree from
-      inside the diagnosis. Iterating costs a push-per-attempt CI cycle (~35 min,
+      **The runtime update did not take (2026-08-04, second run).** The Evergreen
+      bootstrapper returned in 0.7 s with an empty exit code and the version did
+      not move (`before` and `after` both 150.0.4078.105), so the runtime
+      hypothesis is still **untested** — not confirmed, not ruled out. The step
+      now reports the update path it depends on (the `edgeupdate` service and the
+      EdgeUpdate policies, commonly disabled on CI images) and tries to start it
+      first; if the image will not budge, forcing a fixed-version runtime through
+      `WEBVIEW2_BROWSER_EXECUTABLE_FOLDER` is the way that does not need the
+      updater at all.
+
+      Next, and the reason the following cycle is worth spending: the diagnosis
+      now samples the app's **process tree** while the attach is in flight, which
+      separates three failures that look identical from outside — no webview
+      process at all (the switches prevent it), a webview whose command line
+      lacks `--remote-debugging-port` (the runtime dropped what
+      `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` asked for), or a webview that was
+      asked and refused to listen (the machine, not the arguments). Each points
+      at a different fix. Iterating costs a push-per-attempt CI cycle (~35 min,
       dominated by the release build).
 - [ ] **Multi-window journeys are unproven** with this driver — the pet overlay
       and the browser panel are both separate windows. Find out before promising

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -1005,15 +1005,36 @@ go stale; these are the ones worth calling out.
       path is covered in Rust but never end to end.
 - [ ] **Make E2E a required gate** once `e2e-desktop.yml` has run green for a
       fortnight. Blocking before it has a track record on that runner is how a
-      gate earns a reputation for false failures. **Its first scheduled run
-      (2026-08-01) failed as pure infrastructure**: all 9 specs died identically
-      in `Failed to create a session` (timeout POSTing `127.0.0.1:4444/session`)
-      — tauri-driver never accepted a session on `windows-latest`, so no spec
-      even started; the same 9-spec suite ran green locally the same night. The
-      runner needs provisioning work (msedgedriver ↔ installed-WebView2 version
-      matching is the first suspect — locally `test:e2e:setup` resolves the
-      driver against the machine's WebView2; the runner's Edge/WebView2 pairing
-      is unverified), and iterating on it needs push-per-attempt CI cycles.
+      gate earns a reputation for false failures. **It has never been green on
+      CI**: the four scheduled runs so far (2026-08-01 … 2026-08-04) failed
+      identically — all 9 specs dying in `Failed to create a session` before a
+      single assertion — while the same suite runs green locally.
+
+      What the logs have since settled, so nobody re-investigates it:
+
+      - **Not the driver pairing**, the standing first suspect, now ruled out.
+        `test:e2e:setup` resolves and fetches the matching driver on the runner
+        too (`fetching WebDriver 150.0.4078.105… ready`), and a mismatch fails
+        with an explicit "only supports version" message. The real error is
+        `session not created: DevToolsActivePort file doesn't exist`, which is
+        about the **attach**, not the versions.
+      - **Not the app.** `resource-benchmarks.yml` is green on the same runner
+        image on the same nights, launching the same release binary and
+        recording a full WebView2 process tree (R01: ~425 MB own RSS, ~513 MB
+        managed). The app runs there; only the automation attach fails.
+      - **The failures left no evidence**, which is part of why this stalled:
+        the upload step pointed at `.artifacts/`, and upload-artifact skips
+        dot-paths unless `include-hidden-files` is set — so every run logged
+        "No files were found" and discarded the driver log. Fixed, together with
+        `npm run test:e2e:diagnose` (`tests/e2e/diagnose-session.mjs`), which now
+        runs after the suite on CI and answers the two questions the failure
+        leaves open, with data: does the app expose a remote-debugging endpoint
+        on that machine, and does a session succeed when the capabilities carry
+        the webview's real `userDataFolder`.
+
+      Next: read the first diagnosis artifact and act on its verdict. Iterating
+      still costs a push-per-attempt CI cycle (~35 min, dominated by the release
+      build).
 - [ ] **Multi-window journeys are unproven** with this driver — the pet overlay
       and the browser panel are both separate windows. Find out before promising
       coverage for either.

--- a/uxnandesktop/architecture/04-technical-reference.md
+++ b/uxnandesktop/architecture/04-technical-reference.md
@@ -458,8 +458,14 @@ operativa en `docs/testing.md`.
   ninguna puede listar una capa como cubierta y planificada a la vez. Registra lo
   que **no** está probado con el mismo cuidado que lo que sí.
 - **CI**: los tests de componente entran en el gate obligatorio desde el primer
-  día; E2E vive en `e2e-desktop.yml` (bajo demanda y nocturno, Windows), sin
-  bloquear hasta tener historial.
+  día; E2E vive en `e2e-desktop.yml` (Windows, **solo bajo demanda**) y no
+  bloquea. El nocturno se retiró tras medir por qué nunca pasó en un runner de
+  GitHub: allí el proceso navegador arranca **sin `--remote-debugging-port`**,
+  así que nada queda escuchando y la sesión de WebDriver no llega a crearse.
+  Descartados el emparejamiento del driver, la versión del runtime (se forzó el
+  runner al mismo 151.0.4129.59 de la máquina donde sí pasa) y
+  `webviewOptions.userDataFolder`. E2E es, por tanto, una capa **local**; la
+  evidencia está en la cabecera del workflow y en `uxnandesktop/FOR-DEV.md`.
 - **Restricción conocida**: E2E no puede convivir con otra instancia de uxnan
   —misma compartición del proceso navegador de WebView2 que ya afecta al banco de
   recursos— y el teardown mata **por PID, nunca por nombre**, porque una barrida

--- a/uxnandesktop/docs/platform-support.md
+++ b/uxnandesktop/docs/platform-support.md
@@ -100,13 +100,17 @@ CI already gives every platform what a runner can give it:
   Rust + Vitest suites on `{ubuntu-latest, windows-latest, macos-14}` for every
   PR (`ci-desktop.yml`), and `release-desktop.yml` bundles installers for all
   four targets on tags.
-- **Smoke on a runner** — the E2E suite (`e2e-desktop.yml`) runs the real
-  release binary on `windows-latest`, on demand and nightly. `tauri-driver`
-  supports Linux (WebKitWebDriver) but the harness — driver fetch, preflight,
-  teardown — is Windows-specific today and has never executed on Linux; wiring
-  a Linux leg without being able to run it once would be exactly the
-  speculative platform code this matrix exists to prevent, so it stays on the
-  `linux-x64` checklist. `tauri-driver` does not support macOS at all.
+- **Smoke, but not on a runner** — the E2E suite (`e2e-desktop.yml`) drives the
+  real release binary on the **maintainer's Windows machine**, not in CI: on
+  `windows-latest` the WebDriver attach never gets a debugging port, so no
+  session is ever created (measured — the evidence is in that workflow's
+  header). It is dispatch-only there, and the Windows `smoke` claim rests on
+  local runs, which is what its evidence cites. `tauri-driver` supports Linux
+  (WebKitWebDriver) but the harness — driver fetch, preflight, teardown — is
+  Windows-specific today and has never executed on Linux; wiring a Linux leg
+  without being able to run it once would be exactly the speculative platform
+  code this matrix exists to prevent, so it stays on the `linux-x64` checklist.
+  `tauri-driver` does not support macOS at all.
 - **Everything past that needs hardware** — the maintainer has Windows
   hardware only, which is precisely why macOS and Linux sit at `builds`: their
   remaining items (Gatekeeper walkthrough, LaunchAgent/systemd registration,

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -230,7 +230,19 @@ cleanup rules are in [`../tests/e2e/README.md`](../tests/e2e/README.md).
 npm run bench:build      # a release binary with the frontend embedded
 npm run test:e2e:setup   # fetch the WebDriver matching this machine's WebView2
 npm run test:e2e         # close every other uxnan window first
+npm run test:e2e:diagnose  # only when no session starts at all (see below)
 ```
+
+> **This layer is green locally and has never been green on CI.** Every
+> scheduled `e2e-desktop.yml` run so far fails the same way — all 9 specs die in
+> `session not created: DevToolsActivePort file doesn't exist`, before any
+> assertion. It is the WebDriver attach, not the app: the resource benchmarks
+> launch the same release binary on the same runner image and record a full
+> WebView2 process tree. `npm run test:e2e:diagnose` is the instrument for it
+> (what it measures: [`../tests/e2e/README.md`](../tests/e2e/README.md) → *When
+> no session starts at all*); the workflow runs it after the suite and uploads
+> its report. Until that comes back green, E2E stays outside the required gate —
+> tracked in [`../FOR-DEV.md`](../FOR-DEV.md).
 
 **Eight journeys, 24 tests, ~39 s for the suite**, verified green on consecutive
 runs with zero leftover processes: launch, session restore, terminals in a split,

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -233,16 +233,19 @@ npm run test:e2e         # close every other uxnan window first
 npm run test:e2e:diagnose  # only when no session starts at all (see below)
 ```
 
-> **This layer is green locally and has never been green on CI.** Every
-> scheduled `e2e-desktop.yml` run so far fails the same way — all 9 specs die in
-> `session not created: DevToolsActivePort file doesn't exist`, before any
-> assertion. It is the WebDriver attach, not the app: the resource benchmarks
-> launch the same release binary on the same runner image and record a full
-> WebView2 process tree. `npm run test:e2e:diagnose` is the instrument for it
-> (what it measures: [`../tests/e2e/README.md`](../tests/e2e/README.md) → *When
-> no session starts at all*); the workflow runs it after the suite and uploads
-> its report. Until that comes back green, E2E stays outside the required gate —
-> tracked in [`../FOR-DEV.md`](../FOR-DEV.md).
+> **This layer is green locally and does not run on a hosted runner.** Every
+> `e2e-desktop.yml` run failed the same way — all 9 specs dying in `session not
+> created: DevToolsActivePort file doesn't exist`, before any assertion — so the
+> nightly schedule was removed rather than left red, and the workflow is now
+> dispatch-only. It is the WebDriver attach, not the app: the browser process
+> comes up on the runner with **no `--remote-debugging-port`**, so nothing was
+> ever listening, while the identical binary and runtime answer in 611 ms here.
+> Ruled out along the way: the driver pairing, the runtime version (the runner
+> was forced to the same 151.0.4129.59) and `webviewOptions.userDataFolder`.
+> `npm run test:e2e:diagnose` is the instrument that measured all of it
+> ([`../tests/e2e/README.md`](../tests/e2e/README.md) → *When no session starts
+> at all*). E2E therefore stays outside the required gate, and what is still
+> owed is in [`../FOR-DEV.md`](../FOR-DEV.md).
 
 **Eight journeys, 24 tests, ~39 s for the suite**, verified green on consecutive
 runs with zero leftover processes: launch, session restore, terminals in a split,

--- a/uxnandesktop/package.json
+++ b/uxnandesktop/package.json
@@ -19,6 +19,7 @@
     "test:dom": "svelte-kit sync && vitest run --project dom",
     "test:watch": "vitest",
     "test:e2e:setup": "node tests/e2e/setup-driver.mjs",
+    "test:e2e:diagnose": "node tests/e2e/diagnose-session.mjs",
     "test:e2e": "wdio run tests/e2e/wdio.conf.mjs",
     "bench:build": "tauri build --no-bundle",
     "bench": "node scripts/resources/run.mjs",

--- a/uxnandesktop/tests/e2e/README.md
+++ b/uxnandesktop/tests/e2e/README.md
@@ -104,9 +104,17 @@ from the saved HTML.
 
 A different failure, and nothing above explains it: every spec dies in
 `session not created: DevToolsActivePort file doesn't exist` before its first
-assertion. That is the **attach** failing, not the app — and it is what the
-nightly CI run has done since it was added, on a runner where the resource
-benchmarks launch the same binary and record a full WebView2 process tree.
+assertion. That is the **attach** failing, not the app.
+
+It is also what `e2e-desktop.yml` does on every GitHub-hosted runner, which is
+why **this suite is a local layer** and that workflow is dispatch-only. Measured
+there: the browser process starts with **no `--remote-debugging-port`** (the
+webview itself comes up fine — 6 processes), so nothing is listening.
+`WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` is dropped on that machine and honoured
+here. Ruled out: the driver pairing, the runtime version (the runner was forced
+to the same 151.0.4129.59) and `webviewOptions.userDataFolder`. The leads that
+remain are in [`../../FOR-DEV.md`](../../FOR-DEV.md) — don't spend a cycle
+re-deriving any of the above.
 
 ```bash
 npm run test:e2e:diagnose

--- a/uxnandesktop/tests/e2e/README.md
+++ b/uxnandesktop/tests/e2e/README.md
@@ -133,6 +133,15 @@ binary, and no other uxnan running, which it refuses to start without. It reaps
 only what it started, and the name-based sweep is armed **only** after that
 guard passes, so a failure before it can never touch an app you had open.
 
+**A healthy machine, for comparison** (WebView2 151.0.4129.59, 2026-08-04):
+the endpoint answers in **611 ms** and a session is created in **956 ms**. A
+report that instead shows silence at 90 s is not a slow machine — the runner's
+numbers, and what they narrowed the cause to, are in
+[`../../FOR-DEV.md`](../../FOR-DEV.md) → *Make E2E a required gate*. Note that
+`DevToolsActivePort` is absent from the app's own user-data folder **even on a
+green run**: the driver locates the port some other way, so that file missing is
+not itself the fault.
+
 ## Platforms
 
 Windows only for now. `tauri-driver` supports Linux (WebKitWebDriver) and does

--- a/uxnandesktop/tests/e2e/README.md
+++ b/uxnandesktop/tests/e2e/README.md
@@ -100,6 +100,39 @@ app that outlives its session is matched on *our* profile directory, killed, and
 test, plus the driver log. The empty-document case above is diagnosable straight
 from the saved HTML.
 
+### When no session starts at all
+
+A different failure, and nothing above explains it: every spec dies in
+`session not created: DevToolsActivePort file doesn't exist` before its first
+assertion. That is the **attach** failing, not the app — and it is what the
+nightly CI run has done since it was added, on a runner where the resource
+benchmarks launch the same binary and record a full WebView2 process tree.
+
+```bash
+npm run test:e2e:diagnose
+```
+
+`diagnose-session.mjs` runs the experiment the suite cannot run around itself,
+and prints a verdict:
+
+1. **Does the app expose a debugging endpoint at all?** It launches the release
+   binary with the environment `tauri-driver` arranges
+   (`TAURI_WEBVIEW_AUTOMATION`, plus `--remote-debugging-port` through
+   `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`) and asks `/json/version` who
+   answers. Silence means the problem sits below WebDriver.
+2. **Can `msedgedriver` attach?** It drives `msedgedriver` directly — verbose,
+   logging into `.artifacts/` — first with the exact capabilities
+   `tauri-driver` forwards, then with `webviewOptions.userDataFolder` naming the
+   folder Tauri forces the webview to use. Plain failing while scoped succeeds
+   would make the fix a capability the suite can pass, proved rather than
+   guessed.
+
+It asserts nothing and changes nothing; the report is
+`.artifacts/diagnose-session.json`. Same preconditions as the suite — a release
+binary, and no other uxnan running, which it refuses to start without. It reaps
+only what it started, and the name-based sweep is armed **only** after that
+guard passes, so a failure before it can never touch an app you had open.
+
 ## Platforms
 
 Windows only for now. `tauri-driver` supports Linux (WebKitWebDriver) and does

--- a/uxnandesktop/tests/e2e/diagnose-session.mjs
+++ b/uxnandesktop/tests/e2e/diagnose-session.mjs
@@ -112,6 +112,109 @@ async function waitForEndpoint(url, { timeoutMs, pollMs = 250 }) {
 }
 
 /**
+ * The webview processes under an app, and what switches they were given.
+ *
+ * The single most useful reading when a debugging port never opens, because it
+ * separates three failures that look identical from outside:
+ *
+ * - **no webview process at all** — the automation switches are stopping the
+ *   webview from being created (a plain launch does create one, so that would
+ *   be the switches, not the app);
+ * - **a webview without `--remote-debugging-port`** — the runtime dropped what
+ *   `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` asked for, so the port was never
+ *   requested and no driver could attach;
+ * - **a webview *with* the switch and still no port** — the runtime accepted it
+ *   and refused to listen, which points at the machine, not at the arguments.
+ */
+export function webviewProcesses(rootPid) {
+  if (process.platform !== "win32" || !rootPid) return null;
+  const script =
+    "Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,Name,CommandLine | " +
+    "Select-Object ProcessId,ParentProcessId,Name,CommandLine | ConvertTo-Json -Compress -Depth 2";
+  let all;
+  try {
+    const out = spawnSync("powershell.exe", ["-NoProfile", "-Command", script], {
+      encoding: "utf8",
+      windowsHide: true,
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    all = JSON.parse(out.stdout);
+  } catch {
+    return null;
+  }
+
+  const children = new Map();
+  for (const p of all) {
+    const list = children.get(p.ParentProcessId) ?? [];
+    list.push(p);
+    children.set(p.ParentProcessId, list);
+  }
+  const descendants = [];
+  const walk = (pid, depth) => {
+    if (depth > 6) return;
+    for (const child of children.get(pid) ?? []) {
+      descendants.push(child);
+      walk(child.ProcessId, depth + 1);
+    }
+  };
+  walk(rootPid, 0);
+
+  const webviews = descendants.filter((p) => p.Name === "msedgewebview2.exe");
+  const withPort = webviews.filter((p) => /--remote-debugging-port=/.test(p.CommandLine ?? ""));
+  const browser = webviews.find((p) => !/--type=/.test(p.CommandLine ?? ""));
+  return {
+    descendants: descendants.length,
+    webviews: webviews.length,
+    types: webviews.map((p) => (p.CommandLine ?? "").match(/--type=([a-z-]+)/)?.[1] ?? "browser"),
+    withRemoteDebuggingPort: withPort.length,
+    // The browser process's own switches, trimmed: the answer to "did the
+    // arguments survive?" is in here, and nowhere else.
+    browserArgs: (browser?.CommandLine ?? "").slice(0, 1500) || null,
+  };
+}
+
+/**
+ * Take a reading in `ms`, unless the thing being measured finishes first.
+ *
+ * A session that succeeds does so in about a second, and waiting out a sampling
+ * timer to learn nothing would make the healthy path the slow one.
+ */
+function deferredSample(ms, take) {
+  let cancel = () => {};
+  const promise = new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(take()), ms);
+    let done = false;
+    cancel = () => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve(null);
+    };
+    timer.unref?.();
+  });
+  return { promise, cancel };
+}
+
+/** The app under test, by name. Safe only after the guard in `main`: whatever
+ *  answers to that name is what this run started. */
+function firstAppPid() {
+  if (!mayReapByName) return null;
+  const script =
+    "Get-CimInstance Win32_Process -Property ProcessId,Name | " +
+    "Where-Object { $_.Name -eq 'uxnan-desktop.exe' } | " +
+    "Select-Object -First 1 -ExpandProperty ProcessId";
+  try {
+    const out = spawnSync("powershell.exe", ["-NoProfile", "-Command", script], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    return Number((out.stdout ?? "").trim()) || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * A. Does the app expose a remote-debugging endpoint at all?
  *
  * The environment is the one `tauri-driver` arranges: `TAURI_WEBVIEW_AUTOMATION`
@@ -134,9 +237,16 @@ async function probeAppEndpoint(binary, report) {
     },
   });
 
+  // Sampled while the app is still up, in parallel with the wait: after the
+  // timeout the processes are gone and the most useful evidence with them.
+  const treeAt20s = new Promise((resolve) =>
+    setTimeout(() => resolve(webviewProcesses(app.pid)), 20_000),
+  );
+
   const endpoint = await waitForEndpoint(`http://127.0.0.1:${port}/json/version`, {
     timeoutMs: 90_000,
   });
+  const tree = await treeAt20s;
 
   const portFile = path.join(webviewUserDataFolder(), "DevToolsActivePort");
   const portFileContents = fs.existsSync(portFile)
@@ -152,6 +262,7 @@ async function probeAppEndpoint(binary, report) {
     endpointBody: endpoint.ok ? endpoint.body : null,
     endpointError: endpoint.ok ? null : endpoint.error,
     devToolsActivePort: { path: portFile, exists: portFileContents !== null, contents: portFileContents },
+    tree,
   };
 
   await app.quit({ graceMs: 8_000 });
@@ -200,6 +311,12 @@ async function trySession(binary, variant, report) {
     const edgeOptions = { binary, args: [] };
     if (variant.webviewOptions) edgeOptions.webviewOptions = variant.webviewOptions;
 
+    // What `msedgedriver` actually launched, sampled 25 s into its own attach
+    // window — long after the app is up and well before it gives up at 60 s and
+    // kills everything. Safe to find by name: the guard in `main` established
+    // that anything running now is ours.
+    const sample = deferredSample(25_000, () => webviewProcesses(firstAppPid()));
+
     const started = Date.now();
     const res = await httpJson(`http://127.0.0.1:${port}/session`, {
       method: "POST",
@@ -215,6 +332,8 @@ async function trySession(binary, variant, report) {
       },
     });
     result.ms = Date.now() - started;
+    sample.cancel(); // a fast answer needs no post-mortem
+    result.tree = await sample.promise;
 
     const sessionId = res.json?.value?.sessionId ?? res.json?.sessionId ?? null;
     result.created = Boolean(sessionId);
@@ -307,8 +426,29 @@ function verdict(report) {
   if (report.app && !report.app.endpointAnswered) {
     lines.push(
       "The app never exposed a remote-debugging endpoint, so no WebDriver could have attached.",
-      "The problem is below WebDriver: WebView2 automation is not coming up in this environment.",
     );
+    // Which of the three failures it is, from the process tree — see
+    // `webviewProcesses`. Without this the verdict stops at "it did not work".
+    const tree = report.app.tree ?? plain?.tree;
+    if (!tree) {
+      lines.push("No process tree was sampled, so which layer dropped it is still open.");
+    } else if (tree.webviews === 0) {
+      lines.push(
+        "It created no webview process at all, though a plain launch does.",
+        "So the automation switches are stopping the webview from being created.",
+      );
+    } else if (tree.withRemoteDebuggingPort === 0) {
+      lines.push(
+        `It created ${tree.webviews} webview process(es), none carrying --remote-debugging-port.`,
+        "The runtime dropped what WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS asked for: the port was",
+        "never requested, so nothing could have answered. The fix is in how the switch is passed.",
+      );
+    } else {
+      lines.push(
+        `The webview was asked for the port (${tree.withRemoteDebuggingPort} of ${tree.webviews} process(es) carry it)`,
+        "and never listened. That points at the machine or its runtime, not at the arguments.",
+      );
+    }
   } else if (plain?.created) {
     lines.push(
       "A plain session — the exact capabilities tauri-driver sends — was created here.",
@@ -392,11 +532,16 @@ async function main() {
   return 0;
 }
 
-main().then(
-  (code) => process.exit(code),
-  (error) => {
-    process.stderr.write(`${error?.stack ?? error}\n`);
-    reapStrayApps();
-    process.exit(1);
-  },
-);
+// Only when run as a script — the same guard `setup-driver.mjs` uses. Importing
+// this file has to stay side-effect free, so its readings can be exercised
+// against any process tree without launching anything.
+if (process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1]))) {
+  main().then(
+    (code) => process.exit(code),
+    (error) => {
+      process.stderr.write(`${error?.stack ?? error}\n`);
+      reapStrayApps();
+      process.exit(1);
+    },
+  );
+}

--- a/uxnandesktop/tests/e2e/diagnose-session.mjs
+++ b/uxnandesktop/tests/e2e/diagnose-session.mjs
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+/**
+ * Why a WebDriver session refuses to start on a machine where the app is fine.
+ *
+ * The nightly E2E workflow has never been green: every spec dies identically in
+ * `session not created: DevToolsActivePort file doesn't exist`, before a single
+ * assertion runs. That message is about the **attach**, not the app — and on the
+ * same runner, the resource benchmarks launch the same release binary and record
+ * a full WebView2 process tree, so "the app cannot run there" is already ruled
+ * out.
+ *
+ * What is *not* ruled out is everything between: whether WebView2 exposes a
+ * remote-debugging endpoint at all under that session, and whether
+ * `msedgedriver` looks for the port file where WebView2 actually writes it. This
+ * script answers both, on whatever machine it runs on, without the suite in the
+ * way:
+ *
+ *   **A. the app's own endpoint** — launch the release binary with the same
+ *   automation environment `tauri-driver` gives it, then ask
+ *   `http://127.0.0.1:<port>/json/version` who answers. If nothing answers, no
+ *   driver could ever have attached and the problem is below WebDriver.
+ *
+ *   **B. a session, driven directly** — run `msedgedriver` ourselves (verbose,
+ *   logging to `.artifacts/`) and POST the exact capabilities `tauri-driver`
+ *   sends, then the same ones plus `webviewOptions.userDataFolder` pointing at
+ *   the folder Tauri forces the webview to use. If the plain attempt fails and
+ *   the second succeeds, the fix is a capability the suite can pass, and this
+ *   run proved it rather than guessed it.
+ *
+ * It changes nothing and asserts nothing — it prints what happened and exits 0
+ * whenever it managed to run the experiment. A verdict a human reads is the
+ * whole product here, so a failed attach is a *result*, not an error.
+ *
+ *   npm run test:e2e:diagnose
+ *
+ * It refuses to run beside another uxnan, for the reason the whole harness does
+ * (one WebView2 browser process per user-data folder: a second instance attaches
+ * to the first one's), and it reaps only what it started.
+ */
+
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { DRIVER_PATH, driverStatus, installedWebViewVersion } from "./setup-driver.mjs";
+import { findBinary, launchApp } from "../../scripts/resources/lib/app.mjs";
+import { checkNoForeignInstance } from "../../scripts/resources/lib/preflight.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DESKTOP_ROOT = path.resolve(HERE, "..", "..");
+const ARTIFACTS = path.join(HERE, ".artifacts");
+
+/** Tauri forces the webview's user-data folder to `LocalData/<identifier>`
+ *  (`EBWebView` inside it) unless a window config names one, and none does. That
+ *  is where WebView2 writes `DevToolsActivePort`, so it is also the folder
+ *  `msedgedriver` has to be watching. */
+function webviewUserDataFolder() {
+  const identifier = JSON.parse(
+    fs.readFileSync(path.join(DESKTOP_ROOT, "src-tauri", "tauri.conf.json"), "utf8"),
+  ).identifier;
+  const localAppData =
+    process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local");
+  return path.join(localAppData, identifier, "EBWebView");
+}
+
+/** A port nothing is listening on right now. Bound and released rather than
+ *  guessed: a hard-coded 9222 is exactly the port another Chromium on the
+ *  machine already took. */
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function httpJson(url, { method = "GET", body, timeoutMs = 5_000 } = {}) {
+  const res = await fetch(url, {
+    method,
+    headers: body ? { "content-type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const text = await res.text();
+  try {
+    return { status: res.status, json: JSON.parse(text), text };
+  } catch {
+    return { status: res.status, json: null, text };
+  }
+}
+
+/** Poll until `url` answers or the budget runs out; report how long it took. */
+async function waitForEndpoint(url, { timeoutMs, pollMs = 250 }) {
+  const started = Date.now();
+  let lastError = null;
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const res = await httpJson(url, { timeoutMs: 2_000 });
+      if (res.status === 200) return { ok: true, ms: Date.now() - started, body: res.json ?? res.text };
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((r) => setTimeout(r, pollMs));
+  }
+  return { ok: false, ms: Date.now() - started, error: lastError ? String(lastError) : "timed out" };
+}
+
+/**
+ * A. Does the app expose a remote-debugging endpoint at all?
+ *
+ * The environment is the one `tauri-driver` arranges: `TAURI_WEBVIEW_AUTOMATION`
+ * (wry enables automation on it) and `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`
+ * (how a WebView2 host passes Chromium switches). Nothing here is special to the
+ * test suite — it is what `msedgedriver` does, minus `msedgedriver`.
+ */
+async function probeAppEndpoint(binary, report) {
+  const port = await freePort();
+  const dataDir = path.join(HERE, ".profile", "diagnose");
+  fs.rmSync(dataDir, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+
+  const app = launchApp(binary, {
+    dataDir,
+    env: {
+      TAURI_AUTOMATION: "true",
+      TAURI_WEBVIEW_AUTOMATION: "true",
+      WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS: `--remote-debugging-port=${port}`,
+    },
+  });
+
+  const endpoint = await waitForEndpoint(`http://127.0.0.1:${port}/json/version`, {
+    timeoutMs: 90_000,
+  });
+
+  const portFile = path.join(webviewUserDataFolder(), "DevToolsActivePort");
+  const portFileContents = fs.existsSync(portFile)
+    ? fs.readFileSync(portFile, "utf8").trim().split(/\r?\n/)
+    : null;
+
+  report.app = {
+    requestedPort: port,
+    exited: app.exited,
+    exitCode: app.exitCode,
+    endpointAnswered: endpoint.ok,
+    endpointMs: endpoint.ms,
+    endpointBody: endpoint.ok ? endpoint.body : null,
+    endpointError: endpoint.ok ? null : endpoint.error,
+    devToolsActivePort: { path: portFile, exists: portFileContents !== null, contents: portFileContents },
+  };
+
+  await app.quit({ graceMs: 8_000 });
+  return report.app;
+}
+
+/**
+ * B. Can `msedgedriver` start a session against that binary?
+ *
+ * Run verbatim what `tauri-driver` forwards (`browserName: "webview2"`, the app
+ * as `binary`) so a failure here is the failure the nightly hits, and then the
+ * same request carrying the webview's real user-data folder — the one variable
+ * that plausibly differs between a developer's machine, where this suite is
+ * green, and a runner that has never launched the app before.
+ */
+async function trySession(binary, variant, report) {
+  const port = await freePort();
+  const log = path.join(ARTIFACTS, `msedgedriver-${variant.name}.log`);
+  const driver = spawn(DRIVER_PATH, [`--port=${port}`, "--verbose", `--log-path=${log}`], {
+    stdio: ["ignore", "ignore", "pipe"],
+    windowsHide: true,
+    // The app is a grandchild of this process and inherits its environment.
+    // `TAURI_WEBVIEW_AUTOMATION` is what makes wry turn automation on — without
+    // it there is nothing for a session to attach to — and `UXNAN_DATA_DIR` is
+    // the same isolation the suite learned to enforce here rather than through
+    // `tauri:options.env`, which never reached the app: a diagnosis is not worth
+    // running against someone's real profile.
+    env: {
+      ...process.env,
+      TAURI_AUTOMATION: "true",
+      TAURI_WEBVIEW_AUTOMATION: "true",
+      UXNAN_DATA_DIR: path.join(HERE, ".profile", "diagnose"),
+    },
+  });
+
+  const result = { variant: variant.name, capabilities: variant.webviewOptions ?? null };
+  try {
+    const up = await waitForEndpoint(`http://127.0.0.1:${port}/status`, { timeoutMs: 20_000 });
+    if (!up.ok) {
+      result.driverStarted = false;
+      result.error = `msedgedriver never answered /status: ${up.error}`;
+      return result;
+    }
+    result.driverStarted = true;
+
+    const edgeOptions = { binary, args: [] };
+    if (variant.webviewOptions) edgeOptions.webviewOptions = variant.webviewOptions;
+
+    const started = Date.now();
+    const res = await httpJson(`http://127.0.0.1:${port}/session`, {
+      method: "POST",
+      timeoutMs: 180_000,
+      body: {
+        capabilities: {
+          alwaysMatch: {
+            "ms:edgeChromium": true,
+            browserName: "webview2",
+            "ms:edgeOptions": edgeOptions,
+          },
+        },
+      },
+    });
+    result.ms = Date.now() - started;
+
+    const sessionId = res.json?.value?.sessionId ?? res.json?.sessionId ?? null;
+    result.created = Boolean(sessionId);
+    result.error = sessionId
+      ? null
+      : (res.json?.value?.message ?? res.text ?? "").split("\n")[0].slice(0, 400);
+
+    if (sessionId) {
+      // Close it the way a suite would, so the app gets its own shutdown path.
+      try {
+        await httpJson(`http://127.0.0.1:${port}/session/${sessionId}`, {
+          method: "DELETE",
+          timeoutMs: 30_000,
+        });
+      } catch {
+        /* the reaper below is the backstop */
+      }
+    }
+  } catch (error) {
+    result.created = false;
+    result.error = String(error);
+  } finally {
+    killTree(driver.pid);
+    reapStrayApps();
+    result.driverLog = fs.existsSync(log) ? path.relative(DESKTOP_ROOT, log) : null;
+    // In `finally`, so the "the driver itself never came up" path is reported
+    // too — that is a result, and the early return would have dropped it.
+    report.sessions.push(result);
+  }
+  return result;
+}
+
+/** Kill a process and its children, by pid — never by name. */
+function killTree(pid) {
+  if (!pid) return;
+  if (process.platform === "win32") {
+    spawnSync("taskkill.exe", ["/PID", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+    return;
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    /* already gone */
+  }
+}
+
+/**
+ * Latched by the foreign-instance guard, and the only thing that lets the
+ * name-based reaper below run.
+ *
+ * Without it, any failure *before* the guard — no release binary, an unreadable
+ * config — would land in the top-level error handler, call the reaper, and kill
+ * whatever `uxnan-desktop.exe` the operator had open. Quite possibly the one
+ * hosting the terminal this was started from.
+ */
+let mayReapByName = false;
+
+/**
+ * Reap an app instance `msedgedriver` left behind.
+ *
+ * By executable name, which is safe **only** once the guard above has confirmed
+ * no other `uxnan-desktop.exe` was alive: whatever is running now is what this
+ * run launched. The suite's teardown carries the same reasoning and the same
+ * caveat — if that guard goes, this must go with it.
+ */
+function reapStrayApps() {
+  if (!mayReapByName) return [];
+  if (process.platform !== "win32") return [];
+  const script =
+    "Get-CimInstance Win32_Process -Property ProcessId,Name | " +
+    "Where-Object { $_.Name -eq 'uxnan-desktop.exe' } | ForEach-Object { $_.ProcessId }";
+  try {
+    const out = spawnSync("powershell.exe", ["-NoProfile", "-Command", script], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    const pids = (out.stdout ?? "").split(/\r?\n/).map((l) => Number(l.trim())).filter(Boolean);
+    for (const pid of pids) killTree(pid);
+    return pids;
+  } catch {
+    return [];
+  }
+}
+
+function verdict(report) {
+  const lines = [];
+  const plain = report.sessions.find((s) => s.variant === "plain");
+  const scoped = report.sessions.find((s) => s.variant === "userdatafolder");
+
+  if (report.app && !report.app.endpointAnswered) {
+    lines.push(
+      "The app never exposed a remote-debugging endpoint, so no WebDriver could have attached.",
+      "The problem is below WebDriver: WebView2 automation is not coming up in this environment.",
+    );
+  } else if (plain?.created) {
+    lines.push(
+      "A plain session — the exact capabilities tauri-driver sends — was created here.",
+      "So this machine is not where the nightly fails; compare its report with the runner's.",
+    );
+  } else if (scoped?.created) {
+    lines.push(
+      "A plain session failed and one carrying webviewOptions.userDataFolder succeeded.",
+      "The suite can pass that capability through tauri:options.webviewOptions — that is the fix.",
+    );
+  } else {
+    lines.push(
+      "The app answers on its debugging port but no session could be created either way.",
+      `Read the verbose driver logs in ${path.relative(DESKTOP_ROOT, ARTIFACTS)} — they name the step that timed out.`,
+    );
+  }
+  return lines;
+}
+
+async function main() {
+  if (process.platform !== "win32") {
+    process.stderr.write("This diagnosis is Windows-only, like the suite it explains.\n");
+    return 1;
+  }
+
+  const problem = driverStatus();
+  if (problem) {
+    process.stderr.write(`${problem}\nRun: node tests/e2e/setup-driver.mjs\n`);
+    return 1;
+  }
+
+  const binary = findBinary({ root: DESKTOP_ROOT });
+  const foreign = checkNoForeignInstance(binary);
+  if (foreign) {
+    process.stderr.write(
+      `${foreign}\n\nThe diagnosis cannot run alongside another instance: a second app shares the\n` +
+        "first one's WebView2 browser process, and every reading below would be about that one.\n",
+    );
+    return 1;
+  }
+  // Only now: nothing named `uxnan-desktop.exe` is alive that this run did not
+  // start, so teardown may match on the name (see `reapStrayApps`).
+  mayReapByName = true;
+
+  fs.mkdirSync(ARTIFACTS, { recursive: true });
+  const report = {
+    binary,
+    webview2: installedWebViewVersion(),
+    msedgedriver: spawnSync(DRIVER_PATH, ["--version"], { encoding: "utf8", windowsHide: true })
+      .stdout?.trim(),
+    userDataFolder: webviewUserDataFolder(),
+    userDataFolderExisted: fs.existsSync(webviewUserDataFolder()),
+    sessions: [],
+  };
+
+  process.stderr.write("A. asking the app for a remote-debugging endpoint…\n");
+  const app = await probeAppEndpoint(binary, report);
+  process.stderr.write(
+    app.endpointAnswered
+      ? `   answered in ${app.endpointMs} ms\n`
+      : `   no answer after ${app.endpointMs} ms (${app.endpointError})\n`,
+  );
+
+  for (const variant of [
+    { name: "plain" },
+    { name: "userdatafolder", webviewOptions: { userDataFolder: report.userDataFolder } },
+  ]) {
+    process.stderr.write(`B. creating a session — ${variant.name}…\n`);
+    const result = await trySession(binary, variant, report);
+    process.stderr.write(
+      result.created
+        ? `   created in ${result.ms} ms\n`
+        : `   refused: ${result.error}\n`,
+    );
+  }
+
+  const out = path.join(ARTIFACTS, "diagnose-session.json");
+  fs.writeFileSync(out, JSON.stringify(report, null, 2), "utf8");
+
+  process.stderr.write(`\n${verdict(report).join("\n")}\n\nfull report: ${path.relative(DESKTOP_ROOT, out)}\n`);
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (error) => {
+    process.stderr.write(`${error?.stack ?? error}\n`);
+    reapStrayApps();
+    process.exit(1);
+  },
+);


### PR DESCRIPTION
The nightly `e2e-desktop.yml` had failed every run since it was added — all 9
specs dying in `session not created: DevToolsActivePort file doesn't exist`,
before a single assertion. This finds out why, fixes what was fixable, and stops
the red nightly rather than leaving it to teach people to ignore CI mail.

## What it is

On a GitHub-hosted runner the browser process comes up with **no
`--remote-debugging-port`** and none of msedgedriver's other switches, so nothing
was ever listening and no session could be created:
`WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS` is dropped there and honoured locally.
The env-var channel itself works — the webview does take msedgedriver's
`--user-data-dir` (`C:\Windows\SystemTemp\scoped_dir…`) — so it is the additional
*arguments* specifically.

| | local (green) | runner (red) |
|---|---|---|
| remote-debugging endpoint | **611 ms** | never, at 90 s |
| session, capabilities as sent | **956 ms** | refused at 60 s |
| session + `webviewOptions.userDataFolder` | 748 ms | refused at 60 s |
| webview processes under automation | — | **6** (browser, gpu, renderer, …) |
| of those carrying `--remote-debugging-port` | — | **0** |

## What it is not — each ruled out with a measurement

- **The driver pairing** (the standing first suspect): the matching driver is
  fetched on the runner exactly as it is locally, and a mismatch says so
  explicitly.
- **The app, or the graphics environment**: `resource-benchmarks.yml` is green on
  the same image, and the diagnosis sees the webview come up under automation
  too — 6 processes, renderer and GPU included.
- **The runtime version**: with the `edgeupdate` service started (it ships
  `Stopped`, which is why the first attempt was a silent no-op) the bootstrapper
  works — the runner ran 151.0.4129.59, byte for byte what the green machine
  runs, and failed identically.
- **`webviewOptions.userDataFolder`**: no difference, and locally
  `DevToolsActivePort` is absent from that folder on a *passing* run anyway.

## Changes

- **No more cron.** `e2e-desktop.yml` is dispatch-only; the workflow stays so the
  next attempt costs a dispatch, not a rebuild.
- **Failure evidence actually uploads.** The artifact step pointed at
  `.artifacts/` and upload-artifact skips dot-paths without
  `include-hidden-files`, so all four failed nightlies logged "No files were
  found" and discarded the driver log. That is why this went undiagnosed.
- **`npm run test:e2e:diagnose`** (`tests/e2e/diagnose-session.mjs`): launches the
  binary with the environment tauri-driver arranges and asks whether a debugging
  endpoint answers; drives msedgedriver directly (verbose) with the capabilities
  tauri-driver forwards; samples the app's process tree mid-attach to separate
  "no webview", "webview without the switch" and "switch ignored". Asserts
  nothing, cannot fail the job, refuses to run beside another uxnan — and arms
  its name-based reaper only after that guard passes, so it can never take down
  an app you had open.
- **Docs corrected wherever they claimed a nightly or a runner smoke**:
  `docs/testing.md`, `docs/platform-support.md`,
  `architecture/04-technical-reference.md`, `verify-desktop.yml`'s comment,
  `tests/e2e/README.md`, `FOR-DEV.md` and the `CHANGELOG`. The Windows `smoke`
  claim in `platform-support.json` was already cited to local runs, so the matrix
  did not overstate anything.

Two leads are recorded in `FOR-DEV.md` for anyone who wants CI E2E later: a
machine policy stripping the switch (the workflow now dumps the four Edge/WebView2
policy keys — empty on the machine where the suite passes, so one dispatch
answers it), or the app passing the switch itself through wry's
`additional_browser_args` instead of the environment — a change to the shipped
binary, so a deliberate decision rather than a drive-by patch.

## Verification

- 698 tests pass in the `node` Vitest project locally, including
  `platform-support.test.mjs` and `quality-matrix.test.mjs`, the two that check
  these docs against the repo.
- The diagnosis was run on both sides: green here (611 ms / 956 ms), red on the
  runner, which is where every number above comes from.
- Three CI dispatches on this branch produced the evidence; the artifacts of the
  last one are attached to run 30958615323.
