### PR TITLE
fix(bridge): verify agent usage on the surface the bridge actually drives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,7 @@ Before writing code in any component, you MUST read the corresponding architectu
 | `uxnanmobile/` | `architecture/00-index.md` and the documents it references for the affected module |
 | `uxnandesktop/` | `uxnandesktop/architecture/00-index.md` and the relevant documents |
 | `bridge/` | `architecture/02a-system-architecture.md` (section 5.8) + `uxnandesktop/architecture/02e-bridge-integration.md` |
+| `bridge/src/adapters/` (**any** wired-agent work) | **`bridge/docs/agents.md` → _Drive surface_ first** — it records which headless surface each CLI is actually driven on, and every CLI has more than one that behave differently |
 | `relay/` | `architecture/02a-system-architecture.md` (section 5.10) |
 | `shared/` | `architecture/02b-contracts-and-requirements.md` (JSON-RPC contracts) |
 | `web/` | `web/README.md` + `web/docs/content.md` — the site has no `architecture/` page of its own; the products it describes are the source of truth, and `web/src/lib/site.ts` is where every claim it makes is centralized |
@@ -340,6 +341,19 @@ Three audiences, three homes — keep them separate so none of them rots:
 - **Never reference a git-ignored / local-only file from a tracked file.**
   Anything in `.git/info/exclude` (local `*_MVP.md` snapshots, scratch notes) is
   the maintainer's own context and won't exist on a fresh clone.
+- **NEVER validate an adapter against a surface the bridge does not drive.**
+  Every wired CLI exposes several headless surfaces — an ACP/JSON-RPC server, a
+  one-shot `-p`/`exec` run, an on-disk session store — and they **do not behave
+  alike**: the same CLI can report token usage on one and nothing at all on
+  another. This has shipped two wrong "fixes": usage read from `zero exec`'s
+  session store and from the transcript `grok -p` writes, neither of which the
+  driven surface ever produces (one of them left the phone showing a meter
+  pinned at zero, worse than hiding it). Before claiming an adapter behaves a
+  certain way, **run that adapter** and read what it emits — not what the CLI
+  writes somewhere else. The per-agent surface, transport and what each one
+  reports live in [`bridge/docs/agents.md`](bridge/docs/agents.md) →
+  *Drive surface*; keep it current in the same change set.
+
 - **Hand-kept model tables come in PAIRS — a new model goes in BOTH.** Agent CLIs
   are discovered live except **Claude Code**, whose curated table exists once per
   app:

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -5,6 +5,35 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — Grok's token usage actually reaches the phone this time
+
+0.0.17 claimed to fix Grok and did not: it accepted `_x.ai/session/update`,
+while the update that carries the usage arrives on **`_x.ai/session_notification`**.
+Captured off the live wire *while the adapter drove a real turn*, then verified
+end to end through the adapter itself — `turn_completed` now emits
+`{tokens: 24381, contextWindow: 500000}`.
+
+### Fixed — Zero no longer claims a context meter it can never fill
+
+0.0.17 flipped `reportsContextUsage` to true after reading a `provider_usage`
+event out of Zero's session store. That event is real — and it is written only
+for a session driven by `zero exec`. Verified by running the adapter and reading
+the store it wrote: an **ACP-driven** session holds `message` events and nothing
+else, so the meter showed and stayed at zero, which is worse than hiding it.
+
+The capability is honest again and the reader is deleted rather than left
+unwired.
+
+### Added — a per-agent drive-surface table
+
+Both bugs above are the same mistake: validating against a surface the bridge
+does not drive. `docs/agents.md` now records, per agent, **which** headless
+surface is driven, its transport/framing, and whether usage is reported on it —
+with the two cases where the CLI reports usage *somewhere else* called out
+explicitly. It also states plainly that every model list is discovered live
+except **Claude Code's**, which is the one curated, hand-maintained list.
+
+
 ## [0.0.17-alpha.20260805] - 2026-08-05
 
 ### Fixed — Codex's context meter works: usage is not on `turn/completed`

--- a/bridge/FOR-DEV.md
+++ b/bridge/FOR-DEV.md
@@ -384,6 +384,16 @@ push validation (FOR-HUMAN).
 
 ### Adding the next agent (recipe — do these one by one)
 
+**Step 0, before any code: pick the surface and write it down.** Every CLI has
+several headless surfaces and they do not behave alike — one may stream token
+usage while another reports none, and an on-disk store can record something the
+driven surface never emits. Choose the surface deliberately, then add its row to
+[`docs/agents.md`](docs/agents.md) → *Drive surface* (surface, transport/framing,
+whether it reports usage) **in the same change set**. Validate every claim by
+running the adapter and reading what it emits — two shipped "fixes" were
+validated against a surface the bridge does not drive, and did nothing.
+
+
 Pick the template that matches the CLI's headless surface. For a **one-shot
 per-turn CLI** (spawns once per turn) copy `pi-adapter.ts`;
 for a **long-lived server** with a pre-tool approval channel copy `codex-adapter.ts`

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -182,7 +182,7 @@ Task-focused guides live in [`docs/`](docs/):
 [installation & autostart](docs/installation.md) ·
 [configuration](docs/configuration.md) ·
 [connectivity (LAN / Tailscale / relay)](docs/connectivity.md) ·
-[how agents are driven](docs/agents.md) ·
+[how agents are driven](docs/agents.md) (start at *Drive surface*) ·
 [testing](docs/testing.md) ·
 [packaging & deploy](docs/deploy.md) ·
 [push notifications](docs/push-notifications.md).

--- a/bridge/docs/agents.md
+++ b/bridge/docs/agents.md
@@ -132,6 +132,50 @@ its provisional name. That is how the desktop's `agy` mapping was caught —
 The whole path is best-effort and bounded (30s): no credit, a missing CLI or a
 timeout leaves the provisional title in place and never disturbs the thread.
 
+## Drive surface (read this before touching an adapter)
+
+Every wired CLI exposes **more than one** headless surface, and they do not
+behave alike — the same CLI can report token usage on one and nothing on
+another. This table is the record of which surface the bridge actually drives,
+so a future change is validated against the right one.
+
+**This has bitten us twice.** Usage was once read from `zero exec`'s session
+store and from the transcript `grok -p` writes; both are real, and both are
+invisible to the surface the bridge uses. **Never validate an adapter against a
+surface it does not drive.**
+
+| Agent | Surface the bridge drives | Transport / framing | Reports usage |
+|---|---|---|---|
+| **OpenCode** | `opencode serve` | local HTTP + SSE | yes |
+| **Claude Code** | `claude -p` | NDJSON both ways (`--input-format`/`--output-format stream-json`), prompt + follow-ups on an open stdin | yes |
+| **Codex** | `codex app-server` | JSON-RPC 2.0 over NDJSON stdio | yes — on its **own notification**, `thread/tokenUsage/updated` (a completed turn carries none), which also brings `modelContextWindow` |
+| **pi** | `pi --mode rpc` | JSON-RPC over stdio | yes |
+| **Grok** | `grok agent stdio` | ACP (JSON-RPC over stdio) **plus `_x.ai/*` extension methods** | yes — on `_x.ai/session_notification`, **not** on ACP's own `session/update`; the `turn_completed` update carries the `usage` block |
+| **Zero** | `zero acp` | ACP (JSON-RPC over stdio) | **no** — see below |
+| **Antigravity** | `agy -p` | one process per turn, plain text on stdout | **not on this surface** — see below |
+| ~~Gemini CLI~~ | — | non-runnable legacy | — |
+
+Two agents report no usage, and in both cases the CLI *can* report it somewhere
+else — which is exactly the trap:
+
+- **Zero.** It appends a `provider_usage` event per turn to its session store,
+  but only for a session driven by `zero exec`. Verified by running the adapter
+  and reading the store it wrote: an **ACP-driven** session holds `message`
+  events and nothing else. `reportsContextUsage` is false so the phone hides the
+  meter rather than showing one pinned at zero.
+- **Antigravity.** `agy` reports `{input_tokens, output_tokens, thinking_tokens,
+  cache_read_tokens, total_tokens}` on its `result` event — but only under
+  `--output-format stream-json`, while the turn runs on `text`. Surfacing it
+  means migrating the turn's whole stream parse to the JSON events (tracked in
+  [`../FOR-DEV.md`](../FOR-DEV.md)).
+
+**Model lists follow the same read-the-source rule.** Every agent's list is
+**discovered live** from the CLI — `opencode models`, `model/list`,
+`pi --list-models`, `agy models`, `zero models list`, Grok's `initialize`
+handshake. **Claude Code is the only curated, hand-maintained list** (see
+*Claude Code models* below); it is the one place a new model has to be added by
+hand, and it has a matching half in the desktop app.
+
 ## Wired agents
 
 | Agent | CLI invocation | Continuity | Permission posture | Models |

--- a/bridge/src/adapters/grok-adapter.ts
+++ b/bridge/src/adapters/grok-adapter.ts
@@ -467,11 +467,20 @@ export class GrokAdapter extends BaseAgentAdapter {
 
   /** Route a `session/update` notification to the run + bridge events. */
   #onNotification(method: string, params: unknown): void {
-    // Grok splits its stream across two methods: the plain ACP `session/update`
-    // and its own `_x.ai/session/update`, which is where `turn_completed` — and
-    // with it the turn's token usage — actually arrives. Accepting only the
-    // former dropped every usage report on the floor.
-    if (method !== 'session/update' && method !== '_x.ai/session/update') return;
+    // Grok splits its stream across THREE methods, and only the first is ACP's
+    // own. Captured off the live wire while the adapter drove a real turn:
+    // `session/update` carries the ACP-standard updates, while `turn_completed`
+    // — and with it the turn's token usage — arrives on
+    // `_x.ai/session_notification`. Accepting only the standard method dropped
+    // every usage report on the floor, which is why Grok's context meter and
+    // its share of the profile metrics stayed empty.
+    if (
+      method !== 'session/update' &&
+      method !== '_x.ai/session/update' &&
+      method !== '_x.ai/session_notification'
+    ) {
+      return;
+    }
     const p = isRecord(params) ? params : {};
     const update = isRecord(p['update']) ? p['update'] : {};
     // Slash-command availability is session-scoped and can arrive before any

--- a/bridge/src/adapters/zero-adapter.ts
+++ b/bridge/src/adapters/zero-adapter.ts
@@ -683,7 +683,6 @@ export class ZeroAdapter extends BaseAgentAdapter {
     });
   }
 
-
   #finishError(run: ActiveRun, text: string): void {
     run.finished = true;
     this.#active.delete(run.bridgeTurnId);

--- a/bridge/src/adapters/zero-adapter.ts
+++ b/bridge/src/adapters/zero-adapter.ts
@@ -32,16 +32,16 @@
  *    (matched by `kind`: allow_once/allow_always/reject_once).
  *  - `session/cancel` (notification) ← cancelTurn.
  *
- * ACP carries no token usage, but Zero's own session store does: it appends a
- * `provider_usage` event per turn, which is where the context meter's numbers
- * come from (see {@link readZeroUsage}).
+ * **No token usage on this surface.** Zero *does* record a `provider_usage`
+ * event per turn — but only for a session driven by `zero exec`. Verified by
+ * running the adapter and reading the store it wrote: a session created over
+ * ACP holds `message` events and nothing else. So `reportsContextUsage` is
+ * false and the phone hides the meter rather than showing one stuck at zero
+ * (FOR-DEV: revisit if Zero starts reporting usage over ACP).
  *
  * See bridge/FOR-DEV.md (agent adapters) and bridge/docs/testing.md.
  */
 import { spawn } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
 import type { Readable, Writable } from 'node:stream';
 import type {
   AgentCapabilities,
@@ -73,9 +73,9 @@ const ZERO_CAPABILITIES: AgentCapabilities = {
   // `read_file` tool is line-oriented text — so the bridge's usual file-path
   // delivery would have it read a PNG as garbage. See `handlesAttachments`.
   images: true,
-  // ACP carries no per-turn usage, but Zero records one itself: a
-  // `provider_usage` event per turn in its session store (see `readZeroUsage`).
-  reportsContextUsage: true,
+  // Verified against a real ACP-driven run: no usage on the wire and none in
+  // the session store either (that is an `exec`-only record). See the header.
+  reportsContextUsage: false,
   // ACP advertises slash commands via `available_commands_update` (captured below).
   commands: true,
 };
@@ -114,68 +114,10 @@ export interface SpawnedAcp {
   kill: () => void;
 }
 
-/**
- * Root of Zero's own session store.
- *
- * Zero is XDG-shaped even on Windows (`~/.local/share/zero/sessions`, verified
- * against a real install), and honours `XDG_DATA_HOME` when it is set.
- */
-export function zeroSessionsRoot(env: NodeJS.ProcessEnv = process.env): string {
-  const base = env['XDG_DATA_HOME'] || join(homedir(), '.local', 'share');
-  return join(base, 'zero', 'sessions');
-}
-
-/**
- * Context-occupying tokens of `sessionId`'s most recent turn, or `undefined`.
- *
- * Zero appends one `provider_usage` event per turn to its session's
- * `events.jsonl`, carrying `{ promptTokens, completionTokens, totalTokens,
- * cachedInputTokens, reasoningTokens }` — captured from a real run. The LAST one
- * is this turn's; `totalTokens` is Zero's own sum, with prompt + completion as
- * the fallback. `cachedInputTokens` is a SUBSET of `promptTokens` and is never
- * added, or the meter would read high.
- */
-export async function readZeroUsage(
-  sessionId: string,
-  root: string = zeroSessionsRoot(),
-): Promise<number | undefined> {
-  let raw: string;
-  try {
-    raw = await readFile(join(root, sessionId, 'events.jsonl'), 'utf8');
-  } catch {
-    return undefined;
-  }
-  let tokens: number | undefined;
-  for (const line of raw.split('\n')) {
-    if (!line.includes('provider_usage')) continue;
-    let event: unknown;
-    try {
-      event = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    if (!isRecord(event) || event['type'] !== 'provider_usage') continue;
-    const payload = event['payload'];
-    if (!isRecord(payload)) continue;
-    const total = numberOf(payload['totalTokens']);
-    const sum = numberOf(payload['promptTokens']) + numberOf(payload['completionTokens']);
-    const value = total > 0 ? total : sum;
-    if (value > 0) tokens = Math.round(value);
-  }
-  return tokens;
-}
-
-/** A finite non-negative number, or 0 — usage fields are optional per provider. */
-function numberOf(value: unknown): number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
-}
-
 interface ActiveRun {
   bridgeTurnId: string;
   threadId: string;
   sessionId: string;
-  /** Model this run was launched with, for the context window. */
-  model?: string;
   /** Accumulated assistant text, for `turn_completed`. */
   full: string;
   /** Tool calls in flight, keyed by ACP `toolCallId` (emit a block at terminal). */
@@ -407,7 +349,6 @@ export class ZeroAdapter extends BaseAgentAdapter {
       bridgeTurnId: turnId,
       threadId,
       sessionId,
-      ...(model ? { model } : {}),
       full: '',
       tools: new Map(),
       emitted: new Set(),
@@ -734,43 +675,14 @@ export class ZeroAdapter extends BaseAgentAdapter {
       this.emit({ type: 'turn_aborted', threadId: run.threadId, turnId: run.bridgeTurnId });
       return;
     }
-    void this.#completeWithUsage(run);
-  }
-
-  /**
-   * Emit `turn_completed`, enriched with the turn's token usage.
-   *
-   * Zero's ACP stream carries no usage, but Zero records one itself: a
-   * `provider_usage` event per turn in its own session store. Reading it is what
-   * lights up the phone's context meter — without it Zero was one of the agents
-   * showing no context at all. Best-effort by contract: a missing or unreadable
-   * store just means the turn completes without usage, never that it fails.
-   */
-  async #completeWithUsage(run: ActiveRun): Promise<void> {
-    let usage: { tokens: number; contextWindow?: number } | undefined;
-    try {
-      const tokens = await readZeroUsage(run.sessionId);
-      if (tokens !== undefined) {
-        const contextWindow = this.#contextWindowOf(run.model);
-        usage = { tokens, ...(contextWindow !== undefined ? { contextWindow } : {}) };
-      }
-    } catch {
-      // Usage is decoration on a turn that already succeeded.
-    }
     this.emit({
       type: 'turn_completed',
       threadId: run.threadId,
       turnId: run.bridgeTurnId,
-      data: { text: run.full, ...(usage ? { usage } : {}) },
+      data: { text: run.full },
     });
   }
 
-  /** The context window Zero's registry gives for `model`, when known. */
-  #contextWindowOf(model: string | undefined): number | undefined {
-    const models = this.#modelsCache ?? [];
-    const match = model ? models.find((m) => m.id === model) : undefined;
-    return (match ?? models.find((m) => m.isDefault))?.contextWindow;
-  }
 
   #finishError(run: ActiveRun, text: string): void {
     run.finished = true;

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -165,8 +165,6 @@ export {
   ZeroAdapter,
   parseZeroModels,
   mergeZeroProviderModels,
-  readZeroUsage,
-  zeroSessionsRoot,
   type ZeroAdapterOptions,
   type SpawnedAcp,
   type ZeroProvider,

--- a/bridge/test/adapters/zero-adapter.test.ts
+++ b/bridge/test/adapters/zero-adapter.test.ts
@@ -1,15 +1,11 @@
 import { test, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { PassThrough } from 'node:stream';
-import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import {
   ZeroAdapter,
   parseZeroModels,
   mergeZeroProviderModels,
   zeroToolBlock,
-  readZeroUsage,
   type SpawnedAcp,
 } from '../../src/index.js';
 import type { AgentStreamEvent } from '@uxnan/shared';
@@ -422,74 +418,4 @@ test('ZeroAdapter keeps a text block for an image-only turn', async () => {
   const prompt = server.sent.find((m) => m.method === 'session/prompt');
   // The image rides alone — no empty text block padding the prompt.
   assert.deepEqual(prompt.params.prompt, [{ type: 'image', mimeType: 'image/jpeg', data: 'BBBB' }]);
-});
-
-// --- token usage, read from Zero's own session store -----------------------
-//
-// Zero's ACP stream carries no usage, but Zero appends a `provider_usage` event
-// per turn to `<store>/<sessionId>/events.jsonl`. These payloads are the shape
-// captured from a real run.
-
-test('zero usage takes the LAST turn, and never double-counts the cache', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'uxnan-zero-usage-'));
-  const session = 'zero_20260804224613_1785883573227519400_1';
-  await mkdir(join(dir, session), { recursive: true });
-  await writeFile(
-    join(dir, session, 'events.jsonl'),
-    [
-      JSON.stringify({ type: 'message', payload: { role: 'user', content: 'hola?' } }),
-      JSON.stringify({
-        type: 'provider_usage',
-        payload: {
-          completionTokens: 108,
-          promptTokens: 17335,
-          cachedInputTokens: 17280,
-          reasoningTokens: 46,
-          totalTokens: 17443,
-        },
-      }),
-      JSON.stringify({
-        type: 'provider_usage',
-        payload: {
-          completionTokens: 422,
-          promptTokens: 18780,
-          cachedInputTokens: 17408,
-          reasoningTokens: 14,
-          totalTokens: 19202,
-        },
-      }),
-    ].join('\n'),
-  );
-
-  // The newest turn — an earlier one would under-report a grown context.
-  // 19202, not 19202 + 17408: cachedInputTokens is a SUBSET of promptTokens.
-  assert.equal(await readZeroUsage(session, dir), 19202);
-});
-
-test('zero usage falls back to prompt + completion when there is no total', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'uxnan-zero-usage-'));
-  const session = 's1';
-  await mkdir(join(dir, session), { recursive: true });
-  await writeFile(
-    join(dir, session, 'events.jsonl'),
-    JSON.stringify({
-      type: 'provider_usage',
-      payload: { promptTokens: 15481, completionTokens: 55 },
-    }),
-  );
-  assert.equal(await readZeroUsage(session, dir), 15536);
-});
-
-test('zero usage is absent, not an error, when the store has nothing to say', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'uxnan-zero-usage-'));
-  // A session Zero never wrote: usage is decoration on a turn that succeeded.
-  assert.equal(await readZeroUsage('missing', dir), undefined);
-
-  const session = 's2';
-  await mkdir(join(dir, session), { recursive: true });
-  await writeFile(
-    join(dir, session, 'events.jsonl'),
-    ['not json at all', JSON.stringify({ type: 'message', payload: {} })].join('\n'),
-  );
-  assert.equal(await readZeroUsage(session, dir), undefined);
 });


### PR DESCRIPTION
Both usage fixes shipped in `0.0.17` were validated against a surface the bridge does **not** drive, so neither did anything on a real device. This corrects them against the one it does, verified end to end by running the adapters themselves.

## Grok — usage arrives on a third method
`0.0.17` accepted `_x.ai/session/update`; the update carrying usage arrives on **`_x.ai/session_notification`**. Captured off the live wire while the adapter drove a real turn on the production path (`grok agent stdio`).

**Verified:** `turn_completed` now emits `{tokens: 24381, contextWindow: 500000}`.

## Zero — it can't report usage on this surface, so it no longer claims to
`0.0.17` flipped `reportsContextUsage` to `true` after reading a `provider_usage` event from Zero's session store. That event is real, and it is written **only for a `zero exec` session**. Running the adapter and reading the store it wrote shows an ACP-driven session holds `message` events and nothing else — so the phone showed a context meter pinned at zero, which is worse than hiding it.

Capability honest again; `readZeroUsage`, `zeroSessionsRoot`, their exports and their tests are deleted rather than left unwired.

## Codex — genuinely fixed
Re-verified on the same footing: `{tokens: 25235, contextWindow: 258400}`. The earlier "it fails too" reading came from a stale `dist/`, not from the code.

## The docs that stop this recurring
Both bugs are one mistake, so `bridge/docs/agents.md` gains a **Drive surface** table: per agent, which headless surface the bridge drives, its transport/framing, and whether usage is reported there — with the two CLIs that report usage on a *different* surface called out, since that is the trap. It also records that every model list is discovered live except **Claude Code's**, the single curated hand-maintained one.

A stale claim was corrected while there: the table said Grok is driven with `grok acp`; the adapter spawns `grok agent stdio`.

**And made discoverable**, because nothing routed anyone there: `AGENTS.md`'s "read first" table gains a `bridge/src/adapters/` row, the rule itself is written alongside the counts/model-table rules with both real failures named, and `bridge/FOR-DEV.md`'s "adding the next agent" recipe gains a step 0 (pick the surface, document it in the same change set).

## Verification
Bridge **632 passing**, typecheck and prettier clean.