### PR TITLE
build(release-tooling): release status and prepare scripts

### DIFF
--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -11,7 +11,13 @@ jobs:
   verify:
     name: verify (node ${{ matrix.node }} · ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    # `timeout-minutes` counts from the moment the job is QUEUED, not from when a
+    # runner picks it up. The work here takes 2-6 minutes, so 15 looked generous
+    # — until 2026-08-06, when GitHub's hosted queue stalled and both Linux legs
+    # were cancelled at exactly 15m01s without ever starting. A cancellation that
+    # says nothing about the code is worse than a slow run, so this leaves ~25
+    # minutes of queue tolerance while still catching a genuine hang.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/verify-web.yml
+++ b/.github/workflows/verify-web.yml
@@ -15,7 +15,10 @@ jobs:
   verify:
     name: verify (node ${{ matrix.node }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Queue time counts against this — see the note in `verify-node.yml`, where a
+    # stalled hosted queue cancelled two legs at 15m01s without starting them.
+    # The build itself takes about two minutes.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -77,11 +77,22 @@ which versions "go together".
 
 ## Release checklist
 
+> **Two commands do the mechanical half of this.** `npm run release:status`
+> prints, for every component, what shipped last, what changed since, whether
+> that change can affect a build, and what the next version would be — so step 0
+> is never guesswork. `npm run release:prepare -- <comp> [--channel=nightly]`
+> then computes the version, refuses it if the component has nothing to ship or
+> the base would not move past every channel, writes it into **every**
+> version-bearing file, reads them all back to prove they agree, and prints the
+> exact commit/tag commands. It never commits, tags or pushes. See
+> [`scripts/release/README.md`](scripts/release/README.md).
+
 Cutting a release for component `<comp>` (tag `<comp>-v<version>`; Desktop uses
 the channel-specific forms above):
 
 1. **Pre-flight** — the commit you will tag is green on CI (`ci-*.yml`) and its
-   `CHANGELOG.md [Unreleased]` accurately describes what ships.
+   `CHANGELOG.md [Unreleased]` accurately describes what ships. `npm run
+   release:status` confirms the component genuinely has something to ship.
 2. **Mobile only — bump the source version FIRST (non-negotiable)** — set
    `uxnanmobile/pubspec.yaml` `version:` to the release `<name>+<build>` (e.g.
    `0.0.1-alpha.20260621+5`), then **commit and push it**, so the *tagged commit*

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "uxnan-monorepo",
   "private": true,
   "version": "0.0.0",
-  "description": "Uxnan ecosystem — Node.js workspaces (shared contracts, bridge daemon, relay).",
+  "description": "Uxnan ecosystem \u2014 Node.js workspaces (shared contracts, bridge daemon, relay).",
   "license": "MPL-2.0",
   "author": "Luis Donaldo Gamas Vazquez",
   "workspaces": [
@@ -16,9 +16,12 @@
   "scripts": {
     "build": "npm run build -w @uxnan/shared && npm run build -w uxnan-relay && npm run build -w uxnan-bridge",
     "typecheck": "npm run typecheck -w @uxnan/shared && npm run typecheck -w uxnan-relay && npm run typecheck -w uxnan-bridge",
-    "test": "npm run build && npm run test -w @uxnan/shared && npm run test -w uxnan-relay && npm run test -w uxnan-bridge",
-    "format": "prettier --write \"{shared,bridge,relay}/{src,test}/**/*.{ts,json}\"",
-    "format:check": "prettier --check \"{shared,bridge,relay}/{src,test}/**/*.{ts,json}\""
+    "test": "npm run build && npm run test -w @uxnan/shared && npm run test -w uxnan-relay && npm run test -w uxnan-bridge && npm run test:release",
+    "format": "prettier --write \"{shared,bridge,relay}/{src,test}/**/*.{ts,json}\" \"scripts/**/*.mjs\"",
+    "format:check": "prettier --check \"{shared,bridge,relay}/{src,test}/**/*.{ts,json}\" \"scripts/**/*.mjs\"",
+    "release:status": "node scripts/release/status.mjs",
+    "test:release": "node --test \"scripts/release/*.test.mjs\"",
+    "release:prepare": "node scripts/release/prepare.mjs"
   },
   "devDependencies": {
     "prettier": "^3.3.3",

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,0 +1,70 @@
+# Release tooling
+
+Two commands that take the guesswork and the transcription errors out of cutting
+a release. [`VERSIONS.md`](../../VERSIONS.md) remains the source of truth for the
+convention; this is the code that follows it.
+
+Everything here is read-only or writes version files. **Nothing commits, tags or
+pushes** — that stays with a human, and from phase 2 with the release workflow.
+
+## `npm run release:status`
+
+The state of the whole monorepo in one table:
+
+```
+component last tag                                changed  needs release  next
+shared    shared-v0.0.13-alpha.20260804           0+0d     no             —
+relay     relay-v0.0.2-alpha.20260720             0+1d     no (docs only) —
+desktop   desktop-stable-v0.0.28                  25+9d    YES            0.0.29-nightly.20260806.1
+```
+
+`changed` is `files that can affect a build + files that cannot`. That second
+number is the whole point: on 2026-08-06 the only change in `relay/` since its
+tag was `FOR-DEV.md`, and a trigger that fired on "the folder changed" would have
+published an identical package.
+
+Flags: `--channel=stable|nightly` (how to compute the desktop's next version,
+default `nightly`) and `--json` (for the workflow's job summary).
+
+## `npm run release:prepare -- <component> [flags]`
+
+Computes the next version, then writes it into every file that carries one and
+reads them all back:
+
+```
+desktop → 0.0.29-nightly.20260806.1 (nightly)
+  0.0.28 → 0.0.29  uxnandesktop/src-tauri/tauri.conf.json
+  0.0.28 → 0.0.29  uxnandesktop/src-tauri/Cargo.toml
+  0.0.28 → 0.0.29  uxnandesktop/src-tauri/Cargo.lock
+  0.0.28 → 0.0.29  uxnandesktop/package.json
+  0.0.28 → 0.0.29  uxnandesktop/package-lock.json
+```
+
+It refuses to run when the component has nothing release-worthy, when the tree is
+dirty, or when the version would not move past every channel. `--force`
+overrides the first two; nothing overrides the third, because a reused numeric
+base does not fail — it ships a build the Windows MSI and the updater cannot see.
+
+Flags: `--channel=stable|nightly`, `--version=<exact>`, `--dry-run`, `--force`.
+
+## What the pieces are
+
+| File | Responsibility |
+|---|---|
+| `components.mjs` | the registry: paths, tag prefixes, every version-bearing file, release order |
+| `version.mjs` | pure version arithmetic — next version per kind and channel, and the guard against a base that has already shipped |
+| `adapters.mjs` | pure text transforms per file format (`package.json`, both lockfile shapes, `Cargo.toml`, `Cargo.lock`, `pubspec.yaml`) |
+| `bump.mjs` | applies a version to every file, then asserts they all agree |
+| `changes.mjs` | "does this component need a release?" — path diff since its last tag, minus docs |
+| `git.mjs` | the only place that shells out to git |
+
+`node --test "scripts/release/*.test.mjs"` (also part of the root `npm test`)
+covers all of it, including the two failures that have actually shipped here: a
+lockfile left behind a manifest, and a desktop base reused across channels.
+
+## Adding a component, or a file that carries a version
+
+Both are one edit in `components.mjs` — add the entry, or add the file to
+`versionFiles` with the adapter that matches its format. `components.test.mjs`
+then enforces that the path exists and that a manifest never travels without its
+lockfile.

--- a/scripts/release/adapters.mjs
+++ b/scripts/release/adapters.mjs
@@ -1,0 +1,108 @@
+/**
+ * Version file adapters: pure `read` / `write` over a file's *text*.
+ *
+ * Every one of them exists because a real release shipped wrong when a file was
+ * missed. `uxnandesktop/package-lock.json` sat at `0.0.2` while the app shipped
+ * `0.0.4`, because the release workflow re-applies the version at build time
+ * with `--allow-same-version` — which hides an un-bumped committed lock. So the
+ * bump writes every file and then reads them all back, and a mismatch is an
+ * error rather than a surprise three releases later.
+ *
+ * Text in, text out: no file I/O here, so every rule is testable on a string.
+ */
+
+/** `package.json`, `tauri.conf.json` — a top-level `"version"`. */
+export const json = {
+  read: (text) => JSON.parse(text).version ?? null,
+  write: (text, version) => {
+    const data = JSON.parse(text);
+    data.version = version;
+    // Keep the file's own trailing newline habit.
+    return JSON.stringify(data, null, 2) + (text.endsWith('\n') ? '\n' : '');
+  },
+};
+
+/** A component's entry inside the **root** `package-lock.json`. */
+export const lockWorkspace = {
+  read: (text, { pkgPath }) => JSON.parse(text).packages?.[pkgPath]?.version ?? null,
+  write: (text, version, { pkgPath }) => {
+    const data = JSON.parse(text);
+    if (!data.packages?.[pkgPath]) {
+      throw new Error(`package-lock.json has no entry for "${pkgPath}"`);
+    }
+    data.packages[pkgPath].version = version;
+    return JSON.stringify(data, null, 2) + (text.endsWith('\n') ? '\n' : '');
+  },
+};
+
+/** A standalone `package-lock.json` (the desktop's own): root + `packages[""]`. */
+export const lockRoot = {
+  read: (text) => JSON.parse(text).version ?? null,
+  write: (text, version) => {
+    const data = JSON.parse(text);
+    data.version = version;
+    if (data.packages?.['']) data.packages[''].version = version;
+    return JSON.stringify(data, null, 2) + (text.endsWith('\n') ? '\n' : '');
+  },
+};
+
+/** `[package] version = "…"` — the first one, which is the crate's own. */
+export const cargoToml = {
+  read: (text) => /^\s*version\s*=\s*"([^"]+)"/m.exec(text)?.[1] ?? null,
+  write: (text, version) => {
+    let replaced = false;
+    return text.replace(/^(\s*version\s*=\s*")([^"]+)(")/m, (match, head, _old, tail) => {
+      if (replaced) return match;
+      replaced = true;
+      return `${head}${version}${tail}`;
+    });
+  },
+};
+
+/** The named crate's entry in `Cargo.lock`. */
+export const cargoLock = {
+  read: (text, { crate }) => blockOf(text, crate)?.version ?? null,
+  write: (text, version, { crate }) => {
+    const block = blockOf(text, crate);
+    if (!block) throw new Error(`Cargo.lock has no [[package]] named "${crate}"`);
+    const updated = block.raw.replace(/^(version\s*=\s*")([^"]+)(")/m, `$1${version}$3`);
+    return text.slice(0, block.start) + updated + text.slice(block.end);
+  },
+};
+
+function blockOf(text, crate) {
+  const blocks = [...text.matchAll(/\[\[package\]\]\n(?:[^\n]*\n)*?(?:\n|$)/g)];
+  for (const match of blocks) {
+    const raw = match[0];
+    if (new RegExp(`^name\\s*=\\s*"${crate}"$`, 'm').test(raw)) {
+      return {
+        raw,
+        start: match.index,
+        end: match.index + raw.length,
+        version: /^version\s*=\s*"([^"]+)"/m.exec(raw)?.[1] ?? null,
+      };
+    }
+  }
+  return null;
+}
+
+/** Flutter's `pubspec.yaml`: `version: 0.0.18-alpha.20260805+20260805`. */
+export const pubspec = {
+  read: (text) => /^version:\s*(\S+)/m.exec(text)?.[1] ?? null,
+  write: (text, version) => text.replace(/^(version:\s*)(\S+)/m, `$1${version}`),
+};
+
+export const ADAPTERS = {
+  json,
+  'lock-workspace': lockWorkspace,
+  'lock-root': lockRoot,
+  'cargo-toml': cargoToml,
+  'cargo-lock': cargoLock,
+  pubspec,
+};
+
+export function adapterFor(name) {
+  const adapter = ADAPTERS[name];
+  if (!adapter) throw new Error(`unknown version-file adapter: ${name}`);
+  return adapter;
+}

--- a/scripts/release/adapters.test.mjs
+++ b/scripts/release/adapters.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  adapterFor,
+  cargoLock,
+  cargoToml,
+  json,
+  lockRoot,
+  lockWorkspace,
+  pubspec,
+} from './adapters.mjs';
+
+describe('json', () => {
+  const text = '{\n  "name": "uxnan-bridge",\n  "version": "0.0.18-alpha.20260805"\n}\n';
+
+  it('reads and writes the version, keeping the trailing newline', () => {
+    assert.equal(json.read(text), '0.0.18-alpha.20260805');
+    const next = json.write(text, '0.0.19-alpha.20260806');
+    assert.equal(json.read(next), '0.0.19-alpha.20260806');
+    assert.ok(next.endsWith('}\n'));
+  });
+
+  it('leaves the rest of the document intact', () => {
+    assert.equal(JSON.parse(json.write(text, '1.2.3')).name, 'uxnan-bridge');
+  });
+});
+
+describe('lockWorkspace', () => {
+  // The root lock is the file that silently drifts: `npm version -w` updates it,
+  // a hand edit of package.json does not.
+  const text = JSON.stringify(
+    {
+      name: 'uxnan-monorepo',
+      packages: { '': { name: 'uxnan-monorepo' }, shared: { version: '0.0.13' } },
+    },
+    null,
+    2,
+  );
+
+  it('reads and writes the workspace entry', () => {
+    assert.equal(lockWorkspace.read(text, { pkgPath: 'shared' }), '0.0.13');
+    const next = lockWorkspace.write(text, '0.0.14', { pkgPath: 'shared' });
+    assert.equal(lockWorkspace.read(next, { pkgPath: 'shared' }), '0.0.14');
+  });
+
+  it('refuses a workspace the lock does not know', () => {
+    assert.throws(() => lockWorkspace.write(text, '1.0.0', { pkgPath: 'nope' }), /no entry/);
+  });
+});
+
+describe('lockRoot', () => {
+  const text = JSON.stringify(
+    {
+      name: 'uxnan-desktop',
+      version: '0.0.28',
+      packages: { '': { name: 'uxnan-desktop', version: '0.0.28' } },
+    },
+    null,
+    2,
+  );
+
+  it('writes both the root version and packages[""]', () => {
+    // Missing the second one is exactly how the desktop lock sat at 0.0.2.
+    const next = JSON.parse(lockRoot.write(text, '0.0.29'));
+    assert.equal(next.version, '0.0.29');
+    assert.equal(next.packages[''].version, '0.0.29');
+  });
+});
+
+describe('cargoToml', () => {
+  const text = `[package]\nname = "uxnan-desktop"\nversion = "0.0.28"\nedition = "2021"\n\n[dependencies]\nserde = { version = "1.0" }\n`;
+
+  it('reads the crate version', () => {
+    assert.equal(cargoToml.read(text), '0.0.28');
+  });
+
+  it('writes only the crate version, never a dependency', () => {
+    const next = cargoToml.write(text, '0.0.29');
+    assert.match(next, /name = "uxnan-desktop"\nversion = "0\.0\.29"/);
+    assert.match(next, /serde = \{ version = "1\.0" \}/);
+  });
+});
+
+describe('cargoLock', () => {
+  const text = `# auto-generated\nversion = 3\n\n[[package]]\nname = "serde"\nversion = "1.0.200"\n\n[[package]]\nname = "uxnan-desktop"\nversion = "0.0.28"\ndependencies = [\n "serde",\n]\n\n[[package]]\nname = "tauri"\nversion = "2.0.0"\n`;
+
+  it('finds the named crate among many', () => {
+    assert.equal(cargoLock.read(text, { crate: 'uxnan-desktop' }), '0.0.28');
+  });
+
+  it('writes that crate and leaves its neighbours alone', () => {
+    const next = cargoLock.write(text, '0.0.29', { crate: 'uxnan-desktop' });
+    assert.equal(cargoLock.read(next, { crate: 'uxnan-desktop' }), '0.0.29');
+    assert.equal(cargoLock.read(next, { crate: 'serde' }), '1.0.200');
+    assert.equal(cargoLock.read(next, { crate: 'tauri' }), '2.0.0');
+  });
+
+  it('refuses a crate that is not there', () => {
+    assert.throws(() => cargoLock.write(text, '1.0.0', { crate: 'ghost' }), /no \[\[package\]\]/);
+  });
+});
+
+describe('pubspec', () => {
+  const text = `name: uxnanmobile\ndescription: Uxnan Mobile\npublish_to: 'none'\nversion: 0.0.18-alpha.20260805+20260805\n\nenvironment:\n  sdk: '>=3.4.0 <3.7.0'\n`;
+
+  it('reads and writes the app version', () => {
+    assert.equal(pubspec.read(text), '0.0.18-alpha.20260805+20260805');
+    const next = pubspec.write(text, '0.0.19-alpha.20260806+20260806');
+    assert.equal(pubspec.read(next), '0.0.19-alpha.20260806+20260806');
+  });
+
+  it('does not touch the sdk constraint', () => {
+    assert.match(pubspec.write(text, '1.0.0'), /sdk: '>=3\.4\.0 <3\.7\.0'/);
+  });
+});
+
+describe('adapterFor', () => {
+  it('resolves every name the registry uses', () => {
+    for (const name of [
+      'json',
+      'lock-workspace',
+      'lock-root',
+      'cargo-toml',
+      'cargo-lock',
+      'pubspec',
+    ]) {
+      assert.equal(typeof adapterFor(name).read, 'function');
+    }
+  });
+
+  it('fails loudly on an unknown one', () => {
+    assert.throws(() => adapterFor('nope'), /unknown version-file adapter/);
+  });
+});

--- a/scripts/release/bump.mjs
+++ b/scripts/release/bump.mjs
@@ -1,0 +1,76 @@
+/**
+ * Writes a version into every file that carries it, then reads them all back.
+ *
+ * The read-back is the point. `VERSIONS.md` says "verify each manifest version
+ * equals its lockfile counterpart" and asks a human to do it; this does it, and
+ * refuses to leave a half-bumped tree behind.
+ *
+ * The desktop is the special case: its tag can carry a pre-release id but its
+ * *files* must hold the plain numeric base, because the Windows MSI rejects
+ * anything else. `versionForFiles` is where that rule lives.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { adapterFor } from './adapters.mjs';
+import { component } from './components.mjs';
+import { baseOf } from './version.mjs';
+
+/** What actually goes *in the files* for a component's release version. */
+export function versionForFiles(id, version) {
+  if (component(id).kind !== 'desktop') return version;
+  const base = baseOf(version);
+  if (!base) throw new Error(`cannot read a numeric base out of "${version}"`);
+  return `${base.major}.${base.minor}.${base.patch}`;
+}
+
+/** What each file holds today, without changing anything. */
+export function readCurrent(id, { cwd = process.cwd() } = {}) {
+  return component(id).versionFiles.map((entry) => {
+    const text = readFileSync(join(cwd, entry.file), 'utf8');
+    return { file: entry.file, version: adapterFor(entry.adapter).read(text, entry) };
+  });
+}
+
+/**
+ * Applies the version everywhere, then verifies. Returns what changed so the
+ * caller can print it.
+ *
+ * @returns {{file: string, from: string|null, to: string}[]}
+ */
+export function applyVersion(id, version, { cwd = process.cwd(), dryRun = false } = {}) {
+  const meta = component(id);
+  const target = versionForFiles(id, version);
+  const changes = [];
+
+  for (const entry of meta.versionFiles) {
+    const path = join(cwd, entry.file);
+    const text = readFileSync(path, 'utf8');
+    const adapter = adapterFor(entry.adapter);
+    const from = adapter.read(text, entry);
+    const next = adapter.write(text, target, entry);
+
+    if (adapter.read(next, entry) !== target) {
+      throw new Error(`${entry.file}: writing ${target} did not take — the file's shape changed?`);
+    }
+    if (!dryRun && next !== text) writeFileSync(path, next);
+    changes.push({ file: entry.file, from, to: target });
+  }
+
+  if (!dryRun) assertConsistent(id, target, { cwd });
+  return changes;
+}
+
+/**
+ * Every version-bearing file agrees. Called after a bump, and worth calling on
+ * its own before tagging — a manifest/lock mismatch is exactly the drift that
+ * `--allow-same-version` hides at build time.
+ */
+export function assertConsistent(id, expected, { cwd = process.cwd() } = {}) {
+  const wrong = readCurrent(id, { cwd }).filter((entry) => entry.version !== expected);
+  if (wrong.length > 0) {
+    const detail = wrong.map((e) => `  ${e.file}: ${e.version ?? '(none)'}`).join('\n');
+    throw new Error(`${id}: these files do not say ${expected}:\n${detail}`);
+  }
+}

--- a/scripts/release/bump.test.mjs
+++ b/scripts/release/bump.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { applyVersion, assertConsistent, readCurrent, versionForFiles } from './bump.mjs';
+import { component } from './components.mjs';
+
+/** A throwaway tree shaped like the repo, so the writers run for real. */
+let cwd;
+
+function put(file, contents) {
+  const path = join(cwd, file);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, contents);
+}
+
+/** Every file the desktop carries a version in, all agreeing at 0.0.28. */
+function seedDesktop(version = '0.0.28') {
+  put(
+    'uxnandesktop/src-tauri/tauri.conf.json',
+    JSON.stringify({ productName: 'Uxnan Desktop', version }, null, 2) + '\n',
+  );
+  put(
+    'uxnandesktop/src-tauri/Cargo.toml',
+    `[package]\nname = "uxnan-desktop"\nversion = "${version}"\n`,
+  );
+  put(
+    'uxnandesktop/src-tauri/Cargo.lock',
+    `version = 3\n\n[[package]]\nname = "serde"\nversion = "1.0.200"\n\n[[package]]\nname = "uxnan-desktop"\nversion = "${version}"\n`,
+  );
+  put(
+    'uxnandesktop/package.json',
+    JSON.stringify({ name: 'uxnan-desktop', version }, null, 2) + '\n',
+  );
+  put(
+    'uxnandesktop/package-lock.json',
+    JSON.stringify({ name: 'uxnan-desktop', version, packages: { '': { version } } }, null, 2) +
+      '\n',
+  );
+}
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'uxnan-bump-'));
+});
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true });
+});
+
+describe('versionForFiles', () => {
+  it('strips the pre-release id for the desktop', () => {
+    // The Windows MSI rejects a non-numeric version; the full one rides the tag.
+    assert.equal(versionForFiles('desktop', '0.0.29-nightly.20260806.1'), '0.0.29');
+    assert.equal(versionForFiles('desktop', '0.0.29'), '0.0.29');
+  });
+
+  it('leaves every other component version exactly as tagged', () => {
+    assert.equal(versionForFiles('shared', '0.0.14-alpha.20260806'), '0.0.14-alpha.20260806');
+    assert.equal(
+      versionForFiles('mobile', '0.0.19-alpha.20260806+20260806'),
+      '0.0.19-alpha.20260806+20260806',
+    );
+  });
+});
+
+describe('applyVersion', () => {
+  it('writes the base into all five desktop files', () => {
+    seedDesktop();
+    const changes = applyVersion('desktop', '0.0.29-nightly.20260806.1', { cwd });
+
+    assert.equal(changes.length, component('desktop').versionFiles.length);
+    for (const change of changes) {
+      assert.equal(change.from, '0.0.28');
+      assert.equal(change.to, '0.0.29');
+    }
+    for (const entry of readCurrent('desktop', { cwd })) {
+      assert.equal(entry.version, '0.0.29', entry.file);
+    }
+  });
+
+  it('leaves neighbouring crates and the lock root in agreement', () => {
+    seedDesktop();
+    applyVersion('desktop', '0.0.29', { cwd });
+    const lock = JSON.parse(readFileSync(join(cwd, 'uxnandesktop/package-lock.json'), 'utf8'));
+    assert.equal(lock.version, '0.0.29');
+    assert.equal(lock.packages[''].version, '0.0.29');
+    assert.match(
+      readFileSync(join(cwd, 'uxnandesktop/src-tauri/Cargo.lock'), 'utf8'),
+      /name = "serde"\nversion = "1\.0\.200"/,
+    );
+  });
+
+  it('changes nothing on a dry run', () => {
+    seedDesktop();
+    applyVersion('desktop', '0.0.29', { cwd, dryRun: true });
+    for (const entry of readCurrent('desktop', { cwd })) {
+      assert.equal(entry.version, '0.0.28', entry.file);
+    }
+  });
+});
+
+describe('assertConsistent', () => {
+  it('passes when every file agrees', () => {
+    seedDesktop();
+    assert.doesNotThrow(() => assertConsistent('desktop', '0.0.28', { cwd }));
+  });
+
+  it('names the file that drifted', () => {
+    // This is the check that would have caught the lock sitting at 0.0.2 while
+    // the app shipped 0.0.4.
+    seedDesktop();
+    put(
+      'uxnandesktop/package-lock.json',
+      JSON.stringify(
+        { name: 'uxnan-desktop', version: '0.0.2', packages: { '': { version: '0.0.2' } } },
+        null,
+        2,
+      ),
+    );
+    assert.throws(
+      () => assertConsistent('desktop', '0.0.28', { cwd }),
+      /package-lock\.json: 0\.0\.2/,
+    );
+  });
+});

--- a/scripts/release/changes.mjs
+++ b/scripts/release/changes.mjs
@@ -1,0 +1,59 @@
+/**
+ * "Does this component actually need a release?"
+ *
+ * The rule that matters: a folder changing is not the same as a build changing.
+ * On 2026-08-06 the only change in `relay/` since its tag was `FOR-DEV.md` — a
+ * checklist. A trigger that fires on any path under the component would have cut
+ * a release of identical code, published it to npm, and put a row in the history
+ * for nothing.
+ */
+
+import { component, isDocsOnly } from './components.mjs';
+import { changedFiles, commitSubjects, latestTag } from './git.mjs';
+import { highestBase, nextVersion } from './version.mjs';
+import { tagsFor } from './git.mjs';
+
+/**
+ * @param {string} id component id
+ * @param {{cwd?: string, channel?: 'stable'|'nightly', date?: Date}} [options]
+ * @returns {{
+ *   id: string, since: string|null, files: string[], docsOnly: string[],
+ *   substantive: string[], commits: number, worthy: boolean,
+ *   shipped: string|null, next: string,
+ * }}
+ */
+export function inspect(id, options = {}) {
+  const meta = component(id);
+  const gitOptions = { cwd: options.cwd };
+
+  const since = latestTag(meta.tagPrefixes, gitOptions);
+  const files = changedFiles(since, meta.path, gitOptions);
+  const docsOnly = files.filter(isDocsOnly);
+  const substantive = files.filter((file) => !isDocsOnly(file));
+
+  const tags = tagsFor(meta.tagPrefixes, gitOptions);
+  const shipped = highestBase(tags);
+  const { version } = nextVersion({
+    kind: meta.kind,
+    tags,
+    channel: options.channel ?? 'stable',
+    date: options.date,
+  });
+
+  return {
+    id,
+    since,
+    files,
+    docsOnly,
+    substantive,
+    commits: commitSubjects(since, meta.path, gitOptions).length,
+    worthy: substantive.length > 0,
+    shipped: shipped ? `${shipped.major}.${shipped.minor}.${shipped.patch}` : null,
+    next: version,
+  };
+}
+
+/** The same answer for every component, in the order releases must be cut. */
+export function inspectAll(options = {}) {
+  return ['shared', 'bridge', 'relay', 'mobile', 'desktop'].map((id) => inspect(id, options));
+}

--- a/scripts/release/components.mjs
+++ b/scripts/release/components.mjs
@@ -1,0 +1,116 @@
+/**
+ * The release registry: one place that knows what each component is, where its
+ * version lives, and which tag drives it.
+ *
+ * `VERSIONS.md` describes all of this in prose for humans. This file is the
+ * machine's copy — when the two disagree, one of them is a bug, and the tests in
+ * `components.test.mjs` pin the parts that have burned us before (a version file
+ * left out of a bump is invisible until a release ships wrong).
+ */
+
+/** Paths whose change cannot possibly need a new build. */
+export const DOCS_ONLY = [
+  /\.md$/i,
+  /(^|\/)docs\//,
+  /(^|\/)architecture(\.old)?\//,
+  /(^|\/)\.github\//,
+];
+
+/**
+ * `kind` decides how a version string is built:
+ *   npm      → 0.0.PATCH-alpha.YYYYMMDD
+ *   mobile   → 0.0.PATCH-alpha.YYYYMMDD+BUILD   (Play needs a rising integer)
+ *   desktop  → 0.0.PATCH            (stable)
+ *              0.0.PATCH-nightly.YYYYMMDD.N     (nightly)
+ */
+export const COMPONENTS = [
+  {
+    id: 'shared',
+    name: '@uxnan/shared',
+    kind: 'npm',
+    path: 'shared',
+    tagPrefixes: ['shared-v'],
+    workspace: 'shared',
+    /** Every file that carries the version, in the order a human would check. */
+    versionFiles: [
+      { file: 'shared/package.json', adapter: 'json' },
+      { file: 'package-lock.json', adapter: 'lock-workspace', pkgPath: 'shared' },
+    ],
+    /** Consumers that resolve this from npm at build time — order matters. */
+    releaseBefore: ['bridge', 'relay'],
+  },
+  {
+    id: 'bridge',
+    name: 'uxnan-bridge',
+    kind: 'npm',
+    path: 'bridge',
+    tagPrefixes: ['bridge-v'],
+    workspace: 'bridge',
+    versionFiles: [
+      { file: 'bridge/package.json', adapter: 'json' },
+      { file: 'package-lock.json', adapter: 'lock-workspace', pkgPath: 'bridge' },
+    ],
+    releaseBefore: [],
+  },
+  {
+    id: 'relay',
+    name: 'uxnan-relay',
+    kind: 'npm',
+    path: 'relay',
+    tagPrefixes: ['relay-v'],
+    workspace: 'relay',
+    versionFiles: [
+      { file: 'relay/package.json', adapter: 'json' },
+      { file: 'package-lock.json', adapter: 'lock-workspace', pkgPath: 'relay' },
+    ],
+    releaseBefore: [],
+  },
+  {
+    id: 'desktop',
+    name: 'uxnan-desktop',
+    kind: 'desktop',
+    path: 'uxnandesktop',
+    // Both channels share one numeric line: a base must be new against BOTH, or
+    // the Windows MSI and the updater cannot see the newer build.
+    tagPrefixes: ['desktop-stable-v', 'desktop-nightly-v'],
+    versionFiles: [
+      { file: 'uxnandesktop/src-tauri/tauri.conf.json', adapter: 'json' },
+      { file: 'uxnandesktop/src-tauri/Cargo.toml', adapter: 'cargo-toml' },
+      { file: 'uxnandesktop/src-tauri/Cargo.lock', adapter: 'cargo-lock', crate: 'uxnan-desktop' },
+      { file: 'uxnandesktop/package.json', adapter: 'json' },
+      { file: 'uxnandesktop/package-lock.json', adapter: 'lock-root' },
+    ],
+    releaseBefore: [],
+  },
+  {
+    id: 'mobile',
+    name: 'uxnanmobile',
+    kind: 'mobile',
+    path: 'uxnanmobile',
+    tagPrefixes: ['mobile-v'],
+    versionFiles: [{ file: 'uxnanmobile/pubspec.yaml', adapter: 'pubspec' }],
+    releaseBefore: [],
+  },
+];
+
+/** The order releases must be cut in: a component never precedes its provider. */
+export const RELEASE_ORDER = ['shared', 'bridge', 'relay', 'mobile', 'desktop'];
+
+export function component(id) {
+  const found = COMPONENTS.find((c) => c.id === id);
+  if (!found) throw new Error(`unknown component: ${id}`);
+  return found;
+}
+
+/** True when a changed path cannot affect what a build produces. */
+export function isDocsOnly(file) {
+  return DOCS_ONLY.some((rule) => rule.test(file));
+}
+
+/**
+ * The desktop's numeric base must exceed every build already shipped in either
+ * channel, so its "previous version" is not one tag but the whole line.
+ */
+export function tagPrefixes(id) {
+  return component(id).tagPrefixes;
+}

--- a/scripts/release/components.test.mjs
+++ b/scripts/release/components.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+import { COMPONENTS, RELEASE_ORDER, component, isDocsOnly } from './components.mjs';
+
+const repo = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('the registry', () => {
+  it('describes every component the repo releases', () => {
+    assert.deepEqual(COMPONENTS.map((c) => c.id).sort(), [
+      'bridge',
+      'desktop',
+      'mobile',
+      'relay',
+      'shared',
+    ]);
+  });
+
+  it('points every version file at something that exists', () => {
+    // A path typo here is invisible until a release half-bumps the tree.
+    for (const meta of COMPONENTS) {
+      for (const entry of meta.versionFiles) {
+        assert.ok(existsSync(join(repo, entry.file)), `${meta.id}: missing ${entry.file}`);
+      }
+    }
+  });
+
+  it('gives the desktop both channels, since one numeric line feeds both', () => {
+    assert.deepEqual(component('desktop').tagPrefixes, ['desktop-stable-v', 'desktop-nightly-v']);
+  });
+
+  it('bumps the lockfile alongside every manifest', () => {
+    // The rule VERSIONS.md states in prose: a manifest without its lock is the
+    // drift that `--allow-same-version` hides at build time.
+    for (const meta of COMPONENTS) {
+      const files = meta.versionFiles.map((e) => e.file);
+      const manifests = files.filter((f) => f.endsWith('package.json'));
+      for (const manifest of manifests) {
+        const hasLock = files.some((f) => f.endsWith('package-lock.json'));
+        assert.ok(hasLock, `${meta.id}: ${manifest} has no lockfile in the bump list`);
+      }
+      if (files.some((f) => f.endsWith('Cargo.toml'))) {
+        assert.ok(
+          files.some((f) => f.endsWith('Cargo.lock')),
+          `${meta.id}: Cargo.toml has no Cargo.lock in the bump list`,
+        );
+      }
+    }
+  });
+
+  it('orders shared before the packages that resolve it from npm', () => {
+    // The bridge pins @uxnan/shared by reading npm at build time, so tagging
+    // them together publishes a bridge against the previous shared.
+    assert.deepEqual(component('shared').releaseBefore, ['bridge', 'relay']);
+    assert.ok(RELEASE_ORDER.indexOf('shared') < RELEASE_ORDER.indexOf('bridge'));
+    assert.ok(RELEASE_ORDER.indexOf('shared') < RELEASE_ORDER.indexOf('relay'));
+  });
+
+  it('covers every component in the release order', () => {
+    assert.deepEqual([...RELEASE_ORDER].sort(), COMPONENTS.map((c) => c.id).sort());
+  });
+
+  it('rejects an unknown id instead of returning undefined', () => {
+    assert.throws(() => component('web'), /unknown component/);
+  });
+});
+
+describe('isDocsOnly', () => {
+  it('treats prose and specs as unable to change a build', () => {
+    for (const file of [
+      'relay/FOR-DEV.md',
+      'bridge/README.md',
+      'uxnandesktop/docs/agent-launch.md',
+      'uxnandesktop/architecture/02b-terminal-engine.md',
+      'architecture.old/whitepaper.md',
+      '.github/workflows/ci-node.yml',
+    ]) {
+      assert.equal(isDocsOnly(file), true, file);
+    }
+  });
+
+  it('treats anything that ships as release-worthy', () => {
+    for (const file of [
+      'bridge/src/adapters/zero-adapter.ts',
+      'uxnandesktop/src/lib/agentCatalog.ts',
+      'uxnandesktop/static/agents/codex.svg',
+      'uxnanmobile/lib/main.dart',
+      'shared/package.json',
+      'uxnandesktop/src-tauri/Cargo.toml',
+    ]) {
+      assert.equal(isDocsOnly(file), false, file);
+    }
+  });
+});

--- a/scripts/release/git.mjs
+++ b/scripts/release/git.mjs
@@ -1,0 +1,68 @@
+/**
+ * The thin git layer. Everything the release scripts need to know about history,
+ * and nothing else — kept in one place so the logic modules stay pure and
+ * testable, and so a shell quoting mistake can only live here.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+function git(args, { cwd = process.cwd() } = {}) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+}
+
+/** Every tag matching any of the prefixes, newest first by version order. */
+export function tagsFor(prefixes, options) {
+  const out = [];
+  for (const prefix of prefixes) {
+    const listed = git(['tag', '-l', `${prefix}*`, '--sort=-v:refname'], options)
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    out.push(...listed);
+  }
+  return out;
+}
+
+/**
+ * The most recently created tag among the prefixes — the last build shipped.
+ * Commit date beats version order here: "changes since the last release" means
+ * the newest build, whichever channel produced it.
+ */
+export function latestTag(prefixes, options) {
+  const all = prefixes.flatMap((prefix) =>
+    git(['tag', '-l', `${prefix}*`, '--sort=-creatordate'], options)
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((tag) => ({ tag, at: git(['log', '-1', '--format=%ct', tag], options).trim() })),
+  );
+  if (all.length === 0) return null;
+  all.sort((a, b) => Number(b.at) - Number(a.at));
+  return all[0].tag;
+}
+
+/** Files changed between a ref and HEAD, restricted to one path. */
+export function changedFiles(fromRef, path, options) {
+  const range = fromRef ? `${fromRef}..HEAD` : 'HEAD';
+  return git(['diff', '--name-only', range, '--', path], options)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/** Commit subjects in the same range, for the summary. */
+export function commitSubjects(fromRef, path, options) {
+  const range = fromRef ? `${fromRef}..HEAD` : 'HEAD';
+  return git(['log', '--format=%s', range, '--', path], options)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+/** Refuses to compute a release from a dirty or unexpected tree. */
+export function workingTreeState(options) {
+  const dirty = git(['status', '--porcelain'], options).trim().length > 0;
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], options).trim();
+  const head = git(['rev-parse', '--short', 'HEAD'], options).trim();
+  return { dirty, branch, head };
+}

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * `npm run release:prepare -- <component> [--channel=nightly] [--version=x] [--dry-run]`
+ *
+ * Does the part of a release that is mechanical and easy to get wrong: works out
+ * the next version, refuses it if the component has nothing to ship or the base
+ * would not move forward, writes it into every version-bearing file, and reads
+ * them all back to prove they agree.
+ *
+ * It deliberately stops there. Committing, tagging and pushing stay in human
+ * hands (and, from phase 2, in the release workflow) — this prints the exact
+ * commands so the tag can never disagree with the files it just wrote.
+ */
+
+import { inspect } from './changes.mjs';
+import { applyVersion, versionForFiles } from './bump.mjs';
+import { component } from './components.mjs';
+import { tagsFor, workingTreeState } from './git.mjs';
+import { assertMovesForward } from './version.mjs';
+
+const [id, ...rest] = process.argv.slice(2);
+const flag = (name) =>
+  rest
+    .find((a) => a.startsWith(`--${name}=`))
+    ?.split('=')
+    .slice(1)
+    .join('=');
+const has = (name) => rest.includes(`--${name}`);
+
+if (!id) {
+  console.error(
+    'usage: release:prepare -- <shared|bridge|relay|mobile|desktop> [--channel=nightly] [--version=…] [--dry-run] [--force]',
+  );
+  process.exit(2);
+}
+
+const meta = component(id);
+const channel = flag('channel') ?? 'stable';
+const dryRun = has('dry-run');
+
+if (meta.kind === 'desktop' && !['stable', 'nightly'].includes(channel)) {
+  console.error(`desktop releases are stable or nightly, not "${channel}"`);
+  process.exit(2);
+}
+
+const tree = workingTreeState();
+if (tree.dirty && !has('force')) {
+  console.error(`the working tree is dirty — commit or stash first (or pass --force)`);
+  process.exit(1);
+}
+
+const report = inspect(id, { channel });
+if (!report.worthy && !has('force')) {
+  console.error(`\n${id} has nothing to release since ${report.since ?? 'the beginning'}.`);
+  if (report.docsOnly.length > 0) {
+    console.error('Only these changed, and none of them can affect a build:');
+    for (const file of report.docsOnly) console.error(`  ${file}`);
+  }
+  console.error('\nPass --force to release it anyway.\n');
+  process.exit(1);
+}
+
+const version = flag('version') ?? report.next;
+const tags = tagsFor(meta.tagPrefixes);
+assertMovesForward({ version, tags });
+
+const tagPrefix =
+  meta.kind === 'desktop'
+    ? channel === 'nightly'
+      ? 'desktop-nightly-v'
+      : 'desktop-stable-v'
+    : meta.tagPrefixes[0];
+const tag = `${tagPrefix}${version}`;
+
+console.log(`\n${id} → ${version}${meta.kind === 'desktop' ? ` (${channel})` : ''}`);
+console.log(`  last shipped: ${report.since ?? '(never)'}`);
+console.log(`  files carry:  ${versionForFiles(id, version)}\n`);
+
+for (const change of applyVersion(id, version, { dryRun })) {
+  console.log(`  ${change.from ?? '(none)'} → ${change.to}  ${change.file}`);
+}
+
+console.log(dryRun ? '\n(dry run — nothing written)\n' : '\nAll version files agree.\n');
+console.log('Next, once the CHANGELOG entry is under the right heading:\n');
+console.log(`  git commit -am "chore(release): ${id} ${version}"`);
+console.log(`  git tag ${tag}`);
+console.log(`  git push origin main --tags\n`);
+
+if (meta.releaseBefore.length > 0) {
+  console.log(
+    `Wait for this to publish before tagging ${meta.releaseBefore.join(' / ')} — they resolve it from npm at build time.\n`,
+  );
+}

--- a/scripts/release/status.mjs
+++ b/scripts/release/status.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * `npm run release:status` — the state of every component in one table.
+ *
+ * Answers, without anyone having to remember the convention: what shipped last,
+ * what changed since, whether that change can affect a build, and what the next
+ * version would be. Read-only; it never writes a file or touches a tag.
+ *
+ * Flags:
+ *   --channel=nightly   compute the desktop's next version as a nightly
+ *   --json              machine-readable, for the release workflow's summary
+ */
+
+import { inspectAll } from './changes.mjs';
+import { readCurrent } from './bump.mjs';
+import { component } from './components.mjs';
+import { workingTreeState } from './git.mjs';
+import { versionForFiles } from './bump.mjs';
+
+const args = process.argv.slice(2);
+const channel =
+  /^--channel=(stable|nightly)$/.exec(args.find((a) => a.startsWith('--channel=')) ?? '')?.[1] ??
+  'nightly';
+const asJson = args.includes('--json');
+
+const rows = inspectAll({ channel });
+
+/** A component whose files already disagree with each other is a release bug. */
+function fileState(id) {
+  try {
+    const current = readCurrent(id);
+    const values = new Set(current.map((entry) => entry.version));
+    return values.size === 1 ? { ok: true, version: [...values][0] } : { ok: false, current };
+  } catch (error) {
+    return { ok: false, error: error.message };
+  }
+}
+
+if (asJson) {
+  console.log(JSON.stringify({ rows, tree: workingTreeState() }, null, 2));
+  process.exit(0);
+}
+
+const tree = workingTreeState();
+console.log(
+  `\nuxnan release status — ${tree.branch} @ ${tree.head}${tree.dirty ? ' (dirty)' : ''}\n`,
+);
+
+const pad = (value, width) => String(value).padEnd(width);
+console.log(
+  `${pad('component', 10)}${pad('last tag', 40)}${pad('changed', 9)}${pad('needs release', 15)}next`,
+);
+console.log('-'.repeat(104));
+
+let owed = 0;
+for (const row of rows) {
+  const changed = `${row.substantive.length}+${row.docsOnly.length}d`;
+  const verdict = row.worthy ? 'YES' : row.files.length ? 'no (docs only)' : 'no';
+  if (row.worthy) owed += 1;
+  const suffix = row.id === 'desktop' ? ` (${channel})` : '';
+  console.log(
+    `${pad(row.id, 10)}${pad(row.since ?? '(never released)', 40)}${pad(changed, 9)}${pad(verdict, 15)}${row.worthy ? row.next + suffix : '—'}`,
+  );
+}
+
+console.log(
+  '\nchanged = files that can affect a build + files that cannot (docs, architecture, .github)\n',
+);
+
+for (const row of rows.filter((r) => r.worthy)) {
+  const meta = component(row.id);
+  console.log(`${row.id}: ${row.commits} commit(s), ${row.substantive.length} file(s)`);
+  for (const file of row.substantive.slice(0, 8)) console.log(`  ${file}`);
+  if (row.substantive.length > 8) console.log(`  … ${row.substantive.length - 8} more`);
+  const state = fileState(row.id);
+  if (state.ok) {
+    console.log(
+      `  version files agree at ${state.version} → would become ${versionForFiles(row.id, row.next)}`,
+    );
+  } else if (state.current) {
+    console.log('  ⚠ version files DISAGREE already:');
+    for (const entry of state.current)
+      console.log(`    ${entry.file}: ${entry.version ?? '(none)'}`);
+  } else {
+    console.log(`  ⚠ could not read version files: ${state.error}`);
+  }
+  if (meta.releaseBefore.length > 0) {
+    console.log(
+      `  must be published (and visible on npm) before: ${meta.releaseBefore.join(', ')}`,
+    );
+  }
+  console.log('');
+}
+
+console.log(owed === 0 ? 'Nothing owes a release.\n' : `${owed} component(s) owe a release.\n`);

--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -1,0 +1,114 @@
+/**
+ * Version arithmetic for the release convention in `VERSIONS.md`.
+ *
+ * Everything here is pure: given the tags that already exist and a date, it says
+ * what the next version and tag are. No git, no filesystem — so the rules can be
+ * tested exhaustively, which matters because getting one wrong is not a typo,
+ * it is a shipped build nobody's updater can see.
+ */
+
+/** `20260806` — the date component every alpha and nightly carries. */
+export function dateStamp(date = new Date()) {
+  const iso = date.toISOString();
+  return `${iso.slice(0, 4)}${iso.slice(5, 7)}${iso.slice(8, 10)}`;
+}
+
+/**
+ * Pulls `0.0.PATCH` out of any tag this repo has ever used, whatever rides
+ * behind it (`-alpha.20260805`, `-nightly.20260724.1`, `+20260805`).
+ * Returns null for a tag that does not carry one.
+ */
+export function baseOf(tag) {
+  const match = /(\d+)\.(\d+)\.(\d+)/.exec(tag ?? '');
+  if (!match) return null;
+  return { major: +match[1], minor: +match[2], patch: +match[3] };
+}
+
+/** `0.0.28` → 28. The number the desktop's MSI and updater actually compare. */
+export function patchOf(tag) {
+  return baseOf(tag)?.patch ?? null;
+}
+
+/** The highest numeric base across a set of tags (channels included). */
+export function highestBase(tags) {
+  let best = null;
+  for (const tag of tags) {
+    const base = baseOf(tag);
+    if (!base) continue;
+    const rank = base.major * 1e6 + base.minor * 1e3 + base.patch;
+    if (!best || rank > best.rank) best = { ...base, rank };
+  }
+  return best ? { major: best.major, minor: best.minor, patch: best.patch } : null;
+}
+
+function nextBase(tags) {
+  const highest = highestBase(tags);
+  return highest ? { ...highest, patch: highest.patch + 1 } : { major: 0, minor: 0, patch: 1 };
+}
+
+const fmt = (b) => `${b.major}.${b.minor}.${b.patch}`;
+
+/**
+ * The next version for a component.
+ *
+ * @param {object} input
+ * @param {'npm'|'mobile'|'desktop'} input.kind
+ * @param {string[]} input.tags   every existing tag for the component (all channels)
+ * @param {'stable'|'nightly'} [input.channel]  desktop only
+ * @param {Date} [input.date]
+ * @returns {{version: string, base: string, tag: (prefix: string) => string}}
+ */
+export function nextVersion({ kind, tags, channel = 'stable', date = new Date() }) {
+  const base = fmt(nextBase(tags));
+  const stamp = dateStamp(date);
+
+  if (kind === 'npm') {
+    return { version: `${base}-alpha.${stamp}`, base };
+  }
+
+  if (kind === 'mobile') {
+    // Play needs a strictly rising integer. The date is one, and it is
+    // self-documenting — but a second release on the same day would repeat it,
+    // so step past any build number already used.
+    const used = new Set(
+      tags.map((t) => Number(/\+(\d+)$/.exec(t)?.[1])).filter((n) => Number.isFinite(n)),
+    );
+    let build = Number(stamp);
+    while (used.has(build)) build += 1;
+    return { version: `${base}-alpha.${stamp}+${build}`, base, build };
+  }
+
+  if (kind === 'desktop') {
+    if (channel === 'stable') return { version: base, base };
+    // `N` only separates nightlies cut on the same date for the same base.
+    const sameDay = tags.filter((t) => t.includes(`-nightly.${stamp}.`));
+    const highestN = sameDay.reduce((max, t) => {
+      const n = Number(/-nightly\.\d+\.(\d+)/.exec(t)?.[1]);
+      return Number.isFinite(n) && n > max ? n : max;
+    }, 0);
+    return { version: `${base}-nightly.${stamp}.${highestN + 1}`, base };
+  }
+
+  throw new Error(`unknown component kind: ${kind}`);
+}
+
+/**
+ * Refuses a version that would not be seen as newer than what already shipped.
+ * For the desktop that is the whole point: the MSI and the updater compare only
+ * `0.0.PATCH`, so reusing a base makes the new build invisible rather than
+ * failing loudly.
+ */
+export function assertMovesForward({ version, tags }) {
+  const proposed = baseOf(version);
+  const highest = highestBase(tags);
+  if (!proposed) throw new Error(`cannot read a 0.0.PATCH base out of "${version}"`);
+  if (!highest) return;
+
+  const rank = (b) => b.major * 1e6 + b.minor * 1e3 + b.patch;
+  if (rank(proposed) <= rank(highest)) {
+    throw new Error(
+      `version ${version} does not move past ${fmt(highest)}, which has already shipped — ` +
+        `pick a base above every tag in every channel`,
+    );
+  }
+}

--- a/scripts/release/version.test.mjs
+++ b/scripts/release/version.test.mjs
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { assertMovesForward, baseOf, dateStamp, highestBase, nextVersion } from './version.mjs';
+
+/** The real tag history, so the rules are pinned against what actually shipped. */
+const NPM_TAGS = [
+  'shared-v0.0.13-alpha.20260804',
+  'shared-v0.0.12-alpha.20260803',
+  'shared-v0.0.11-alpha.20260729',
+];
+const DESKTOP_TAGS = [
+  'desktop-stable-v0.0.28',
+  'desktop-stable-v0.0.23',
+  'desktop-nightly-v0.0.22-nightly.20260724.1',
+  'desktop-v0.0.9-alpha.20260711',
+];
+const MOBILE_TAGS = [
+  'mobile-v0.0.18-alpha.20260805+20260805',
+  'mobile-v0.0.17-alpha.20260804+20260804',
+];
+
+const AUG_6 = new Date('2026-08-06T09:00:00Z');
+
+describe('dateStamp', () => {
+  it('is the UTC date, zero-padded', () => {
+    assert.equal(dateStamp(new Date('2026-08-06T23:59:59Z')), '20260806');
+    assert.equal(dateStamp(new Date('2026-01-02T00:00:00Z')), '20260102');
+  });
+
+  it('does not drift with the local timezone', () => {
+    // 23:30 UTC is already "tomorrow" in +02:00 — the stamp must stay UTC, or
+    // two machines cutting the same release disagree on the version.
+    assert.equal(dateStamp(new Date('2026-08-06T23:30:00Z')), '20260806');
+  });
+});
+
+describe('baseOf / highestBase', () => {
+  it('reads the numeric base out of every tag shape this repo has used', () => {
+    assert.deepEqual(baseOf('shared-v0.0.13-alpha.20260804'), { major: 0, minor: 0, patch: 13 });
+    assert.deepEqual(baseOf('desktop-nightly-v0.0.22-nightly.20260724.1'), {
+      major: 0,
+      minor: 0,
+      patch: 22,
+    });
+    assert.deepEqual(baseOf('mobile-v0.0.18-alpha.20260805+20260805'), {
+      major: 0,
+      minor: 0,
+      patch: 18,
+    });
+    assert.equal(baseOf('not-a-version'), null);
+  });
+
+  it('takes the highest across channels, not the newest tag', () => {
+    // The nightly line sits below the stable one here; picking "most recent"
+    // instead of "highest" would reuse a base the MSI has already seen.
+    assert.deepEqual(highestBase(DESKTOP_TAGS), { major: 0, minor: 0, patch: 28 });
+  });
+
+  it('is null when nothing has shipped', () => {
+    assert.equal(highestBase([]), null);
+  });
+});
+
+describe('nextVersion — npm', () => {
+  it('bumps the patch and stamps today', () => {
+    assert.equal(
+      nextVersion({ kind: 'npm', tags: NPM_TAGS, date: AUG_6 }).version,
+      '0.0.14-alpha.20260806',
+    );
+  });
+
+  it('starts at 0.0.1 for a component that has never shipped', () => {
+    assert.equal(
+      nextVersion({ kind: 'npm', tags: [], date: AUG_6 }).version,
+      '0.0.1-alpha.20260806',
+    );
+  });
+});
+
+describe('nextVersion — mobile', () => {
+  it('carries a build number Play will accept', () => {
+    assert.equal(
+      nextVersion({ kind: 'mobile', tags: MOBILE_TAGS, date: AUG_6 }).version,
+      '0.0.19-alpha.20260806+20260806',
+    );
+  });
+
+  it('steps past a build number already used the same day', () => {
+    // Two releases in one day would otherwise repeat the integer, and Play
+    // rejects a versionCode it has already seen.
+    const tags = ['mobile-v0.0.19-alpha.20260806+20260806', ...MOBILE_TAGS];
+    assert.equal(
+      nextVersion({ kind: 'mobile', tags, date: AUG_6 }).version,
+      '0.0.20-alpha.20260806+20260807',
+    );
+  });
+});
+
+describe('nextVersion — desktop', () => {
+  it('cuts a stable above every channel', () => {
+    assert.equal(
+      nextVersion({ kind: 'desktop', tags: DESKTOP_TAGS, channel: 'stable', date: AUG_6 }).version,
+      '0.0.29',
+    );
+  });
+
+  it('cuts a nightly on a fresh base', () => {
+    assert.equal(
+      nextVersion({ kind: 'desktop', tags: DESKTOP_TAGS, channel: 'nightly', date: AUG_6 }).version,
+      '0.0.29-nightly.20260806.1',
+    );
+  });
+
+  it('increments N for a second nightly the same day', () => {
+    const tags = ['desktop-nightly-v0.0.29-nightly.20260806.1', ...DESKTOP_TAGS];
+    assert.equal(
+      nextVersion({ kind: 'desktop', tags, channel: 'nightly', date: AUG_6 }).version,
+      '0.0.30-nightly.20260806.2',
+    );
+  });
+});
+
+describe('assertMovesForward', () => {
+  it('accepts a base above everything shipped', () => {
+    assert.doesNotThrow(() => assertMovesForward({ version: '0.0.29', tags: DESKTOP_TAGS }));
+  });
+
+  it('refuses a base that has already shipped in either channel', () => {
+    // The failure mode this prevents is silent: the MSI and the updater compare
+    // only the numeric base, so a reused one makes the build invisible.
+    assert.throws(
+      () => assertMovesForward({ version: '0.0.28-nightly.20260806.1', tags: DESKTOP_TAGS }),
+      /does not move past 0\.0\.28/,
+    );
+    assert.throws(
+      () => assertMovesForward({ version: '0.0.22', tags: DESKTOP_TAGS }),
+      /already shipped/,
+    );
+  });
+
+  it('accepts anything when nothing has shipped yet', () => {
+    assert.doesNotThrow(() => assertMovesForward({ version: '0.0.1', tags: [] }));
+  });
+});


### PR DESCRIPTION
Phase 1 of the release automation: the two commands that remove the guesswork and the transcription errors from cutting a release. Nothing here commits, tags or pushes — that stays manual until the workflow lands in phase 2.

## `npm run release:status`

The whole monorepo in one table. Run against `main` right now:

```
component last tag                                changed  needs release  next
shared    shared-v0.0.13-alpha.20260804           0+0d     no             —
bridge    bridge-v0.0.18-alpha.20260805           0+0d     no             —
relay     relay-v0.0.2-alpha.20260720             0+1d     no (docs only) —
mobile    mobile-v0.0.18-alpha.20260805+20260805  0+0d     no             —
desktop   desktop-stable-v0.0.28                  25+9d    YES            0.0.29-nightly.20260806.1
```

`changed` is `files that can affect a build + files that cannot`. That second number matters: the only change in `relay/` since its tag is `FOR-DEV.md`, and a trigger firing on "the folder changed" would publish an identical package.

## `npm run release:prepare -- <component> [--channel=nightly]`

Computes the version, refuses it when there is nothing to ship / the tree is dirty / the base would not move past **every** channel, writes it into every version-bearing file, reads them all back, and prints the exact commit and tag commands.

Note what it encodes: the desktop tag carries `0.0.29-nightly.20260806.1` while its five files carry `0.0.29` alone, because the Windows MSI rejects a pre-release id.

## Why these rules and not others

Each guard is a failure that already shipped here:

- **A lockfile left behind a manifest.** `uxnandesktop/package-lock.json` sat at `0.0.2` while the app shipped `0.0.4`, because the release workflow re-applies the version with `--allow-same-version` and hides the drift. `assertConsistent` now reads every file back and names the one that disagrees.
- **A reused numeric base.** The MSI and the updater compare only `0.0.PATCH`, so reusing one does not fail — it ships a build nobody can see. `assertMovesForward` refuses it.
- **Ordering.** `shared` is marked as required-before `bridge` and `relay`, which resolve it from npm at build time; bridge 0.0.14 published against the previous shared exactly because two tags went up together.

## Verification

45 tests (`node --test`, no new dependencies), wired into the root `npm test`; `scripts/**/*.mjs` added to the prettier gate. The pure split — `version.mjs` is arithmetic, `adapters.mjs` is text in / text out — is what makes the rules testable without git or disk.

Heads-up on the local run: the bridge suite failed once with `ENOTEMPTY: rmdir` in a test's temp-dir teardown, the known Windows flake; it passed 632/632 on re-run.