### PR TITLE
fix(release-tooling): bump a version without reformatting the file

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -11,6 +11,8 @@ on:
       - "shared/**"
       - "bridge/**"
       - "relay/**"
+      # The release tooling lives here and its tests run in the root `npm test`.
+      - "scripts/**"
       - "package.json"
       - "package-lock.json"
       - "tsconfig.base.json"
@@ -22,6 +24,8 @@ on:
       - "shared/**"
       - "bridge/**"
       - "relay/**"
+      # The release tooling lives here and its tests run in the root `npm test`.
+      - "scripts/**"
       - "package.json"
       - "package-lock.json"
       - "tsconfig.base.json"

--- a/scripts/release/adapters.mjs
+++ b/scripts/release/adapters.mjs
@@ -11,27 +11,57 @@
  * Text in, text out: no file I/O here, so every rule is testable on a string.
  */
 
+/**
+ * Replaces a JSON string value **in place**, leaving every other byte alone.
+ *
+ * Re-serialising with `JSON.stringify` is the obvious implementation, and it is
+ * wrong: it reformats whatever the author wrote. The first real use of this
+ * tooling turned `"dangerousDisableAssetCspModification": ["style-src"]` in
+ * `tauri.conf.json` into a three-line array — churn inside a security block, in
+ * a release commit. A version bump reformats nothing.
+ *
+ * `indent` anchors the key to its nesting level, so a top-level `"version"` is
+ * never confused with one belonging to a dependency. When the pattern does not
+ * match — a minified file, say — the caller falls back to re-serialising, and
+ * `applyVersion` reads the value back either way.
+ */
+function replaceValue(text, key, version, { indent = '  ' } = {}) {
+  const pattern = new RegExp(`^(${indent}"${key}"\\s*:\\s*")([^"]*)(")`, 'm');
+  return pattern.test(text) ? text.replace(pattern, `$1${version}$3`) : null;
+}
+
+function reserialise(text, mutate) {
+  const data = JSON.parse(text);
+  mutate(data);
+  return JSON.stringify(data, null, 2) + (text.endsWith('\n') ? '\n' : '');
+}
+
 /** `package.json`, `tauri.conf.json` — a top-level `"version"`. */
 export const json = {
   read: (text) => JSON.parse(text).version ?? null,
-  write: (text, version) => {
-    const data = JSON.parse(text);
-    data.version = version;
-    // Keep the file's own trailing newline habit.
-    return JSON.stringify(data, null, 2) + (text.endsWith('\n') ? '\n' : '');
-  },
+  write: (text, version) =>
+    replaceValue(text, 'version', version) ??
+    reserialise(text, (data) => {
+      data.version = version;
+    }),
 };
 
 /** A component's entry inside the **root** `package-lock.json`. */
 export const lockWorkspace = {
   read: (text, { pkgPath }) => JSON.parse(text).packages?.[pkgPath]?.version ?? null,
   write: (text, version, { pkgPath }) => {
-    const data = JSON.parse(text);
-    if (!data.packages?.[pkgPath]) {
+    if (!JSON.parse(text).packages?.[pkgPath]) {
       throw new Error(`package-lock.json has no entry for "${pkgPath}"`);
     }
-    data.packages[pkgPath].version = version;
-    return JSON.stringify(data, null, 2) + (text.endsWith('\n') ? '\n' : '');
+    // The entry sits one level inside `packages`, so its keys are indented by 6.
+    const block = new RegExp(`("${pkgPath}"\\s*:\\s*\\{)([\\s\\S]*?)(\\n    \\})`);
+    const found = block.exec(text);
+    const bumped = found && replaceValue(found[2], 'version', version, { indent: '      ' });
+    if (bumped) return text.replace(block, `$1${bumped}$3`);
+
+    return reserialise(text, (data) => {
+      data.packages[pkgPath].version = version;
+    });
   },
 };
 
@@ -39,10 +69,17 @@ export const lockWorkspace = {
 export const lockRoot = {
   read: (text) => JSON.parse(text).version ?? null,
   write: (text, version) => {
-    const data = JSON.parse(text);
-    data.version = version;
-    if (data.packages?.['']) data.packages[''].version = version;
-    return JSON.stringify(data, null, 2) + (text.endsWith('\n') ? '\n' : '');
+    // Both copies, or the next install re-resolves the root package.
+    const top = replaceValue(text, 'version', version);
+    const block = /("" *: *\{)([\s\S]*?)(\n    \})/;
+    const found = top && block.exec(top);
+    const bumped = found && replaceValue(found[2], 'version', version, { indent: '      ' });
+    if (top && bumped) return top.replace(block, `$1${bumped}$3`);
+
+    return reserialise(text, (data) => {
+      data.version = version;
+      if (data.packages?.['']) data.packages[''].version = version;
+    });
   },
 };
 

--- a/scripts/release/adapters.test.mjs
+++ b/scripts/release/adapters.test.mjs
@@ -26,6 +26,44 @@ describe('json', () => {
   });
 });
 
+describe('json — formatting', () => {
+  // The bug this exists to prevent: the first real release cut reformatted a
+  // one-line array in tauri.conf.json, inside its CSP block.
+  const tauri = [
+    '{',
+    '  "$schema": "https://schema.tauri.app/config/2",',
+    '  "productName": "Uxnan Desktop",',
+    '  "version": "0.0.28",',
+    '  "app": {',
+    '    "security": {',
+    '      "dangerousDisableAssetCspModification": ["style-src"]',
+    '    }',
+    '  }',
+    '}',
+    '',
+  ].join('\n');
+
+  it('changes the version line and nothing else', () => {
+    const next = json.write(tauri, '0.0.29');
+    assert.equal(json.read(next), '0.0.29');
+    assert.equal(next, tauri.replace('"version": "0.0.28"', '"version": "0.0.29"'));
+    assert.match(next, /"dangerousDisableAssetCspModification": \["style-src"\]/);
+  });
+
+  it('never mistakes a nested version for the top-level one', () => {
+    const nested = '{\n  "version": "0.0.28",\n  "deps": {\n    "version": "9.9.9"\n  }\n}\n';
+    const next = json.write(nested, '0.0.29');
+    assert.equal(json.read(next), '0.0.29');
+    assert.match(next, /"version": "9\.9\.9"/);
+  });
+
+  it('still works on a file it cannot edit surgically', () => {
+    // Minified: no indentation to anchor to, so it falls back to re-serialising.
+    const minified = '{"name":"x","version":"0.0.28"}';
+    assert.equal(json.read(json.write(minified, '0.0.29')), '0.0.29');
+  });
+});
+
 describe('lockWorkspace', () => {
   // The root lock is the file that silently drifts: `npm version -w` updates it,
   // a hand edit of package.json does not.


### PR DESCRIPTION
Caught on the first real use of `release:prepare`, before anything was tagged.

Bumping the desktop rewrote this line in `src-tauri/tauri.conf.json`:

```diff
-      "dangerousDisableAssetCspModification": ["style-src"]
+      "dangerousDisableAssetCspModification": [
+        "style-src"
+      ]
```

Churn inside a security block, in a release commit. The cause is that `JSON.stringify(data, null, 2)` is the obvious way to write a version back, and it reformats whatever the author wrote — only `tauri.conf.json` differs from npm's own style, so it was the only file affected, but the rule is wrong everywhere.

## The fix

The JSON adapters now replace the value **in place**, anchored to the key's indentation so a top-level `version` can never be confused with one belonging to a dependency. They fall back to re-serialising only when there is nothing to anchor to (a minified file), and `applyVersion` still reads every file back afterwards either way.

## Verified against the real tree

```
 uxnandesktop/package-lock.json         | 4 ++--
 uxnandesktop/package.json              | 2 +-
 uxnandesktop/src-tauri/Cargo.lock      | 2 +-
 uxnandesktop/src-tauri/Cargo.toml      | 2 +-
 uxnandesktop/src-tauri/tauri.conf.json | 2 +-
 5 files changed, 6 insertions(+), 6 deletions(-)
```

Byte-identical in footprint to `build: prepare desktop 0.0.22`, the last nightly cut by hand.

## Tests

48 (up from 45): byte-for-byte preservation on a `tauri.conf.json` shape, a nested `version` that must survive untouched, and the minified fallback.