### PR TITLE
feat(release): cut releases from one workflow, and let the nightly cut itself

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -160,3 +160,62 @@ jobs:
           releaseDraft: true
           prerelease: ${{ steps.meta.outputs.prerelease }}
           args: ${{ matrix.args }} # per-arch --target on macOS; empty on win/linux
+
+  # The body, and — for nightlies only — the publish.
+  #
+  # tauri-action leaves the draft with an EMPTY body: the "What's Changed" list
+  # you normally see is produced by the "Generate release notes" button at
+  # publish time. This writes the same thing from the API, with one correction:
+  # the baseline is pinned to the previous desktop build in EITHER channel.
+  # Left to choose, GitHub compared a nightly against the previous *nightly* —
+  # two weeks and six releases back — and re-listed 9 pull requests that had
+  # already shipped. (The "Contributors" block is not part of the body at all;
+  # GitHub renders it from the commit range once a release is published.)
+  #
+  # Nightly publishes itself, which is what fires `release-desktop-manifest.yml`
+  # and lets the in-app updater see the build. Stable stays a draft on purpose:
+  # "this is now the default download" is a human decision.
+  notes:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # the notes script reads the tag history
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Read the channel from the tag
+        id: meta
+        run: node uxnandesktop/scripts/desktop-release-tag.mjs "$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Write the release body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          node scripts/release/notes.mjs "$GITHUB_REF_NAME" --repo="$GITHUB_REPOSITORY" > notes.md
+          echo "--- generated body ---"
+          cat notes.md
+          gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --notes-file notes.md
+
+      - name: Publish (nightly only)
+        if: steps.meta.outputs.channel == 'nightly'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false
+
+      - name: Say what is left to a human
+        run: |
+          if [ "${{ steps.meta.outputs.channel }}" = "stable" ]; then
+            echo "::notice::Stable draft is ready with its notes — review the assets and press Publish."
+          else
+            echo "::notice::Nightly published; release-desktop-manifest.yml will roll latest.json onto the nightly channel."
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,268 @@
+name: Release — cut versions
+
+# The single entry point for cutting a release, and the nightly that cuts itself.
+#
+# What it does, in order: work out what genuinely needs releasing, refuse a
+# version that cannot move forward, write it into every version-bearing file,
+# verify those files agree, commit, tag, and push. The tag is what triggers the
+# existing `release-*.yml` workflows, which are untouched by this.
+#
+# What it deliberately does NOT do: publish. A desktop nightly publishes itself
+# from `release-desktop.yml` once its installers are built; a stable stays a
+# draft for a human to review. npm and Play publish from their own workflows, as
+# before.
+#
+# Ordering is the reason this is one workflow rather than "push some tags":
+# `release-npm.yml` resolves `@uxnan/shared` from npm AT BUILD TIME, so a bridge
+# tagged alongside shared publishes against the *previous* shared. That happened
+# (bridge 0.0.14, superseded by 0.0.15). Here, shared is cut first and the
+# consumers wait until npm actually serves the new version.
+#
+# It never pushes to `main`, so it needs no ruleset bypass. The bump lands on its
+# own branch, the tag points at that commit, and a pull request brings the branch
+# into `main` through the same reviewed path as everything else.
+#
+# The one credential it wants is a GitHub App token, and NOT for permissions:
+# GitHub refuses to start a workflow from an event created with `GITHUB_TOKEN`
+# (its anti-recursion rule), so a tag pushed with the default token would never
+# trigger `release-*.yml`. Without the app the run does everything except push
+# the tag, and prints the single command to finish by hand. See
+# `docs/releases.md` → *The credential*.
+
+on:
+  workflow_dispatch:
+    inputs:
+      shared:
+        description: 'Cut @uxnan/shared'
+        type: boolean
+        default: false
+      bridge:
+        description: 'Cut uxnan-bridge'
+        type: boolean
+        default: false
+      relay:
+        description: 'Cut uxnan-relay'
+        type: boolean
+        default: false
+      mobile:
+        description: 'Cut Uxnan Mobile (Play open testing)'
+        type: boolean
+        default: false
+      desktop:
+        description: 'Cut Uxnan Desktop'
+        type: choice
+        default: none
+        options: [none, nightly, stable]
+      force:
+        description: 'Cut even when nothing release-worthy changed'
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Work everything out and print it, but tag nothing'
+        type: boolean
+        default: true
+  schedule:
+    # 06:20 UTC = 00:20 in Mexico City (UTC-6 all year). Cutting just after
+    # midnight local keeps the version's date stamp — which is UTC — equal to
+    # the local day it belongs to, and the installers are built by morning.
+    - cron: '20 6 * * *'
+
+permissions:
+  contents: write # push the release branch and the tag
+  pull-requests: write # open the bump PR
+
+# Never let two cuts race: they would compute the same next version.
+concurrency:
+  group: release-cut
+  cancel-in-progress: false
+
+jobs:
+  cut:
+    # A fork running the schedule would tag and push its own main every night.
+    if: github.repository == 'luisgamas/uxnan'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      # A token that is not GITHUB_TOKEN, so the tag push actually starts the
+      # release build. Absent, the run still does everything else.
+      - name: Mint a release token
+        id: token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0 # the scripts read the whole tag history
+          token: ${{ steps.token.outputs.token || github.token }}
+
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # The release scripts use only Node built-ins and git, so there is nothing
+      # to install — one less way for a release to fail.
+      - name: Work out what to cut
+        id: plan
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            node scripts/release/plan.mjs --scheduled > plan.json
+          else
+            components=""
+            [ "${{ inputs.shared }}" = "true" ] && components="$components,shared"
+            [ "${{ inputs.bridge }}" = "true" ] && components="$components,bridge"
+            [ "${{ inputs.relay }}"  = "true" ] && components="$components,relay"
+            [ "${{ inputs.mobile }}" = "true" ] && components="$components,mobile"
+            [ "${{ inputs.desktop }}" != "none" ] && components="$components,desktop"
+            components="${components#,}"
+
+            if [ -z "$components" ]; then
+              echo "::error::Nothing was selected. Tick at least one component."
+              exit 1
+            fi
+
+            channel="stable"
+            [ "${{ inputs.desktop }}" = "nightly" ] && channel="nightly"
+            force=""
+            [ "${{ inputs.force }}" = "true" ] && force="--force"
+
+            node scripts/release/plan.mjs --components="$components" --channel="$channel" $force > plan.json
+          fi
+
+          cat plan.json
+          echo "count=$(jq '.cuts | length' plan.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Report the plan
+        run: |
+          {
+            echo "### Release plan"
+            echo
+            jq -r '.cuts[] | "- **\(.id)** → `\(.tag)`"' plan.json
+            jq -r '.skipped[] | "- _\(.id)_ skipped — \(.reason)"' plan.json
+            echo
+            if [ "${{ github.event_name }}" = "schedule" ]; then
+              echo "_Scheduled nightly._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Nothing to do
+        if: steps.plan.outputs.count == '0'
+        run: echo "::notice::No component has a release-worthy change. Nothing was tagged."
+
+      - name: Identify as the release bot
+        if: steps.plan.outputs.count != '0' && inputs.dry_run != true
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Cut each component, in order
+        if: steps.plan.outputs.count != '0'
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+          HAS_APP: ${{ steps.token.outputs.token != '' }}
+        run: |
+          set -euo pipefail
+
+          # The channel the plan settled on, not the raw input — a scheduled run
+          # has no inputs at all.
+          channel=$(jq -r '.channel' plan.json)
+          dry=""
+          [ "$DRY_RUN" = "true" ] && dry="--dry-run"
+
+          jq -c '.cuts[]' plan.json | while read -r cut; do
+            id=$(jq -r '.id' <<<"$cut")
+            version=$(jq -r '.version' <<<"$cut")
+            tag=$(jq -r '.tag' <<<"$cut")
+            waitFor=$(jq -r '.waitFor // empty' <<<"$cut")
+
+            echo "::group::$id → $version"
+
+            # `prepare` writes every version-bearing file and then reads them all
+            # back; a manifest that disagrees with its lockfile stops the run here
+            # rather than shipping.
+            node scripts/release/prepare.mjs "$id" \
+              --version="$version" \
+              --channel="$channel" \
+              --force $dry
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "dry run — not committing or tagging $tag"
+              echo "::endgroup::"
+              continue
+            fi
+
+            git commit -am "build: prepare $id $version"
+            git tag "$tag"
+
+            # The tag is what starts the build — but only if it was pushed by
+            # something other than GITHUB_TOKEN. Without the app, stop short and
+            # say exactly how to finish, rather than leaving a tag that triggers
+            # nothing.
+            if [ "$HAS_APP" = "true" ]; then
+              git push origin "$tag"
+              echo "::notice::Tagged and pushed $tag"
+            else
+              echo "::warning::$tag was created but NOT pushed: a tag pushed with GITHUB_TOKEN does not start a workflow. Push it yourself to build: git push origin $tag"
+              echo "- \`git push origin $tag\`" >> "$GITHUB_STEP_SUMMARY"
+            fi
+
+            # A consumer resolving this from npm must not build until npm serves
+            # it, or it silently pins the previous version. Pointless if the tag
+            # was never pushed — nothing is publishing it.
+            if [ -n "$waitFor" ] && [ "$HAS_APP" = "true" ]; then
+              echo "waiting for npm to serve $waitFor@$version"
+              for attempt in $(seq 1 60); do
+                published=$(npm view "$waitFor" version 2>/dev/null || echo "")
+                if [ "$published" = "$version" ]; then
+                  echo "npm serves $version"
+                  break
+                fi
+                if [ "$attempt" = "60" ]; then
+                  echo "::error::$waitFor@$version never appeared on npm; its consumers were NOT tagged."
+                  exit 1
+                fi
+                sleep 30
+              done
+            fi
+
+            echo "::endgroup::"
+          done
+
+      # `main` is protected and stays that way: the bumps arrive through a pull
+      # request, reviewed like everything else. The tags already point at these
+      # commits, so the builds do not wait for the merge.
+      - name: Open the bump pull request
+        if: steps.plan.outputs.count != '0' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
+        run: |
+          set -euo pipefail
+          branch="release/$(date -u +%Y%m%d-%H%M%S)"
+          git push origin "HEAD:$branch"
+
+          titles=$(jq -r '[.cuts[] | "\(.id) \(.version)"] | join(", ")' plan.json)
+          body="Version bumps for the tags this run created. The tags already point at these commits, so the builds are under way; merging this only brings main level with them."
+
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "build(release): $titles" \
+            --body "$body"
+
+          echo "::notice::Bump PR opened from $branch"
+
+      - name: What happens next
+        if: steps.plan.outputs.count != '0'
+        run: |
+          {
+            echo
+            echo "Each pushed tag triggers its own release workflow. A desktop nightly"
+            echo "publishes itself once built; a stable waits as a draft for a human."
+            echo "Merge the bump pull request to bring \`main\` level with the tags."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -539,6 +539,16 @@ that component's `release-*.yml` workflow. The version convention, the release
 matrix, and the full step-by-step are in **[`VERSIONS.md`](VERSIONS.md)**; the
 contributor-facing summary is in [`CONTRIBUTING.md`](CONTRIBUTING.md) → *Releases*.
 
+> **Do not cut a release by hand.** `npm run release:status` says what genuinely
+> needs one; the **Release — cut versions** workflow (`release.yml`) does the cut —
+> it computes the version, writes every version-bearing file, proves they agree,
+> commits, tags, and pushes **in the required order**, waiting for npm between
+> `shared` and its consumers. The desktop nightly cuts itself at 06:20 UTC when
+> there is something to ship. How it all fits together, and what is deliberately
+> left to a human, is in **[`docs/releases.md`](docs/releases.md)**. The rules
+> below are what that automation enforces — they still bind anyone doing it
+> manually, which should be nobody.
+
 **Non-negotiable rules when cutting a release:**
 
 1. **The release version comes from the tag** (e.g.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -77,7 +77,14 @@ which versions "go together".
 
 ## Release checklist
 
-> **Two commands do the mechanical half of this.** `npm run release:status`
+> **A workflow does all of this now.** Actions → **Release — cut versions**
+> computes the versions, writes the files, commits, tags and pushes in the right
+> order (waiting for npm between `shared` and its consumers), and the desktop
+> nightly cuts itself at 06:20 UTC. See [`docs/releases.md`](docs/releases.md).
+> The checklist below is what it automates — and what to follow if you ever cut
+> one by hand.
+>
+> **Two commands cover the local half.** `npm run release:status`
 > prints, for every component, what shipped last, what changed since, whether
 > that change can affect a build, and what the next version would be — so step 0
 > is never guesswork. `npm run release:prepare -- <comp> [--channel=nightly]`

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,229 @@
+# Releases — how the automation works
+
+Everything about cutting and publishing a version of Uxnan: what happens by
+itself, what waits for you, and what to do when something goes wrong.
+
+[`VERSIONS.md`](../VERSIONS.md) stays the source of truth for the **convention**
+(version formats, tag names, which files carry a version). This page is about the
+**machinery** that follows it.
+
+---
+
+## The short version
+
+| I want to… | Do this |
+|---|---|
+| See what needs releasing | `npm run release:status` |
+| Cut a nightly desktop build | Nothing — it happens at 00:20 Mexico City if there is something to ship |
+| Cut anything else | Actions → **Release — cut versions** → tick the components → Run |
+| Publish a stable desktop build | Review the draft release on GitHub and press **Publish** |
+| Bring `main` level after a cut | Merge the `build(release): …` pull request the run opened |
+| Know why a release did not happen | Read the run summary; a component with no real change is skipped on purpose |
+
+---
+
+## What is automated, and what is not
+
+**Automated.** Working out whether a component genuinely changed, computing the
+next version, writing it into every version-bearing file, proving those files
+agree, committing, tagging, pushing the tag, opening the pull request that brings
+the bump into `main`, and — for a desktop **nightly** — writing the release notes
+and publishing.
+
+**Not automated, on purpose.**
+
+- **Publishing a stable desktop release.** The draft arrives complete: installers,
+  signatures, `latest.json`, and its notes already written. Pressing *Publish* is
+  the moment it becomes the default download and the updater starts offering it.
+  That is a judgement call, not a build step.
+- **Merging the bump pull request.** `main` is protected and stays that way; the
+  run opens the PR, you merge it. The tags already point at those commits, so the
+  builds never wait for it.
+- **The `VERSIONS.md` history row.** Still added by hand after a release lands.
+- **The CHANGELOG.** The tooling never writes your prose. For a stable release,
+  rename `## [Unreleased]` to the version yourself before cutting.
+
+---
+
+## The two entry points
+
+### The nightly, at 00:20 Mexico City
+
+`release.yml` runs on a cron at **06:20 UTC**, which is 00:20 in Mexico City
+(UTC−6 all year). It asks whether `uxnandesktop/` has changed in a way that can
+affect a build since the last desktop tag **in either channel**. If not, it
+finishes green having done nothing — most days.
+
+The time is not arbitrary. Version stamps are UTC, and 00:20 local is 06:20 UTC
+**of the same date**, so `nightly.20260808.1` really is the nightly of the 8th on
+your calendar. Cutting at 23:00 local would stamp it with the following day.
+
+### The dispatch, for everything else
+
+Actions → **Release — cut versions**. Tick `shared`, `bridge`, `relay`, `mobile`;
+pick `none` / `nightly` / `stable` for the desktop. Two switches matter:
+
+- **`dry_run`** — on by default. Computes and prints everything, tags nothing.
+  Use it first when releasing several components together.
+- **`force`** — cut even when nothing release-worthy changed. Rarely right;
+  its usual use is republishing after a failed publish.
+
+---
+
+## The credential, and why `main` is never touched
+
+Two constraints shaped this, and neither is about permissions being convenient.
+
+**The workflow never pushes to `main`.** The bump commit lands on a
+`release/<timestamp>` branch, the tag points at that commit, and a pull request
+brings it into `main` through the same reviewed path as everything else. So the
+`main-protection` ruleset stays exactly as it is: **nothing is added to its
+bypass list**. Granting a bypass to the `github-actions` app would let *any*
+workflow in the repository write to `main`, which is a much larger door than this
+needs.
+
+**But a tag pushed with `GITHUB_TOKEN` starts no build.** GitHub refuses to
+trigger a workflow from an event created with the default token — its
+anti-recursion rule — so `release-desktop.yml` would simply never run. This is
+the one thing the automation cannot do with the permissions it is given.
+
+The fix is a **GitHub App** used only for this, which is narrower than a personal
+token in three ways that matter: its permissions are just `contents: write` and
+`pull requests: write` on this repository, the token it mints **expires in an
+hour**, and it appears in the audit log as itself rather than as you.
+
+### Setting it up (once, in a browser — the API cannot create apps)
+
+1. **Settings → Developer settings → GitHub Apps → New GitHub App.**
+   Name it something like `uxnan-release`. Homepage URL can be the repo. Uncheck
+   **Webhook → Active**.
+2. **Repository permissions:** `Contents: Read and write`, `Pull requests: Read
+   and write`. Nothing else.
+3. **Where can this app be installed:** *Only on this account*. Create it.
+4. On the app's page: **Generate a private key** (downloads a `.pem`), and note
+   the **App ID**.
+5. **Install App** → this repository only.
+6. In the repo: **Settings → Secrets and variables → Actions**
+   - **Variables** → `RELEASE_APP_ID` = the App ID
+   - **Secrets** → `RELEASE_APP_PRIVATE_KEY` = the whole `.pem`, including the
+     `-----BEGIN…` and `-----END…` lines.
+
+### Until it exists
+
+The run still does everything else: it plans, refuses empty or backwards
+versions, writes every version file, verifies them, commits, creates the tag
+locally and opens the bump pull request. It stops short of *pushing* the tag and
+prints the one command to finish:
+
+```
+git push origin desktop-nightly-v0.0.30-nightly.20260808.1
+```
+
+That is deliberate. Pushing a tag that triggers nothing would leave a released
+version with no build behind it — worse than stopping.
+
+---
+
+## Order, and why it is not negotiable
+
+`release-npm.yml` resolves `@uxnan/shared` **from npm at build time**. Tagging
+`shared` and `bridge` together therefore publishes a bridge pinned to the
+*previous* shared — and because `HandlerRouter` validates every request against
+the shared method registry, that bridge answers this cycle's new methods with
+"method not found". It happened once, on 2026-08-03.
+
+So the run cuts `shared` first, then **waits until `npm view @uxnan/shared
+version` reports the new version**, and only then tags its consumers. If npm
+never serves it, the run fails and the consumers are left untagged — deliberately
+better than publishing them against the wrong dependency.
+
+---
+
+## What each tag triggers
+
+```
+shared-v* / bridge-v* / relay-v*   → release-npm.yml      → npm, `latest` dist-tag
+mobile-v*                          → release-mobile.yml   → Play, open testing
+desktop-stable-v*                  → release-desktop.yml  → installers + DRAFT release
+desktop-nightly-v*                 → release-desktop.yml  → installers + published pre-release
+publishing any desktop release     → release-desktop-manifest.yml → rolls latest.json onto that channel
+```
+
+That last line is the one worth remembering: **the in-app updater only sees a
+build once its release is published**, because publishing is what copies
+`latest.json` onto the rolling channel release. A stable sitting in draft is
+invisible to users, which is exactly the point.
+
+---
+
+## The release body
+
+`tauri-action` creates the draft with an **empty** body. The "What's Changed" list
+you are used to comes from GitHub's *Generate release notes*, and the automation
+now produces the same thing — with one correction.
+
+Left to pick its own baseline, GitHub compared a nightly against the previous
+*nightly*: two weeks and six releases back. It listed 15 pull requests, 9 of them
+already shipped. The automation passes `previous_tag_name` explicitly — the last
+desktop build in either channel — which for that release gave the 6 that were
+actually new.
+
+The **Contributors** block at the bottom of a published release is *not* part of
+the body. GitHub renders it from the commit range once the release is published,
+so there is nothing to generate or paste; it appears by itself.
+
+---
+
+## What not to do
+
+- **Do not push a release tag by hand.** The tag is what builds and, for a
+  nightly, publishes. Cutting one without the matching version bump ships a build
+  whose files disagree with its tag.
+- **Do not reuse a desktop numeric base.** The Windows MSI and the Tauri updater
+  compare only `0.0.PATCH`. A reused base does not fail — it ships a build nobody
+  can see. The tooling refuses it; do not work around it.
+- **Do not hand-edit a version file.** `npm run release:prepare` writes all of
+  them and then reads them back. A manifest that disagrees with its lockfile is
+  invisible until a release ships wrong: `--allow-same-version` in the release
+  workflows masks it at build time.
+- **Do not lower `timeout-minutes` in the verify workflows.** It counts from the
+  moment a job is *queued*. During the Actions outage of 2026-08-06, jobs were
+  cancelled at 15m01s having never started.
+- **Do not publish a desktop draft without checking its run went green.** A draft
+  exists even when a platform leg failed.
+
+---
+
+## When something goes wrong
+
+**A tag exists but nothing built.** The tag was pushed with `GITHUB_TOKEN`,
+which cannot start a workflow. Either the app credential is missing (the run
+warns and prints the push command) or someone pushed the tag from a workflow by
+hand. Push the tag again from your own machine — `git push origin <tag>` on an
+existing tag is a no-op for git but a real event for Actions — or delete and
+re-push it.
+
+**A release ran but published nothing.** Check whether every component was
+skipped: the summary lists each one and why. "only docs changed" means exactly
+that, and it is the intended behaviour.
+
+**npm never served the new shared.** The run fails after tagging shared. Check
+`release-npm.yml`; once it is green and `npm view @uxnan/shared version` reports
+the version, re-run the dispatch for the consumers only.
+
+**A nightly published something broken.** Delete the release and its tag, then cut
+a new one — the base must still move forward, so the next nightly gets a higher
+`0.0.PATCH`. Never re-cut the same base.
+
+---
+
+## The pieces
+
+| Path | What it is |
+|---|---|
+| `.github/workflows/release.yml` | the entry point: dispatch + the nightly cron |
+| `.github/workflows/release-desktop.yml` | builds installers, writes the body, publishes a nightly |
+| `.github/workflows/release-desktop-manifest.yml` | rolls `latest.json` onto a channel when a release is published |
+| `.github/workflows/release-npm.yml`, `release-mobile.yml` | publish to npm and Play |
+| `scripts/release/` | the decisions: what needs releasing, what version, which files ([README](../scripts/release/README.md)) |
+| `VERSIONS.md` | the convention, and the release history |

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -47,6 +47,21 @@ base does not fail — it ships a build the Windows MSI and the updater cannot s
 
 Flags: `--channel=stable|nightly`, `--version=<exact>`, `--dry-run`, `--force`.
 
+## `plan.mjs` and `notes.mjs` — used by the workflow
+
+`plan.mjs` decides **what a release run should cut and in what order**: it drops
+components with nothing release-worthy, orders `shared` ahead of the packages
+that resolve it from npm, and refuses a version that would not move past every
+channel. `--scheduled` is the nightly cron's plan (desktop, nightly channel).
+
+`notes.mjs` produces the release body the way GitHub's *Generate release notes*
+button does, but with `previous_tag_name` pinned to the previous desktop build in
+**either** channel. Left to choose, GitHub reached back to the previous *nightly*
+and re-listed nine pull requests that had already shipped.
+
+Both print to stdout and change nothing; `.github/workflows/release.yml` is what
+turns their output into commits and tags.
+
 ## What the pieces are
 
 | File | Responsibility |
@@ -57,6 +72,8 @@ Flags: `--channel=stable|nightly`, `--version=<exact>`, `--dry-run`, `--force`.
 | `bump.mjs` | applies a version to every file, then asserts they all agree |
 | `changes.mjs` | "does this component need a release?" — path diff since its last tag, minus docs |
 | `git.mjs` | the only place that shells out to git |
+| `plan.mjs` | what to cut, in what order — the workflow's decisions |
+| `notes.mjs` | the release body, with the baseline pinned |
 
 `node --test "scripts/release/*.test.mjs"` (also part of the root `npm test`)
 covers all of it, including the two failures that have actually shipped here: a

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * The release body, generated the way the "Generate release notes" button does —
+ * but told which tag to compare against.
+ *
+ * Left to itself, GitHub picks the baseline badly for a pre-release: cutting
+ * `desktop-nightly-v0.0.29` it reached back to the previous *nightly* (0.0.22,
+ * two weeks and six releases earlier) and listed 15 pull requests, 9 of which
+ * had already shipped in 0.0.23…0.0.28. Passing `previous_tag_name` explicitly
+ * gives the 6 that are actually new.
+ *
+ * The "Contributors" block on a published release is **not** part of this body —
+ * GitHub renders it from the commit range once the release is published. Nothing
+ * to generate, nothing to paste.
+ *
+ * Usage: node scripts/release/notes.mjs <tag> [--repo owner/name] [--print]
+ */
+
+import { execFileSync } from 'node:child_process';
+
+import { component } from './components.mjs';
+import { tagsFor } from './git.mjs';
+
+/**
+ * The tag a release should be compared against: the newest build of the same
+ * component in **any** channel, excluding the one being released.
+ *
+ * Pure, so the rule can be tested without the network — it is the part that was
+ * wrong, not the API call.
+ *
+ * @param {string} tag the tag being released
+ * @param {string[]} allTags every tag for that component, newest first
+ * @returns {string|null}
+ */
+export function previousTagFor(tag, allTags) {
+  const remaining = allTags.filter((candidate) => candidate !== tag);
+  return remaining.length > 0 ? remaining[0] : null;
+}
+
+/** Which component a tag belongs to, from its prefix. */
+export function componentOf(tag) {
+  for (const id of ['shared', 'bridge', 'relay', 'mobile', 'desktop']) {
+    if (component(id).tagPrefixes.some((prefix) => tag.startsWith(prefix))) return id;
+  }
+  return null;
+}
+
+/** Asks GitHub for the notes, with the baseline pinned. */
+export function generate(tag, { repo, previous }) {
+  const args = [
+    'api',
+    '--method',
+    'POST',
+    `repos/${repo}/releases/generate-notes`,
+    '-f',
+    `tag_name=${tag}`,
+    '--jq',
+    '.body',
+  ];
+  if (previous) args.push('-f', `previous_tag_name=${previous}`);
+  return execFileSync('gh', args, { encoding: 'utf8' }).trimEnd();
+}
+
+if (process.argv[1] && process.argv[1].endsWith('notes.mjs')) {
+  const [tag, ...rest] = process.argv.slice(2);
+  const repo =
+    rest.find((a) => a.startsWith('--repo='))?.split('=')[1] ??
+    process.env.GITHUB_REPOSITORY ??
+    'luisgamas/uxnan';
+
+  if (!tag) {
+    console.error('usage: notes.mjs <tag> [--repo owner/name]');
+    process.exit(2);
+  }
+
+  const id = componentOf(tag);
+  if (!id) {
+    console.error(`"${tag}" does not look like a release tag for any known component`);
+    process.exit(2);
+  }
+
+  // Sorted newest-first by version, which is what "the build before this one"
+  // means for every scheme this repo uses.
+  const all = tagsFor(component(id).tagPrefixes).sort((a, b) =>
+    b.localeCompare(a, 'en', { numeric: true }),
+  );
+  const previous = previousTagFor(tag, all);
+  process.stdout.write(generate(tag, { repo, previous }) + '\n');
+}

--- a/scripts/release/notes.test.mjs
+++ b/scripts/release/notes.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { componentOf, previousTagFor } from './notes.mjs';
+
+/** Newest first, the way the CLI sorts them before asking. */
+const DESKTOP = [
+  'desktop-nightly-v0.0.29-nightly.20260807.1',
+  'desktop-stable-v0.0.28',
+  'desktop-stable-v0.0.27',
+  'desktop-nightly-v0.0.22-nightly.20260724.1',
+];
+
+describe('previousTagFor', () => {
+  it('compares against the last build in ANY channel', () => {
+    // The bug this fixes: left alone, GitHub compared the 0.0.29 nightly against
+    // the previous *nightly* (0.0.22) and re-listed 9 pull requests that had
+    // already shipped in 0.0.23 through 0.0.28.
+    assert.equal(
+      previousTagFor('desktop-nightly-v0.0.29-nightly.20260807.1', DESKTOP),
+      'desktop-stable-v0.0.28',
+    );
+  });
+
+  it('works for a stable cut too', () => {
+    const tags = ['desktop-stable-v0.0.30', ...DESKTOP];
+    assert.equal(
+      previousTagFor('desktop-stable-v0.0.30', tags),
+      'desktop-nightly-v0.0.29-nightly.20260807.1',
+    );
+  });
+
+  it('returns null for the first release a component ever cuts', () => {
+    assert.equal(
+      previousTagFor('relay-v0.0.1-alpha.20260627', ['relay-v0.0.1-alpha.20260627']),
+      null,
+    );
+    assert.equal(previousTagFor('relay-v0.0.1-alpha.20260627', []), null);
+  });
+});
+
+describe('componentOf', () => {
+  it('recognises every tag scheme in use', () => {
+    assert.equal(componentOf('shared-v0.0.13-alpha.20260804'), 'shared');
+    assert.equal(componentOf('bridge-v0.0.18-alpha.20260805'), 'bridge');
+    assert.equal(componentOf('relay-v0.0.2-alpha.20260720'), 'relay');
+    assert.equal(componentOf('mobile-v0.0.18-alpha.20260805+20260805'), 'mobile');
+    assert.equal(componentOf('desktop-stable-v0.0.28'), 'desktop');
+    assert.equal(componentOf('desktop-nightly-v0.0.22-nightly.20260724.1'), 'desktop');
+  });
+
+  it('does not guess at something that is not a release tag', () => {
+    assert.equal(componentOf('v1.0.0'), null);
+    assert.equal(componentOf('desktop-updater-stable'), null);
+  });
+});

--- a/scripts/release/plan.mjs
+++ b/scripts/release/plan.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * What a release run should cut, in what order — decided here so the workflow
+ * YAML only has to execute it.
+ *
+ * Two rules it exists to enforce, both learned the hard way:
+ *
+ *  - **Nothing empty.** A component whose only change since its tag is a
+ *    checklist gets skipped, not published.
+ *  - **Order.** `shared` is cut first and the consumers wait for npm to serve
+ *    it, because `release-npm.yml` resolves `@uxnan/shared` at build time.
+ *    Tagging them together published bridge 0.0.14 against the previous shared.
+ *
+ * Usage:
+ *   node scripts/release/plan.mjs --components=shared,bridge [--channel=nightly] [--force]
+ *   node scripts/release/plan.mjs --scheduled     # the nightly cron's plan
+ */
+
+import { inspect } from './changes.mjs';
+import { component, RELEASE_ORDER } from './components.mjs';
+import { tagsFor } from './git.mjs';
+import { assertMovesForward } from './version.mjs';
+
+/** The tag prefix a cut writes, which for the desktop depends on the channel. */
+export function tagPrefixFor(id, channel) {
+  const meta = component(id);
+  if (meta.kind !== 'desktop') return meta.tagPrefixes[0];
+  return channel === 'nightly' ? 'desktop-nightly-v' : 'desktop-stable-v';
+}
+
+/**
+ * Orders the requested components and drops the ones with nothing to ship.
+ *
+ * @param {object} input
+ * @param {string[]} input.components ids the operator asked for
+ * @param {'stable'|'nightly'} [input.channel] desktop channel
+ * @param {boolean} [input.force] cut even without release-worthy changes
+ * @param {(id: string) => object} [input.inspector] injected for tests
+ * @returns {{cuts: object[], skipped: object[]}}
+ */
+export function planCuts({ components, channel = 'stable', force = false, inspector = inspect }) {
+  const wanted = RELEASE_ORDER.filter((id) => components.includes(id));
+  const unknown = components.filter((id) => !RELEASE_ORDER.includes(id));
+  if (unknown.length > 0) throw new Error(`unknown component(s): ${unknown.join(', ')}`);
+
+  const cuts = [];
+  const skipped = [];
+
+  for (const id of wanted) {
+    const report = inspector(id, { channel });
+    if (!report.worthy && !force) {
+      skipped.push({
+        id,
+        since: report.since,
+        reason: report.files.length > 0 ? 'only docs changed' : 'no changes',
+        files: report.docsOnly,
+      });
+      continue;
+    }
+    cuts.push({
+      id,
+      version: report.next,
+      tag: `${tagPrefixFor(id, channel)}${report.next}`,
+      // Consumers that resolve this from npm must wait for it to be visible.
+      waitFor: component(id).releaseBefore.length > 0 ? component(id).name : null,
+      blocks: component(id).releaseBefore,
+    });
+  }
+
+  return { cuts, skipped };
+}
+
+if (process.argv[1] && process.argv[1].endsWith('plan.mjs')) {
+  const args = process.argv.slice(2);
+  const flag = (name) => args.find((a) => a.startsWith(`--${name}=`))?.split('=')[1];
+  const scheduled = args.includes('--scheduled');
+
+  const channel = scheduled ? 'nightly' : (flag('channel') ?? 'stable');
+  const components = scheduled
+    ? ['desktop']
+    : (flag('components') ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+
+  if (components.length === 0) {
+    console.error('nothing requested — pass --components=… or --scheduled');
+    process.exit(2);
+  }
+
+  const plan = planCuts({ components, channel, force: args.includes('--force') });
+
+  // Refusing a version that cannot move forward belongs here, before anything
+  // is written: a reused desktop base does not fail, it ships invisibly.
+  for (const cut of plan.cuts) {
+    assertMovesForward({ version: cut.version, tags: tagsFor(component(cut.id).tagPrefixes) });
+  }
+
+  process.stdout.write(JSON.stringify({ ...plan, channel }, null, 2) + '\n');
+}

--- a/scripts/release/plan.test.mjs
+++ b/scripts/release/plan.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { planCuts, tagPrefixFor } from './plan.mjs';
+
+/** A stand-in for the git-backed inspector, so the rules are testable. */
+function inspectorFor(state) {
+  return (id, { channel } = {}) => {
+    const entry = state[id] ?? { worthy: false, files: [], docsOnly: [] };
+    return {
+      id,
+      since: entry.since ?? `${id}-v0.0.1`,
+      files: entry.files ?? [],
+      docsOnly: entry.docsOnly ?? [],
+      substantive: entry.worthy ? ['src/x.ts'] : [],
+      worthy: entry.worthy,
+      next:
+        entry.next ??
+        (id === 'desktop' && channel === 'nightly' ? '0.0.29-nightly.20260807.1' : '0.0.2'),
+    };
+  };
+}
+
+describe('tagPrefixFor', () => {
+  it('picks the desktop channel from the request', () => {
+    assert.equal(tagPrefixFor('desktop', 'nightly'), 'desktop-nightly-v');
+    assert.equal(tagPrefixFor('desktop', 'stable'), 'desktop-stable-v');
+  });
+
+  it('ignores the channel for everything else', () => {
+    assert.equal(tagPrefixFor('shared', 'nightly'), 'shared-v');
+    assert.equal(tagPrefixFor('mobile', 'stable'), 'mobile-v');
+  });
+});
+
+describe('planCuts', () => {
+  it('cuts shared before the packages that resolve it from npm', () => {
+    // Order is the whole point: tagging them together published bridge 0.0.14
+    // against the previous shared.
+    const plan = planCuts({
+      components: ['bridge', 'shared'],
+      inspector: inspectorFor({ shared: { worthy: true }, bridge: { worthy: true } }),
+    });
+    assert.deepEqual(
+      plan.cuts.map((c) => c.id),
+      ['shared', 'bridge'],
+    );
+    assert.equal(plan.cuts[0].waitFor, '@uxnan/shared');
+    assert.deepEqual(plan.cuts[0].blocks, ['bridge', 'relay']);
+    assert.equal(plan.cuts[1].waitFor, null);
+  });
+
+  it('drops a component whose only change is documentation', () => {
+    const plan = planCuts({
+      components: ['relay', 'desktop'],
+      channel: 'nightly',
+      inspector: inspectorFor({
+        relay: { worthy: false, files: ['relay/FOR-DEV.md'], docsOnly: ['relay/FOR-DEV.md'] },
+        desktop: { worthy: true },
+      }),
+    });
+    assert.deepEqual(
+      plan.cuts.map((c) => c.id),
+      ['desktop'],
+    );
+    assert.equal(plan.skipped[0].id, 'relay');
+    assert.equal(plan.skipped[0].reason, 'only docs changed');
+  });
+
+  it('reports an untouched component as having no changes at all', () => {
+    const plan = planCuts({ components: ['shared'], inspector: inspectorFor({}) });
+    assert.deepEqual(plan.cuts, []);
+    assert.equal(plan.skipped[0].reason, 'no changes');
+  });
+
+  it('cuts anyway under --force', () => {
+    const plan = planCuts({ components: ['shared'], force: true, inspector: inspectorFor({}) });
+    assert.equal(plan.cuts.length, 1);
+    assert.deepEqual(plan.skipped, []);
+  });
+
+  it('builds the desktop tag from the channel', () => {
+    const plan = planCuts({
+      components: ['desktop'],
+      channel: 'nightly',
+      inspector: inspectorFor({ desktop: { worthy: true } }),
+    });
+    assert.equal(plan.cuts[0].tag, 'desktop-nightly-v0.0.29-nightly.20260807.1');
+  });
+
+  it('refuses a component it does not know instead of ignoring it', () => {
+    assert.throws(
+      () => planCuts({ components: ['web'], inspector: inspectorFor({}) }),
+      /unknown component/,
+    );
+  });
+});


### PR DESCRIPTION
Phase 2 of the release automation. Phase 1 gave the decisions a home; this gives them a trigger.

## The entry points

**Actions → Release — cut versions.** Tick `shared` / `bridge` / `relay` / `mobile`, pick `none` / `nightly` / `stable` for the desktop. `dry_run` is **on by default**: it computes and prints everything and tags nothing.

**The nightly cron, 06:20 UTC** — 00:20 in Mexico City. The time is not arbitrary: version stamps are UTC, so just after local midnight is the only evening slot where `nightly.20260808.1` is really the nightly of the 8th on your calendar. Most nights it finds nothing and finishes green.

## `main` is never touched, so nothing is added to the ruleset

The bump lands on a `release/<timestamp>` branch, the tag points at that commit, and a pull request brings it into `main` through the same reviewed path as everything else. `main-protection` keeps its bypass list exactly as it is — granting the `github-actions` app a bypass would let *every* workflow in the repository write to the default branch, which is a much larger door than a version bump needs.

## The one credential, and what it is actually for

**A tag pushed with `GITHUB_TOKEN` starts no build.** GitHub refuses to trigger a workflow from an event created with the default token, so `release-desktop.yml` would simply never run. That — not permissions — is why a credential is needed.

A **GitHub App** scoped to this repo with only `contents: write` and `pull requests: write`, minting tokens that **expire in an hour** and appear in the audit log as themselves. `docs/releases.md` has the six-step setup; the app cannot be created through the API, so those steps are a browser flow.

**Until it exists the automation still works**: it plans, refuses empty or backwards versions, writes and verifies every version file, commits, creates the tag and opens the bump PR — then stops short of pushing the tag and prints the single command to finish. Pushing a tag that triggers nothing would leave a released version with no build behind it.

## Order is enforced, not remembered

`release-npm.yml` resolves `@uxnan/shared` from npm **at build time**, so tagging shared and bridge together publishes a bridge pinned to the previous shared — it shipped once, as bridge 0.0.14. The run cuts `shared` first, waits until `npm view` reports the new version, and only then tags its consumers.

## The release body, fixed

`tauri-action` creates the draft with an **empty** body. Left to pick its own baseline, GitHub compared the 0.0.29 nightly against the previous *nightly* — six releases back — and listed **15** pull requests, 9 already shipped. Pinning `previous_tag_name` to the last desktop build in either channel gives the **6** that are actually new. Measured against the real draft, not assumed.

The **Contributors** block is not part of the body: GitHub renders it from the commit range once a release is published.

## Publish policy

- **Nightly** publishes itself once built — which is what fires `release-desktop-manifest.yml` and lets the updater see it.
- **Stable** stops at a complete draft: installers, signatures, `latest.json`, notes already written.

## Verification

61 tests (`node --test`); both workflow files parse; every `run:` block passes `bash -n`. The planner was exercised against the real repository and correctly reports `no changes` everywhere now that 0.0.29 is cut, and `notes.mjs` produces the correct 6-entry body for the existing draft.

## Docs

`docs/releases.md` is new and human-facing: what is automated and what is not, both entry points, the credential and the reasoning behind it, what each tag triggers, **what not to do**, and how to diagnose a bad run. `AGENTS.md` and `VERSIONS.md` point at it; `scripts/release/README.md` covers the new scripts.