### PR TITLE
fix(release): three defects the first real cut exposed

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -177,11 +177,30 @@ jobs:
   # "this is now the default download" is a human decision.
   notes:
     needs: build
+    # `build` tolerates a macOS leg failing on purpose (fail-fast: false) — the
+    # Windows and Linux installers are still worth shipping. `needs:` alone would
+    # skip this job in that case, leaving the release with no body and, for a
+    # nightly, unpublished. It happened on 0.0.30, where the Intel mac leg built
+    # everything and then hit a network timeout uploading it.
+    if: always() && needs.build.result != 'cancelled' && needs.build.result != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: write
     steps:
+      # Publishing with GITHUB_TOKEN creates a `release: published` event that
+      # GitHub refuses to act on — the same anti-recursion rule that stops a tag
+      # from starting a build. On 0.0.30 the release went public and
+      # `release-desktop-manifest.yml` never ran, so the updater kept serving
+      # 0.0.29. The app token makes the publish a real event.
+      - name: Mint a release token
+        id: token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -206,11 +225,32 @@ jobs:
           cat notes.md
           gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --notes-file notes.md
 
+      # Publishing a nightly whose installers are all missing would be worse than
+      # leaving it: the updater would offer a release with nothing to download.
+      - name: Refuse to publish an empty release
+        id: assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          count=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY"             --json assets --jq '[.assets[] | select(.name | test("\.(msi|exe|dmg|deb|rpm|AppImage)$"))] | length')
+          echo "installers=$count" >> "$GITHUB_OUTPUT"
+          echo "$count installer(s) attached"
+          if [ "$count" = "0" ]; then
+            echo "::error::No installers were attached — not publishing."
+            exit 1
+          fi
+
       - name: Publish (nightly only)
         if: steps.meta.outputs.channel == 'nightly'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false
+          GH_TOKEN: ${{ steps.token.outputs.token || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false
+          if [ -z "${{ steps.token.outputs.token }}" ]; then
+            echo "::warning::Published with GITHUB_TOKEN, so release-desktop-manifest.yml will NOT run and the updater will not see this build. Re-publish it by hand (unpublish, publish) to roll latest.json."
+          fi
 
       - name: Say what is left to a human
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,7 @@ jobs:
         env:
           DRY_RUN: ${{ inputs.dry_run }}
           HAS_APP: ${{ steps.token.outputs.token != '' }}
+          GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
         run: |
           set -euo pipefail
 
@@ -196,6 +197,17 @@ jobs:
               echo "::endgroup::"
               continue
             fi
+
+            # The history row travels in the same commit, so the pull request
+            # carries both and the table can never silently fall behind — which
+            # is what happened to 0.0.29. The summary is seeded from the pull
+            # request titles this release contains; enrich it by hand if you
+            # want, but nobody has to remember to add it.
+            note=""
+            if [ "$HAS_APP" = "true" ] || [ -n "${GH_TOKEN:-}" ]; then
+              note=$(node scripts/release/notes.mjs "$tag" --repo="$GITHUB_REPOSITORY" 2>/dev/null                 | grep '^\* ' | sed 's/^\* //; s/ by @.*//' | paste -sd ';' - | sed 's/;/; /g' || true)
+            fi
+            node scripts/release/record.mjs "$id" "$version" ${note:+--note="$note"}
 
             git commit -am "build: prepare $id $version"
             git tag "$tag"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -26,9 +26,9 @@ itself, what waits for you, and what to do when something goes wrong.
 
 **Automated.** Working out whether a component genuinely changed, computing the
 next version, writing it into every version-bearing file, proving those files
-agree, committing, tagging, pushing the tag, opening the pull request that brings
-the bump into `main`, and — for a desktop **nightly** — writing the release notes
-and publishing.
+agree, adding the `VERSIONS.md` history row, committing, tagging, pushing the
+tag, opening the pull request that brings all of it into `main`, and — for a
+desktop **nightly** — writing the release notes and publishing.
 
 **Not automated, on purpose.**
 
@@ -39,7 +39,10 @@ and publishing.
 - **Merging the bump pull request.** `main` is protected and stays that way; the
   run opens the PR, you merge it. The tags already point at those commits, so the
   builds never wait for it.
-- **The `VERSIONS.md` history row.** Still added by hand after a release lands.
+- **Enriching the `VERSIONS.md` note.** The row itself is written for you — date,
+  version in its column, and a summary seeded from the pull request titles the
+  release contains. Rewrite that summary if it deserves better prose; nobody has
+  to remember to add the row.
 - **The CHANGELOG.** The tooling never writes your prose. For a stable release,
   rename `## [Unreleased]` to the version yourself before cutting.
 
@@ -196,6 +199,12 @@ so there is nothing to generate or paste; it appears by itself.
 
 ## When something goes wrong
 
+**A release is public but the updater does not offer it.** `latest.json` on the
+rolling channel was not rolled, because the publish event came from
+`GITHUB_TOKEN` — the same anti-recursion rule that stops a tag from starting a
+build. It happened to 0.0.30. Unpublish and publish it again from the UI or with
+your own `gh`, which is a real event.
+
 **A tag exists but nothing built.** The tag was pushed with `GITHUB_TOKEN`,
 which cannot start a workflow. Either the app credential is missing (the run
 warns and prints the push command) or someone pushed the tag from a workflow by
@@ -225,5 +234,5 @@ a new one — the base must still move forward, so the next nightly gets a highe
 | `.github/workflows/release-desktop.yml` | builds installers, writes the body, publishes a nightly |
 | `.github/workflows/release-desktop-manifest.yml` | rolls `latest.json` onto a channel when a release is published |
 | `.github/workflows/release-npm.yml`, `release-mobile.yml` | publish to npm and Play |
-| `scripts/release/` | the decisions: what needs releasing, what version, which files ([README](../scripts/release/README.md)) |
+| `scripts/release/` | the decisions: what needs releasing, what version, which files, and the history row ([README](../scripts/release/README.md)) |
 | `VERSIONS.md` | the convention, and the release history |

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -59,8 +59,14 @@ button does, but with `previous_tag_name` pinned to the previous desktop build i
 **either** channel. Left to choose, GitHub reached back to the previous *nightly*
 and re-listed nine pull requests that had already shipped.
 
-Both print to stdout and change nothing; `.github/workflows/release.yml` is what
-turns their output into commits and tags.
+`record.mjs` writes the `VERSIONS.md` row — date, the version in its component's
+column, and a summary seeded from the pull request titles in the release. It is
+idempotent on the version, so a retried run cannot record the same release
+twice. The row goes in the **same commit as the version bump**, so it travels in
+the same pull request: merging that is what records the release.
+
+`plan.mjs` and `notes.mjs` print to stdout and change nothing;
+`.github/workflows/release.yml` is what turns their output into commits and tags.
 
 ## What the pieces are
 
@@ -74,6 +80,7 @@ turns their output into commits and tags.
 | `git.mjs` | the only place that shells out to git |
 | `plan.mjs` | what to cut, in what order — the workflow's decisions |
 | `notes.mjs` | the release body, with the baseline pinned |
+| `record.mjs` | the `VERSIONS.md` history row, written at cut time |
 
 `node --test "scripts/release/*.test.mjs"` (also part of the root `npm test`)
 covers all of it, including the two failures that have actually shipped here: a

--- a/scripts/release/notes.mjs
+++ b/scripts/release/notes.mjs
@@ -20,21 +20,44 @@ import { execFileSync } from 'node:child_process';
 
 import { component } from './components.mjs';
 import { tagsFor } from './git.mjs';
+import { baseOf } from './version.mjs';
 
 /**
- * The tag a release should be compared against: the newest build of the same
- * component in **any** channel, excluding the one being released.
+ * How far back a tag sits, as a sortable number: the numeric base first, then
+ * the nightly counter. String order cannot do this — `desktop-stable-v0.0.28`
+ * sorts *after* `desktop-nightly-v0.0.30` alphabetically, which is exactly how
+ * 0.0.30's notes ended up listing everything since 0.0.28.
+ */
+function rankOf(tag) {
+  const base = baseOf(tag);
+  if (!base) return null;
+  const nightly = Number(/-nightly\.\d+\.(\d+)$/.exec(tag)?.[1] ?? 0);
+  return base.major * 1e9 + base.minor * 1e6 + base.patch * 1e3 + nightly;
+}
+
+/**
+ * The tag a release should be compared against: the build immediately below it
+ * in the same component, in **any** channel.
  *
- * Pure, so the rule can be tested without the network — it is the part that was
- * wrong, not the API call.
+ * Pure, so the rule can be tested without the network — it is the part that has
+ * been wrong twice, not the API call.
  *
  * @param {string} tag the tag being released
- * @param {string[]} allTags every tag for that component, newest first
+ * @param {string[]} allTags every tag for that component, any order
  * @returns {string|null}
  */
 export function previousTagFor(tag, allTags) {
-  const remaining = allTags.filter((candidate) => candidate !== tag);
-  return remaining.length > 0 ? remaining[0] : null;
+  const mine = rankOf(tag);
+  if (mine === null) return null;
+
+  let best = null;
+  for (const candidate of allTags) {
+    if (candidate === tag) continue;
+    const rank = rankOf(candidate);
+    if (rank === null || rank >= mine) continue;
+    if (!best || rank > best.rank) best = { tag: candidate, rank };
+  }
+  return best?.tag ?? null;
 }
 
 /** Which component a tag belongs to, from its prefix. */
@@ -79,11 +102,6 @@ if (process.argv[1] && process.argv[1].endsWith('notes.mjs')) {
     process.exit(2);
   }
 
-  // Sorted newest-first by version, which is what "the build before this one"
-  // means for every scheme this repo uses.
-  const all = tagsFor(component(id).tagPrefixes).sort((a, b) =>
-    b.localeCompare(a, 'en', { numeric: true }),
-  );
-  const previous = previousTagFor(tag, all);
+  const previous = previousTagFor(tag, tagsFor(component(id).tagPrefixes));
   process.stdout.write(generate(tag, { repo, previous }) + '\n');
 }

--- a/scripts/release/notes.test.mjs
+++ b/scripts/release/notes.test.mjs
@@ -5,9 +5,9 @@ import { componentOf, previousTagFor } from './notes.mjs';
 
 /** Newest first, the way the CLI sorts them before asking. */
 const DESKTOP = [
+  'desktop-nightly-v0.0.30-nightly.20260807.2',
   'desktop-nightly-v0.0.29-nightly.20260807.1',
   'desktop-stable-v0.0.28',
-  'desktop-stable-v0.0.27',
   'desktop-nightly-v0.0.22-nightly.20260724.1',
 ];
 
@@ -22,11 +22,40 @@ describe('previousTagFor', () => {
     );
   });
 
-  it('works for a stable cut too', () => {
-    const tags = ['desktop-stable-v0.0.30', ...DESKTOP];
+  it('picks the build immediately below, across channels', () => {
+    // The bug: `desktop-stable-v0.0.28` sorts AFTER `desktop-nightly-v0.0.30`
+    // alphabetically, so a string sort made 0.0.30 compare against 0.0.28 and
+    // re-list everything 0.0.29 had already shipped.
     assert.equal(
-      previousTagFor('desktop-stable-v0.0.30', tags),
+      previousTagFor('desktop-nightly-v0.0.30-nightly.20260807.2', DESKTOP),
       'desktop-nightly-v0.0.29-nightly.20260807.1',
+    );
+  });
+
+  it('separates two nightlies cut on the same day', () => {
+    const tags = [
+      'desktop-nightly-v0.0.30-nightly.20260807.2',
+      'desktop-nightly-v0.0.29-nightly.20260807.1',
+    ];
+    assert.equal(
+      previousTagFor('desktop-nightly-v0.0.30-nightly.20260807.2', tags),
+      'desktop-nightly-v0.0.29-nightly.20260807.1',
+    );
+  });
+
+  it('ignores anything above the tag being released', () => {
+    // Cutting an older tag late must reach DOWN to 0.0.22, never up to 0.0.28+.
+    assert.equal(
+      previousTagFor('desktop-stable-v0.0.27', DESKTOP),
+      'desktop-nightly-v0.0.22-nightly.20260724.1',
+    );
+  });
+
+  it('works for a stable cut too', () => {
+    const tags = ['desktop-stable-v0.0.31', ...DESKTOP];
+    assert.equal(
+      previousTagFor('desktop-stable-v0.0.31', tags),
+      'desktop-nightly-v0.0.30-nightly.20260807.2',
     );
   });
 

--- a/scripts/release/record.mjs
+++ b/scripts/release/record.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * The `VERSIONS.md` history row, written by the release itself.
+ *
+ * It was step 6 of the checklist and the one that got forgotten — desktop
+ * 0.0.29 shipped, was published, and the table never learned about it. Nothing
+ * breaks when that happens (no tool reads this file; versions come from git
+ * tags), but the record is the only place a human can see what shipped when, so
+ * a gap in it is a small lie.
+ *
+ * The row is written **at cut time**, in the same commit as the version bump, so
+ * it travels in the same pull request. Merging that pull request is what records
+ * the release — which keeps the convention's intent: the row lands once a human
+ * has seen the release go green.
+ *
+ * Usage:
+ *   node scripts/release/record.mjs <component> <version> [--date=YYYY-MM-DD] [--note="…"]
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+import { component } from './components.mjs';
+
+/** Column order of the history table, left to right after the date. */
+export const COLUMNS = ['shared', 'bridge', 'relay', 'desktop', 'mobile'];
+
+/** `2026-08-07`, in UTC like every other stamp the release convention uses. */
+export function today(date = new Date()) {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Builds one table row: the date, a version in its component's column, an
+ * em dash everywhere else, and an optional HTML comment carrying the summary.
+ */
+export function buildRow({ id, version, date, note }) {
+  if (!COLUMNS.includes(id)) throw new Error(`no history column for "${id}"`);
+  const cells = COLUMNS.map((column) => (column === id ? version : '—'));
+  const comment = note ? ` <!-- ${note} -->` : '';
+  return `| ${date} | ${cells.join(' | ')} |${comment}`;
+}
+
+/**
+ * Inserts a row directly under the table header, where the newest release goes.
+ *
+ * Idempotent on the version: re-running a cut, or a workflow retrying, must not
+ * leave the same release recorded twice.
+ */
+export function insertRow(markdown, row, { version }) {
+  if (markdown.includes(`| ${version} `) || markdown.includes(`| ${version} |`)) {
+    return { markdown, inserted: false, reason: `${version} is already in the table` };
+  }
+
+  const separator = /^\| -+ \| -+ \| -+ \| -+ \| -+ \| -+ \|$/m.exec(markdown);
+  if (!separator) {
+    throw new Error('VERSIONS.md has no history table header to insert under');
+  }
+
+  const at = separator.index + separator[0].length;
+  return {
+    markdown: `${markdown.slice(0, at)}\n${row}${markdown.slice(at)}`,
+    inserted: true,
+  };
+}
+
+if (process.argv[1] && process.argv[1].endsWith('record.mjs')) {
+  const [id, version, ...rest] = process.argv.slice(2);
+  const flag = (name) =>
+    rest
+      .find((a) => a.startsWith(`--${name}=`))
+      ?.split('=')
+      .slice(1)
+      .join('=');
+
+  if (!id || !version) {
+    console.error('usage: record.mjs <component> <version> [--date=YYYY-MM-DD] [--note="…"]');
+    process.exit(2);
+  }
+
+  component(id); // throws on an unknown component before touching the file
+  const path = flag('file') ?? 'VERSIONS.md';
+  const row = buildRow({ id, version, date: flag('date') ?? today(), note: flag('note') });
+
+  const result = insertRow(readFileSync(path, 'utf8'), row, { version });
+  if (!result.inserted) {
+    console.log(`nothing to record — ${result.reason}`);
+    process.exit(0);
+  }
+
+  writeFileSync(path, result.markdown);
+  console.log(`recorded in ${path}:`);
+  console.log(row);
+}

--- a/scripts/release/record.test.mjs
+++ b/scripts/release/record.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { buildRow, insertRow, today } from './record.mjs';
+
+/** The shape of the real table, trimmed to what the insert cares about. */
+const TABLE = [
+  '## History',
+  '',
+  '| Date (YYYY-MM-DD) | shared | bridge | relay | desktop | mobile |',
+  '| ----------------- | ------ | ------ | ----- | ------- | ------ |',
+  '| 2026-08-05 | — | 0.0.18-alpha.20260805 | — | — | — |',
+  '| 2026-08-04 | 0.0.13-alpha.20260804 | — | — | — | — |',
+  '',
+].join('\n');
+
+describe('today', () => {
+  it('is the UTC date, like every other stamp in the convention', () => {
+    assert.equal(today(new Date('2026-08-07T23:59:00Z')), '2026-08-07');
+  });
+});
+
+describe('buildRow', () => {
+  it('puts the version in its own column and dashes the rest', () => {
+    assert.equal(
+      buildRow({ id: 'desktop', version: '0.0.30-nightly.20260807.2', date: '2026-08-07' }),
+      '| 2026-08-07 | — | — | — | 0.0.30-nightly.20260807.2 | — |',
+    );
+    assert.equal(
+      buildRow({ id: 'shared', version: '0.0.14-alpha.20260807', date: '2026-08-07' }),
+      '| 2026-08-07 | 0.0.14-alpha.20260807 | — | — | — | — |',
+    );
+  });
+
+  it('carries the summary as an HTML comment, like the hand-written rows', () => {
+    const row = buildRow({
+      id: 'desktop',
+      version: '0.0.30',
+      date: '2026-08-07',
+      note: 'search inside files (PR #156)',
+    });
+    assert.ok(row.endsWith('| <!-- search inside files (PR #156) -->'));
+  });
+
+  it('refuses a component the table has no column for', () => {
+    assert.throws(
+      () => buildRow({ id: 'web', version: '1.0.0', date: '2026-08-07' }),
+      /no history column/,
+    );
+  });
+});
+
+describe('insertRow', () => {
+  it('puts the newest release directly under the header', () => {
+    const row = buildRow({ id: 'desktop', version: '0.0.30', date: '2026-08-07' });
+    const { markdown, inserted } = insertRow(TABLE, row, { version: '0.0.30' });
+
+    assert.equal(inserted, true);
+    const lines = markdown.split('\n');
+    const separator = lines.findIndex((l) => l.startsWith('| ---'));
+    assert.equal(lines[separator + 1], row);
+    // and the rows that were there are still there, in order
+    assert.ok(lines[separator + 2].startsWith('| 2026-08-05'));
+    assert.ok(lines[separator + 3].startsWith('| 2026-08-04'));
+  });
+
+  it('does not record the same version twice', () => {
+    // A retried workflow, or a second run of the same cut, must not duplicate.
+    const once = insertRow(
+      TABLE,
+      buildRow({ id: 'desktop', version: '0.0.30', date: '2026-08-07' }),
+      {
+        version: '0.0.30',
+      },
+    );
+    const twice = insertRow(
+      once.markdown,
+      buildRow({ id: 'desktop', version: '0.0.30', date: '2026-08-08' }),
+      {
+        version: '0.0.30',
+      },
+    );
+
+    assert.equal(twice.inserted, false);
+    assert.equal(twice.markdown, once.markdown);
+    assert.match(twice.reason, /already in the table/);
+  });
+
+  it('leaves everything above and below the table untouched', () => {
+    const { markdown } = insertRow(
+      TABLE,
+      buildRow({ id: 'relay', version: '0.0.3', date: '2026-08-07' }),
+      {
+        version: '0.0.3',
+      },
+    );
+    assert.ok(markdown.startsWith('## History\n'));
+    assert.ok(markdown.includes('| 2026-08-04 | 0.0.13-alpha.20260804 |'));
+  });
+
+  it('fails loudly rather than guessing when the table is missing', () => {
+    assert.throws(
+      () => insertRow('# VERSIONS\n\nno table here\n', '| x |', { version: '1.0.0' }),
+      /no history table/,
+    );
+  });
+});


### PR DESCRIPTION
Cutting desktop **0.0.30** end to end found three defects. None of them could have shown up in a dry run — they only exist once a tag, a build and a publish are real.

## 1. A tolerated mac failure blocked the publish

`build` sets `fail-fast: false` on purpose: a macOS leg failing must not cost the Windows and Linux installers. But my `notes` job used `needs: build`, which **skips** when any matrix leg fails — so the release kept an empty body and, being a nightly, never published.

On 0.0.30 the Intel mac leg built every artifact and then hit `Connect Timeout Error` uploading them. Infrastructure, not code — and it took the whole release down with it.

Now the job runs unless the build was *cancelled*, plus a new guard: it refuses to publish a release with no installers attached at all, because an updater offering a release with nothing to download is worse than a draft.

## 2. Publishing with `GITHUB_TOKEN` did not roll the updater manifest

The same anti-recursion rule that stops a tag from starting a build also stops a `release: published` event from reaching `release-desktop-manifest.yml`. Measured: 0.0.30 was public while `latest.json` on the nightly channel still said **0.0.29**. The publish now uses the app token, and warns explicitly when it cannot.

## 3. The body compared against the wrong baseline — again

Tags were sorted as strings, and `desktop-stable-v0.0.28` sorts *after* `desktop-nightly-v0.0.30` alphabetically. So 0.0.30's notes listed everything since 0.0.28, re-including what 0.0.29 shipped — the same class of bug I fixed in #158, in a different place.

`previousTagFor` now ranks by numeric base and nightly counter and picks the build immediately below. Verified against the real tag list: `0.0.30 → 0.0.29`, `0.0.29 → 0.0.28`.

## Plus phase 4: the history row writes itself

`record.mjs` adds the `VERSIONS.md` row **at cut time, in the same commit as the version bump**, so it travels in the same pull request — merging that is what records the release. The summary is seeded from the pull request titles the release contains:

```
| 2026-08-07 | — | — | — | 0.0.30-nightly.20260807.2 | — | <!-- feat(release): …; feat(desktop): search inside files… -->
```

Idempotent on the version, so a retried run cannot record a release twice. This is the step that was forgotten for 0.0.29 and had to be added by hand.

## Verification

72 tests (`node --test`), both workflows parse, every `run:` block passes `bash -n`, and the note seeding was run against the real 0.0.30 release.