### PR TITLE
fix(release): the guard that refused a good nightly, and a teardown race

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -233,7 +233,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          count=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY"             --json assets --jq '[.assets[] | select(.name | test("\.(msi|exe|dmg|deb|rpm|AppImage)$"))] | length')
+          # `[.]` and not `\.`: this string reaches jq through YAML and bash, and
+          # jq rejects `\.` in a string literal outright ("invalid escape
+          # sequence"). It took the whole 0.0.31 nightly down — four installers
+          # built, body written, and then the guard that exists to protect the
+          # publish is what refused it. A character class needs no escaping at
+          # any of the three layers.
+          count=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY"             --json assets --jq '[.assets[] | select(.name | test("[.](msi|exe|dmg|deb|rpm|AppImage)$"))] | length')
           echo "installers=$count" >> "$GITHUB_OUTPUT"
           echo "$count installer(s) attached"
           if [ "$count" = "0" ]; then

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -236,7 +236,7 @@ but their last leg has not been exercised since the automation existed:
 
 | Component | Exercised | What is still unproven |
 |---|---|---|
-| desktop | ✅ 0.0.29 and 0.0.30, end to end | — |
+| desktop | ✅ 0.0.29, 0.0.30 and 0.0.31, end to end — the last one cut by the cron, unattended | — |
 | shared | ❌ | that `release-npm.yml` fires from an app-token tag, and that the npm-visibility wait behaves on a real publish |
 | bridge | ❌ | the same, **plus** the shared→bridge ordering, which is the reason this workflow exists |
 | relay | ❌ | the same as shared |
@@ -246,6 +246,20 @@ One desktop detail is also still unproven: the `notes` job now survives a failed
 macOS leg (`if: always()`), but every run since that fix has been fully green, so
 the path it was written for has not run again. The next release that loses a mac
 leg is the one that confirms it.
+
+**What the first unattended cut cost, and what it teaches.** 0.0.31 was cut by
+the cron with nobody watching, and it got everything right up to the last step:
+it saw the merged work, computed the version, wrote the files, pushed the tag,
+built four installers and wrote the body — then the *guard* added in the previous
+fix refused it. The `--jq` filter counting installers used `\.` for a literal
+dot, which jq rejects outright ("invalid escape sequence"), so the step exited
+non-zero and the nightly stayed a draft. The lesson is narrow and worth keeping:
+**a shell one-liner added to a workflow is untested code shipped straight to
+production.** That expression passes through YAML, then bash, then jq, and only
+the third one has an opinion about backslashes. It is now a `[.]` character
+class, which needs no escaping at any layer, and it was checked against a real
+release before being committed. Anything with the same shape — a guard that only
+runs on the unhappy path, a filter with escapes — deserves the same treatment.
 
 When the next one of those genuinely needs a release, cut it with `dry_run` on
 first and read the plan. The riskiest is **shared + bridge together**: that is

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -181,7 +181,19 @@ instead of quietly agreeing with a mock nobody updated.
 - `src/test/setup.dom.ts` — jsdom's gaps filled once (`matchMedia`,
   `ResizeObserver`, canvas), plus a console policy: an unknown-prop or
   lifecycle-outside-component warning **fails** the test; known third-party
-  teardown noise is suppressed.
+  teardown noise is suppressed. It also unmounts and then **waits out `bits-ui`'s
+  body-style restore** — see below.
+- **Dialogs leave a timer armed after they unmount.** `bits-ui` restores the body
+  style 24 ms after the last scroll lock is released (a deliberate delay, so a
+  modal that closes and reopens in the same tick does not flicker). If Vitest
+  tears the jsdom environment down inside that window, the callback fires with no
+  `document` and the whole run dies on an unhandled `ReferenceError` — *with
+  every test passing*. It is a race, so it fails one platform at a time: it took
+  the macOS leg of the 0.0.31 release build at 882/882 green while Linux and
+  Windows won it. `setup.dom.ts` closes it by waiting ~40 ms after each test that
+  actually left lock styles on the body — no cost for the tests that never open
+  one. If you add a global body style for another reason, expect those files to
+  pay the wait too.
 - `MarkdownView.svelte.test.ts` — README-style badges render through the typed
   safe-HTML path, unsafe attributes/content stay absent, the full-width preview
   uses the native overflow treatment shared with CodeMirror, explicit badge

--- a/uxnandesktop/src/test/setup.dom.ts
+++ b/uxnandesktop/src/test/setup.dom.ts
@@ -15,13 +15,43 @@
  */
 
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/svelte";
 import { afterEach, vi } from "vitest";
 
 import { uninstallFakeBackend } from "./tauri";
 
-afterEach(() => {
+afterEach(async () => {
+  // Unmount here instead of leaving it to `svelteTesting()`'s own hook: what
+  // follows has to happen *after* the components are gone, and hook order
+  // between two setup files is not something to depend on. `cleanup()` is
+  // idempotent, so running it twice costs nothing.
+  cleanup();
+  await flushScrollLockRestore();
   uninstallFakeBackend();
 });
+
+/**
+ * Wait out `bits-ui`'s body-style restore before the test ends.
+ *
+ * Releasing the last scroll lock (unmounting a dialog) does not restore the
+ * body style immediately — `bits-ui` schedules it 24 ms later, on purpose, so a
+ * modal that closes and reopens in the same tick does not flicker. Unmounting
+ * the last dialog of a file therefore leaves a timer armed, and if Vitest tears
+ * the jsdom environment down inside that window the callback fires into a world
+ * with no `document`: `ReferenceError: document is not defined`, reported as an
+ * unhandled error, exit code 1 — with every test green.
+ *
+ * That is exactly how it surfaced: the macOS leg of the 0.0.31 release build
+ * failed at 882/882 passing, while Linux and Windows won the same race.
+ *
+ * Waiting unconditionally would tax every test in the project for a delay only
+ * dialogs incur, so this waits only when a lock actually left its mark on the
+ * body.
+ */
+async function flushScrollLockRestore(): Promise<void> {
+  if (!document.body.getAttribute("style")) return;
+  await new Promise((resolve) => setTimeout(resolve, 40));
+}
 
 // --- jsdom gaps -------------------------------------------------------------
 


### PR DESCRIPTION
The first unattended cut (desktop 0.0.31, by the cron) did everything right and failed on the last step.

**The installer guard could never pass.** The `--jq` filter used `\.` for a literal dot; jq rejects that in a string literal outright, so the step exited non-zero and a nightly with four installers and a written body stayed a draft — the guard meant to stop an *empty* release published nothing at all. Now `[.]`, which needs no escaping through YAML → bash → jq, and checked against the real release (7 installers) before landing.

**A dialog leaves a timer armed after it unmounts.** bits-ui restores the body style 24 ms after the last scroll lock is released, so the last dialog test in a file races the jsdom teardown — when teardown wins, the callback fires with no `document` and the run dies on an unhandled ReferenceError *with every test green*. That is how the macOS leg failed at 882/882. `setup.dom.ts` now unmounts explicitly and waits the restore out, only after a test that left lock styles on the body.

Verified locally: 882/882 across 79 files, `npm run check` 1587 files / 0 errors. The three-platform CI on this PR is the real proof for the second fix.