### PR TITLE
fix(release): the history row recorded the release bot as a change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,11 +203,22 @@ jobs:
             # is what happened to 0.0.29. The summary is seeded from the pull
             # request titles this release contains; enrich it by hand if you
             # want, but nobody has to remember to add it.
-            note=""
+            #
+            # Summarising is `record.mjs`'s job, not this file's. It was a
+            # `grep | sed | paste` pipeline here and got it wrong on the first
+            # unattended run — "New Contributors" is a bullet list too, so the
+            # release bot's first contribution was recorded as one of 0.0.31's
+            # changes. Tested code cannot fail that way in production only.
+            rm -f history-notes.md
             if [ "$HAS_APP" = "true" ] || [ -n "${GH_TOKEN:-}" ]; then
-              note=$(node scripts/release/notes.mjs "$tag" --repo="$GITHUB_REPOSITORY" 2>/dev/null                 | grep '^\* ' | sed 's/^\* //; s/ by @.*//' | paste -sd ';' - | sed 's/;/; /g' || true)
+              node scripts/release/notes.mjs "$tag" --repo="$GITHUB_REPOSITORY" > history-notes.md 2>/dev/null || true
             fi
-            node scripts/release/record.mjs "$id" "$version" ${note:+--note="$note"}
+            if [ -s history-notes.md ]; then
+              node scripts/release/record.mjs "$id" "$version" --notes-file=history-notes.md
+            else
+              node scripts/release/record.mjs "$id" "$version"
+            fi
+            rm -f history-notes.md
 
             git commit -am "build: prepare $id $version"
             git tag "$tag"

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -60,10 +60,19 @@ button does, but with `previous_tag_name` pinned to the previous desktop build i
 and re-listed nine pull requests that had already shipped.
 
 `record.mjs` writes the `VERSIONS.md` row — date, the version in its component's
-column, and a summary seeded from the pull request titles in the release. It is
+column, and a summary seeded from the pull request titles in the release
+(`summarizeNotes`, given the generated notes through `--notes-file`). It is
 idempotent on the version, so a retried run cannot record the same release
 twice. The row goes in the **same commit as the version bump**, so it travels in
 the same pull request: merging that is what records the release.
+
+The summary keeps only the **What's Changed** list, drops GitHub's `by @… in …`
+attribution, and drops the release plumbing — `build(release):` names the
+*previous* version and reads, in the row, as if that version shipped inside this
+one. This was a shell pipeline in the workflow until the first unattended run
+recorded "@uxnan-releases[bot] made their first contribution" as one of 0.0.31's
+changes: **New Contributors** is a bullet list too. Moving it here is the point —
+a `grep | sed` in YAML has no tests and fails only in production.
 
 `plan.mjs` and `notes.mjs` print to stdout and change nothing;
 `.github/workflows/release.yml` is what turns their output into commits and tags.

--- a/scripts/release/record.mjs
+++ b/scripts/release/record.mjs
@@ -14,7 +14,8 @@
  * has seen the release go green.
  *
  * Usage:
- *   node scripts/release/record.mjs <component> <version> [--date=YYYY-MM-DD] [--note="…"]
+ *   node scripts/release/record.mjs <component> <version> [--date=YYYY-MM-DD]
+ *                                   [--note="…"] [--notes-file=notes.md]
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -38,6 +39,50 @@ export function buildRow({ id, version, date, note }) {
   const cells = COLUMNS.map((column) => (column === id ? version : '—'));
   const comment = note ? ` <!-- ${note} -->` : '';
   return `| ${date} | ${cells.join(' | ')} |${comment}`;
+}
+
+/** Entries that describe the release plumbing, not anything that shipped. */
+const PLUMBING = [/^build\(release\):/i, /^chore\(release\):/i, /^build: prepare /i];
+
+/** The ` by @someone in <url>` GitHub appends to every generated bullet. */
+const ATTRIBUTION = /\s+by\s+@\S+\s+in\s+https?:\/\/\S+$/;
+
+/**
+ * Turns GitHub's generated release notes into the one line the history row
+ * carries.
+ *
+ * This lived in the release workflow as a `grep | sed | paste` pipeline, and it
+ * was wrong on its first unattended run: **New Contributors** is also a bullet
+ * list, so 0.0.31's row was recorded with "@uxnan-releases[bot] made their first
+ * contribution" among the changes — the release tooling's own bot, described as
+ * if it were a feature. It also kept the `build(release):` commit that names the
+ * *previous* version, which reads as if 0.0.30 shipped inside 0.0.31.
+ *
+ * Only the **What's Changed** list contributes; every other section is about
+ * people or links. Plumbing entries are dropped, because the row answers "what
+ * shipped in this version" and preparing the release is not part of the answer.
+ *
+ * It is here rather than in the workflow for the reason the bug proves: a shell
+ * one-liner in a YAML file is untested code with a production-only failure mode.
+ */
+export function summarizeNotes(markdown) {
+  const entries = [];
+  let inChanges = false;
+
+  for (const raw of String(markdown ?? '').split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('#')) {
+      inChanges = /^#+\s+what's changed\b/i.test(line);
+      continue;
+    }
+    if (!inChanges || !line.startsWith('* ')) continue;
+
+    const title = line.slice(2).replace(ATTRIBUTION, '').trim();
+    if (!title || PLUMBING.some((pattern) => pattern.test(title))) continue;
+    if (!entries.includes(title)) entries.push(title);
+  }
+
+  return entries.join('; ');
 }
 
 /**
@@ -73,13 +118,17 @@ if (process.argv[1] && process.argv[1].endsWith('record.mjs')) {
       .join('=');
 
   if (!id || !version) {
-    console.error('usage: record.mjs <component> <version> [--date=YYYY-MM-DD] [--note="…"]');
+    console.error(
+      'usage: record.mjs <component> <version> [--date=YYYY-MM-DD] [--note="…"] [--notes-file=…]',
+    );
     process.exit(2);
   }
 
   component(id); // throws on an unknown component before touching the file
   const path = flag('file') ?? 'VERSIONS.md';
-  const row = buildRow({ id, version, date: flag('date') ?? today(), note: flag('note') });
+  const notesFile = flag('notes-file');
+  const note = flag('note') ?? (notesFile ? summarizeNotes(readFileSync(notesFile, 'utf8')) : '');
+  const row = buildRow({ id, version, date: flag('date') ?? today(), note });
 
   const result = insertRow(readFileSync(path, 'utf8'), row, { version });
   if (!result.inserted) {

--- a/scripts/release/record.test.mjs
+++ b/scripts/release/record.test.mjs
@@ -1,7 +1,21 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { buildRow, insertRow, today } from './record.mjs';
+import { buildRow, insertRow, summarizeNotes, today } from './record.mjs';
+
+/** Exactly what GitHub generated for desktop 0.0.31 — the run that got it wrong. */
+const REAL_NOTES = [
+  "## What's Changed",
+  '* fix(release): three defects the first real cut exposed by @luisgamas in https://github.com/luisgamas/uxnan/pull/160',
+  '* build(release): desktop 0.0.30-nightly.20260807.2 by @uxnan-releases[bot] in https://github.com/luisgamas/uxnan/pull/159',
+  '* feat(svelte): make the left panel legible without expanding it by @luisgamas in https://github.com/luisgamas/uxnan/pull/154',
+  '* feat: workspace lifecycle — know when a space is finished, and close it by @luisgamas in https://github.com/luisgamas/uxnan/pull/155',
+  '',
+  '## New Contributors',
+  '* @uxnan-releases[bot] made their first contribution in https://github.com/luisgamas/uxnan/pull/159',
+  '',
+  '**Full Changelog**: https://github.com/luisgamas/uxnan/compare/desktop-nightly-v0.0.30-nightly.20260807.2...desktop-nightly-v0.0.31-nightly.20260807.3',
+].join('\n');
 
 /** The shape of the real table, trimmed to what the insert cares about. */
 const TABLE = [
@@ -103,5 +117,56 @@ describe('insertRow', () => {
       () => insertRow('# VERSIONS\n\nno table here\n', '| x |', { version: '1.0.0' }),
       /no history table/,
     );
+  });
+});
+
+describe('summarizeNotes', () => {
+  it('keeps what shipped, in order, without the attribution', () => {
+    assert.equal(
+      summarizeNotes(REAL_NOTES),
+      'fix(release): three defects the first real cut exposed; ' +
+        'feat(svelte): make the left panel legible without expanding it; ' +
+        'feat: workspace lifecycle — know when a space is finished, and close it',
+    );
+  });
+
+  it('never lets New Contributors into the row', () => {
+    // The bug this whole function exists for: 0.0.31 was recorded claiming the
+    // release bot's first contribution was one of the changes.
+    assert.ok(!summarizeNotes(REAL_NOTES).includes('first contribution'));
+    assert.ok(!summarizeNotes(REAL_NOTES).includes('Full Changelog'));
+  });
+
+  it('drops the release plumbing, which names the previous version', () => {
+    assert.ok(!summarizeNotes(REAL_NOTES).includes('0.0.30-nightly'));
+    assert.equal(
+      summarizeNotes(
+        ["## What's Changed", '* build: prepare desktop 0.0.31', '* chore(release): bridge 0.0.17'].join(
+          '\n',
+        ),
+      ),
+      '',
+    );
+  });
+
+  it('survives notes with nothing in them, and notes that are not notes', () => {
+    assert.equal(summarizeNotes(''), '');
+    assert.equal(summarizeNotes(undefined), '');
+    assert.equal(summarizeNotes('## New Contributors\n* @someone made their first contribution'), '');
+  });
+
+  it('does not repeat an entry that appears twice', () => {
+    assert.equal(
+      summarizeNotes(
+        ["## What's Changed", '* feat: a thing by @a in https://x/1', '* feat: a thing by @b in https://x/2'].join(
+          '\n',
+        ),
+      ),
+      'feat: a thing',
+    );
+  });
+
+  it('leaves a title alone when it has no attribution suffix', () => {
+    assert.equal(summarizeNotes("## What's Changed\n* feat: written by hand"), 'feat: written by hand');
   });
 });

--- a/scripts/release/record.test.mjs
+++ b/scripts/release/record.test.mjs
@@ -141,9 +141,11 @@ describe('summarizeNotes', () => {
     assert.ok(!summarizeNotes(REAL_NOTES).includes('0.0.30-nightly'));
     assert.equal(
       summarizeNotes(
-        ["## What's Changed", '* build: prepare desktop 0.0.31', '* chore(release): bridge 0.0.17'].join(
-          '\n',
-        ),
+        [
+          "## What's Changed",
+          '* build: prepare desktop 0.0.31',
+          '* chore(release): bridge 0.0.17',
+        ].join('\n'),
       ),
       '',
     );
@@ -152,21 +154,29 @@ describe('summarizeNotes', () => {
   it('survives notes with nothing in them, and notes that are not notes', () => {
     assert.equal(summarizeNotes(''), '');
     assert.equal(summarizeNotes(undefined), '');
-    assert.equal(summarizeNotes('## New Contributors\n* @someone made their first contribution'), '');
+    assert.equal(
+      summarizeNotes('## New Contributors\n* @someone made their first contribution'),
+      '',
+    );
   });
 
   it('does not repeat an entry that appears twice', () => {
     assert.equal(
       summarizeNotes(
-        ["## What's Changed", '* feat: a thing by @a in https://x/1', '* feat: a thing by @b in https://x/2'].join(
-          '\n',
-        ),
+        [
+          "## What's Changed",
+          '* feat: a thing by @a in https://x/1',
+          '* feat: a thing by @b in https://x/2',
+        ].join('\n'),
       ),
       'feat: a thing',
     );
   });
 
   it('leaves a title alone when it has no attribution suffix', () => {
-    assert.equal(summarizeNotes("## What's Changed\n* feat: written by hand"), 'feat: written by hand');
+    assert.equal(
+      summarizeNotes("## What's Changed\n* feat: written by hand"),
+      'feat: written by hand',
+    );
   });
 });


### PR DESCRIPTION
The first unattended cut wrote this into `VERSIONS.md` for desktop 0.0.31:

> build(release): desktop 0.0.30-nightly.20260807.2; …; @uxnan-releases[bot] made their first contribution in …/pull/159

**New Contributors is a bullet list too**, so the release tooling's own bot landed among the changes — and `build(release):` names the *previous* version, reading as if 0.0.30 shipped inside 0.0.31.

The summary was a `grep | sed | paste` pipeline inside `release.yml`. It is now `summarizeNotes()` in `record.mjs` (`--notes-file`), with six tests whose first case is the exact notes GitHub generated for the run that got it wrong.

Second bug in two days from a shell one-liner in a workflow — the other refused a good nightly on an invalid jq escape. Both were untested and failed only in production; that pattern is the real finding, and it is written down in `scripts/release/README.md`.

Release tooling: 78 tests passing.