### PR TITLE
fix(release): a test-only change was about to cut a nightly

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -57,6 +57,11 @@ desktop **nightly** — writing the release notes and publishing.
 affect a build since the last desktop tag **in either channel**. If not, it
 finishes green having done nothing — most days.
 
+"In a way that can affect a build" excludes prose *and tests*: a documentation
+pass or a test-only fix does not earn four installers, a published pre-release
+and an updater roll for a binary nobody can tell apart. `npm run release:status`
+shows both counts, and `scripts/release/README.md` lists what each class covers.
+
 The time is not arbitrary. Version stamps are UTC, and 00:20 local is 06:20 UTC
 **of the same date**, so `nightly.20260808.1` really is the nightly of the 8th on
 your calendar. Cutting at 23:00 local would stamp it with the following day.

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -12,16 +12,27 @@ pushes** — that stays with a human, and from phase 2 with the release workflow
 The state of the whole monorepo in one table:
 
 ```
-component last tag                                changed  needs release  next
-shared    shared-v0.0.13-alpha.20260804           0+0d     no             —
-relay     relay-v0.0.2-alpha.20260720             0+1d     no (docs only) —
-desktop   desktop-stable-v0.0.28                  25+9d    YES            0.0.29-nightly.20260806.1
+component last tag                                changed needs release     next
+shared    shared-v0.0.13-alpha.20260804           0+0n    no                —
+relay     relay-v0.0.2-alpha.20260720             0+1n    no (nothing ships) —
+desktop   desktop-stable-v0.0.28                  25+9n   YES               0.0.29-nightly.20260806.1
 ```
 
 `changed` is `files that can affect a build + files that cannot`. That second
 number is the whole point: on 2026-08-06 the only change in `relay/` since its
 tag was `FOR-DEV.md`, and a trigger that fired on "the folder changed" would have
 published an identical package.
+
+Two kinds of file cannot reach a build: **prose** (`*.md`, `docs/`,
+`architecture/`, `.github/`) and **tests** (`*.test.*`, `*.spec.*`, `test/`,
+`tests/`). Tests were added to the list when, with 0.0.31 shipped and the only
+desktop change since it being a fix to `setup.dom.ts`, the status still said the
+component owed a release — the next cron would have cut 0.0.32 for a test. A test
+proves something about code that already shipped, and a nightly is four
+installers, a published pre-release and an updater roll for a build nobody can
+tell apart from the one before it. Rust unit
+tests live inline in `src/` under `#[cfg(test)]`, so those files are still source
+and still count: the rule errs toward releasing.
 
 Flags: `--channel=stable|nightly` (how to compute the desktop's next version,
 default `nightly`) and `--json` (for the workflow's job summary).

--- a/scripts/release/changes.mjs
+++ b/scripts/release/changes.mjs
@@ -8,7 +8,7 @@
  * for nothing.
  */
 
-import { component, isDocsOnly } from './components.mjs';
+import { component, isNonShipping } from './components.mjs';
 import { changedFiles, commitSubjects, latestTag } from './git.mjs';
 import { highestBase, nextVersion } from './version.mjs';
 import { tagsFor } from './git.mjs';
@@ -17,7 +17,7 @@ import { tagsFor } from './git.mjs';
  * @param {string} id component id
  * @param {{cwd?: string, channel?: 'stable'|'nightly', date?: Date}} [options]
  * @returns {{
- *   id: string, since: string|null, files: string[], docsOnly: string[],
+ *   id: string, since: string|null, files: string[], nonShipping: string[],
  *   substantive: string[], commits: number, worthy: boolean,
  *   shipped: string|null, next: string,
  * }}
@@ -28,8 +28,8 @@ export function inspect(id, options = {}) {
 
   const since = latestTag(meta.tagPrefixes, gitOptions);
   const files = changedFiles(since, meta.path, gitOptions);
-  const docsOnly = files.filter(isDocsOnly);
-  const substantive = files.filter((file) => !isDocsOnly(file));
+  const nonShipping = files.filter(isNonShipping);
+  const substantive = files.filter((file) => !isNonShipping(file));
 
   const tags = tagsFor(meta.tagPrefixes, gitOptions);
   const shipped = highestBase(tags);
@@ -44,7 +44,7 @@ export function inspect(id, options = {}) {
     id,
     since,
     files,
-    docsOnly,
+    nonShipping,
     substantive,
     commits: commitSubjects(since, meta.path, gitOptions).length,
     worthy: substantive.length > 0,

--- a/scripts/release/components.mjs
+++ b/scripts/release/components.mjs
@@ -8,12 +8,30 @@
  * left out of a bump is invisible until a release ships wrong).
  */
 
-/** Paths whose change cannot possibly need a new build. */
-export const DOCS_ONLY = [
+/**
+ * Paths whose change cannot possibly need a new build.
+ *
+ * Two classes, kept in one list because the question they answer is the same —
+ * "would a user get anything different if we released this?".
+ *
+ * **Prose and specs.** Documentation, architecture, workflow files.
+ *
+ * **Tests and their helpers.** A test change proves something about code that
+ * already shipped; it never alters what a user downloads. Without this, the
+ * nightly cron cuts a release for a test-only commit — it did, the day
+ * `setup.dom.ts` was fixed, and a nightly is four installers, a published
+ * pre-release and an updater roll for a build nobody can tell apart from the
+ * one before it. Rust unit tests live inline in `src/` under `#[cfg(test)]` and
+ * are deliberately NOT matched: this errs toward releasing.
+ */
+export const NON_SHIPPING = [
   /\.md$/i,
   /(^|\/)docs\//,
   /(^|\/)architecture(\.old)?\//,
   /(^|\/)\.github\//,
+  /\.test\.[cm]?[jt]sx?$/i,
+  /\.spec\.[cm]?[jt]sx?$/i,
+  /(^|\/)(test|tests|__tests__)\//,
 ];
 
 /**
@@ -103,8 +121,8 @@ export function component(id) {
 }
 
 /** True when a changed path cannot affect what a build produces. */
-export function isDocsOnly(file) {
-  return DOCS_ONLY.some((rule) => rule.test(file));
+export function isNonShipping(file) {
+  return NON_SHIPPING.some((rule) => rule.test(file));
 }
 
 /**

--- a/scripts/release/components.test.mjs
+++ b/scripts/release/components.test.mjs
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 
-import { COMPONENTS, RELEASE_ORDER, component, isDocsOnly } from './components.mjs';
+import { COMPONENTS, RELEASE_ORDER, component, isNonShipping } from './components.mjs';
 
 const repo = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -68,7 +68,7 @@ describe('the registry', () => {
   });
 });
 
-describe('isDocsOnly', () => {
+describe('isNonShipping', () => {
   it('treats prose and specs as unable to change a build', () => {
     for (const file of [
       'relay/FOR-DEV.md',
@@ -78,7 +78,25 @@ describe('isDocsOnly', () => {
       'architecture.old/whitepaper.md',
       '.github/workflows/ci-node.yml',
     ]) {
-      assert.equal(isDocsOnly(file), true, file);
+      assert.equal(isNonShipping(file), true, file);
+    }
+  });
+
+  it('treats tests and their helpers as unable to change a build', () => {
+    // A test proves something about code that already shipped. Cutting a
+    // nightly for one means four installers and an updater roll for a build
+    // nobody can tell apart — which is exactly what happened the day
+    // `setup.dom.ts` was fixed.
+    for (const file of [
+      'uxnandesktop/src/test/setup.dom.ts',
+      'uxnandesktop/src/lib/components/FileTreePanel.svelte.test.ts',
+      'uxnandesktop/src/lib/agentModel.test.ts',
+      'bridge/test/handlers/threads.test.ts',
+      'scripts/release/record.test.mjs',
+      'uxnandesktop/tests/platform-support.json',
+      'shared/src/__tests__/validators.spec.ts',
+    ]) {
+      assert.equal(isNonShipping(file), true, file);
     }
   });
 
@@ -90,8 +108,15 @@ describe('isDocsOnly', () => {
       'uxnanmobile/lib/main.dart',
       'shared/package.json',
       'uxnandesktop/src-tauri/Cargo.toml',
+      // Rust keeps its unit tests inline under `#[cfg(test)]`, so a file with
+      // tests in it is still a source file. Erring toward releasing is correct.
+      'uxnandesktop/src-tauri/src/agentcli.rs',
+      // "latest" is not "test": the rule must match a path segment, not a
+      // substring of a longer word.
+      'uxnandesktop/src/lib/latest/index.ts',
+      'bridge/src/protest-banner.ts',
     ]) {
-      assert.equal(isDocsOnly(file), false, file);
+      assert.equal(isNonShipping(file), false, file);
     }
   });
 });

--- a/scripts/release/plan.mjs
+++ b/scripts/release/plan.mjs
@@ -52,8 +52,8 @@ export function planCuts({ components, channel = 'stable', force = false, inspec
       skipped.push({
         id,
         since: report.since,
-        reason: report.files.length > 0 ? 'only docs changed' : 'no changes',
-        files: report.docsOnly,
+        reason: report.files.length > 0 ? 'nothing that ships changed' : 'no changes',
+        files: report.nonShipping,
       });
       continue;
     }

--- a/scripts/release/plan.test.mjs
+++ b/scripts/release/plan.test.mjs
@@ -6,12 +6,12 @@ import { planCuts, tagPrefixFor } from './plan.mjs';
 /** A stand-in for the git-backed inspector, so the rules are testable. */
 function inspectorFor(state) {
   return (id, { channel } = {}) => {
-    const entry = state[id] ?? { worthy: false, files: [], docsOnly: [] };
+    const entry = state[id] ?? { worthy: false, files: [], nonShipping: [] };
     return {
       id,
       since: entry.since ?? `${id}-v0.0.1`,
       files: entry.files ?? [],
-      docsOnly: entry.docsOnly ?? [],
+      nonShipping: entry.nonShipping ?? [],
       substantive: entry.worthy ? ['src/x.ts'] : [],
       worthy: entry.worthy,
       next:
@@ -50,12 +50,16 @@ describe('planCuts', () => {
     assert.equal(plan.cuts[1].waitFor, null);
   });
 
-  it('drops a component whose only change is documentation', () => {
+  it('drops a component whose only changes cannot reach a build', () => {
     const plan = planCuts({
       components: ['relay', 'desktop'],
       channel: 'nightly',
       inspector: inspectorFor({
-        relay: { worthy: false, files: ['relay/FOR-DEV.md'], docsOnly: ['relay/FOR-DEV.md'] },
+        relay: {
+          worthy: false,
+          files: ['relay/FOR-DEV.md', 'relay/test/ws.test.ts'],
+          nonShipping: ['relay/FOR-DEV.md', 'relay/test/ws.test.ts'],
+        },
         desktop: { worthy: true },
       }),
     });
@@ -64,7 +68,8 @@ describe('planCuts', () => {
       ['desktop'],
     );
     assert.equal(plan.skipped[0].id, 'relay');
-    assert.equal(plan.skipped[0].reason, 'only docs changed');
+    assert.equal(plan.skipped[0].reason, 'nothing that ships changed');
+    assert.deepEqual(plan.skipped[0].files, ['relay/FOR-DEV.md', 'relay/test/ws.test.ts']);
   });
 
   it('reports an untouched component as having no changes at all', () => {

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -52,9 +52,9 @@ if (tree.dirty && !has('force')) {
 const report = inspect(id, { channel });
 if (!report.worthy && !has('force')) {
   console.error(`\n${id} has nothing to release since ${report.since ?? 'the beginning'}.`);
-  if (report.docsOnly.length > 0) {
+  if (report.nonShipping.length > 0) {
     console.error('Only these changed, and none of them can affect a build:');
-    for (const file of report.docsOnly) console.error(`  ${file}`);
+    for (const file of report.nonShipping) console.error(`  ${file}`);
   }
   console.error('\nPass --force to release it anyway.\n');
   process.exit(1);

--- a/scripts/release/status.mjs
+++ b/scripts/release/status.mjs
@@ -46,25 +46,29 @@ console.log(
   `\nuxnan release status — ${tree.branch} @ ${tree.head}${tree.dirty ? ' (dirty)' : ''}\n`,
 );
 
-const pad = (value, width) => String(value).padEnd(width);
+// Every column keeps at least one space after its widest value, so a long tag
+// or a long verdict pushes the row along instead of swallowing the gap — the
+// desktop's nightly tag is 40 characters and used to run straight into the next
+// column.
+const pad = (value, width) => `${value}`.padEnd(width) + ' ';
 console.log(
-  `${pad('component', 10)}${pad('last tag', 40)}${pad('changed', 9)}${pad('needs release', 15)}next`,
+  `${pad('component', 9)}${pad('last tag', 41)}${pad('changed', 7)}${pad('needs release', 17)}next`,
 );
-console.log('-'.repeat(104));
+console.log('-'.repeat(110));
 
 let owed = 0;
 for (const row of rows) {
-  const changed = `${row.substantive.length}+${row.docsOnly.length}d`;
-  const verdict = row.worthy ? 'YES' : row.files.length ? 'no (docs only)' : 'no';
+  const changed = `${row.substantive.length}+${row.nonShipping.length}n`;
+  const verdict = row.worthy ? 'YES' : row.files.length ? 'no (nothing ships)' : 'no';
   if (row.worthy) owed += 1;
   const suffix = row.id === 'desktop' ? ` (${channel})` : '';
   console.log(
-    `${pad(row.id, 10)}${pad(row.since ?? '(never released)', 40)}${pad(changed, 9)}${pad(verdict, 15)}${row.worthy ? row.next + suffix : '—'}`,
+    `${pad(row.id, 9)}${pad(row.since ?? '(never released)', 41)}${pad(changed, 7)}${pad(verdict, 17)}${row.worthy ? row.next + suffix : '—'}`,
   );
 }
 
 console.log(
-  '\nchanged = files that can affect a build + files that cannot (docs, architecture, .github)\n',
+  '\nchanged = files that can affect a build + files that cannot (docs, specs, .github, tests)\n',
 );
 
 for (const row of rows.filter((r) => r.worthy)) {


### PR DESCRIPTION
With 0.0.31 shipped, the only desktop change since its tag was the `setup.dom.ts` fix — and `release:status` still said the component owed a release. The next cron would have cut 0.0.32: four installers, a published pre-release and an updater roll for a binary nobody could tell apart from the one before it.

A test proves something about code that already shipped; it cannot change what a user downloads. The classifier now covers tests as well as prose, and says so in its name — `isDocsOnly` → `isNonShipping`, since "docs only" had stopped describing what it decides. Rust keeps unit tests inline under `#[cfg(test)]`, so those files stay source: the rule errs toward releasing.

Also fixes the status table's columns colliding (the desktop's 40-character nightly tag ran into the next column).

79 tests passing; on the real repo `release:status` now reports "Nothing owes a release", which is the truth.