### PR TITLE
feat(web): draw the site with Hugeicons, the set the desktop app uses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,13 @@ If it affects contracts in `shared/`, all consuming components must be updated i
   a mobile screen changes shape, `web/src/components/mockups/` is part of that
   change set. Phone screens are drawn once at a canonical size and scaled by the
   frame — never re-size their contents to fit (`web/docs/design.md`).
+- **Icons are Hugeicons, the same set `uxnandesktop/` draws**, imported one glyph
+  per subpath. The site uses upstream's `@hugeicons/react`; the desktop needs its
+  own primitive because the *Svelte* component is broken for its call sites — do
+  not "align" one onto the other. Where a mockup recreates a screen, take the
+  glyph the app takes (the agent-state icons are `AgentStatusIndicator.svelte`'s),
+  and keep `@hugeicons/core-free-icons` pinned exactly in **both** `package.json`
+  files so the art cannot drift between app and site (`web/docs/design.md` §7).
 - **Agent marks live once, in `assets/agents/`** — the root READMEs render those
   files directly and the site syncs them into `web/public/agents/` before dev and
   build (`web/scripts/sync-agent-marks.mjs`; the synced copy is git-ignored).

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -7,6 +7,28 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **The site draws Hugeicons, the same set as the desktop app.** All 33 glyphs
+  across 61 render sites move off `lucide-react` and onto
+  [`@hugeicons/core-free-icons`](https://www.npmjs.com/package/@hugeicons/core-free-icons)
+  (MIT), one glyph per subpath. Every pair the desktop already chose is reused
+  verbatim, so the interface visuals stop drawing a different icon set from the
+  product they recreate — most visibly in the desktop window's agent list, whose
+  done / blocked / waiting glyphs are now literally the ones
+  `AgentStatusIndicator.svelte` draws.
+
+  Seven glyphs had no counterpart in that mapping and were chosen here: a real
+  pull-request glyph for the "1 ready" line (the desktop's `git-pull-request`
+  pair is the GitHub mark, because there it stands in for the brand), a mug for
+  Buy Me a Coffee, stacked coins for Tokens, a 2×2 grid for Activity, plus the
+  laptop, mic and overflow glyphs the phone screens use.
+
+  Drawn through upstream's `HugeiconsIcon` rather than a primitive of our own —
+  it is a plain `createElement` tree, so unlike the Svelte component the desktop
+  had to replace, it renders during the static export. Verified in the built
+  `out/index.html`: 88 pre-rendered `<svg>`, none of them empty. The icon
+  package is pinned exactly, matching the desktop, so the drawn art cannot
+  drift away from the app's on an unrelated install.
+
 - **The agent section shows the whole catalog, not seven names.** Two rows of
   tiles now — same compact shape as before, mark on the left and name on the
   right: the **22 agents that report precise state** (working / blocked / waiting /

--- a/web/FOR-DEV.md
+++ b/web/FOR-DEV.md
@@ -15,7 +15,7 @@ the previous site is what `uxnan.pages.dev` serves until this lands on `main`.
 
 The site is one route (`/`) that runs hero → agents → parallel worktrees →
 mobile → measured footprint → open source → call to action. It is a Next.js 15
-static export (React 19, Tailwind v4, `lucide-react`), self-hosting Geist and
+static export (React 19, Tailwind v4, Hugeicons), self-hosting Geist and
 JetBrains Mono through `next/font`.
 
 What works today:

--- a/web/README.md
+++ b/web/README.md
@@ -24,7 +24,8 @@ the technical detail lives in each component's `README.md` and `docs/`.
 ## Stack
 
 Next.js 15 (App Router) with `output: "export"` — a fully static site, no server
-runtime. React 19, TypeScript, Tailwind CSS v4, `lucide-react` for icons, Geist +
+runtime. React 19, TypeScript, Tailwind CSS v4, Hugeicons for icons — the same
+set the desktop app draws (see [`docs/design.md`](docs/design.md)) — Geist +
 JetBrains Mono self-hosted through `next/font`. No analytics, no third-party
 scripts, no external requests at runtime — the agent marks are the repository's
 own SVGs (see [`docs/design.md`](docs/design.md)).

--- a/web/docs/design.md
+++ b/web/docs/design.md
@@ -53,8 +53,9 @@ same software a visitor is about to download.
 2. **Only show states the product can actually be in.** Four agents, one of them
    idle; a subagent nested under its parent; a queued message that "delivers
    mid-turn" — each of those is a real feature. Never invent a control.
-3. **Never show an agent that is not offered.** The seven come from `AGENTS` in
-   `src/lib/site.ts`; the deprecated Gemini CLI must not appear.
+3. **Never show an agent that is not offered.** They come from `AGENTS_PRECISE`
+   and `AGENTS_BASIC` in `src/lib/site.ts`; the deprecated Gemini CLI must not
+   appear.
 4. **Keep the content plausible and boring.** Branch names, repo names and
    terminal output describe work on this monorepo. No invented customers, no
    fake handles, no personal paths.
@@ -76,6 +77,33 @@ same software a visitor is about to download.
    `<img>`, and `openclaude.svg` ships solid black. The phone mockups must
    **not** invert: their tiles are white, which is exactly where a black mark
    belongs. Claude's orange and Antigravity's gradient are never touched.
+7. **Icons are Hugeicons, and the desktop mockup uses the app's own glyph.**
+   The site draws [`@hugeicons/core-free-icons`](https://www.npmjs.com/package/@hugeicons/core-free-icons)
+   (MIT), imported one glyph per subpath so a page only bundles what it draws,
+   through the upstream `HugeiconsIcon` component from `@hugeicons/react`.
+
+   The desktop app draws the same set but through a primitive of its own
+   (`uxnandesktop/docs/design-tokens.md` → *The icon set*), because
+   `@hugeicons/svelte` paints inside `onMount` and never repaints when its
+   `icon` prop changes. **None of that applies here:** the React component is a
+   plain `createElement` tree, so it renders during the static export — and it
+   has to, since a marketing page whose icons only appear after hydration is a
+   page that ships blank squares. If you change how icons are drawn, re-check
+   `out/index.html` for empty `<svg>` elements; the build will not tell you.
+
+   **Where a mockup recreates a screen, take the glyph the app takes.** The
+   agent state icons in the desktop window are the same three
+   `AgentStatusIndicator.svelte` draws — `CircleCheckIcon` for done,
+   `PauseCircleIcon` for blocked, `ChatQuestionIcon` for waiting, and CSS dots
+   for working — so the vocabulary a visitor learns here is the one they meet in
+   the app. The `core-free-icons` version is **pinned exactly**, in both
+   `package.json` files, for the same reason: a caret would let the drawn art
+   drift away from the app's on an unrelated install.
+
+   The phone screens are a knowing approximation: Uxnan Mobile is Flutter and
+   draws **Material** icons, which are not on this site at all. Hugeicons is the
+   closest single family the site can hold without shipping a second icon set,
+   and it is what the previous `lucide-react` was doing too.
 
 ## Phone mockups scale, they do not resize
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "lucide-react": "^1.28.0",
+        "@hugeicons/core-free-icons": "4.2.3",
+        "@hugeicons/react": "^1.1.9",
         "next": "^15.5.4",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -214,6 +215,21 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hugeicons/core-free-icons": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@hugeicons/core-free-icons/-/core-free-icons-4.2.3.tgz",
+      "integrity": "sha512-fpiU0qFZkv4ABi23xJ2m4qNr0BBfuIaYjPboN8WDA6aj9D+OzXa7eykxKOpACZRuGbDz1U9S5DsNx1d5KNnsgA==",
+      "license": "MIT"
+    },
+    "node_modules/@hugeicons/react": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@hugeicons/react/-/react-1.1.9.tgz",
+      "integrity": "sha512-O+lWSWjbijoAvMCxn4K2bQWCGN5+mP1y5j+X99j23mXMj+s0X25fs71T6t9YJLaBodwmZdaewD27dzS/PiboQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4710,15 +4726,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
-      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "lucide-react": "^1.28.0",
+    "@hugeicons/core-free-icons": "4.2.3",
+    "@hugeicons/react": "^1.1.9",
     "next": "^15.5.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/web/scripts/fetch-agent-favicons.mjs
+++ b/web/scripts/fetch-agent-favicons.mjs
@@ -15,7 +15,7 @@
 // answered with the service's generic globe, because those are the ones that
 // need a hand-made mark instead of a silent grey circle.
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 

--- a/web/src/components/mockups/desktop.tsx
+++ b/web/src/components/mockups/desktop.tsx
@@ -1,19 +1,18 @@
-import {
-  ChevronDown,
-  ChevronRight,
-  CircleCheck,
-  CirclePause,
-  Folder,
-  GitBranch,
-  MessageCircleQuestionMark,
-  Minus,
-  Plus,
-  RefreshCw,
-  Search,
-  Square,
-  SquareTerminal,
-  X,
-} from "lucide-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import ChevronDownIcon from "@hugeicons/core-free-icons/ChevronDownIcon";
+import ChevronRightIcon from "@hugeicons/core-free-icons/ChevronRightIcon";
+import CircleCheckIcon from "@hugeicons/core-free-icons/CircleCheckIcon";
+import CirclePauseIcon from "@hugeicons/core-free-icons/PauseCircleIcon";
+import FolderIcon from "@hugeicons/core-free-icons/Folder01Icon";
+import GitBranchIcon from "@hugeicons/core-free-icons/GitBranchIcon";
+import MessageCircleQuestionMarkIcon from "@hugeicons/core-free-icons/ChatQuestionIcon";
+import MinusIcon from "@hugeicons/core-free-icons/MinusSignIcon";
+import PlusIcon from "@hugeicons/core-free-icons/PlusSignIcon";
+import RefreshCwIcon from "@hugeicons/core-free-icons/RefreshIcon";
+import SearchIcon from "@hugeicons/core-free-icons/Search01Icon";
+import SquareIcon from "@hugeicons/core-free-icons/SquareIcon";
+import SquareTerminalIcon from "@hugeicons/core-free-icons/ComputerTerminal01Icon";
+import XIcon from "@hugeicons/core-free-icons/Cancel01Icon";
 import { AGENT_ICON, CLAUDE_TERMINAL_ICON, INVERT_ON_DARK } from "@/lib/site";
 
 /* ───────────────────────────────────────────────────────────────────────────
@@ -151,12 +150,12 @@ function Dot({ tone = "live" }: { tone?: Tone }) {
   if (tone === "live") return <Comet />;
   if (tone === "waiting")
     return (
-      <MessageCircleQuestionMark className="size-[9px] shrink-0 text-orange" />
+      <HugeiconsIcon icon={MessageCircleQuestionMarkIcon} className="size-[9px] shrink-0 text-orange" />
     );
   if (tone === "blocked")
-    return <CirclePause className="size-[9px] shrink-0 text-amber" />;
+    return <HugeiconsIcon icon={CirclePauseIcon} className="size-[9px] shrink-0 text-amber" />;
   if (tone === "done")
-    return <CircleCheck className="size-[9px] shrink-0 text-brand-lit" />;
+    return <HugeiconsIcon icon={CircleCheckIcon} className="size-[9px] shrink-0 text-brand-lit" />;
   return <span className={`size-[5px] shrink-0 rounded-full ${DOT[tone]}`} />;
 }
 
@@ -207,16 +206,16 @@ export function DesktopWindow({ className = "" }: { className?: string }) {
             >
               <Dot tone={a.tone} />
               <span className="max-w-[110px] truncate">{a.name}</span>
-              <X className="size-3 opacity-40" />
+              <HugeiconsIcon icon={XIcon} className="size-3 opacity-40" />
             </div>
           ))}
-          <Plus className="size-3.5 shrink-0 text-faint" />
+          <HugeiconsIcon icon={PlusIcon} className="size-3.5 shrink-0 text-faint" />
         </div>
 
         <div className="ml-auto flex shrink-0 items-center gap-3 text-faint">
-          <Minus className="size-3.5" />
-          <Square className="size-[11px]" />
-          <X className="size-3.5" />
+          <HugeiconsIcon icon={MinusIcon} className="size-3.5" />
+          <HugeiconsIcon icon={SquareIcon} className="size-[11px]" />
+          <HugeiconsIcon icon={XIcon} className="size-3.5" />
         </div>
       </div>
 
@@ -224,7 +223,7 @@ export function DesktopWindow({ className = "" }: { className?: string }) {
         {/* ── Project rail with the live agent view ──────────────────── */}
         <aside className="hidden w-[212px] shrink-0 flex-col border-r border-line bg-panel/60 p-2.5 md:flex">
           <div className="flex items-center gap-2 rounded-md border border-line bg-ink px-2 py-1.5 text-[10.5px] text-faint">
-            <Search className="size-3" />
+            <HugeiconsIcon icon={SearchIcon} className="size-3" />
             <span className="truncate">Search a project…</span>
             <kbd className="ml-auto shrink-0 rounded border border-line px-1 text-[9px] whitespace-nowrap text-faint">
               Ctrl P
@@ -236,17 +235,17 @@ export function DesktopWindow({ className = "" }: { className?: string }) {
               PROJECTS (8)
             </span>
             <span className="ml-auto flex items-center gap-1.5 text-faint">
-              <RefreshCw className="size-2.5" />
-              <Plus className="size-2.5" />
+              <HugeiconsIcon icon={RefreshCwIcon} className="size-2.5" />
+              <HugeiconsIcon icon={PlusIcon} className="size-2.5" />
             </span>
           </div>
 
           {/* the open project */}
           <div className="flex items-center gap-2 rounded-md px-2 py-1.5 text-fg">
-            <Folder className="size-3 shrink-0 opacity-70" />
+            <HugeiconsIcon icon={FolderIcon} className="size-3 shrink-0 opacity-70" />
             <span className="truncate text-[10.5px]">uxnan</span>
             <span className="ml-auto flex items-center gap-1 text-[9px] text-dim">
-              <SquareTerminal className="size-2.5" />4
+              <HugeiconsIcon icon={SquareTerminalIcon} className="size-2.5" />4
             </span>
           </div>
 
@@ -256,13 +255,13 @@ export function DesktopWindow({ className = "" }: { className?: string }) {
               <Dot />
               <span className="text-[10.5px] text-fg">main</span>
               <span className="ml-auto flex items-center gap-1 text-[9px] text-dim">
-                <SquareTerminal className="size-2.5" />4
+                <HugeiconsIcon icon={SquareTerminalIcon} className="size-2.5" />4
               </span>
             </div>
             <div className="mb-1 px-1 pl-[13px] text-[9px] text-faint">uxnan</div>
 
             <div className="flex items-center gap-1 px-1 py-1 text-[8.5px] tracking-[0.14em] text-faint">
-              <ChevronDown className="size-2.5" />
+              <HugeiconsIcon icon={ChevronDownIcon} className="size-2.5" />
               AGENTS {AGENTS_RUNNING.length}
             </div>
 
@@ -306,7 +305,7 @@ export function DesktopWindow({ className = "" }: { className?: string }) {
             ))}
 
             <div className="mt-1.5 flex items-center gap-1.5 border-t border-line px-1 pt-1.5">
-              <GitBranch className="size-2.5 shrink-0 text-faint" />
+              <HugeiconsIcon icon={GitBranchIcon} className="size-2.5 shrink-0 text-faint" />
               <div className="min-w-0">
                 <div className="truncate text-[10px] leading-tight text-dim">
                   feat/branding
@@ -324,7 +323,7 @@ export function DesktopWindow({ className = "" }: { className?: string }) {
                 key={p}
                 className="flex items-center gap-2 rounded-md px-2 py-1.5 text-dim"
               >
-                <Folder className="size-3 shrink-0 opacity-60" />
+                <HugeiconsIcon icon={FolderIcon} className="size-3 shrink-0 opacity-60" />
                 <span className="truncate text-[10.5px]">{p}</span>
               </div>
             ))}
@@ -429,8 +428,8 @@ export function DesktopWindow({ className = "" }: { className?: string }) {
           <div className="flex items-center gap-1.5 px-2.5 py-2 text-[9px] tracking-[0.14em] text-faint">
             UXNAN
             <span className="ml-auto flex items-center gap-1.5">
-              <Search className="size-2.5" />
-              <RefreshCw className="size-2.5" />
+              <HugeiconsIcon icon={SearchIcon} className="size-2.5" />
+              <HugeiconsIcon icon={RefreshCwIcon} className="size-2.5" />
             </span>
           </div>
 
@@ -442,8 +441,8 @@ export function DesktopWindow({ className = "" }: { className?: string }) {
               >
                 {t.dir ? (
                   <>
-                    <ChevronRight className="size-2.5 text-faint" />
-                    <Folder className="size-3 opacity-70" />
+                    <HugeiconsIcon icon={ChevronRightIcon} className="size-2.5 text-faint" />
+                    <HugeiconsIcon icon={FolderIcon} className="size-3 opacity-70" />
                   </>
                 ) : (
                   <span className="ml-[18px]" />
@@ -455,10 +454,10 @@ export function DesktopWindow({ className = "" }: { className?: string }) {
 
           <div className="mt-auto border-t border-line px-2.5 py-2 text-[9.5px] text-faint">
             <div className="flex items-center gap-1.5">
-              <GitBranch className="size-2.5" />
+              <HugeiconsIcon icon={GitBranchIcon} className="size-2.5" />
               <span>uxnan / main</span>
               <span className="ml-auto flex items-center gap-1">
-                <SquareTerminal className="size-2.5" />4
+                <HugeiconsIcon icon={SquareTerminalIcon} className="size-2.5" />4
               </span>
             </div>
           </div>

--- a/web/src/components/mockups/phone.tsx
+++ b/web/src/components/mockups/phone.tsx
@@ -1,27 +1,26 @@
-import {
-  ArrowLeft,
-  Check,
-  CircleDashed,
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight,
-  Coins,
-  Copy,
-  Folder,
-  GitBranch,
-  LayoutGrid,
-  Laptop,
-  ListFilter,
-  Mic,
-  MoreVertical,
-  Pencil,
-  Plus,
-  RefreshCw,
-  Search,
-  Sparkles,
-  SquarePen,
-  X,
-} from "lucide-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import ArrowLeftIcon from "@hugeicons/core-free-icons/ArrowLeft01Icon";
+import CheckIcon from "@hugeicons/core-free-icons/CheckIcon";
+import CircleDashedIcon from "@hugeicons/core-free-icons/CircleDashedIcon";
+import ChevronDownIcon from "@hugeicons/core-free-icons/ChevronDownIcon";
+import ChevronLeftIcon from "@hugeicons/core-free-icons/ChevronLeftIcon";
+import ChevronRightIcon from "@hugeicons/core-free-icons/ChevronRightIcon";
+import CoinsIcon from "@hugeicons/core-free-icons/Coins01Icon";
+import CopyIcon from "@hugeicons/core-free-icons/CopyIcon";
+import FolderIcon from "@hugeicons/core-free-icons/Folder01Icon";
+import GitBranchIcon from "@hugeicons/core-free-icons/GitBranchIcon";
+import LayoutGridIcon from "@hugeicons/core-free-icons/Grid2X2Icon";
+import LaptopIcon from "@hugeicons/core-free-icons/LaptopIcon";
+import ListFilterIcon from "@hugeicons/core-free-icons/FilterIcon";
+import MicIcon from "@hugeicons/core-free-icons/Mic01Icon";
+import MoreVerticalIcon from "@hugeicons/core-free-icons/MoreVerticalIcon";
+import PencilIcon from "@hugeicons/core-free-icons/PencilIcon";
+import PlusIcon from "@hugeicons/core-free-icons/PlusSignIcon";
+import RefreshCwIcon from "@hugeicons/core-free-icons/RefreshIcon";
+import SearchIcon from "@hugeicons/core-free-icons/Search01Icon";
+import SparklesIcon from "@hugeicons/core-free-icons/SparklesIcon";
+import SquarePenIcon from "@hugeicons/core-free-icons/Edit02Icon";
+import XIcon from "@hugeicons/core-free-icons/Cancel01Icon";
 import { AGENT_ICON, AGENTS } from "@/lib/site";
 
 /* ───────────────────────────────────────────────────────────────────────────
@@ -205,18 +204,18 @@ export function PhoneConversations() {
     <>
       <div className="flex items-center gap-[6px] px-[10px] pt-[4px] pb-[8px]">
         <RoundBtn>
-          <ArrowLeft className="size-[11px]" />
+          <HugeiconsIcon icon={ArrowLeftIcon} className="size-[11px]" />
         </RoundBtn>
         <span className="truncate text-[12px] font-medium">DESKTOP-4RO7…</span>
         <span className="ml-auto flex items-center gap-[5px]">
           <RoundBtn>
-            <Search className="size-[10px]" />
+            <HugeiconsIcon icon={SearchIcon} className="size-[10px]" />
           </RoundBtn>
           <RoundBtn>
-            <ListFilter className="size-[10px]" />
+            <HugeiconsIcon icon={ListFilterIcon} className="size-[10px]" />
           </RoundBtn>
           <RoundBtn>
-            <MoreVertical className="size-[10px]" />
+            <HugeiconsIcon icon={MoreVerticalIcon} className="size-[10px]" />
           </RoundBtn>
         </span>
       </div>
@@ -226,13 +225,13 @@ export function PhoneConversations() {
           className="flex h-[21px] items-center gap-[4px] rounded-[8px] px-[8px] text-[7.5px]"
           style={{ border: `1px solid ${M3.hairline}` }}
         >
-          Agent <ChevronDown className="size-[7px]" />
+          Agent <HugeiconsIcon icon={ChevronDownIcon} className="size-[7px]" />
         </span>
         <span
           className="flex h-[21px] items-center gap-[4px] rounded-[8px] px-[9px] text-[7.5px] font-medium"
           style={{ background: M3.mint, color: M3.onMint }}
         >
-          <Check className="size-[7px]" /> All
+          <HugeiconsIcon icon={CheckIcon} className="size-[7px]" /> All
         </span>
         <span
           className="flex h-[21px] shrink-0 items-center gap-[4px] rounded-[8px] px-[8px] text-[7.5px]"
@@ -288,7 +287,7 @@ export function PhoneConversations() {
           className="flex h-[30px] items-center gap-[6px] rounded-[11px] px-[12px] text-[9px] font-medium"
           style={{ background: M3.periwinkle, color: M3.onPeriwinkle }}
         >
-          <SquarePen className="size-[11px]" /> New conversation
+          <HugeiconsIcon icon={SquarePenIcon} className="size-[11px]" /> New conversation
         </span>
       </div>
     </>
@@ -308,7 +307,7 @@ export function PhoneConversation() {
     <>
       <div className="flex items-center gap-[5px] px-[9px] pt-[4px] pb-[8px]">
         <RoundBtn>
-          <ArrowLeft className="size-[11px]" />
+          <HugeiconsIcon icon={ArrowLeftIcon} className="size-[11px]" />
         </RoundBtn>
 
         {/* the agent / model chip the app puts in the app bar */}
@@ -316,19 +315,19 @@ export function PhoneConversation() {
           className="flex h-[23px] min-w-0 flex-1 items-center gap-[4px] rounded-full px-[8px] text-[8.5px]"
           style={{ background: M3.container }}
         >
-          <Sparkles className="size-[9px] shrink-0" />
+          <HugeiconsIcon icon={SparklesIcon} className="size-[9px] shrink-0" />
           <span className="truncate">claude/opus-5</span>
-          <ChevronDown className="ml-auto size-[8px] shrink-0" />
+          <HugeiconsIcon icon={ChevronDownIcon} className="ml-auto size-[8px] shrink-0" />
         </span>
 
         <RoundBtn>
-          <Folder className="size-[10px]" />
+          <HugeiconsIcon icon={FolderIcon} className="size-[10px]" />
         </RoundBtn>
         <RoundBtn>
-          <GitBranch className="size-[10px]" />
+          <HugeiconsIcon icon={GitBranchIcon} className="size-[10px]" />
         </RoundBtn>
         <RoundBtn>
-          <MoreVertical className="size-[10px]" />
+          <HugeiconsIcon icon={MoreVerticalIcon} className="size-[10px]" />
         </RoundBtn>
       </div>
 
@@ -377,7 +376,7 @@ export function PhoneConversation() {
           className="mt-[10px] flex items-center gap-[5px] text-[8.5px]"
           style={{ color: M3.onSurfaceVar }}
         >
-          <Copy className="size-[9px]" />
+          <HugeiconsIcon icon={CopyIcon} className="size-[9px]" />
           Copy response
         </div>
       </div>
@@ -388,13 +387,13 @@ export function PhoneConversation() {
           className="grid size-[21px] place-items-center rounded-full"
           style={{ background: M3.container }}
         >
-          <ChevronRight className="size-[10px]" />
+          <HugeiconsIcon icon={ChevronRightIcon} className="size-[10px]" />
         </span>
         <span
           className="ml-auto flex items-center gap-[4px] rounded-full px-[8px] py-[3px] text-[8px]"
           style={{ background: M3.container, color: M3.onSurfaceVar }}
         >
-          <CircleDashed className="size-[8px]" /> 17.9k
+          <HugeiconsIcon icon={CircleDashedIcon} className="size-[8px]" /> 17.9k
         </span>
         <span
           className="grid size-[21px] place-items-center rounded-full border-[1.5px] text-[7.5px] font-medium"
@@ -410,11 +409,11 @@ export function PhoneConversation() {
           className="flex h-[29px] items-center gap-[8px] rounded-full px-[10px]"
           style={{ background: M3.container }}
         >
-          <Plus className="size-[12px] shrink-0" />
+          <HugeiconsIcon icon={PlusIcon} className="size-[12px] shrink-0" />
           <span className="truncate text-[9px]" style={{ color: M3.outline }}>
             Message…
           </span>
-          <Mic
+          <HugeiconsIcon icon={MicIcon}
             className="ml-auto size-[11px] shrink-0"
             style={{ color: M3.onSurfaceVar }}
           />
@@ -432,7 +431,7 @@ export function PhoneNewConversation() {
     <>
       <div className="flex items-center px-[10px] pt-[4px] pb-[10px]">
         <RoundBtn>
-          <X className="size-[11px]" />
+          <HugeiconsIcon icon={XIcon} className="size-[11px]" />
         </RoundBtn>
         <span className="ml-auto text-[9px]" style={{ color: M3.outline }}>
           Start conversation
@@ -453,7 +452,7 @@ export function PhoneNewConversation() {
             className="grid size-[23px] shrink-0 place-items-center rounded-[7px]"
             style={{ background: M3.mint }}
           >
-            <Folder className="size-[12px]" style={{ color: M3.onMint }} />
+            <HugeiconsIcon icon={FolderIcon} className="size-[12px]" style={{ color: M3.onMint }} />
           </span>
           <div className="min-w-0">
             <div className="text-[9px]">GitHub</div>
@@ -464,7 +463,7 @@ export function PhoneNewConversation() {
               C:\Users\dev\Documents\GitHub
             </div>
           </div>
-          <ChevronRight
+          <HugeiconsIcon icon={ChevronRightIcon}
             className="ml-auto size-[11px] shrink-0"
             style={{ color: M3.outline }}
           />
@@ -524,7 +523,7 @@ export function PhoneProfile() {
     <>
       <div className="flex items-center gap-[7px] px-[10px] pt-[4px] pb-[10px]">
         <RoundBtn>
-          <ArrowLeft className="size-[11px]" />
+          <HugeiconsIcon icon={ArrowLeftIcon} className="size-[11px]" />
         </RoundBtn>
         <span className="text-[13px]">Profile</span>
       </div>
@@ -553,7 +552,7 @@ export function PhoneProfile() {
               1 online now
             </div>
           </div>
-          <Pencil
+          <HugeiconsIcon icon={PencilIcon}
             className="ml-auto size-[10px] shrink-0"
             style={{ color: M3.onSurfaceVar }}
           />
@@ -565,7 +564,7 @@ export function PhoneProfile() {
             className="ml-auto grid size-[21px] place-items-center rounded-full"
             style={{ background: M3.mint }}
           >
-            <RefreshCw className="size-[10px]" style={{ color: M3.onMint }} />
+            <HugeiconsIcon icon={RefreshCwIcon} className="size-[10px]" style={{ color: M3.onMint }} />
           </span>
         </div>
 
@@ -597,13 +596,13 @@ export function PhoneProfile() {
             className="flex flex-1 items-center justify-center gap-[4px] rounded-full font-medium"
             style={{ background: M3.mint, color: M3.onMint }}
           >
-            <LayoutGrid className="size-[8px]" /> Activity
+            <HugeiconsIcon icon={LayoutGridIcon} className="size-[8px]" /> Activity
           </span>
           <span
             className="flex flex-1 items-center justify-center gap-[4px]"
             style={{ color: M3.onSurfaceVar }}
           >
-            <Coins className="size-[8px]" /> Tokens
+            <HugeiconsIcon icon={CoinsIcon} className="size-[8px]" /> Tokens
           </span>
         </div>
 
@@ -611,9 +610,9 @@ export function PhoneProfile() {
           className="mb-[7px] flex h-[18px] w-[74px] items-center justify-between rounded-full px-[7px] text-[8px]"
           style={{ background: M3.container }}
         >
-          <ChevronLeft className="size-[8px]" style={{ color: M3.onSurfaceVar }} />
+          <HugeiconsIcon icon={ChevronLeftIcon} className="size-[8px]" style={{ color: M3.onSurfaceVar }} />
           2026
-          <ChevronRight className="size-[8px]" style={{ color: M3.onSurfaceVar }} />
+          <HugeiconsIcon icon={ChevronRightIcon} className="size-[8px]" style={{ color: M3.onSurfaceVar }} />
         </div>
 
         <div className="grid grid-cols-[repeat(13,1fr)] gap-[2.5px]">
@@ -654,7 +653,7 @@ export function PhoneDevices() {
               className="grid size-[25px] shrink-0 place-items-center rounded-[8px]"
               style={{ background: M3.mint }}
             >
-              <Laptop className="size-[12px]" style={{ color: M3.onMint }} />
+              <HugeiconsIcon icon={LaptopIcon} className="size-[12px]" style={{ color: M3.onMint }} />
             </span>
             <div className="min-w-0">
               <div className="truncate text-[9.5px]">DESKTOP-4RO76Q2</div>
@@ -662,7 +661,7 @@ export function PhoneDevices() {
                 Last seen 13:00
               </div>
             </div>
-            <MoreVertical
+            <HugeiconsIcon icon={MoreVerticalIcon}
               className="ml-auto size-[10px] shrink-0"
               style={{ color: M3.onSurfaceVar }}
             />
@@ -695,7 +694,7 @@ export function PhoneDevices() {
             className="grid size-[25px] shrink-0 place-items-center rounded-[8px] bg-white"
             style={{ border: `1px solid ${M3.hairline}` }}
           >
-            <Laptop className="size-[12px]" style={{ color: M3.onSurfaceVar }} />
+            <HugeiconsIcon icon={LaptopIcon} className="size-[12px]" style={{ color: M3.onSurfaceVar }} />
           </span>
           <div className="min-w-0">
             <div className="truncate text-[9.5px]">MBP-DEV</div>

--- a/web/src/components/sections/cta.tsx
+++ b/web/src/components/sections/cta.tsx
@@ -1,4 +1,6 @@
-import { Coffee, Heart } from "lucide-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import CoffeeIcon from "@hugeicons/core-free-icons/Coffee02Icon";
+import HeartIcon from "@hugeicons/core-free-icons/HeartIcon";
 import { DownloadButton } from "@/components/download-button";
 import { Reveal } from "@/components/reveal";
 import { LICENSE, LINKS, SITE } from "@/lib/site";
@@ -72,13 +74,13 @@ const SUPPORT = [
   {
     label: "Sponsor on GitHub",
     href: LINKS.sponsor,
-    icon: <Heart className="size-4" />,
+    icon: <HugeiconsIcon icon={HeartIcon} className="size-4" />,
     hover: "#db61a2",
   },
   {
     label: "Buy the maintainer a coffee",
     href: LINKS.coffee,
-    icon: <Coffee className="size-4" />,
+    icon: <HugeiconsIcon icon={CoffeeIcon} className="size-4" />,
     hover: "#ffdd00",
   },
 ];

--- a/web/src/components/sections/hero.tsx
+++ b/web/src/components/sections/hero.tsx
@@ -1,4 +1,6 @@
-import { Download, Star } from "lucide-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import DownloadIcon from "@hugeicons/core-free-icons/Download01Icon";
+import StarIcon from "@hugeicons/core-free-icons/StarIcon";
 import { DownloadButton } from "@/components/download-button";
 import { DesktopWindow } from "@/components/mockups/desktop";
 import { Phone, PhoneConversations } from "@/components/mockups/phone";
@@ -40,12 +42,12 @@ export async function Hero() {
         {stats ? (
           <p className="mt-3.5 flex items-center justify-center gap-4 text-[12.5px] text-faint">
             <span className="inline-flex items-center gap-1.5">
-              <Star className="size-3.5 text-amber" />
+              <HugeiconsIcon icon={StarIcon} className="size-3.5 text-amber" />
               <span className="text-muted">{formatCount(stats.stars)}</span>
               stars
             </span>
             <span className="inline-flex items-center gap-1.5">
-              <Download className="size-3.5" />
+              <HugeiconsIcon icon={DownloadIcon} className="size-3.5" />
               <span className="text-muted">{formatCount(stats.downloads)}</span>
               downloads
             </span>

--- a/web/src/components/sections/parallel.tsx
+++ b/web/src/components/sections/parallel.tsx
@@ -1,4 +1,7 @@
-import { Check, GitBranch, GitPullRequest } from "lucide-react";
+import { HugeiconsIcon } from "@hugeicons/react";
+import CheckIcon from "@hugeicons/core-free-icons/CheckIcon";
+import GitBranchIcon from "@hugeicons/core-free-icons/GitBranchIcon";
+import GitPullRequestIcon from "@hugeicons/core-free-icons/GitPullRequestIcon";
 import { Reveal } from "@/components/reveal";
 import { AGENT_ICON, INVERT_ON_DARK } from "@/lib/site";
 
@@ -61,7 +64,7 @@ export function Parallel() {
           <ul className="mt-8 flex flex-col gap-3.5">
             {POINTS.map((p) => (
               <li key={p} className="flex gap-3 text-[14.5px] text-muted">
-                <Check className="mt-[3px] size-4 shrink-0 text-live" />
+                <HugeiconsIcon icon={CheckIcon} className="mt-[3px] size-4 shrink-0 text-live" />
                 <span>{p}</span>
               </li>
             ))}
@@ -71,11 +74,11 @@ export function Parallel() {
         <Reveal delay={100}>
           <div className="tile overflow-hidden">
             <div className="flex items-center gap-2 border-b border-line px-4 py-3 text-[12px] text-dim">
-              <GitBranch className="size-3.5" />
+              <HugeiconsIcon icon={GitBranchIcon} className="size-3.5" />
               <span className="text-fg">uxnan</span>
               <span className="text-faint">· 3 active worktrees</span>
               <span className="ml-auto flex items-center gap-1.5 text-[11px]">
-                <GitPullRequest className="size-3.5" /> 1 ready
+                <HugeiconsIcon icon={GitPullRequestIcon} className="size-3.5" /> 1 ready
               </span>
             </div>
 


### PR DESCRIPTION
The interface visuals recreate the shipped UI, but they had been drawing a
**different icon set from the product** ever since the desktop moved to
Hugeicons in #166. All **33 glyphs** across **61 render sites** in 5 files move
off `lucide-react` and onto
[`@hugeicons/core-free-icons`](https://www.npmjs.com/package/@hugeicons/core-free-icons)
(MIT), imported one glyph per subpath so a page still bundles only what it
draws. `lucide-react` is removed.

## The mapping is the desktop's, not a fresh set of opinions

**26 of the 33 pairs were extracted from #166's own migration** rather than
re-decided, so a glyph already reviewed there draws the same shape here.

The one that matters most: the desktop window's agent list now uses **literally
the three glyphs `AgentStatusIndicator.svelte` draws** — `CircleCheckIcon` for
done, `PauseCircleIcon` for blocked, `ChatQuestionIcon` for waiting, and the CSS
comet dots for working. The state vocabulary a visitor learns on the site is now
the one they meet in the app.

**Seven had no counterpart in that mapping and were chosen here:** a real
pull-request glyph for the "1 ready" line, a mug for Buy Me a Coffee, stacked
coins for Tokens, a 2×2 grid for Activity, plus the laptop, mic and overflow
glyphs the phone screens use.

One of those is a **deliberate departure** from the desktop: it maps
`git-pull-request` → `GithubIcon`, because there the PR glyph had been standing
in for the GitHub brand after lucide dropped its brand icons. In
`parallel.tsx` it means an actual pull request, so copying that pair would have
put the GitHub logo where a PR belongs.

## Why upstream's component here, when the desktop has its own

`@hugeicons/svelte` was rejected in #166 because it paints via `innerHTML`
inside `onMount` and never repaints when its `icon` prop changes. **None of that
is true of `@hugeicons/react`** — its source is a plain `forwardRef` +
`createElement` tree with no effects, and React re-renders on a prop change by
construction. Checked before deciding, not assumed.

That matters twice over for a **static export**: a component that painted on
hydration would ship a marketing page of blank squares. So the built
`out/index.html` is checked for exactly that.

`@hugeicons/core-free-icons` is **pinned exactly**, as the desktop pins it, so
an unrelated install cannot drift the site's art away from the app's.

## Verification

| gate | result |
|---|---|
| `npm run typecheck` | clean |
| `npm run lint` | **0 problems** |
| `npm run build` | green, static export 6/6 |
| built `out/index.html` | **88 pre-rendered `<svg>`, 0 empty**, 0 camelCase attributes leaking |
| runtime | built page driven end to end in a browser over CDP — **0 console errors** |
| glyphs | all 33 rendered at 16px and 40px on a contact sheet built from the installed package data, and reviewed one by one |

The desktop mockup's state glyphs were also checked magnified against the app's,
since at `size-[9px]` a wrong glyph is invisible in a normal capture.

## Docs, in the same change set

`web/CHANGELOG.md` · the stack line in `web/README.md` and `web/FOR-DEV.md` · a
new **rule 7** in `web/docs/design.md` (the subpath import rule, why upstream
here and not in the desktop, taking the app's glyph in a mockup, and the pin) ·
an `AGENTS.md` bullet, so the next change to either app knows both halves exist.

## Two things recorded rather than hidden

- **The phone screens are a knowing approximation.** Uxnan Mobile is Flutter and
  draws **Material** icons (457 sites), which are not on this site at all.
  Hugeicons is the closest single family the site can hold without shipping a
  second icon set — and it is what `lucide-react` was already doing. Written
  down in `design.md` rather than left to look like parity.
- **Rule 3 of that same numbered list was stale** — it still said the agents
  "are seven" and came from `AGENTS`; since #167 they come from
  `AGENTS_PRECISE` and `AGENTS_BASIC`. Corrected on the lines this change had to
  touch anyway.

The unused-import lint warning that #167 left behind is fixed in its own commit,
so this branch leaves `npm run lint` at zero problems.
