### PR TITLE
fix(rust): an untouched branch is not "landed", however far the base moves

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -279,6 +279,25 @@ new controls now carry `aria-label`s, so the panel is operable by name.
 
 ### Fixed
 
+- **The "landed" chip appeared on worktrees that had never been touched.** A
+  worktree created from `main` and left alone showed it as soon as `main` moved
+  on, sitting next to genuinely merged branches. Ancestry cannot tell "has
+  landed" from "has not started" — a branch that contributed nothing has all of
+  its commits trivially reachable from the base, so `--is-ancestor` says yes.
+  The previous guard compared the two tips, which only covers the window before
+  the base moves.
+
+  `branch_has_diverged` now asks the branch's **reflog** where it was created and
+  reports it unfinished when it never moved from there. That is the only thing
+  that can decide it: two branches can be the same commit — create one from
+  another's tip and touch neither — while one landed real work and the other
+  never began, so no walk of the commit graph can separate them. Without a
+  reflog (expired, disabled, a fresh clone) it falls back to the shape of the
+  history: a tip sitting on the base's own first-parent chain is an older point
+  of that line, not a contribution to it. When git says nothing, the answer is
+  "unfinished" — under-reporting costs a manual close, over-reporting offers to
+  delete work that never happened.
+
 - **A Grok sub-agent no longer marks its parent "Done" while it is still
   working.** Grok runs a child in a session of its own, and the child's events
   come up under the parent's terminal: its `session_end` mapped to `done` on the

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -28,7 +28,7 @@ background consumers**, `docs/resource-mode.md`), **post-mortem diagnostics**
 the tab strip** (`convtitle.rs`, the agent's own CLI on its cheapest model,
 named from the session's **terminal transcript** — the only material every agent
 has, since only Claude reports a prompt through the hook; a hand-renamed tab
-always wins). 536 Rust tests (508 unit + 28
+always wins). 538 Rust tests (510 unit + 28
 integration; +7 ignored supervised live GitHub tests + 1 ignored real-scheduler
 probe) + 926 frontend Vitest tests across two
 projects — pure logic and **Svelte

--- a/uxnandesktop/architecture/02c-git-worktrees.md
+++ b/uxnandesktop/architecture/02c-git-worktrees.md
@@ -159,19 +159,38 @@ sola al eliminar el worktree, para que el mapa no acumule rutas muertas.
 por defecto — ancestría real (`merge-base --is-ancestor`) o **squash**
 (`is_squash_merged`) — **sin borrar nada**.
 
-> **Una rama que no se ha movido de su base NO ha aterrizado: no ha empezado.**
-> La ancestría no distingue los dos casos — una rama recién creada no aporta
-> nada, así que todo lo alcanzable desde ella lo es también desde la base y
-> `--is-ancestor` dice que sí. Por eso se compara primero el tip: si coincide con
-> el de la base, la respuesta es `false`. Sin esa guarda, un worktree se marcaba
-> "aterrizado" en el instante de crearlo, invitando a cerrar el espacio que
-> acababas de montar — y el **cierre en lote** lo habría barrido como seguro.
+> **Una rama que nunca se movió NO ha aterrizado: no ha empezado** —
+> `branch_has_diverged`, la guarda que corre *antes* de la ancestría.
 >
-> El intercambio es deliberado: una rama mergeada por *fast-forward* también
-> termina compartiendo el tip de la base y se reporta como no-terminada. Reportar
-> de menos cuesta un cierre manual; reportar de más ofrece borrar trabajo que
-> nunca ocurrió. Los merges con commit y los squash — las formas que produce un
-> flujo de revisión real — no se ven afectados. Es deliberadamente la misma detección
+> La ancestría sola no distingue los dos casos: una rama que no aportó nada tiene
+> todos sus commits trivialmente alcanzables desde la base, así que
+> `--is-ancestor` dice que sí sobre un worktree que creaste esta mañana y no
+> tocaste. Sin la guarda, el chip «integrada» aparecía en espacios recién
+> montados y el **cierre en lote** los barría como seguros.
+>
+> **Por qué no basta comparar tips.** Fue el primer intento y solo cubre el caso
+> en que la base no se ha movido. En cuanto la base avanza, una rama intacta deja
+> de compartir su tip y vuelve a parecer aterrizada — reportado desde uso real.
+>
+> **Por qué el reflog.** Dos ramas pueden ser *literalmente el mismo commit*
+> (crea una desde el tip de otra y no toques ninguna) y una haber aterrizado
+> trabajo real mientras la otra jamás empezó. Ningún recorrido del grafo puede
+> separarlas, porque no hay nada que recorrer que las diferencie. Lo que las
+> separa es el **movimiento**, y git lo registra: la entrada más vieja del reflog
+> de la rama es el commit donde nació (`git rev-list -g <rama> | tail -1`).
+>
+> **Respaldo sin reflog** (expirado a los 90 días, deshabilitado, o una rama de un
+> clon que nunca lo tuvo): la forma de la historia. Un tip que cae sobre la cadena
+> de **primer padre** de la base es simplemente un punto anterior de esa línea, no
+> una contribución; el tip de una rama mergeada cuelga de ella como segundo padre
+> de un merge. Es más débil — no ve el caso de los dos refs en el mismo commit —
+> pero cubre el común: creada desde la base, sin tocar, base avanzada.
+>
+> **Ante la duda, `false`.** Reportar de menos cuesta un cierre manual; reportar
+> de más ofrece borrar trabajo que nunca ocurrió. Un merge por *fast-forward*
+> queda sub-reportado a propósito por esa misma regla.
+>
+> Es deliberadamente la misma detección
 que corre `remove_worktree` camino de un borrado seguro: lo que la sidebar declare
 "terminado" es, por construcción, lo que la eliminación aceptaría limpiar. La rama
 base contesta `false` (nunca se propone cerrar aquello sobre lo que todo aterriza),

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -58,10 +58,10 @@ non-interactive env all run for real with no network; and `github_live.rs`
 holds the **supervised live suite** (every test `#[ignore]`, armed only by
 `UXNAN_GH_SANDBOX` naming the allowlisted sandbox — its 3 non-ignored tests
 prove the guard refuses everything else; procedure in
-[`github-sandbox-runbook.md`](github-sandbox-runbook.md)). **488 backend tests**
+[`github-sandbox-runbook.md`](github-sandbox-runbook.md)). **538 backend tests**
 in total (plus the 7 ignored live tests and the ignored real-scheduler probe).
 
-The 460 unit tests cover the Serde model shape, persistence round-trip / atomicity /
+The 510 unit tests cover the Serde model shape, persistence round-trip / atomicity /
 migration / backups (including a corrupt state file and an obstructed data
 directory failing cleanly instead of panicking), the GitHub layer's parsers —
 including **contract tests that feed them captured real `gh` output** frozen

--- a/uxnandesktop/src-tauri/src/git.rs
+++ b/uxnandesktop/src-tauri/src/git.rs
@@ -807,25 +807,14 @@ pub async fn branch_integrated(repo_path: &str, branch: &str) -> bool {
     if base.is_empty() || base == branch {
         return false;
     }
-    // A branch that still points at the base's tip has not *landed* — it has not
-    // started. Ancestry cannot tell those apart: a brand-new branch contributes
-    // nothing, so every commit reachable from it is trivially reachable from the
-    // base, and `--is-ancestor` says yes. Without this guard a worktree was
-    // marked "landed" the moment it was created, inviting you to close the space
-    // you had just set up — and the batch close would have swept it up as safe.
-    //
-    // The trade is deliberate: a branch merged by *fast-forward* also ends up
-    // sharing the base's tip and is reported as not-finished. Under-reporting a
-    // finished space costs a manual close; over-reporting one offers to delete
-    // work that never happened. Merge commits and squashes — the shapes a review
-    // flow actually produces — are unaffected.
-    if let (Ok(branch_tip), Ok(base_tip)) = (
-        git(repo_path, &["rev-parse", "--verify", "--quiet", branch]).await,
-        git(repo_path, &["rev-parse", "--verify", "--quiet", &base]).await,
-    ) {
-        if !branch_tip.trim().is_empty() && branch_tip.trim() == base_tip.trim() {
-            return false;
-        }
+    // A branch that never moved has not *landed* — it has not started, and the
+    // difference matters because the sidebar offers to close what it calls
+    // finished. Ancestry alone cannot tell the two apart: a branch that
+    // contributed nothing has every one of its commits trivially reachable from
+    // the base, so `--is-ancestor` says yes about a worktree you created this
+    // morning and never touched.
+    if !branch_has_diverged(repo_path, branch, &base).await {
+        return false;
     }
     // Real ancestry: the common case for a merge commit. `--is-ancestor` exits 0
     // when every commit on `branch` is already reachable from `base`.
@@ -836,6 +825,49 @@ pub async fn branch_integrated(repo_path: &str, branch: &str) -> bool {
         return true;
     }
     is_squash_merged(repo_path, branch, &base).await
+}
+
+/// Whether `branch` has done anything since it was created — the question
+/// ancestry cannot answer.
+///
+/// Two branches can be **literally the same commit** (create one from another's
+/// tip and touch neither) while one of them landed real work and the other never
+/// began, so no walk of the commit graph can separate them. What separates them
+/// is movement, and git records that in the branch's **reflog**: its oldest entry
+/// is the commit the branch was created at.
+///
+/// Falls back to the shape of the history when there is no reflog — expired
+/// (90 days by default), disabled, or a branch from a clone that never had one.
+/// A tip sitting on the base's own first-parent chain is simply an older point of
+/// the base line, not a contribution to it; a merged branch's tip hangs off it as
+/// a merge's second parent. That fallback is weaker — it cannot see the
+/// same-commit case above — but it catches the common one: forked from the base,
+/// never touched, base moved on.
+///
+/// Best-effort in the safe direction: when git tells us nothing, answer `false`
+/// so the space is reported as unfinished. Under-reporting costs a manual close;
+/// over-reporting offers to delete work that never happened.
+async fn branch_has_diverged(repo_path: &str, branch: &str, base: &str) -> bool {
+    let Ok(tip) = git(repo_path, &["rev-parse", "--verify", "--quiet", branch]).await else {
+        return false;
+    };
+    let tip = tip.trim();
+    if tip.is_empty() {
+        return false;
+    }
+
+    // The reflog, when there is one: oldest entry = where the branch started.
+    if let Ok(log) = git(repo_path, &["rev-list", "-g", branch]).await {
+        if let Some(created_at) = log.split_whitespace().last() {
+            return created_at != tip;
+        }
+    }
+
+    // No reflog. Is the tip a plain older commit of the base line?
+    let Ok(first_parents) = git(repo_path, &["rev-list", "--first-parent", base]).await else {
+        return false;
+    };
+    !first_parents.split_whitespace().any(|sha| sha == tip)
 }
 
 /// Whether `branch`'s net changes are already present in `base` as a squash
@@ -1951,6 +1983,70 @@ mod tests {
         assert!(
             branch_integrated(&repo_path, "squashed").await,
             "a squash-merged branch is finished even though its commits aren't ancestors"
+        );
+    }
+
+    #[tokio::test]
+    async fn branch_integrated_ignores_an_untouched_branch_after_the_base_moves() {
+        // Reported from real use, and the case the first guard missed: the
+        // worktree was created from `main`, never touched, and `main` moved on.
+        // The tips no longer match, so comparing them proves nothing — but the
+        // branch is still just an older point of the base line, and ancestry says
+        // yes about it. It showed the "landed" chip next to genuinely merged
+        // branches.
+        let repo = tempfile::tempdir().unwrap();
+        let repo_path = repo.path().to_string_lossy().replace('\\', "/");
+        init_repo(&repo_path).await;
+
+        let wt = worktree_path_for(&repo_path, "untouched");
+        add_worktree(&repo_path, "untouched", &wt, Some("main"))
+            .await
+            .unwrap();
+
+        // The base moves on, without the branch contributing anything.
+        std::fs::write(format!("{repo_path}/later.txt"), "moved on\n").unwrap();
+        run_git(&repo_path, &["add", "-A"]).await;
+        run_git(&repo_path, &["commit", "-m", "base moves on"]).await;
+
+        assert!(
+            !branch_integrated(&repo_path, "untouched").await,
+            "a branch that never moved has not landed, however far the base went"
+        );
+    }
+
+    #[tokio::test]
+    async fn branch_integrated_separates_two_branches_on_the_same_commit() {
+        // The case no walk of the commit graph can decide: create a branch from a
+        // merged branch's tip and touch neither, and the two refs are literally
+        // the same commit. One did the work, the other never started. Only the
+        // reflog — which records where each branch began — tells them apart.
+        let repo = tempfile::tempdir().unwrap();
+        let repo_path = repo.path().to_string_lossy().replace('\\', "/");
+        init_repo(&repo_path).await;
+
+        let wt = worktree_path_for(&repo_path, "did-the-work");
+        add_worktree(&repo_path, "did-the-work", &wt, Some("main"))
+            .await
+            .unwrap();
+        std::fs::write(format!("{wt}/w.txt"), "real work\n").unwrap();
+        run_git(&wt, &["add", "-A"]).await;
+        run_git(&wt, &["commit", "-m", "the work"]).await;
+        run_git(
+            &repo_path,
+            &["merge", "--no-ff", "-m", "merge", "did-the-work"],
+        )
+        .await;
+
+        // A second branch created at the first one's tip, never touched.
+        run_git(&repo_path, &["branch", "never-started", "did-the-work"]).await;
+
+        assert!(
+            branch_integrated(&repo_path, "did-the-work").await,
+            "it contributed the commit the base merged"
+        );
+        assert!(
+            !branch_integrated(&repo_path, "never-started").await,
+            "same commit, but this one never did anything"
         );
     }
 


### PR DESCRIPTION
A worktree created from `main` and never touched showed the **"landed"** chip,
sitting in the sidebar next to genuinely merged branches — so the panel offered
to close a space that had never been used.

## Why ancestry cannot answer this

A branch that contributed nothing has all of its commits trivially reachable
from the base, so `merge-base --is-ancestor` says yes about a worktree created
this morning. "Has landed" and "has not started" are the same shape.

An earlier guard compared the branch tip with the base tip. That only covers the
window **before the base moves** — once `main` advances the tips differ, the
guard stops firing, and the false positive is back. Same bug, second shape.

## Why the reflog

Two branches can be **literally the same commit** — create one from another's
tip and touch neither — while one landed real work and the other never began. No
walk of the commit graph can separate them, because there is nothing in the
graph that differs. What differs is **movement**, and git records movement: the
oldest entry of a branch's reflog is where it was created.

`branch_has_diverged` asks that first, and reports the branch unfinished when it
never moved from where it started.

**Fallback without a reflog** (expired at 90 days, disabled, a clone that never
had one): the shape of the history. A tip sitting on the base's own
**first-parent** chain is an older point of that line, not a contribution to it;
a merged branch's tip hangs off it as a merge's second parent. Weaker — it
cannot see the same-commit case — but it catches the common one.

When git says nothing at all, the answer is "unfinished". That is the standing
rule here: under-reporting costs a manual close, over-reporting offers to delete
work that never happened. A fast-forward merge stays deliberately under-reported
for the same reason.

## Validation

Judged on the repository that reported it, not only on fixtures. Replaying the
old and new logic over its seven live branches:

| Branch | Before | After | Expected |
|---|---|---|---|
| `corregir-estilos-y-tamanos` | **landed** ❌ | not landed | not landed (untouched) |
| 5 merged branches | landed | landed | ✅ |
| `compartir-ui-desktop-mobile` | not landed | not landed | ✅ (in progress) |

Exactly the wrong one flips.

Both new tests were **verified to fail against the previous guard** while the
four existing ones kept passing — including the one that no graph walk can
decide (two branches on the same commit, one of which did the work).

| Gate | Result |
|---|---|
| `cargo test` | 510 unit + 28 integration = **538** |
| `cargo clippy --all-targets -D warnings` | clean |
| `cargo fmt --check` | clean |
| `svelte-check` | not run — zero frontend files touched (1 `.rs`, 4 `.md`) |

## Docs

`architecture/02c-git-worktrees.md` — why tip comparison was not enough, why the
reflog, and the fallback. `docs/testing.md` also had its backend test counts
corrected: they had drifted 50 behind the tree (488/460 → 538/510).
