### PR TITLE
fix(release): the desktop's own tooling was about to cut a nightly

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -23,9 +23,13 @@ number is the whole point: on 2026-08-06 the only change in `relay/` since its
 tag was `FOR-DEV.md`, and a trigger that fired on "the folder changed" would have
 published an identical package.
 
-Two kinds of file cannot reach a build: **prose** (`*.md`, `docs/`,
+Two kinds of file cannot reach a build anywhere: **prose** (`*.md`, `docs/`,
 `architecture/`, `.github/`) and **tests** (`*.test.*`, `*.spec.*`, `test/`,
-`tests/`). Tests were added to the list when, with 0.0.31 shipped and the only
+`tests/`). A component can add its own — the desktop excludes
+`uxnandesktop/scripts/`, which is check and benchmark tooling that Tauri never
+bundles. That one is deliberately not global: `bridge/package.json` lists
+`scripts` in its `files`, so the bridge's identically-named folder is published
+to npm and does ship. Tests were added to the list when, with 0.0.31 shipped and the only
 desktop change since it being a fix to `setup.dom.ts`, the status still said the
 component owed a release — the next cron would have cut 0.0.32 for a test. A test
 proves something about code that already shipped, and a nightly is four

--- a/scripts/release/changes.mjs
+++ b/scripts/release/changes.mjs
@@ -53,8 +53,9 @@ export function inspect(id, options = {}) {
   const bookkeeping = (file) =>
     versionFiles.has(file) && isVersionOnlyDiff(since, file, gitOptions);
 
-  const nonShipping = files.filter((file) => isNonShipping(file) || bookkeeping(file));
-  const substantive = files.filter((file) => !isNonShipping(file) && !bookkeeping(file));
+  const skip = (file) => isNonShipping(file, meta) || bookkeeping(file);
+  const nonShipping = files.filter(skip);
+  const substantive = files.filter((file) => !skip(file));
 
   const tags = tagsFor(meta.tagPrefixes, gitOptions);
   const shipped = highestBase(tags);

--- a/scripts/release/components.mjs
+++ b/scripts/release/components.mjs
@@ -91,6 +91,12 @@ export const COMPONENTS = [
     // Both channels share one numeric line: a base must be new against BOTH, or
     // the Windows MSI and the updater cannot see the newer build.
     tagPrefixes: ['desktop-stable-v', 'desktop-nightly-v'],
+    // `uxnandesktop/scripts/` is check, benchmark and release tooling. Tauri
+    // declares no `bundle.resources` and its `beforeBuildCommand` is the Vite
+    // build, so nothing in there reaches an installer. This is deliberately NOT
+    // a global rule: `bridge/package.json` lists `scripts` in its `files`, so
+    // the bridge's scripts folder is published to npm and does ship.
+    nonShipping: [/^uxnandesktop\/scripts\//],
     versionFiles: [
       { file: 'uxnandesktop/src-tauri/tauri.conf.json', adapter: 'json' },
       { file: 'uxnandesktop/src-tauri/Cargo.toml', adapter: 'cargo-toml' },
@@ -120,9 +126,16 @@ export function component(id) {
   return found;
 }
 
-/** True when a changed path cannot affect what a build produces. */
-export function isNonShipping(file) {
-  return NON_SHIPPING.some((rule) => rule.test(file));
+/**
+ * True when a changed path cannot affect what a build produces.
+ *
+ * `meta` adds the component's own exceptions, because "does this ship?" is not
+ * always answerable from the path alone — the same `scripts/` folder is dev
+ * tooling in one component and published files in another.
+ */
+export function isNonShipping(file, meta) {
+  if (NON_SHIPPING.some((rule) => rule.test(file))) return true;
+  return (meta?.nonShipping ?? []).some((rule) => rule.test(file));
 }
 
 /**

--- a/scripts/release/components.test.mjs
+++ b/scripts/release/components.test.mjs
@@ -68,6 +68,21 @@ describe('the registry', () => {
   });
 });
 
+describe('isNonShipping — a component that says what does not ship', () => {
+  it("excludes the desktop's own tooling, and only the desktop's", () => {
+    // Tauri bundles no resources from there and its beforeBuildCommand is the
+    // Vite build, so a change under `uxnandesktop/scripts/` cannot reach an
+    // installer. The bridge's identically-named folder is published to npm.
+    const desktop = component('desktop');
+    const bridge = component('bridge');
+    const file = 'uxnandesktop/scripts/check-version-sync.mjs';
+
+    assert.equal(isNonShipping(file, desktop), true);
+    assert.equal(isNonShipping(file), false, 'not a global rule');
+    assert.equal(isNonShipping('bridge/scripts/install-service-linux.sh', bridge), false);
+  });
+});
+
 describe('isNonShipping', () => {
   it('treats prose and specs as unable to change a build', () => {
     for (const file of [
@@ -111,6 +126,10 @@ describe('isNonShipping', () => {
       // Rust keeps its unit tests inline under `#[cfg(test)]`, so a file with
       // tests in it is still a source file. Erring toward releasing is correct.
       'uxnandesktop/src-tauri/src/agentcli.rs',
+      // `bridge/package.json` lists `scripts` in its `files`, so these are
+      // published to npm. A blanket `scripts/` rule would drop real shipped
+      // content — which is why the desktop's exception is per-component.
+      'bridge/scripts/install-service-linux.sh',
       // "latest" is not "test": the rule must match a path segment, not a
       // substring of a longer word.
       'uxnandesktop/src/lib/latest/index.ts',


### PR DESCRIPTION
Repointing one string in `uxnandesktop/scripts/check-version-sync.mjs` (the doc link inside an error message) left the status saying desktop owed a release — tonight's cron would have cut 0.0.35 for it.

Tauri declares no `bundle.resources` and its `beforeBuildCommand` is the Vite build, so nothing under `uxnandesktop/scripts/` reaches an installer.

**A blanket `scripts/` rule would be wrong**, which is the interesting part: `bridge/package.json` lists `scripts` in its `files`, so the bridge publishes that folder to npm. The same folder name is dev tooling in one component and shipped content in another — so the exception belongs to the component. `isNonShipping(file, meta)` now consults a per-component list.

71 tests passing, including one pinning both halves.