### PR TITLE
feat(release): the bump pull request lands itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,22 @@ name: Release — cut versions
 # (bridge 0.0.14, superseded by 0.0.15). Here, shared is cut first and the
 # consumers wait until npm actually serves the new version.
 #
-# It never pushes to `main`, so it needs no ruleset bypass. The bump lands on its
-# own branch, the tag points at that commit, and a pull request brings the branch
-# into `main` through the same reviewed path as everything else.
+# It never pushes to `main`. The bump lands on its own branch, the tag points at
+# that commit, and a pull request brings it in — the same path as everything
+# else. What is different is that this pull request closes itself: the
+# `Uxnan Releases` app is a bypass actor on the `main-protection` ruleset in
+# **pull-request mode**, so an operation authenticated as that app may merge its
+# own PR without the human approval, and still cannot push to `main` directly.
+# Nothing else gains anything: `GITHUB_TOKEN` is not that app, so an ordinary
+# workflow — or a pull request from a fork — is exactly as restricted as before.
 #
-# The one credential it wants is a GitHub App token, and NOT for permissions:
-# GitHub refuses to start a workflow from an event created with `GITHUB_TOKEN`
-# (its anti-recursion rule), so a tag pushed with the default token would never
-# trigger `release-*.yml`. Without the app the run does everything except push
-# the tag, and prints the single command to finish by hand. See
-# `docs/releases.md` → *The credential*.
+# Which is why the credential matters twice over. GitHub refuses to start a
+# workflow from an event created with `GITHUB_TOKEN` (its anti-recursion rule),
+# so a tag pushed with the default token would never trigger `release-*.yml`;
+# and the merge exception is attached to the app's identity, not to Actions.
+# Without the app the run still does everything except push the tag and land the
+# pull request, and says exactly what to finish by hand. See `docs/releases.md`
+# → *The credential*.
 
 on:
   workflow_dispatch:
@@ -81,7 +87,9 @@ jobs:
     # A fork running the schedule would tag and push its own main every night.
     if: github.repository == 'luisgamas/uxnan'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # The npm-visibility wait can take 30 minutes on its own, and landing the
+    # pull request waits up to 20 more for its checks.
+    timeout-minutes: 90
     steps:
       # A token that is not GITHUB_TOKEN, so the tag push actually starts the
       # release build. Absent, the run still does everything else.
@@ -235,10 +243,15 @@ jobs:
             echo "::endgroup::"
           done
 
-      # `main` is protected and stays that way: the bumps arrive through a pull
-      # request, reviewed like everything else. The tags already point at these
-      # commits, so the builds do not wait for the merge.
+      # `main` is protected and stays that way. The bump arrives through a pull
+      # request like everything else — the difference is that this one can close
+      # itself: the `Uxnan Releases` app is a bypass actor on `main-protection`
+      # in **pull-request mode**, which lets it merge its own PR without the
+      # human approval, while still leaving it unable to push to `main` directly.
+      # Ordinary pull requests are untouched by that; only an operation
+      # authenticated with the app's installation token gets the exception.
       - name: Open the bump pull request
+        id: pr
         if: steps.plan.outputs.count != '0' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
@@ -250,13 +263,66 @@ jobs:
           titles=$(jq -r '[.cuts[] | "\(.id) \(.version)"] | join(", ")' plan.json)
           body="Version bumps for the tags this run created. The tags already point at these commits, so the builds are under way; merging this only brings main level with them."
 
-          gh pr create \
+          url=$(gh pr create \
             --base main \
             --head "$branch" \
             --title "build(release): $titles" \
-            --body "$body"
+            --body "$body")
 
+          echo "number=${url##*/}" >> "$GITHUB_OUTPUT"
           echo "::notice::Bump PR opened from $branch"
+
+      # Leaving this open is not a neutral state: an unmerged tag is not an
+      # ancestor of `main`, which is what cut desktop 0.0.34 out of nothing. The
+      # tooling no longer mistakes it for work, but `main` still lags — and this
+      # runs at 00:20 local, with nobody awake to press the button.
+      #
+      # It waits for the pull request's OWN gate — the `verify` checks — and not
+      # for every check on the commit: the release build reports onto the same
+      # SHA (the tag points at it) and a macOS leg is allowed to fail there on
+      # purpose. A red `verify` means `main` itself is red, since this PR adds
+      # nothing but version numbers; it is left unmerged and shouted about.
+      - name: Land it
+        if: steps.plan.outputs.count != '0' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
+          HAS_APP: ${{ steps.token.outputs.token != '' }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+
+          if [ "$HAS_APP" != "true" ]; then
+            echo "::warning::No app credential, so the bump PR (#$PR) cannot merge itself — the bypass belongs to the app, not to GITHUB_TOKEN. Merge it by hand."
+            exit 0
+          fi
+
+          checks=""
+          for attempt in $(seq 1 40); do
+            checks=$(gh pr checks "$PR" --json name,bucket 2>/dev/null || echo '[]')
+            total=$(jq '[.[] | select(.name | startswith("verify"))] | length' <<<"$checks")
+            pending=$(jq '[.[] | select(.name | startswith("verify")) | select(.bucket == "pending")] | length' <<<"$checks")
+            [ "$total" -gt 0 ] && [ "$pending" -eq 0 ] && break
+            sleep 30
+          done
+
+          total=$(jq '[.[] | select(.name | startswith("verify"))] | length' <<<"$checks")
+          pending=$(jq '[.[] | select(.name | startswith("verify")) | select(.bucket == "pending")] | length' <<<"$checks")
+          failed=$(jq '[.[] | select(.name | startswith("verify")) | select(.bucket == "fail")] | length' <<<"$checks")
+
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::#$PR has $failed failing verify check(s) — NOT merging. main is red on its own; the release itself already shipped from the tag."
+            exit 1
+          fi
+          if [ "$pending" -gt 0 ]; then
+            echo "::warning::#$PR still had $pending verify check(s) running after 20 minutes — NOT merging. Merge it once they finish."
+            exit 0
+          fi
+          if [ "$total" -eq 0 ]; then
+            echo "::notice::#$PR has no verify checks (nothing in it matches a CI path filter) — merging."
+          fi
+
+          gh pr merge "$PR" --merge --delete-branch
+          echo "::notice::#$PR merged; main is level with the tags."
 
       - name: What happens next
         if: steps.plan.outputs.count != '0'
@@ -265,5 +331,6 @@ jobs:
             echo
             echo "Each pushed tag triggers its own release workflow. A desktop nightly"
             echo "publishes itself once built; a stable waits as a draft for a human."
-            echo "Merge the bump pull request to bring \`main\` level with the tags."
+            echo "The bump pull request merges itself once its \`verify\` checks pass;"
+            echo "if they fail, it is left open on purpose and this run is red."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -584,9 +584,12 @@ carry a version, the release matrix and the full step-by-step are in
    `release-*.yml` run is green and the artifact landed (npm published to the
    `latest` dist-tag / the Play **open-testing** (beta) build uploaded / the
    desktop GitHub **Release** draft exists). A red or half-finished release run is
-   **not** a release. Then **merge the bump pull request the run opened** — while
-   it sits there the tag is not an ancestor of `main`, which is the state that cut
-   desktop 0.0.34 for nothing. (npm's `latest` dist-tag always tracks the newest
+   **not** a release. The bump pull request the run opened **merges itself** once
+   its `verify` checks pass — the release app is a bypass actor on
+   `main-protection` in pull-request mode. If it is still open, its checks went
+   red: fix that rather than merging past it, because an unmerged tag is not an
+   ancestor of `main`, which is the state that cut desktop 0.0.34 for nothing.
+   (npm's `latest` dist-tag always tracks the newest
    release; `alpha`/`beta` channels are opt-in, added manually per build — see
    `docs/releases.md`.) There is no history file to update: `VERSIONS.md` was
    removed on 2026-08-10, because git tags and GitHub releases already are that

--- a/bridge/docs/testing.md
+++ b/bridge/docs/testing.md
@@ -43,13 +43,18 @@ round-trip; Zero against a fake `zero acp` ACP process incl. a
 `session/request_permission` → approval round-trip; the others against fake spawns);
 and router-level wiring/error mapping.
 
-### Environment notes / known flakes (Windows)
+### Environment notes / known flakes
 - **Serialized runner:** several suites boot a full bridge or spawn real child
   processes (git, fake agents); running them in parallel starved the conversation
   tests' `waitFor` polling, so `npm test` uses `--test-concurrency=1` and the
   `waitFor` guards are 30 s. Keep new boot/spawn-heavy tests tolerant.
-- **File locking:** a just-spawned `git` briefly holds its cwd; temp cleanup uses
-  the retry helper `test/helpers/fs.ts` (`rmrf`). Use it for new temp-dir cleanup.
+- **File locking:** a just-spawned `git` briefly holds its cwd, and a stopped
+  bridge can still be flushing into its own temp dir — `rm` then fails with EBUSY
+  on Windows or **ENOTEMPTY on Linux**, which is what took a `verify` leg down on
+  2026-08-10. Temp cleanup goes through the retry helper `test/helpers/fs.ts`
+  (`rmrf`) in **every** suite; a raw `rm(dir, { recursive: true, force: true })`
+  is the bug. This is no longer only a Windows concern, and it matters more than
+  it used to: a red `verify` leaves the release bump pull request unmerged.
 - **Line endings:** git tests set `core.autocrlf false` so snapshots compare
   byte-for-byte; the repo itself is `autocrlf=true`, so the Prettier gate is
   effectively content-only (CRLF in the working tree is normalized to LF on commit).

--- a/bridge/test/adapters/command-scan.test.ts
+++ b/bridge/test/adapters/command-scan.test.ts
@@ -3,13 +3,14 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import {
   scanCustomCommands,
   expandCustomCommand,
   substituteArgs,
   type CustomCommandSource,
 } from '../../src/adapters/command-scan.js';
+import { rmrf } from '../helpers/fs.js';
 
 /** Make a unique temp dir and return an absolute path under it. */
 async function tempDir(): Promise<string> {
@@ -34,7 +35,7 @@ test('scanCustomCommands parses markdown front-matter (description + argument-hi
     description: 'Refactor a file',
     argumentHint: '<file>',
   });
-  await rm(dir, { recursive: true, force: true });
+  await rmrf(dir);
 });
 
 test('scanCustomCommands parses a TOML command (multiline prompt + description)', async () => {
@@ -49,7 +50,7 @@ test('scanCustomCommands parses a TOML command (multiline prompt + description)'
   assert.equal(commands[0]!.name, 'plan');
   assert.equal(commands[0]!.description, 'Draft a plan');
   assert.equal(commands[0]!.source, 'custom');
-  await rm(dir, { recursive: true, force: true });
+  await rmrf(dir);
 });
 
 test('scanCustomCommands de-dupes by name: a project-scoped file shadows the user-level one', async () => {
@@ -69,8 +70,8 @@ test('scanCustomCommands de-dupes by name: a project-scoped file shadows the use
   const commands = await scanCustomCommands(source);
   assert.equal(commands.length, 1);
   assert.equal(commands[0]!.description, 'project deploy');
-  await rm(projectDir, { recursive: true, force: true });
-  await rm(userDir, { recursive: true, force: true });
+  await rmrf(projectDir);
+  await rmrf(userDir);
 });
 
 test('scanCustomCommands skips a missing directory without throwing', async () => {
@@ -97,14 +98,14 @@ test('expandCustomCommand substitutes $ARGUMENTS / {{args}} / positional $1', as
     'Fix auth.ts then review auth.ts high.',
   );
   assert.equal(await expandCustomCommand(toml, 'greet', 'there'), 'Hi there');
-  await rm(dir, { recursive: true, force: true });
+  await rmrf(dir);
 });
 
 test('expandCustomCommand throws for an unknown command (caller falls back to native form)', async () => {
   const dir = await tempDir();
   const source: CustomCommandSource = { dirs: [dir], ext: '.md', format: 'markdown' };
   await assert.rejects(() => expandCustomCommand(source, 'nope'), /unknown custom command/);
-  await rm(dir, { recursive: true, force: true });
+  await rmrf(dir);
 });
 
 test('substituteArgs: empty args clear placeholders; unknown placeholders are left intact', () => {

--- a/bridge/test/agents/agent-manager.test.ts
+++ b/bridge/test/agents/agent-manager.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import type { AgentCapabilities, AgentCommand, AgentId, SendTurnOptions } from '@uxnan/shared';
 import { StreamNotification } from '@uxnan/shared';
 import {
@@ -15,6 +15,7 @@ import {
   ThreadStore,
   createLogger,
 } from '../../src/index.js';
+import { rmrf } from '../helpers/fs.js';
 
 /** Caps for the controllable test adapter (streaming, no approvals/images). */
 const CONTROLLED_CAPS: AgentCapabilities = {
@@ -112,7 +113,7 @@ test('sendTurn drives the echo agent: persists the reply and broadcasts stream e
   assert.ok(methods.includes(StreamNotification.TurnStarted));
   assert.ok(methods.includes(StreamNotification.MessageDelta));
   assert.ok(methods.includes(StreamNotification.TurnCompleted));
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 baseTest('a failed turn persists an error content block into history', async () => {
@@ -147,7 +148,7 @@ baseTest('a failed turn persists an error content block into history', async () 
   assert.ok(!notifications.some((n) => n.method === StreamNotification.ContentBlock));
   assert.ok(notifications.some((n) => n.method === StreamNotification.TurnError));
 
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 baseTest('activeTurnId reflects the in-flight turn and clears when it ends', async () => {
@@ -176,7 +177,7 @@ baseTest('activeTurnId reflects the in-flight turn and clears when it ends', asy
   // Cleared on completion — authoritative "nothing is running now".
   assert.equal(manager.activeTurnId(thread.id), undefined);
 
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('sendTurn delivers an image-only turn: placeholder user text + attachment path in the prompt', async () => {
@@ -214,8 +215,8 @@ test('sendTurn delivers an image-only turn: placeholder user text + attachment p
   assert.ok(!assistant.includes(cwd));
   // The temp dir is cleaned up once the turn ends (best-effort, async).
   await waitFor(async () => !existsSync(join(cwd, '.uxnan-attachments', turnId)));
-  await rm(cwd, { recursive: true, force: true });
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(cwd);
+  await rmrf(baseDir);
 });
 
 test('a turn without a cwd writes the attachment into the ADAPTER working dir', async () => {
@@ -254,8 +255,8 @@ test('a turn without a cwd writes the attachment into the ADAPTER working dir', 
   assert.ok(!assistant.includes(adapterCwd));
 
   await waitFor(async () => !existsSync(join(adapterCwd, '.uxnan-attachments', turnId)));
-  await rm(adapterCwd, { recursive: true, force: true });
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(adapterCwd);
+  await rmrf(baseDir);
 });
 
 test('an adapter that takes attachments natively gets no file and no path note', async () => {
@@ -290,8 +291,8 @@ test('an adapter that takes attachments natively gets no file and no path note',
   // …and nothing was written to disk.
   assert.equal(existsSync(join(cwd, '.uxnan-attachments')), false);
 
-  await rm(cwd, { recursive: true, force: true });
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(cwd);
+  await rmrf(baseDir);
 });
 
 test('respondApproval drives the echo demo approval to completion', async () => {
@@ -324,7 +325,7 @@ test('respondApproval drives the echo demo approval to completion', async () => 
     String(turn.messages.find((m) => m.role === 'assistant')?.content ?? ''),
     /Approved/,
   );
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('requestApproval emits an approval block and resolves on respondApproval (hook flow)', async () => {
@@ -367,7 +368,7 @@ test('requestApproval emits an approval block and resolves on respondApproval (h
   await manager.respondApproval(thread.id, approvalId, 'approve');
   assert.equal(await decisionPromise, 'approve');
 
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('requestQuestion emits a question block and resolves on respondQuestion', async () => {
@@ -407,7 +408,7 @@ test('requestQuestion emits a question block and resolves on respondQuestion', a
   await manager.respondQuestion(thread.id, questionId, [['Python']]);
   assert.deepEqual(await answersPromise, [['Python']]);
 
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('requestApproval resolves deny on rejection', async () => {
@@ -441,7 +442,7 @@ test('requestApproval resolves deny on rejection', async () => {
   await manager.respondApproval(thread.id, approvalId, 'reject');
   assert.equal(await decisionPromise, 'reject');
 
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('approval waits while no phone is connected, then times out once one connects', async () => {
@@ -484,7 +485,7 @@ test('approval waits while no phone is connected, then times out once one connec
   await decisionPromise;
   assert.equal(settled, 'reject', 'times out to reject once a phone can see it');
 
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('a disconnect pauses the approval countdown so it never fires offline', async () => {
@@ -523,7 +524,7 @@ test('a disconnect pauses the approval countdown so it never fires offline', asy
   await new Promise((resolve) => setTimeout(resolve, 200)); // > window
   assert.equal(settled, undefined, 'paused countdown must not fire while offline');
 
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('respondApproval rejects when the thread has no agent', async () => {
@@ -538,7 +539,7 @@ test('respondApproval rejects when the thread has no agent', async () => {
   });
   manager.register(new EchoAgentAdapter());
   await assert.rejects(manager.respondApproval('no-such-thread', 'appr-x', 'approve'));
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('sendTurn for an unregistered agent rejects with AgentNotRunning', async () => {
@@ -553,7 +554,7 @@ test('sendTurn for an unregistered agent rejects with AgentNotRunning', async ()
   });
   const thread = await store.startThread({ projectId: 'p' }, 1);
   await assert.rejects(manager.sendTurn(thread.id, 'hi'));
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('deprecated agents are unavailable, undiscoverable for models, and cannot run turns', async () => {
@@ -583,7 +584,7 @@ test('deprecated agents are unavailable, undiscoverable for models, and cannot r
   assert.deepEqual(await manager.getCommands('echo', baseDir), []);
   const thread = await store.startThread({ projectId: 'p' }, 1);
   await assert.rejects(manager.sendTurn(thread.id, 'hi'), /deprecated and cannot run new turns/);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 /**
@@ -637,7 +638,7 @@ test('cancelTurn routes to the THREAD’s agent, not the default (global stop-tu
 
   assert.deepEqual(other.canceled, [{ threadId: thread.id, turnId }]);
   assert.deepEqual(def.canceled, []);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 /**
@@ -723,7 +724,7 @@ test('getCommands returns the adapter’s advertised commands (empty for one wit
   // The Echo agent has no listCommands → empty, never throws.
   const none = await manager.getCommands('codex');
   assert.deepEqual(none, []);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('command invocation with an expander: the agent runs the EXPANDED text; history shows /name', async () => {
@@ -750,7 +751,7 @@ test('command invocation with an expander: the agent runs the EXPANDED text; his
   // History persists the command form, not the (potentially huge) expansion.
   const turn = await store.getTurn(turnId);
   assert.equal(turn.messages.find((m) => m.role === 'user')?.content, '/refactor auth.ts');
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('command invocation without an expander: the agent runs the native /name args form', async () => {
@@ -774,7 +775,7 @@ test('command invocation without an expander: the agent runs the native /name ar
 
   // No expander → the CLI's native slash form is sent (Claude/ACP interpret it).
   assert.equal(adapter.lastText, '/compact');
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 /** ControlledAdapter that can also stream deltas and (flagged) blocks. */
@@ -831,7 +832,7 @@ baseTest('a beforeText block is stored before the open run and flagged on the wi
   assert.equal(blockNotes[0]?.params?.['beforeText'], true);
   assert.equal('beforeText' in (blockNotes[1]?.params ?? {}), false);
 
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 baseTest('a terminal event that throws ends the turn instead of hanging it', async () => {
@@ -873,5 +874,5 @@ baseTest('a terminal event that throws ends the turn instead of hanging it', asy
   assert.match(JSON.stringify(errorNote?.params ?? {}), /could not be finalized/);
 
   Object.defineProperty(store, 'completeTurn', { configurable: true, value: original });
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });

--- a/bridge/test/agents/agent-midturn-delivery.test.ts
+++ b/bridge/test/agents/agent-midturn-delivery.test.ts
@@ -12,7 +12,6 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { rm } from 'node:fs/promises';
 import { StreamNotification } from '@uxnan/shared';
 import type { AgentCapabilities, AgentId, SendTurnOptions } from '@uxnan/shared';
 import {
@@ -22,6 +21,7 @@ import {
   ThreadStore,
   createLogger,
 } from '../../src/index.js';
+import { rmrf } from '../helpers/fs.js';
 
 const BASE_CAPS: AgentCapabilities = {
   planMode: false,
@@ -119,7 +119,7 @@ async function harness(steering = true): Promise<Harness> {
     threadId: thread.id,
     notifications,
     methods: () => notifications.map((n) => n.method),
-    cleanup: () => rm(baseDir, { recursive: true, force: true }),
+    cleanup: () => rmrf(baseDir),
   };
 }
 

--- a/bridge/test/agents/agent-queue.test.ts
+++ b/bridge/test/agents/agent-queue.test.ts
@@ -10,7 +10,6 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { rm } from 'node:fs/promises';
 import { JsonRpcErrorCode, StreamNotification } from '@uxnan/shared';
 import type { AgentCapabilities, AgentId, SendTurnOptions } from '@uxnan/shared';
 import {
@@ -20,6 +19,7 @@ import {
   ThreadStore,
   createLogger,
 } from '../../src/index.js';
+import { rmrf } from '../helpers/fs.js';
 
 const CAPS: AgentCapabilities = {
   planMode: false,
@@ -105,7 +105,7 @@ async function harness(): Promise<Harness> {
     threadId: thread.id,
     notifications,
     methods: () => notifications.map((n) => n.method),
-    cleanup: () => rm(baseDir, { recursive: true, force: true }),
+    cleanup: () => rmrf(baseDir),
   };
 }
 

--- a/bridge/test/agents/attachments.test.ts
+++ b/bridge/test/agents/attachments.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { ATTACHMENTS_DIRNAME, materializeAttachments } from '../../src/agents/attachments.js';
+import { rmrf } from '../helpers/fs.js';
 
 // A real 1x1 transparent PNG (base64, no data: prefix) — what the phone sends.
 const PNG_1x1 =
@@ -30,7 +31,7 @@ test('materializeAttachments writes the image INSIDE the cwd and references it r
   assert.ok(note.includes(`${ATTACHMENTS_DIRNAME}/turn-1/image-0.png`));
   assert.ok(!note.includes(cwd));
   assert.equal(dir, join(cwd, ATTACHMENTS_DIRNAME, 'turn-1'));
-  await rm(cwd, { recursive: true, force: true });
+  await rmrf(cwd);
 });
 
 test('materializeAttachments falls back to a temp dir (absolute ref) without a cwd', async () => {
@@ -66,7 +67,7 @@ test('materializeAttachments references an existing path without copying', async
   assert.deepEqual(paths, [file]);
   // Referenced relative to cwd.
   assert.ok(note.includes('src/pic.png'));
-  await rm(cwd, { recursive: true, force: true });
+  await rmrf(cwd);
 });
 
 test('materializeAttachments skips entries with empty base64 and no path', async () => {
@@ -79,7 +80,7 @@ test('materializeAttachments skips entries with empty base64 and no path', async
   );
   assert.deepEqual(paths, []);
   assert.equal(note, '');
-  await rm(cwd, { recursive: true, force: true });
+  await rmrf(cwd);
 });
 
 test('materializeAttachments uses the right extension per MIME type', async () => {
@@ -96,5 +97,5 @@ test('materializeAttachments uses the right extension per MIME type', async () =
   assert.equal(paths.length, 2);
   assert.ok(paths[0]!.endsWith('.jpg'));
   assert.ok(paths[1]!.endsWith('.webp'));
-  await rm(cwd, { recursive: true, force: true });
+  await rmrf(cwd);
 });

--- a/bridge/test/bridge.test.ts
+++ b/bridge/test/bridge.test.ts
@@ -3,9 +3,9 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { rm } from 'node:fs/promises';
 import { JsonRpcErrorCode, makeRequest, validatePairingPayload } from '@uxnan/shared';
 import { InMemorySecretStore, startBridge, type Bridge } from '../src/index.js';
+import { rmrf } from './helpers/fs.js';
 
 const NOW = 1_700_000_000_000;
 
@@ -25,7 +25,7 @@ test('startBridge wires bridge/status through the router', async () => {
   const res = await bridge.router.dispatch(makeRequest('1', 'bridge/status'));
   assert.ok('result' in res);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('startBridge generates a valid pairing payload via the router', async () => {
@@ -35,7 +35,7 @@ test('startBridge generates a valid pairing payload via the router', async () =>
   const validation = validatePairingPayload(res.result, NOW);
   assert.ok(validation.valid);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('stubbed domain methods return a bridge error, not a crash', async () => {
@@ -43,7 +43,7 @@ test('stubbed domain methods return a bridge error, not a crash', async () => {
   const res = await bridge.router.dispatch(makeRequest('3', 'auth/login', { provider: 'x' }));
   assert.ok('error' in res && res.error.code === JsonRpcErrorCode.BridgeError);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('auth/status returns a sanitized per-agent snapshot (no tokens)', async () => {
@@ -64,7 +64,7 @@ test('auth/status returns a sanitized per-agent snapshot (no tokens)', async () 
   assert.ok('error' in bad && bad.error.code === JsonRpcErrorCode.InvalidParams);
 
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('bridge/disconnectPhone validates its params', async () => {
@@ -72,7 +72,7 @@ test('bridge/disconnectPhone validates its params', async () => {
   const res = await bridge.router.dispatch(makeRequest('4', 'bridge/disconnectPhone', {}));
   assert.ok('error' in res && res.error.code === JsonRpcErrorCode.InvalidParams);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('bridge/status reports the real relay-connection state (false when idle)', async () => {
@@ -81,7 +81,7 @@ test('bridge/status reports the real relay-connection state (false when idle)', 
   assert.ok('result' in res);
   assert.equal((res.result as { relayConnected: boolean }).relayConnected, false);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('bridge/status advertises the message-queue feature', async () => {
@@ -94,7 +94,7 @@ test('bridge/status advertises the message-queue feature', async () => {
   const features = (res.result as { features?: { messageQueue?: boolean } }).features;
   assert.equal(features?.messageQueue, true);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('bridge/removeTrustedDevice revokes trust and is idempotent', async () => {
@@ -119,7 +119,7 @@ test('bridge/removeTrustedDevice revokes trust and is idempotent', async () => {
   );
   assert.ok('result' in again);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('bridge/removeTrustedDevice validates its params', async () => {
@@ -127,5 +127,5 @@ test('bridge/removeTrustedDevice validates its params', async () => {
   const res = await bridge.router.dispatch(makeRequest('8', 'bridge/removeTrustedDevice', {}));
   assert.ok('error' in res && res.error.code === JsonRpcErrorCode.InvalidParams);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });

--- a/bridge/test/conversation/session-history.test.ts
+++ b/bridge/test/conversation/session-history.test.ts
@@ -5,12 +5,13 @@ import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
 import { SessionHistoryReader } from '../../src/index.js';
+import { rmrf } from '../helpers/fs.js';
 
 /** Build a throwaway fake-home tree and return its path + a cleanup fn. */
 async function fakeHome(): Promise<{ home: string; cleanup: () => Promise<void> }> {
   const home = join(tmpdir(), `uxnan-hist-${randomUUID()}`);
   await mkdir(home, { recursive: true });
-  return { home, cleanup: () => rm(home, { recursive: true, force: true }) };
+  return { home, cleanup: () => rmrf(home) };
 }
 
 async function writeLines(file: string, objs: unknown[]): Promise<void> {

--- a/bridge/test/conversation/thread-store.test.ts
+++ b/bridge/test/conversation/thread-store.test.ts
@@ -3,9 +3,9 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { rm } from 'node:fs/promises';
 import { RpcError, type Turn } from '@uxnan/shared';
 import { DaemonState, ThreadStore } from '../../src/index.js';
+import { rmrf } from '../helpers/fs.js';
 
 function newStore(): { store: ThreadStore; baseDir: string } {
   const baseDir = join(tmpdir(), `uxnan-ts-${randomUUID()}`);
@@ -24,7 +24,7 @@ test('start/list/read threads', async () => {
 
   const read = await store.getThread(created.id);
   assert.equal(read.id, created.id);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('turn lifecycle: start, delta, complete', async () => {
@@ -42,7 +42,7 @@ test('turn lifecycle: start, delta, complete', async () => {
   assert.equal(assistant?.content, 'answer');
   const user = turn.messages.find((m) => m.role === 'user');
   assert.equal(user?.content, 'ask');
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('reconcileNativeHistory links bridge turns and imports only native-only completed turns', async () => {
@@ -94,7 +94,7 @@ test('reconcileNativeHistory links bridge turns and imports only native-only com
   );
   assert.deepEqual(again, { changed: false, importedTurnIds: [] });
   assert.equal((await store.listTurns(thread.id)).total, 2);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('reconcileNativeHistory ignores an in-progress native user-only turn and refreshes an import', async () => {
@@ -133,7 +133,7 @@ test('reconcileNativeHistory ignores an in-progress native user-only turn and re
   assert.equal((await store.reconcileNativeHistory(thread.id, [complete], 14)).changed, true);
   const assistant = (await store.listTurns(thread.id)).turns[0]?.messages[1];
   assert.equal(assistant?.content, 'final answer');
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('appendThinking accumulates reasoning and surfaces it on the message', async () => {
@@ -150,7 +150,7 @@ test('appendThinking accumulates reasoning and surfaces it on the message', asyn
   const assistant = turn.messages.find((m) => m.role === 'assistant');
   assert.equal(assistant?.content, 'Answer');
   assert.equal(assistant?.thinking, 'Let me think.');
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('setUsage records token usage on the assistant message (context meter)', async () => {
@@ -165,7 +165,7 @@ test('setUsage records token usage on the assistant message (context meter)', as
   const turn = await store.getTurn(turnId);
   const assistant = turn.messages.find((m) => m.role === 'assistant');
   assert.deepEqual(assistant?.usage, { tokens: 1234, contextWindow: 1_000_000 });
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('appendBlock accumulates structured blocks and surfaces them on the message', async () => {
@@ -183,7 +183,7 @@ test('appendBlock accumulates structured blocks and surfaces them on the message
     { type: 'command_execution', command: 'ls' },
     { type: 'diff', filename: 'a.dart' },
   ]);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('segments preserve the interleaved text↔block order for re-sync', async () => {
@@ -210,7 +210,7 @@ test('segments preserve the interleaved text↔block order for re-sync', async (
     { type: 'command_execution', command: 'ls' },
     { type: 'text', text: 'Done — all good.' },
   ]);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('a plain-text turn ships no segments (lean wire shape)', async () => {
@@ -225,7 +225,7 @@ test('a plain-text turn ships no segments (lean wire shape)', async () => {
   // No structured block landed → no `segments` (rendering from `content` alone
   // is already correct), keeping the wire shape unchanged for text-only turns.
   assert.equal(assistant?.segments, undefined);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('completeTurn with no streamed deltas appends the final text after blocks', async () => {
@@ -242,7 +242,7 @@ test('completeTurn with no streamed deltas appends the final text after blocks',
     { type: 'command_execution', command: 'pwd' },
     { type: 'text', text: 'Here is the answer.' },
   ]);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('listTurns paginates with a cursor', async () => {
@@ -260,7 +260,7 @@ test('listTurns paginates with a cursor', async () => {
   assert.equal(page2.turns.length, 1);
   assert.equal(page2.nextCursor, undefined);
   assert.equal(page2.total, 3);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('listTurns fromEnd returns the newest page', async () => {
@@ -286,7 +286,7 @@ test('listTurns fromEnd returns the newest page', async () => {
     older.turns.map((t) => t.messages[0]?.content),
     ['q1', 'q2'],
   );
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('setAccessMode persists the mode, is idempotent, and surfaces it', async () => {
@@ -312,7 +312,7 @@ test('setAccessMode persists the mode, is idempotent, and surfaces it', async ()
   assert.equal(changed.updatedAt, 3);
   // The runtime the AgentManager reads per turn carries the mode (enforcement).
   assert.equal((await store.getThreadRuntime(thread.id)).accessMode, 'fullAccess');
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('rename/archive/unarchive update the thread; delete removes it', async () => {
@@ -330,7 +330,7 @@ test('rename/archive/unarchive update the thread; delete removes it', async () =
 
   await store.deleteThread(thread.id);
   assert.equal((await store.listThreads('p')).threads.length, 0);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('rename/archive/unarchive/delete reject unknown ids', async () => {
@@ -339,7 +339,7 @@ test('rename/archive/unarchive/delete reject unknown ids', async () => {
   await assert.rejects(store.archiveThread('nope', 1), RpcError);
   await assert.rejects(store.unarchiveThread('nope', 1), RpcError);
   await assert.rejects(store.deleteThread('nope'), RpcError);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('delete preserves mutable history if its final metrics projection fails', async () => {
@@ -356,7 +356,7 @@ test('delete preserves mutable history if its final metrics projection fails', a
 
   await assert.rejects(store.deleteThread(thread.id), /ledger unavailable/);
   assert.equal((await store.getThread(thread.id)).id, thread.id);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('agent session id: persisted, idempotent, surfaced via getHistorySource', async () => {
@@ -386,7 +386,7 @@ test('agent session id: persisted, idempotent, surfaced via getHistorySource', a
 
   // Unknown thread is a silent no-op (no throw).
   await store.setAgentSession('nope', 'x', 3);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('fork copies a thread; unknown ids reject', async () => {
@@ -399,7 +399,7 @@ test('fork copies a thread; unknown ids reject', async () => {
 
   await assert.rejects(store.getThread('nope'), RpcError);
   await assert.rejects(store.getTurn('nope'), RpcError);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('appendBlock beforeText slots the block before the open text run', async () => {
@@ -430,7 +430,7 @@ test('appendBlock beforeText slots the block before the open text run', async ()
     { type: 'tool', name: 'Read' },
     { type: 'tool', name: 'Bash' },
   ]);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('appendBlock beforeText with no open text run appends normally', async () => {
@@ -447,7 +447,7 @@ test('appendBlock beforeText with no open text run appends normally', async () =
     { type: 'tool', name: 'Read' },
     { type: 'text', text: 'after' },
   ]);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('completeTurn extends the trailing run when the final text has an unstreamed tail', async () => {
@@ -470,7 +470,7 @@ test('completeTurn extends the trailing run when the final text has an unstreame
     { type: 'text', text: 'second and tail' },
   ]);
   assert.equal(assistant?.content, 'first second and tail');
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('completeTurn never erases streamed responses when terminal text diverges', async () => {
@@ -496,7 +496,7 @@ test('completeTurn never erases streamed responses when terminal text diverges',
     { type: 'assistant_response_boundary', phase: 'final_answer' },
     { type: 'text', text: 'Final answer.' },
   ]);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 // --- a turn that has ended stays ended ---
@@ -523,7 +523,7 @@ test('output arriving after a turn ended is ignored, not appended', async () => 
   assert.equal(assistant?.content, 'the answer');
   assert.equal(assistant?.thinking ?? '', '');
   assert.equal((assistant?.blocks ?? []).length, 0);
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('a second completion cannot overwrite the reply the user already read', async () => {
@@ -538,7 +538,7 @@ test('a second completion cannot overwrite the reply the user already read', asy
   const assistant = turn.messages.find((m) => m.role === 'assistant');
   assert.equal(assistant?.content, 'the real answer');
   assert.equal(turn.completedAt, 3, 'the original end time stands');
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('an aborted turn does not accept late output either', async () => {
@@ -556,5 +556,5 @@ test('an aborted turn does not accept late output either', async () => {
   assert.equal(turn.status, 'aborted');
   const assistant = turn.messages.find((m) => m.role === 'assistant');
   assert.equal(assistant?.content, 'partial');
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });

--- a/bridge/test/daemon-state.test.ts
+++ b/bridge/test/daemon-state.test.ts
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { rm } from 'node:fs/promises';
 import { DaemonState, DEFAULT_DAEMON_CONFIG, renameWithRetry } from '../src/index.js';
+import { rmrf } from './helpers/fs.js';
 
 function freshState(): DaemonState {
   return new DaemonState(join(tmpdir(), `uxnan-test-${randomUUID()}`));
@@ -13,20 +13,20 @@ function freshState(): DaemonState {
 test('readJson returns null for a missing file', async () => {
   const state = freshState();
   assert.equal(await state.readJson('nope.json'), null);
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('writeJson then readJson round-trips data', async () => {
   const state = freshState();
   await state.writeJson('thing.json', { a: 1, b: 'two' });
   assert.deepEqual(await state.readJson('thing.json'), { a: 1, b: 'two' });
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('readConfig returns defaults when no config exists', async () => {
   const state = freshState();
   assert.deepEqual(await state.readConfig(), DEFAULT_DAEMON_CONFIG);
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('initConfig writes defaults and merges a partial on next read', async () => {
@@ -38,7 +38,7 @@ test('initConfig writes defaults and merges a partial on next read', async () =>
   const merged = await state.readConfig();
   assert.equal(merged.lanPort, 20000);
   assert.equal(merged.relayUrl, DEFAULT_DAEMON_CONFIG.relayUrl);
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('initConfig does not freeze the seeded model lists to disk', async () => {
@@ -54,7 +54,7 @@ test('initConfig does not freeze the seeded model lists to disk', async () => {
     typeof m === 'string' ? m : m.id,
   );
   assert.ok(ids.includes('claude-sonnet-5'));
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('renameWithRetry retries a transient EPERM and eventually succeeds', async () => {
@@ -129,5 +129,5 @@ test('writeJson leaves no temp sibling when the rename ultimately fails', async 
   const left = (await readdir(state.baseDir)).filter((f) => f.endsWith('.tmp'));
   assert.deepEqual(left, [], 'the temp file is cleaned up on failure');
   assert.deepEqual(await state.readJson('threads.json'), { v: 1 });
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });

--- a/bridge/test/handlers/thread-handlers.test.ts
+++ b/bridge/test/handlers/thread-handlers.test.ts
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { rm } from 'node:fs/promises';
 import type { AgentCapabilities, AgentId, SendTurnOptions, TurnList } from '@uxnan/shared';
 import { makeRequest, type Project } from '@uxnan/shared';
 import {
@@ -14,6 +13,7 @@ import {
   startBridge,
   type Bridge,
 } from '../../src/index.js';
+import { rmrf } from '../helpers/fs.js';
 
 /**
  * A controllable in-process agent (no subprocess): `sendTurn` opens a turn but
@@ -112,7 +112,7 @@ test(
     assert.equal(turn.messages.find((m) => m.role === 'assistant')?.content, 'ping pong');
 
     await bridge.stop();
-    await rm(baseDir, { recursive: true, force: true });
+    await rmrf(baseDir);
   },
 );
 
@@ -157,7 +157,7 @@ test(
     );
 
     await bridge.stop();
-    await rm(baseDir, { recursive: true, force: true });
+    await rmrf(baseDir);
   },
 );
 
@@ -203,7 +203,7 @@ test('turn/list reports the in-flight turn as activeTurnId and clears it on comp
   assert.equal((listRes2.result as TurnList).activeTurnId, undefined);
 
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('turn/list reconciles native-only turns even when the bridge store is non-empty', async () => {
@@ -279,7 +279,7 @@ test('turn/list reconciles native-only turns even when the bridge store is non-e
   assert.equal(result.turns[1]?.messages[1]?.content, 'desktop answer');
 
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('turn/send rejects a message with neither text nor attachments', async () => {
@@ -298,7 +298,7 @@ test('turn/send rejects a message with neither text nor attachments', async () =
   assert.ok('error' in res && res.error.code === -32602);
 
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test(
@@ -343,7 +343,7 @@ test(
     );
 
     await bridge.stop();
-    await rm(baseDir, { recursive: true, force: true });
+    await rmrf(baseDir);
   },
 );
 
@@ -367,7 +367,7 @@ test('turn/send rejects an approvalResponse with an unknown decision', async () 
   assert.ok('error' in res && res.error.code === -32602);
 
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('agent/list reports the registered agents (echo + opencode + claude-code + codex)', async () => {
@@ -380,7 +380,7 @@ test('agent/list reports the registered agents (echo + opencode + claude-code + 
   assert.ok(ids.includes('claude-code'));
   assert.ok(ids.includes('codex'));
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('thread rename/archive/unarchive/delete lifecycle over the router', async () => {
@@ -418,7 +418,7 @@ test('thread rename/archive/unarchive/delete lifecycle over the router', async (
   assert.ok('error' in readRes && readRes.error.code === -32008);
 
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('thread/start uses the per-project agent/model pin when the phone omits them', async () => {
@@ -461,7 +461,7 @@ test('thread/start uses the per-project agent/model pin when the phone omits the
   assert.equal((overrideRes.result as { model?: string }).model, undefined);
 
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('thread/start with an unknown project id is rejected', async () => {
@@ -471,7 +471,7 @@ test('thread/start with an unknown project id is rejected', async () => {
   );
   assert.ok('error' in res);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('thread/start rejects the deprecated Gemini CLI before creating a thread', async () => {
@@ -489,7 +489,7 @@ test('thread/start rejects the deprecated Gemini CLI before creating a thread', 
   assert.match(res.error.message, /deprecated and cannot start new threads/);
 
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });
 
 test('thread/read of an unknown id returns -32008', async () => {
@@ -497,5 +497,5 @@ test('thread/read of an unknown id returns -32008', async () => {
   const res = await bridge.router.dispatch(makeRequest('3', 'thread/read', { threadId: 'nope' }));
   assert.ok('error' in res && res.error.code === -32008);
   await bridge.stop();
-  await rm(baseDir, { recursive: true, force: true });
+  await rmrf(baseDir);
 });

--- a/bridge/test/logger.test.ts
+++ b/bridge/test/logger.test.ts
@@ -3,8 +3,9 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { readFile, rm } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { createFileLogger, logFileFor, redactSecrets } from '../src/index.js';
+import { rmrf } from './helpers/fs.js';
 
 test('redactSecrets masks JWTs, secret key=values and PEM blocks', () => {
   assert.match(redactSecrets('auth aaaaaaaa.bbbbbbbb.cccccccc done'), /\[REDACTED-JWT\]/);
@@ -38,5 +39,5 @@ test('createFileLogger writes a daily-rotated, redacted, level-filtered file', a
   assert.ok(!contents.includes('topsecret'));
   assert.ok(contents.includes('2026-06-06'));
 
-  await rm(dir, { recursive: true, force: true });
+  await rmrf(dir);
 });

--- a/bridge/test/push/push-service.test.ts
+++ b/bridge/test/push/push-service.test.ts
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { rm } from 'node:fs/promises';
 import {
   PushService,
   DaemonState,
@@ -13,6 +12,7 @@ import {
   type PushPayload,
 } from '../../src/index.js';
 import type { PushPlatform } from '@uxnan/shared';
+import { rmrf } from '../helpers/fs.js';
 
 interface Call {
   url: string;
@@ -199,7 +199,7 @@ test('registrations persist across a restart via push-state.json', async () => {
       false,
     );
   } finally {
-    await rm(baseDir, { recursive: true, force: true });
+    await rmrf(baseDir);
   }
 });
 
@@ -251,7 +251,7 @@ test('direct sender: registration survives a restart and pushes via FCM after re
     assert.equal(sent[0]?.token, 'fcm-tok');
     assert.equal(sent[0]?.platform, 'ios');
   } finally {
-    await rm(baseDir, { recursive: true, force: true });
+    await rmrf(baseDir);
   }
 });
 

--- a/bridge/test/update-check.test.ts
+++ b/bridge/test/update-check.test.ts
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { rm } from 'node:fs/promises';
 import {
   DaemonState,
   DAEMON_FILES,
@@ -14,6 +13,7 @@ import {
   updateNoticeMessage,
   type UpdateCheckCache,
 } from '../src/index.js';
+import { rmrf } from './helpers/fs.js';
 
 function freshState(): DaemonState {
   return new DaemonState(join(tmpdir(), `uxnan-update-test-${randomUUID()}`));
@@ -77,7 +77,7 @@ test('ensureUpdateStatus fetches when the cache is missing and persists it', asy
   const cache = await state.readJson<UpdateCheckCache>(DAEMON_FILES.updateCheck);
   assert.equal(cache?.latestVersion, '0.0.3-alpha.20260805');
   assert.equal(cache?.checkedAt, 1_000);
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('ensureUpdateStatus serves a fresh cache without hitting the network', async () => {
@@ -97,7 +97,7 @@ test('ensureUpdateStatus serves a fresh cache without hitting the network', asyn
   });
   assert.equal(called, false);
   assert.equal(status.latestVersion, '0.0.3-alpha.20260805');
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('ensureUpdateStatus re-checks once the cache is stale', async () => {
@@ -113,7 +113,7 @@ test('ensureUpdateStatus re-checks once the cache is stale', async () => {
   });
   assert.equal(status.latestVersion, '0.0.4-alpha.20260901');
   assert.equal(status.updateAvailable, true);
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('ensureUpdateStatus keeps the last known latest when a re-check fails offline', async () => {
@@ -130,7 +130,7 @@ test('ensureUpdateStatus keeps the last known latest when a re-check fails offli
   // Offline: we keep the previously-cached latest (don't clobber to unknown).
   assert.equal(status.latestVersion, '0.0.4-alpha.20260901');
   assert.equal(status.updateAvailable, true);
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('cachedUpdateStatus never touches the network', async () => {
@@ -143,7 +143,7 @@ test('cachedUpdateStatus never touches the network', async () => {
   const status = await cachedUpdateStatus(state, '0.0.3-alpha.20260702');
   assert.equal(status.updateAvailable, true);
   assert.equal(status.latestVersion, '0.0.5-alpha.20261001');
-  await rm(state.baseDir, { recursive: true, force: true });
+  await rmrf(state.baseDir);
 });
 
 test('updateNoticeMessage is null when up to date and set when outdated', () => {

--- a/bridge/test/workspace/browse-service.test.ts
+++ b/bridge/test/workspace/browse-service.test.ts
@@ -1,10 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { BrowseService, browseRootIdFor } from '../../src/index.js';
 import { JsonRpcErrorCode, RpcError } from '@uxnan/shared';
+import { rmrf } from '../helpers/fs.js';
 
 async function makeTree(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'uxnan-browse-'));
@@ -25,7 +26,7 @@ test('listRoots reports the configured roots with stable ids', async () => {
     assert.equal(roots[0]!.cwd, root);
     assert.equal(roots[0]!.id, browseRootIdFor(root));
   } finally {
-    await rm(root, { recursive: true, force: true });
+    await rmrf(root);
   }
 });
 
@@ -45,7 +46,7 @@ test('browse lists sub-directories, marks git repos, and excludes .git/sensitive
     // the roots list is included so the phone can offer a picker
     assert.equal(res.roots.length, 1);
   } finally {
-    await rm(root, { recursive: true, force: true });
+    await rmrf(root);
   }
 });
 
@@ -63,7 +64,7 @@ test('browse descends into a sub-directory with correct path/parent/cwd', async 
       ['nested'],
     );
   } finally {
-    await rm(root, { recursive: true, force: true });
+    await rmrf(root);
   }
 });
 
@@ -77,7 +78,7 @@ test('browse rejects an attempt to escape above the root', async () => {
         err instanceof RpcError && err.code === JsonRpcErrorCode.WorkspaceAccessDenied,
     );
   } finally {
-    await rm(root, { recursive: true, force: true });
+    await rmrf(root);
   }
 });
 
@@ -90,7 +91,7 @@ test('browse with an unknown root id is rejected', async () => {
       (err: unknown) => err instanceof RpcError && err.code === JsonRpcErrorCode.ResourceNotFound,
     );
   } finally {
-    await rm(root, { recursive: true, force: true });
+    await rmrf(root);
   }
 });
 

--- a/bridge/test/workspace/workspace-service.test.ts
+++ b/bridge/test/workspace/workspace-service.test.ts
@@ -4,10 +4,11 @@ import { tmpdir } from 'node:os';
 import { join, relative } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { randomUUID } from 'node:crypto';
-import { mkdir, realpath, rm, writeFile } from 'node:fs/promises';
+import { mkdir, realpath, writeFile } from 'node:fs/promises';
 import { JsonRpcErrorCode, RpcError } from '@uxnan/shared';
 import { WorkspaceService } from '../../src/index.js';
 import { runGit } from '../../src/git/git-runner.js';
+import { rmrf } from '../helpers/fs.js';
 
 const ws = new WorkspaceService();
 
@@ -27,7 +28,7 @@ test('resolveFileLink keeps files inside the conversation workspace', async () =
 
   const target = await ws.resolveFileLink(root, 'docs/summary.md#L1');
   assert.deepEqual(target, { cwd: root, path: 'docs/summary.md' });
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('resolveFileLink selects a sibling git worktree as the viewer root', async () => {
@@ -52,7 +53,7 @@ test('resolveFileLink selects a sibling git worktree as the viewer root', async 
   const fileUrlTarget = await ws.resolveFileLink(conversation, pathToFileURL(linkedFile).href);
   assert.equal(fileUrlTarget.cwd, linkedWorktree);
   assert.equal(fileUrlTarget.path, relative(linkedWorktree, linkedFile).replaceAll('\\', '/'));
-  await rm(parent, { recursive: true, force: true });
+  await rmrf(parent);
 });
 
 test('resolveFileLink falls back to the containing directory outside a repo', async () => {
@@ -66,7 +67,7 @@ test('resolveFileLink falls back to the containing directory outside a repo', as
   // No git root to anchor to, so the viewer root stays as narrow as possible.
   const target = await ws.resolveFileLink(conversation, join(loose, 'notes.md'));
   assert.deepEqual(target, { cwd: loose, path: 'notes.md' });
-  await rm(parent, { recursive: true, force: true });
+  await rmrf(parent);
 });
 
 test('resolveFileLink resolves an absolute link after the conversation cwd is gone', async () => {
@@ -81,7 +82,7 @@ test('resolveFileLink resolves an absolute link after the conversation cwd is go
   // pruned) while its transcript still cites a file that outlived it.
   const target = await ws.resolveFileLink(conversation, join(worktree, 'resume.md'));
   assert.deepEqual(target, { cwd: worktree, path: 'resume.md' });
-  await rm(parent, { recursive: true, force: true });
+  await rmrf(parent);
 });
 
 test('resolveFileLink denies .git internals in another worktree', async () => {
@@ -99,7 +100,7 @@ test('resolveFileLink denies .git internals in another worktree', async () => {
         error instanceof RpcError && error.code === JsonRpcErrorCode.WorkspaceAccessDenied,
     );
   }
-  await rm(parent, { recursive: true, force: true });
+  await rmrf(parent);
 });
 
 test('resolveFileLink rejects remote, missing, directory, and sensitive targets', async () => {
@@ -125,7 +126,7 @@ test('resolveFileLink rejects remote, missing, directory, and sensitive targets'
     (error: unknown) =>
       error instanceof RpcError && error.code === JsonRpcErrorCode.WorkspaceAccessDenied,
   );
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('readFile returns utf-8 text and binary as base64', async () => {
@@ -138,7 +139,7 @@ test('readFile returns utf-8 text and binary as base64', async () => {
   const bin = await ws.readFile(root, 'blob.bin');
   assert.equal(bin.encoding, 'base64');
   assert.equal(Buffer.from(bin.content, 'base64').length, 5);
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('readFile preserves PDF bytes even when its prefix contains no NUL', async () => {
@@ -150,7 +151,7 @@ test('readFile preserves PDF bytes even when its prefix contains no NUL', async 
 
   assert.equal(result.encoding, 'base64');
   assert.deepEqual(Buffer.from(result.content, 'base64'), pdf);
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('readImage infers the mime type', async () => {
@@ -160,7 +161,7 @@ test('readImage infers the mime type', async () => {
   assert.equal(img.mimeType, 'image/png');
   assert.ok(img.base64Data.length > 0);
   await assert.rejects(ws.readImage(root, 'pic.txt'), RpcError);
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('list excludes .git and sensitive files and sorts dirs first', async () => {
@@ -182,7 +183,7 @@ test('list excludes .git and sensitive files and sorts dirs first', async () => 
   assert.ok((file?.mtime ?? 0) > 0);
   assert.equal(dir?.size, undefined);
   assert.equal(dir?.mtime, undefined);
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('list flags git-ignored entries and leaves tracked/clean ones un-flagged', async () => {
@@ -200,7 +201,7 @@ test('list flags git-ignored entries and leaves tracked/clean ones un-flagged', 
   // A normal file and the `.gitignore` itself are not flagged (absent/false).
   assert.ok(!byName.get('kept.txt')?.ignored);
   assert.ok(!byName.get('.gitignore')?.ignored);
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('list leaves entries un-flagged outside a git repository', async () => {
@@ -208,7 +209,7 @@ test('list leaves entries un-flagged outside a git repository', async () => {
   await writeFile(join(root, 'a.txt'), 'x');
   const listing = await ws.list(root);
   assert.ok(!listing.entries.find((e) => e.name === 'a.txt')?.ignored);
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('applyPatch adds, modifies and deletes files', async () => {
@@ -221,7 +222,7 @@ test('applyPatch adds, modifies and deletes files', async () => {
   assert.deepEqual(result, { success: true, applied: 2 });
   assert.equal((await ws.readFile(root, 'nested/new.txt')).content, 'created');
   await assert.rejects(ws.readFile(root, 'old.txt'), RpcError);
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('path traversal, .git and sensitive files are denied', async () => {
@@ -232,7 +233,7 @@ test('path traversal, .git and sensitive files are denied', async () => {
       (err) => err instanceof RpcError && err.code === JsonRpcErrorCode.WorkspaceAccessDenied,
     );
   }
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('searchFiles fuzzy-matches files and their ancestor dirs across the repo', async () => {
@@ -256,7 +257,7 @@ test('searchFiles fuzzy-matches files and their ancestor dirs across the repo', 
   );
   const dirHit = await ws.searchFiles(root, 'presentation');
   assert.ok(dirHit.matches.some((m) => m.path === 'lib/presentation' && m.type === 'dir'));
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('searchFiles respects .gitignore and excludes sensitive files', async () => {
@@ -277,7 +278,7 @@ test('searchFiles respects .gitignore and excludes sensitive files', async () =>
   assert.ok(!paths.includes('build'));
   assert.ok(!paths.includes('secret.txt'));
   assert.ok(!paths.includes('.env'));
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('searchFiles caps results and flags truncation', async () => {
@@ -289,7 +290,7 @@ test('searchFiles caps results and flags truncation', async () => {
   const capped = await ws.searchFiles(root, 'note', 3);
   assert.equal(capped.matches.length, 3);
   assert.ok(capped.truncated);
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });
 
 test('searchFiles works outside a git repo via the walk fallback', async () => {
@@ -298,5 +299,5 @@ test('searchFiles works outside a git repo via the walk fallback', async () => {
   await writeFile(join(root, 'src', 'app.ts'), '1');
   const res = await ws.searchFiles(root, 'app');
   assert.ok(res.matches.some((m) => m.path === 'src/app.ts'));
-  await rm(root, { recursive: true, force: true });
+  await rmrf(root);
 });

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -24,7 +24,7 @@ which files carry a version) and the **machinery** that follows it.
 | Cut a nightly desktop build | Nothing — it happens at 00:20 Mexico City if there is something to ship |
 | Cut anything else | Actions → **Release — cut versions** → tick the components → Run |
 | Publish a stable desktop build | Review the draft release on GitHub and press **Publish** |
-| Bring `main` level after a cut | Merge the `build(release): …` pull request the run opened |
+| Bring `main` level after a cut | Nothing — the run merges its own bump pull request once `verify` is green |
 | Know why a release did not happen | Read the run summary; a component with no real change is skipped on purpose |
 
 ---
@@ -34,8 +34,9 @@ which files carry a version) and the **machinery** that follows it.
 **Automated.** Working out whether a component genuinely changed, computing the
 next version, writing it into every version-bearing file, proving those files
 agree, committing, tagging, pushing the tag, opening the pull request that brings
-all of it into `main`, and — for a desktop **nightly** — writing the release notes
-and publishing.
+all of it into `main` **and merging it once its checks pass**, and — for a desktop
+**nightly** — writing the release notes and publishing. A nightly at 00:20 local
+therefore finishes on its own, with nobody awake.
 
 **Not automated, on purpose.**
 
@@ -43,11 +44,6 @@ and publishing.
   signatures, `latest.json`, and its notes already written. Pressing *Publish* is
   the moment it becomes the default download and the updater starts offering it.
   That is a judgement call, not a build step.
-- **Merging the bump pull request.** `main` is protected and stays that way; the
-  run opens the PR, you merge it. The tags already point at those commits, so the
-  builds never wait for it. **Do not leave it open**: while it is, the tag is not
-  an ancestor of `main`, and that state has bitten once — see *When something goes
-  wrong* → *A version was cut for nothing*.
 - **The CHANGELOG.** The tooling never writes your prose. For a stable release,
   rename `## [Unreleased]` to the version yourself before cutting.
 
@@ -83,27 +79,49 @@ pick `none` / `nightly` / `stable` for the desktop. Two switches matter:
 
 ---
 
-## The credential, and why `main` is never touched
+## The credential, and why `main` is still protected
 
 Two constraints shaped this, and neither is about permissions being convenient.
 
-**The workflow never pushes to `main`.** The bump commit lands on a
-`release/<timestamp>` branch, the tag points at that commit, and a pull request
-brings it into `main` through the same reviewed path as everything else. So the
-`main-protection` ruleset stays exactly as it is: **nothing is added to its
-bypass list**. Granting a bypass to the `github-actions` app would let *any*
-workflow in the repository write to `main`, which is a much larger door than this
-needs.
+**A tag pushed with `GITHUB_TOKEN` starts no build.** GitHub refuses to trigger a
+workflow from an event created with the default token — its anti-recursion rule —
+so `release-desktop.yml` would simply never run.
 
-**But a tag pushed with `GITHUB_TOKEN` starts no build.** GitHub refuses to
-trigger a workflow from an event created with the default token — its
-anti-recursion rule — so `release-desktop.yml` would simply never run. This is
-the one thing the automation cannot do with the permissions it is given.
+**And `main` must not become writable by workflows.** Granting a bypass to
+`github-actions` would let *any* workflow in the repository through, including
+one a future pull request introduces. That door was never opened and is not open
+now.
 
-The fix is a **GitHub App** used only for this, which is narrower than a personal
-token in three ways that matter: its permissions are just `contents: write` and
-`pull requests: write` on this repository, the token it mints **expires in an
-hour**, and it appears in the audit log as itself rather than as you.
+Both are answered by the same thing: a **GitHub App**, `Uxnan Releases`, used
+only for this. It is narrower than a personal token in three ways that matter —
+its permissions are just `contents: write` and `pull requests: write` on this
+repository, the token it mints **expires in an hour**, and it appears in the
+audit log as itself rather than as you.
+
+### How the pull request merges itself
+
+`Uxnan Releases` is a **bypass actor on the `main-protection` ruleset, in
+pull-request mode** (`Allow for pull requests only`). That mode is precise about
+what it grants:
+
+- the app **cannot push to `main`** — it must open a pull request, exactly as
+  before;
+- an operation **authenticated as the app** may merge that pull request without
+  the required approval;
+- **nothing else changes.** `GITHUB_TOKEN` is not this app, so ordinary
+  workflows, and pull requests from forks, are as restricted as they ever were.
+  Your own pull requests still need their approval.
+
+This is why `git config user.name "…[bot]"` is irrelevant to it — that only
+writes commit metadata. What GitHub matches against the bypass list is the
+identity behind the token: `actions/create-github-app-token`, passed to
+`actions/checkout` and to `gh` as `GH_TOKEN`.
+
+The run merges the pull request itself only after its **`verify`** checks pass.
+Deliberately not *every* check on the commit: the release build reports onto the
+same SHA, because the tag points at it, and a macOS leg is allowed to fail there
+on purpose. A red `verify` means `main` itself is red — this pull request adds
+nothing but version numbers — so it is left open and the run goes red with it.
 
 ### Setting it up (once, in a browser — the API cannot create apps)
 
@@ -120,12 +138,17 @@ hour**, and it appears in the audit log as itself rather than as you.
    - **Variables** → `RELEASE_APP_ID` = the App ID
    - **Secrets** → `RELEASE_APP_PRIVATE_KEY` = the whole `.pem`, including the
      `-----BEGIN…` and `-----END…` lines.
+7. **Settings → Rules → Rulesets → `main-protection` → Bypass list → Add
+   bypass** → the app, with **`Allow for pull requests only`**. Not
+   *Repository administrators*, not `github-actions`, and not *Always allow* —
+   pull-request mode is what keeps it unable to push to `main`.
 
 ### Until it exists
 
 The run still does everything else: it plans, refuses empty or backwards
 versions, writes every version file, verifies them, commits, creates the tag
-locally and opens the bump pull request. It stops short of *pushing* the tag and
+locally and opens the bump pull request. It stops short of *pushing* the tag —
+and of merging that pull request, since the bypass belongs to the app — and
 prints the one command to finish:
 
 ```

--- a/scripts/release/status.mjs
+++ b/scripts/release/status.mjs
@@ -81,8 +81,9 @@ console.log(
 for (const row of rows.filter((r) => r.since && !r.landed)) {
   console.log(
     `⚠  ${row.id}: ${row.since} shipped, but its release pull request is still open —\n` +
-      `   main does not carry that version yet. Merge it. The version files will read as\n` +
-      `   changed until you do; they are counted as bookkeeping, not as work to release.\n`,
+      `   main does not carry that version yet. It normally merges itself, so if it is\n` +
+      `   still there its checks went red: look at those rather than merging past them.\n` +
+      `   The version files read as changed until it lands; they count as bookkeeping.\n`,
   );
 }
 


### PR DESCRIPTION
The cut runs unattended at 00:20 local and then stopped one step short, waiting for someone asleep to press *Merge*. That gap is not neutral — an unmerged tag is not an ancestor of `main`, the state that cut desktop 0.0.34 out of nothing.

`Uxnan Releases` is now a bypass actor on `main-protection` in **pull-request mode**, so the run merges its own PR. What that grants is narrow: the app still cannot push to `main`, and the exception applies only to an operation authenticated with its installation token. `GITHUB_TOKEN` is not that app — every other workflow, and every fork PR, is exactly as restricted as before.

It merges only after the PR's own **`verify`** checks pass, and deliberately not after every check on the commit: the release build reports onto the same SHA and a macOS leg is allowed to fail there on purpose — waiting on that would block the merge precisely on the days it matters most. A red `verify` means `main` itself is red (this PR adds nothing but version numbers), so it is left open and the run goes red.

Docs updated throughout, including why `git config user.name` has nothing to do with the identity GitHub matches against the bypass list.