### PR TITLE
fix(release): create the GitHub Release as the app, not as Actions

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -107,6 +107,22 @@ jobs:
           cache: npm
           cache-dependency-path: uxnandesktop/package-lock.json
 
+      # The release is CREATED with the app's token, not with GITHUB_TOKEN.
+      # Measured on 0.0.36: the Actions token uploaded assets to an existing
+      # release perfectly well and was refused when creating one — "Resource not
+      # accessible by integration", on all four legs, with `Contents: write`
+      # granted and 24 minutes after the identical call had succeeded for 0.0.35.
+      # Whatever moved underneath, release creation is the one release operation
+      # this workflow cannot afford to lose, and every other one here already
+      # runs as the app. So it runs as the app too.
+      - name: Mint a release token
+        id: token
+        if: vars.RELEASE_APP_ID != ''
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Resolve and validate release channel from tag
         id: meta
         shell: bash
@@ -147,7 +163,7 @@ jobs:
       - name: Build installers + draft release
         uses: tauri-apps/tauri-action@v0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GITHUB_TOKEN }}
           # Updater signature (free minisign key). When set, tauri-action emits a
           # `.sig` per installer and a merged `latest.json`; when unset it builds
           # the same installers without them. NOT OS code-signing.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -341,6 +341,18 @@ so there is nothing to generate or paste; it appears by itself.
 
 ## When something goes wrong
 
+**The build compiled everything and then failed to create the release** —
+*"Resource not accessible by integration"*, every leg, `create-a-release`. The
+Actions token can upload assets to a release that exists and be refused when
+creating one, with `Contents: write` granted; it happened on 0.0.36, twenty-four
+minutes after the identical call succeeded for 0.0.35, with nothing changed in
+between that anyone could name. Release creation now runs as the **app** rather
+than as Actions, which is what every other release operation here already does.
+To recover a build already in this state, create the draft yourself
+(`gh api --method POST repos/OWNER/REPO/releases -f tag_name=… -F draft=true -F
+prerelease=true`) and re-run the failed jobs: `tauri-action` finds the existing
+draft and uploads into it.
+
 **A release is public but the updater does not offer it.** `latest.json` on the
 rolling channel was not rolled, because the publish event came from
 `GITHUB_TOKEN` — the same anti-recursion rule that stops a tag from starting a


### PR DESCRIPTION
The 0.0.36 build compiled all four targets and then failed on **every leg** with `Resource not accessible by integration — create-a-release`. The same call succeeded for 0.0.35 twenty-four minutes earlier, from a byte-identical workflow file, with `Contents: write` granted in both runs and no tag ruleset.

**Isolated rather than guessed:** creating the draft by hand and re-running the failed jobs made them pass and upload all 14 artifacts. The Actions token can *upload into* a release and be refused *creating* one. I could not establish what moved underneath — no GitHub incident, nothing changed in the repo in that window.

So the dependency goes away: `tauri-action` now receives the app's installation token, which is what the notes, the publish and the tag push already use. `secrets.GITHUB_TOKEN` stays the fallback, so a fork builds as before.