### PR TITLE
docs: prepare the release prose for shared, bridge and mobile

### DIFF
--- a/.github/whatsnew/whatsnew-en-US
+++ b/.github/whatsnew/whatsnew-en-US
@@ -1,7 +1,9 @@
-Faster replies. Answers appear smoothly as they are written, already formatted — long ones no longer slow down as they grow.
+Your conversations are now grouped by the folder they run in, with the repository shown above the folders that belong together.
 
-Conversation list: each row shows the start of the agent's latest reply, not always its first.
+Each folder tells you at a glance whether it has uncommitted work, or is ahead of or behind its remote.
 
-Context and usage: Codex, Grok and Zero now report how much context a conversation uses, so their meters and your profile stats work like the other agents'.
+Sort projects, folders and conversations the way you prefer.
 
-Fixes: the queued-message bubble is drawn properly, and the effort menu no longer opens behind the keyboard.
+On tablets and foldables the app uses the whole screen: the list stays beside what you are reading.
+
+A refreshed look throughout. Gemini CLI has been removed; every other agent works as before.

--- a/.github/whatsnew/whatsnew-es-ES
+++ b/.github/whatsnew/whatsnew-es-ES
@@ -1,7 +1,9 @@
-Respuestas más rápidas. Aparecen con fluidez mientras se escriben y ya con formato: las largas no se ralentizan al crecer.
+Tus conversaciones se agrupan por la carpeta en la que trabajan, con el repositorio por encima de las carpetas que van juntas.
 
-Conversaciones: cada fila muestra el inicio de la última respuesta del agente, no siempre la primera.
+Cada carpeta indica de un vistazo si tiene cambios sin confirmar o si va por delante o por detrás de su remoto.
 
-Contexto y consumo: Codex, Grok y Zero ya informan cuánto contexto usa la conversación, así que sus medidores y tus estadísticas funcionan como en los demás.
+Ordena proyectos, carpetas y conversaciones como prefieras.
 
-Correcciones: la burbuja de mensajes en cola se dibuja bien y el menú de esfuerzo ya no queda tras el teclado.
+En tablets y plegables la app aprovecha toda la pantalla: la lista se queda junto a lo que estás leyendo.
+
+Nueva imagen en toda la app. Gemini CLI ya no está; el resto de agentes sigue igual.

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+## [0.0.19-alpha.20260810] - 2026-08-10
+
 ### Added — `git/worktrees`
 
 Answers which directories are worktrees of the repository at `cwd`, parsed from

--- a/shared/CHANGELOG.md
+++ b/shared/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+## [0.0.14-alpha.20260810] - 2026-08-10
+
 ### Added — `git/worktrees`
 
 Which directories are worktrees of the repository at a `cwd`:

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.19-alpha.20260810+20260810] - 2026-08-10
+
 ### Fixed — the profile stopped being clamped to a paragraph's width
 
 `NeScaffold` already stops every screen at its window class's content width


### PR DESCRIPTION
The two steps `release.yml` deliberately leaves to a person, done before cutting:

- **Play release notes** rewritten for 0.0.19 (they still described 0.0.18). 490 / 494 chars against the 500-char gate, measured with the same `wc -m` the workflow uses.
- **CHANGELOG headings** converted from `[Unreleased]` to the version being cut, for shared, bridge and mobile.

Docs-only, so it does not change what any component owes.