### PR TITLE
docs: release prose for bridge 0.0.20, mobile 0.0.20 and desktop 0.0.39

### DIFF
--- a/.github/whatsnew/whatsnew-en-US
+++ b/.github/whatsnew/whatsnew-en-US
@@ -1,9 +1,7 @@
-Your conversations are now grouped by the folder they run in, with the repository shown above the folders that belong together.
+Conversations no longer come back duplicated. If one of yours already shows an exchange twice, it repairs itself the next time you open it — nothing you wrote is lost.
 
-Each folder tells you at a glance whether it has uncommitted work, or is ahead of or behind its remote.
+Long replies stay smooth to the end instead of slowing down as they grow.
 
-Sort projects, folders and conversations the way you prefer.
+Opening a second conversation in the same pane now shows the one you picked.
 
-On tablets and foldables the app uses the whole screen: the list stays beside what you are reading.
-
-A refreshed look throughout. Gemini CLI has been removed; every other agent works as before.
+The empty conversation drawer offers to get you set up, instead of the camera.

--- a/.github/whatsnew/whatsnew-es-ES
+++ b/.github/whatsnew/whatsnew-es-ES
@@ -1,9 +1,7 @@
-Tus conversaciones se agrupan por la carpeta en la que trabajan, con el repositorio por encima de las carpetas que van juntas.
+Las conversaciones ya no vuelven duplicadas. Si alguna te muestra un intercambio dos veces, se repara sola la próxima vez que la abras: no se pierde nada de lo que escribiste.
 
-Cada carpeta indica de un vistazo si tiene cambios sin confirmar o si va por delante o por detrás de su remoto.
+Las respuestas largas se mantienen fluidas hasta el final, en vez de ralentizarse al crecer.
 
-Ordena proyectos, carpetas y conversaciones como prefieras.
+Abrir una segunda conversación en el mismo panel ahora muestra la que elegiste.
 
-En tablets y plegables la app aprovecha toda la pantalla: la lista se queda junto a lo que estás leyendo.
-
-Nueva imagen en toda la app. Gemini CLI ya no está; el resto de agentes sigue igual.
+El panel de conversaciones vacío te ofrece configurar la app, no la cámara.

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+## [0.0.20-alpha.20260812] - 2026-08-12
+
 ### Changed — streamed prose is coalesced before it leaves the bridge
 
 Agents emit text in bursts, not at a steady rate: on a real OpenCode turn, 60%

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+## [0.0.39] - 2026-08-12
+
 ### Removed
 
 - Removed the standalone Gemini CLI from the agent catalog, headless runner,

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,8 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.20-alpha.20260812+20260812] - 2026-08-12
+
 ### Changed — a long reply no longer slows itself down while it streams
 
 Past a few thousand characters an answer started arriving in small jerks, and


### PR DESCRIPTION
The two steps the tooling deliberately leaves to a person, before cutting.

**Play notes** rewritten for what 0.0.20 actually fixes: conversations no longer duplicate (and an already-duplicated one repairs itself), long replies stay smooth, the second conversation in a pane is the one you picked. 403 / 432 chars against the 500 gate.

**CHANGELOG headings** converted for bridge, mobile and — because this one is a **stable** — desktop, whose `[Unreleased]` had piled up across nightlies 0.0.29 → 0.0.38 and now becomes 0.0.39.