### PR TITLE
fix(bridge): a tool step could be announced after the sentence that followed it

### DIFF
--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -5,6 +5,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Fixed — a tool step could be announced after the sentence that followed it
+
+The work log is ordered by the order the phone is told, and a content block was
+told last. Its branch notified *after* awaiting the store write, and adapters
+emit without awaiting the handler — so only a handler's synchronous prefix runs
+in arrival order. A delta arriving during that write overtook the block: the
+phone showed "Son 24." before the command whose output that sentence describes.
+
+The block is now announced from the synchronous prefix, with the store write
+following it, exactly as the streamed prose above already works. When something
+becomes durable is a separate question from when the phone is told about it.
+
+Found by CI rather than by a person: the ordering test had been asserting a
+fixed 80 ms snapshot, which hid the reorder as a "missing" block; waiting for
+the three notifications instead is what showed the real order.
+
 ## [0.0.20-alpha.20260812] - 2026-08-12
 
 ### Changed — streamed prose is coalesced before it leaves the bridge

--- a/bridge/src/agents/agent-manager.ts
+++ b/bridge/src/agents/agent-manager.ts
@@ -1195,7 +1195,19 @@ export class AgentManager {
             // rides on the notification so the phone's live buffer applies the
             // identical placement — live view and re-sync render the same order.
             const beforeText = readBeforeText(event.data);
-            await this.#options.store.appendBlock(threadId, turnId, content, now, beforeText);
+            // Notified from the handler's SYNCHRONOUS prefix, before the store
+            // write is awaited — which is the only part of a handler guaranteed
+            // to run in arrival order, since adapters emit without awaiting
+            // (`void this.#onEvent`). Announcing after the await let a delta
+            // that arrived during it overtake the block: the phone was told
+            // "Son 24." before the command whose output that sentence
+            // describes, and the work log read out of order. CI caught it as
+            // `[delta, delta, block]`.
+            //
+            // Persistence still follows immediately, and is what a re-sync
+            // reads. Telling the phone before the disk agrees is the same
+            // trade the streamed prose above already makes: when it becomes
+            // durable is a separate question from when the phone is told.
             this.#options.notify(
               makeNotification(StreamNotification.ContentBlock, {
                 threadId,
@@ -1205,6 +1217,7 @@ export class AgentManager {
                 ...(beforeText ? { beforeText } : {}),
               }),
             );
+            await this.#options.store.appendBlock(threadId, turnId, content, now, beforeText);
           }
           break;
         }


### PR DESCRIPTION
**The `land` job refused to merge the release bump, and it was right to.** The failure it held the line on was `[delta, delta, block]` — not a late block, an **out-of-order** one.

Adapters emit without awaiting the handler, so only a handler's *synchronous prefix* runs in arrival order — the file says so. The `block` branch notified *after* `await store.appendBlock`, so a delta landing during that write overtook it, and the phone's work log showed the sentence above the command whose output it describes.

The block is now announced from the synchronous prefix and persisted right after — the same trade the streamed prose already makes.

**Rejected on the way:** serialising all events through a per-thread chain. It fixes the order and breaks the streaming fast path — every delta would wait on the previous one's disk write, and the 512-char cap stopped tripping synchronously (its own test caught that at 0 notifications).

627 passing; ordering test run 30× without a failure.