### PR TITLE
feat(release): the CHANGELOG heading is written by the cut

### DIFF
--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -35,6 +35,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Tags and history, so the notes check can ask whether anyone has
+          # touched them since the previous mobile release.
+          fetch-depth: 0
 
       # Non-negotiable release rule: every uxnanmobile tag MUST ship short,
       # user-facing "What's new" notes for en-US and es-ES (≤ 500 chars each,
@@ -60,11 +64,29 @@ jobs:
               fail=1
             fi
           done
+          # Present, short and not a placeholder is not the same as CURRENT. The
+          # notes for 0.0.19 were valid prose about 0.0.18 — 491 and 506 bytes,
+          # no placeholder word in sight — and would have shipped to users
+          # describing the previous release. Nothing here can read them, but git
+          # knows whether anyone touched them since the last mobile release, and
+          # notes that have not moved since then either describe that release or
+          # were never reviewed. Both are worth stopping for.
+          previous=$(git describe --tags --match 'mobile-v*' --abbrev=0 "$GITHUB_REF_NAME^" 2>/dev/null || true)
+          if [ -n "$previous" ]; then
+            touched=$(git diff --name-only "$previous" "$GITHUB_REF_NAME" -- .github/whatsnew | wc -l)
+            if [ "$touched" -eq 0 ]; then
+              echo "::error::.github/whatsnew has not changed since $previous, so these notes describe THAT release. Rewrite them for this version and re-tag."
+              fail=1
+            fi
+          else
+            echo "::notice::No earlier mobile tag to compare against — skipping the staleness check."
+          fi
+
           if [ "$fail" -ne 0 ]; then
             echo "::error::Release-notes check failed. Update .github/whatsnew/whatsnew-{en-US,es-ES} (see CONTRIBUTING.md) and re-tag."
             exit 1
           fi
-          echo "Release notes present and within Google Play's 500-char limit."
+          echo "Release notes present, current, and within Google Play's 500-char limit."
 
       # Non-negotiable release rule: the Flutter project's version MUST be bumped to
       # the release version and committed+pushed BEFORE tagging, so uxnanmobile/

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -33,10 +33,11 @@ which files carry a version) and the **machinery** that follows it.
 
 **Automated.** Working out whether a component genuinely changed, computing the
 next version, writing it into every version-bearing file, proving those files
-agree, committing, tagging, pushing the tag, opening the pull request that brings
-all of it into `main` **and merging it once its checks pass**, and — for a desktop
-**nightly** — writing the release notes and publishing. A nightly at 00:20 local
-therefore finishes on its own, with nobody awake.
+agree, **heading the CHANGELOG with that version**, committing, tagging, pushing
+the tag, opening the pull request that brings all of it into `main` **and merging
+it once its checks pass**, and — for a desktop **nightly** — writing the release
+notes and publishing. A nightly at 00:20 local therefore finishes on its own,
+with nobody awake.
 
 **Not automated, on purpose.**
 
@@ -44,17 +45,21 @@ therefore finishes on its own, with nobody awake.
   signatures, `latest.json`, and its notes already written. Pressing *Publish* is
   the moment it becomes the default download and the updater starts offering it.
   That is a judgement call, not a build step.
-- **The CHANGELOG.** The tooling never writes your prose. Rename
-  `## [Unreleased]` to the version yourself before cutting a stable desktop
-  build, or any shared / bridge / relay / mobile release. (Desktop *nightlies*
-  deliberately do not convert it — a run of them piles up under `[Unreleased]`
-  and the next stable absorbs the lot.)
+- **CHANGELOG *entries*.** The heading is written for you — it is a version and
+  a date, and the cut already knows both. The prose under it is not: every entry
+  is authored in the pull request that changed the behaviour, which is the only
+  place anyone knows what happened. If `[Unreleased]` is empty at cut time the
+  run says so out loud, because a release with nothing to tell anyone is a
+  mistake, not a style.
 - **Google Play's "what's new", for a mobile release.**
   `.github/whatsnew/whatsnew-en-US` and `whatsnew-es-ES` must describe *this*
-  version in plain, non-technical language, **≤ 500 characters each**.
-  `release-mobile.yml` fails the release when either is missing, empty, a
-  leftover placeholder, or over the limit — so a stale file does not ship quietly,
-  it stops the cut.
+  version in plain, non-technical language, **≤ 500 characters each**. A workflow
+  can check shape, never meaning — so it checks everything about them that is
+  mechanical: present, non-empty, under the limit, not a placeholder, **and
+  touched since the previous `mobile-v*` tag**. That last one exists because the
+  notes for 0.0.19 were valid prose about 0.0.18 and would have shipped: files
+  nobody has edited since the last release either describe that release or were
+  never reviewed.
 
 ---
 
@@ -262,8 +267,9 @@ run at all.
    component genuinely has something to release.
 2. **Write the version.** `npm run release:prepare -- <component> [--channel=nightly]`
    computes it, refuses it if the base would not move past every channel, writes
-   every file from the registry, reads them back, and prints the exact commit and
-   tag commands. It never commits, tags or pushes.
+   every file from the registry, heads the CHANGELOG with it, reads the version
+   files back, and prints the exact commit and tag commands. It never commits,
+   tags or pushes. `--dry-run` prints all of it and writes nothing.
 3. **Mobile only, and non-negotiable:** commit **and push** the `pubspec.yaml`
    bump *before* tagging, so the tagged commit carries the matching version. Also
    rewrite `.github/whatsnew/whatsnew-en-US` and `whatsnew-es-ES` — a short,

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -91,6 +91,7 @@ way to be wrong.
 | `git.mjs` | the only place that shells out to git |
 | `plan.mjs` | what to cut, in what order — the workflow's decisions |
 | `notes.mjs` | the release body, with the baseline pinned |
+| `changelog.mjs` | heads `[Unreleased]` with the version being cut — and knows a desktop nightly must not |
 
 `node --test "scripts/release/*.test.mjs"` (also part of the root `npm test`)
 covers all of it, including the failures that have actually shipped here: a

--- a/scripts/release/changelog.mjs
+++ b/scripts/release/changelog.mjs
@@ -1,0 +1,67 @@
+/**
+ * The `[Unreleased]` heading, converted at cut time.
+ *
+ * This used to be a human step, and it should never have been one. The tooling
+ * does not write the *prose* — every entry is authored in the pull request that
+ * changes the behaviour, which is the only place anyone knows what happened.
+ * But the heading is not prose: it is the version and the date, both of which
+ * the cut has already computed and written into five other files. Leaving it out
+ * meant a release could not be cut without a person editing Markdown first, and
+ * that person could get the version wrong in a way nothing checked.
+ *
+ * One rule is genuinely conditional, and it is a rule rather than a judgement:
+ * **a desktop nightly does not convert**. A run of nightlies deliberately piles
+ * under `[Unreleased]` and the next stable absorbs the lot, so converting on
+ * each one would shred a release's notes into ten fragments nobody reads.
+ */
+
+/** Matches the `## [Unreleased]` line, however it is spaced. */
+const UNRELEASED = /^##\s*\[Unreleased\]\s*$/m;
+
+/**
+ * True when this cut should convert the heading: everything except a desktop
+ * nightly.
+ */
+export function convertsHeading({ kind, channel }) {
+  return !(kind === 'desktop' && channel === 'nightly');
+}
+
+/**
+ * Renames `## [Unreleased]` to the version being cut and opens a fresh empty
+ * `[Unreleased]` above it.
+ *
+ * Idempotent on the version: a retried cut, or a workflow re-run, must not
+ * stamp the same version twice. Returns `{ markdown, converted, reason }` so the
+ * caller can report honestly rather than guess.
+ */
+export function convertHeading(markdown, { version, date }) {
+  const text = String(markdown ?? '');
+
+  if (text.includes(`## [${version}]`)) {
+    return { markdown: text, converted: false, reason: `${version} already has a heading` };
+  }
+  if (!UNRELEASED.test(text)) {
+    return { markdown: text, converted: false, reason: 'no [Unreleased] heading to convert' };
+  }
+
+  return {
+    markdown: text.replace(UNRELEASED, `## [Unreleased]\n\n## [${version}] - ${date}`),
+    converted: true,
+  };
+}
+
+/**
+ * What sits under `[Unreleased]` right now, trimmed.
+ *
+ * A release whose notes are empty is worth saying out loud: it means every
+ * change that earned this version arrived without a line describing it, and the
+ * published release will say nothing to whoever installs it.
+ */
+export function unreleasedBody(markdown) {
+  const text = String(markdown ?? '');
+  const start = text.search(UNRELEASED);
+  if (start === -1) return '';
+  const after = text.slice(start).replace(UNRELEASED, '');
+  const next = after.search(/^##\s+/m);
+  return (next === -1 ? after : after.slice(0, next)).trim();
+}

--- a/scripts/release/changelog.test.mjs
+++ b/scripts/release/changelog.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { convertHeading, convertsHeading, unreleasedBody } from './changelog.mjs';
+
+const CHANGELOG = [
+  '# Changelog — uxnan-bridge',
+  '',
+  'Format: [Keep a Changelog](https://keepachangelog.com/).',
+  '',
+  '## [Unreleased]',
+  '',
+  '### Fixed — a tool step could be announced out of order',
+  '',
+  'Prose about the fix.',
+  '',
+  '## [0.0.20-alpha.20260812] - 2026-08-12',
+  '',
+  '### Added — something older',
+  '',
+].join('\n');
+
+describe('convertsHeading', () => {
+  it('converts for npm packages, mobile and a desktop stable', () => {
+    assert.equal(convertsHeading({ kind: 'npm', channel: 'stable' }), true);
+    assert.equal(convertsHeading({ kind: 'mobile', channel: 'stable' }), true);
+    assert.equal(convertsHeading({ kind: 'desktop', channel: 'stable' }), true);
+  });
+
+  it('never converts for a desktop nightly', () => {
+    // A run of nightlies piles under [Unreleased] on purpose; the next stable
+    // absorbs the lot. Converting each one would shred the notes.
+    assert.equal(convertsHeading({ kind: 'desktop', channel: 'nightly' }), false);
+  });
+});
+
+describe('convertHeading', () => {
+  it('renames the heading and opens a fresh empty one above it', () => {
+    const { markdown, converted } = convertHeading(CHANGELOG, {
+      version: '0.0.21-alpha.20260812',
+      date: '2026-08-12',
+    });
+
+    assert.equal(converted, true);
+    const lines = markdown.split('\n');
+    const unreleased = lines.indexOf('## [Unreleased]');
+    const cut = lines.indexOf('## [0.0.21-alpha.20260812] - 2026-08-12');
+    assert.ok(unreleased !== -1, 'a fresh [Unreleased] stays at the top');
+    assert.ok(cut > unreleased, 'and the version sits under it');
+    // The entries that were under [Unreleased] belong to the version now.
+    assert.ok(markdown.indexOf('### Fixed — a tool step') > cut);
+    // Older releases are untouched.
+    assert.ok(markdown.includes('## [0.0.20-alpha.20260812] - 2026-08-12'));
+  });
+
+  it('does not stamp the same version twice', () => {
+    const once = convertHeading(CHANGELOG, { version: '0.0.21', date: '2026-08-12' });
+    const twice = convertHeading(once.markdown, { version: '0.0.21', date: '2026-08-13' });
+
+    assert.equal(twice.converted, false);
+    assert.match(twice.reason, /already has a heading/);
+    assert.equal(twice.markdown, once.markdown, 'a retried cut changes nothing');
+  });
+
+  it('says so rather than guessing when there is no [Unreleased]', () => {
+    const { converted, reason } = convertHeading('# Changelog\n\n## [0.0.1] - 2026-01-01\n', {
+      version: '0.0.2',
+      date: '2026-08-12',
+    });
+    assert.equal(converted, false);
+    assert.match(reason, /no \[Unreleased\]/);
+  });
+
+  it('survives an empty or absent file', () => {
+    assert.equal(convertHeading('', { version: '1.0.0', date: 'x' }).converted, false);
+    assert.equal(convertHeading(undefined, { version: '1.0.0', date: 'x' }).converted, false);
+  });
+});
+
+describe('unreleasedBody', () => {
+  it('is what would become the release notes', () => {
+    assert.match(unreleasedBody(CHANGELOG), /^### Fixed/);
+    assert.ok(!unreleasedBody(CHANGELOG).includes('0.0.20-alpha'), 'stops at the next heading');
+  });
+
+  it('is empty when nothing was written — which is worth reporting', () => {
+    const bare = '# Changelog\n\n## [Unreleased]\n\n## [0.0.1] - 2026-01-01\n';
+    assert.equal(unreleasedBody(bare), '');
+  });
+});

--- a/scripts/release/prepare.mjs
+++ b/scripts/release/prepare.mjs
@@ -12,11 +12,14 @@
  * commands so the tag can never disagree with the files it just wrote.
  */
 
+import { readFileSync, writeFileSync } from 'node:fs';
+
 import { inspect } from './changes.mjs';
 import { applyVersion, versionForFiles } from './bump.mjs';
+import { convertHeading, convertsHeading, unreleasedBody } from './changelog.mjs';
 import { component } from './components.mjs';
 import { tagsFor, workingTreeState } from './git.mjs';
-import { assertMovesForward } from './version.mjs';
+import { assertMovesForward, dateStamp } from './version.mjs';
 
 const [id, ...rest] = process.argv.slice(2);
 const flag = (name) =>
@@ -81,7 +84,38 @@ for (const change of applyVersion(id, version, { dryRun })) {
 }
 
 console.log(dryRun ? '\n(dry run — nothing written)\n' : '\nAll version files agree.\n');
-console.log('Next, once the CHANGELOG entry is under the right heading:\n');
+// The CHANGELOG heading is a version and a date, which makes it this script's
+// business and not a person's. The entries under it stay authored where they
+// belong: in the pull request that changed the behaviour.
+const changelogPath = `${meta.path}/CHANGELOG.md`;
+if (!convertsHeading({ kind: meta.kind, channel })) {
+  console.log('CHANGELOG: left at [Unreleased] — a nightly piles up until the next stable.\n');
+} else {
+  let current = '';
+  try {
+    current = readFileSync(changelogPath, 'utf8');
+  } catch {
+    console.log(`CHANGELOG: ${changelogPath} not found — skipped.\n`);
+  }
+  if (current) {
+    if (unreleasedBody(current) === '') {
+      console.log(
+        `CHANGELOG: WARNING — [Unreleased] is empty, so ${version} would ship with nothing to tell anyone.`,
+      );
+    }
+    const heading = convertHeading(current, { version, date: dateStamp() });
+    if (!heading.converted) {
+      console.log(`CHANGELOG: unchanged — ${heading.reason}.\n`);
+    } else if (dryRun) {
+      console.log(`CHANGELOG: would head ${changelogPath} with [${version}].\n`);
+    } else {
+      writeFileSync(changelogPath, heading.markdown);
+      console.log(`CHANGELOG: ${changelogPath} now heads with [${version}].\n`);
+    }
+  }
+}
+
+console.log('Next:\n');
 console.log(`  git commit -am "chore(release): ${id} ${version}"`);
 console.log(`  git tag ${tag}`);
 console.log(`  git push origin main --tags\n`);


### PR DESCRIPTION
"The tooling never writes your prose" conflated two things. The **entries** are prose — authored in the PR that changed the behaviour, uninventable by a workflow. The **heading** is a version and a date, both computed a line earlier and written into five other files. Leaving it to a person meant no release could be cut without someone editing Markdown first, and getting it wrong was unchecked.

`changelog.mjs` heads `[Unreleased]` with the version being cut, idempotently, and knows the one conditional rule: a **desktop nightly never converts** (they pile up on purpose; the next stable absorbs them). It also reports an empty `[Unreleased]` — a release with nothing to tell anyone is a mistake, not a style.

**Play notes now have to be current too.** 0.0.19's notes were valid prose about 0.0.18 and would have shipped. A workflow can't read meaning, but git knows whether anyone touched them since the last `mobile-v*` tag.

79 tests passing.