### PR TITLE
fix(ui): stop the OS back button from closing the app

### DIFF
--- a/architecture/02a-system-architecture.md
+++ b/architecture/02a-system-architecture.md
@@ -1039,6 +1039,30 @@ final projectsProvider = StreamProvider<List<Project>>((ref) => ...);
 > el `Navigator` de la `ShellRoute`, y `GoRouterDelegate.popRoute` — a donde va
 > el boton atras del sistema — lo desreferencia sin comprobar. Sustituirlo por
 > otro widget en alguna ruta rompe el boton atras en TODA la app.
+>
+> **Un unico ambito responde por el boton atras, y esta montado en TODA ruta.**
+> Android no pregunta cuando se pulsa atras: actua sobre una afirmacion que la
+> app publica *antes*
+> (`SystemNavigator.setFrameworkHandlesBack`, que Flutter deriva de la ultima
+> `NavigationNotification` que llega a `WidgetsApp`). Como `AppShell` envuelve
+> al `Navigator` de la `ShellRoute`, ese ambito queda registrado en la ruta que
+> esta **por encima** de ese navigator, y de ahi salen dos reglas que ya se
+> incumplieron una vez:
+>
+> - **Devolver `child` pelado en una ruta desregistra el ambito**, y eso publica
+>   "esta app no gestiona atras". El sistema cerraba la app en vez de salir de
+>   Ajustes, mientras la flecha de la barra — un pop directo, que nunca pasa por
+>   el sistema — seguia funcionando en la misma pantalla.
+> - **El navigator de abajo puede contradecirlo.** Publica lo suyo en cada
+>   cambio de historial; un `Navigator` normal corrige un "no puedo" de su
+>   subarbol cuando el si puede, pero nada corrige el que viene de un navigator
+>   *por debajo* de la ruta que responde. Un panel abierto con `go` deja una
+>   sola pagina y anula asi el "atras vacia el panel" de la tablet. La
+>   correccion la hace el propio ambito mientras atras sea de la app.
+>
+> Lo que significa atras no cambia: sacar la pantalla que abriste; con drawer
+> permanente, vaciar el panel; en telefono sin nada que sacar, subir en la
+> jerarquia; y en la vista general, salir de la app.
 
 ```
 lib/presentation/

--- a/architecture/02c-implementation-guide.md
+++ b/architecture/02c-implementation-guide.md
@@ -1335,6 +1335,55 @@ que es justo donde arranca una tablet. Lo que la raiz **muestra** es asunto de
 la ruta (`AppRoutes.home` devuelve la portada en telefono y el panel tranquilo
 junto al drawer), nunca del shell.
 
+**`_SystemBack` es el unico que responde por el boton atras, y va montado en
+toda ruta** — incluidas las de pantalla completa, que antes devolvian `child`
+pelado. Android no pregunta cuando se pulsa: actua sobre
+`SystemNavigator.setFrameworkHandlesBack`, que Flutter deriva de la ultima
+`NavigationNotification` que llega a `WidgetsApp`. Como `AppShell` esta por
+encima del `Navigator` del router, su `PopScope` se registra en la ruta de
+arriba, y eso obliga a dos cosas:
+
+```dart
+// app_shell.dart — un solo ambito, siempre en el mismo sitio del arbol.
+PopScope(
+  // Atras es de la app en todas partes menos en la vista general, donde ya no
+  // queda nada y debe salir como en cualquier otra app de Android.
+  canPop: location == AppRoutes.home,
+  onPopInvokedWithResult: (didPop, _) {
+    if (didPop || location == AppRoutes.home) return;
+    final nested = shellNavigatorKey.currentState;
+    if (nested != null && nested.canPop()) {
+      nested.pop();
+      return;
+    }
+    context.go(
+      context.hasPermanentPane ? AppRoutes.home : parentOf(location, context),
+    );
+  },
+  child: NotificationListener<NavigationNotification>(
+    onNotification: (n) {
+      // La misma correccion que hace un Navigator con SU subarbol: un "no
+      // puedo" que viene de abajo no puede anular a quien si va a responder.
+      if (n.canHandlePop || location == AppRoutes.home) return false;
+      const NavigationNotification(canHandlePop: true).dispatch(context);
+      return true;
+    },
+    child: child,
+  ),
+)
+```
+
+1. **Desmontar el ambito publica "esta app no gestiona atras".** Devolver
+   `child` pelado en ajustes/perfil/pairing/onboarding cerraba la app al pulsar
+   atras, mientras la flecha de la barra — un pop directo, que no pasa por el
+   sistema — funcionaba en esa misma pantalla. Entrar a una de esas rutas desde
+   una pantalla mas profunda no tocaba el shell, asi que la afirmacion anterior
+   seguia en pie y atras funcionaba: por eso parecia que habia dos perfiles.
+2. **El navigator de abajo publica lo suyo en cada cambio de historial**, y sale
+   por encima del `PopScope` en vez de a traves de el. Un panel abierto con `go`
+   deja una sola pagina que dice "nada que sacar", y eso anulaba el "atras vacia
+   el panel" de la tablet. De ahi el `NotificationListener`.
+
 ---
 
 ## 4. Plan de pruebas

--- a/uxnanmobile/CHANGELOG.md
+++ b/uxnanmobile/CHANGELOG.md
@@ -6,6 +6,46 @@ and the project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed — back from Settings returned to the launcher instead of the overview
+
+On a phone, opening Settings from the overview and pressing Android's back
+button left the app. Same from Profile. The app bar's own arrow worked from
+those very screens, and so did back from anywhere deeper — overview → Settings →
+Profile went back to Settings normally — which made it look like there were two
+Profile screens. There is one, at one route; what differed was the depth.
+
+Android does not ask the app when back is pressed. Through the predictive-back
+dispatcher — which this app is on, targeting SDK 36 — the platform acts on a
+claim published *ahead* of the press: `SystemNavigator.setFrameworkHandlesBack`,
+which Flutter derives from the last `NavigationNotification` to reach
+`WidgetsApp`. When that claim says the framework does not handle back, the
+platform closes the activity without ever calling into Flutter — which is
+exactly why the arrow, and every in-app pop, kept working on the screens that
+were leaving the app.
+
+The shell returned the router's navigator **bare** on its four full-screen
+routes (onboarding, pairing, settings, profile). That unregistered the scope
+answering for back and published precisely that claim. Reaching one of those
+routes from a deeper screen changed nothing in the shell, so the earlier claim
+stood and back behaved.
+
+The same false claim was reaching tablets from the other direction. A pane
+opened with `go` **replaces** the route rather than stacking on it, so the
+shell's navigator holds a single page and publishes its own "nothing to pop" —
+from below the scope answering for back, and late enough to overrule it. The
+first back press on a deep-linked conversation therefore closed an app visibly
+full of work, in spite of the handler written to empty the pane instead.
+
+The shell now mounts one back scope on **every** route, at one fixed place in
+the tree, and replaces a "nothing to pop" coming from below with the truth on
+its way up — the same upgrade an ordinary `Navigator` performs for its own
+subtree. Layouts, the route table and what every screen renders are untouched:
+back pops the screen you opened, empties the pane on a tablet, and still leaves
+the app from the overview, where there is genuinely nothing left.
+
+Eight tests pin both halves at both widths: the claim the app publishes before
+the press, and what the press then does.
+
 ## [0.0.20-alpha.20260812+20260812] - 2026-08-12
 
 ### Changed — a long reply no longer slows itself down while it streams

--- a/uxnanmobile/docs/architecture.md
+++ b/uxnanmobile/docs/architecture.md
@@ -76,9 +76,36 @@ Rule of thumb: `domain` never imports Flutter; `presentation` never reaches into
 
 **Wide windows get a permanent drawer, and only that changes.** `AppShell`
 (`presentation/screens/shell/app_shell.dart`) is the `ShellRoute` builder: on
-compact and medium it returns the routed screen *literally*, so the phone's
-screen stack and back behaviour are untouched; on expanded and above it puts
-that screen in `TwoPaneScaffold`'s content pane beside `NavDrawer`.
+compact and medium it returns the routed screen as-is, so the phone keeps its
+plain screen stack; on expanded and above it puts that screen in
+`TwoPaneScaffold`'s content pane beside `NavDrawer`.
+
+**One place answers the system back button, on every route.** `_SystemBack`
+(same file) wraps the shell at one fixed spot in the tree, and it has to be
+exactly one, always mounted, because of *where* the router's `Navigator` sits:
+`AppShell` is above it, so the scope registers on the route **above** that
+navigator. Two things follow, and both shipped as bugs before they were
+understood.
+
+Android acts on a claim published *before* the press —
+`SystemNavigator.setFrameworkHandlesBack`, derived from the last
+`NavigationNotification` to reach `WidgetsApp` — and a route publishes one
+whenever its pop entries change. Returning the navigator bare on the
+full-screen routes removed that scope and published "this app does not handle
+back", so the OS closed the app rather than popping Settings, while the app
+bar's arrow (a direct pop, never routed through the OS) kept working.
+
+And the navigator underneath publishes its own claim on every history change,
+from below the scope: an ordinary `Navigator` upgrades a "cannot pop" from its
+subtree when it *can* pop, but nothing upgrades one that comes from a navigator
+below the route answering for it. A pane opened with `go` holds one page and
+says "nothing to pop", which overruled the tablet's own back handling. So
+`_SystemBack` performs that upgrade itself while back is the app's to answer.
+
+What back then means is unchanged: pop the screen you opened; with a permanent
+drawer, empty the pane (`closePane`'s rule, for a deep link that left nothing
+behind); on a phone with nothing to pop, walk up the hierarchy the phone would
+have built; and at the overview, leave the app.
 
 **Destinations are never wrapped.** Onboarding and pairing because there is
 nothing to navigate to yet (and pairing would offer to switch to a PC you are

--- a/uxnanmobile/docs/conventions.md
+++ b/uxnanmobile/docs/conventions.md
@@ -134,6 +134,27 @@ spec, the spec wins.
     *went*, not something you opened from a list, so they own the window and the
     drawer steps aside — see `AppShell.isFullScreen`.
 
+- **Which navigation API depends on what the screen IS.** Both are in use, and
+  mixing them is the design, not drift:
+
+  | The screen is… | Open it with | Why |
+  |---|---|---|
+  | a **destination** you went to | `context.push` / `context.go` (go_router) | it is in the flat route table, so deep links and push notifications reach it |
+  | **content** opened from a list | `context.openInPane` | a tap means two different things by width, and this is the one place that decides (`router/pane_navigation.dart`) |
+  | a **child** of what is already open | `Navigator.of(context).push` + a `static push(...)` on the screen | it lands in the nearest navigator, which is the pane's — so it stacks inside instead of taking the window |
+
+  Going back is `Navigator.of(context).maybePop()` — the app bar's arrow
+  (`NeTopBar`) and every screen that draws its own. **Never `context.pop()`**,
+  which is why there are zero of them: a raw `Navigator.push` puts pages
+  go_router does not know about on top of the route, so `context.pop` pops the
+  *route underneath* and leaves the child covering the screen. The same
+  mismatch is why `openInPane` empties `shellNavigatorKey` before it calls
+  `go`.
+
+  The OS back button reaches none of this directly — it goes to
+  `GoRouterDelegate.popRoute`, and what the app tells Android about it lives in
+  `AppShell._SystemBack` (see [`architecture.md`](architecture.md)).
+
 - **Icons come from the catalogue, never from the package.** `UxIcons`
   (`presentation/theme/icons.dart`) names every glyph for what it MEANS, and
   `UxIcon` (`presentation/widgets/ux_icon.dart`) is the only widget that talks

--- a/uxnanmobile/lib/presentation/screens/shell/app_shell.dart
+++ b/uxnanmobile/lib/presentation/screens/shell/app_shell.dart
@@ -65,27 +65,24 @@ class AppShell extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final location = this.location ?? GoRouterState.of(context).uri.path;
-    if (isFullScreen(location)) return child;
 
+    // The system-back answer wraps EVERY route — including the full-screen
+    // ones, which used to return `child` bare. See [_SystemBack]: on Android
+    // that bare return is what told the OS the app does not handle back at
+    // all, and the OS then closed it instead of popping Settings.
+    return _SystemBack(
+      location: location,
+      child: isFullScreen(location) ? child : _layout(context, ref, location),
+    );
+  }
+
+  /// The routed screen, alone on a phone and beside the drawer on a window
+  /// wide enough to hold one.
+  Widget _layout(BuildContext context, WidgetRef ref, String location) {
     return LayoutBuilder(
       builder: (context, constraints) {
         final breakpoint = UxnanBreakpoint.fromWidth(constraints.maxWidth);
-        if (!breakpoint.usesPermanentPane) {
-          // Narrow, but the route may have been REPLACED while the window was
-          // wide — rotate a tablet with a conversation open and the phone
-          // layout inherits a stack of exactly one page. Back would leave the
-          // app from a screen you reached by tapping into it, which no phone
-          // does. So back walks the hierarchy the phone would have built.
-          return PopScope(
-            canPop: location == AppRoutes.home,
-            onPopInvokedWithResult: (didPop, _) {
-              if (didPop || location == AppRoutes.home) return;
-              if (Navigator.of(context).canPop()) return;
-              context.go(parentOf(location, context));
-            },
-            child: child,
-          );
-        }
+        if (!breakpoint.usesPermanentPane) return child;
 
         // Published so the drawer's list can mark the row you are reading.
         // Beside a permanent drawer the list never leaves the screen, and a
@@ -96,35 +93,111 @@ class AppShell extends ConsumerWidget {
           ref.read(openThreadProvider.notifier).set(open);
         });
 
-        return PopScope(
-          // With a drawer up, back must empty the CONTENT, not the app. A deep
-          // link (a push notification) arrives with nothing behind it, so the
-          // route stack cannot pop — and without this the first back press on
-          // a tablet closes an app that is visibly full of your work.
-          canPop: location == AppRoutes.home,
-          onPopInvokedWithResult: (didPop, _) {
-            if (didPop || location == AppRoutes.home) return;
-            context.go(AppRoutes.home);
-          },
-          child: TwoPaneScaffold(
-            pane: NavDrawer(
-              deviceId: ref.watch(shellDeviceProvider(threadIdOf(location))),
-            ),
-            // ALWAYS `child`, on every route and every width.
-            //
-            // `child` is not just the screen — it is the router's own
-            // `Navigator`, the one carrying [shellNavigatorKey]. Swapping it
-            // for another widget (the root used to get [ShellWelcome] here)
-            // unmounts that navigator, and `GoRouterDelegate.popRoute` walks
-            // every shell match dereferencing `navigatorKey.currentState!`.
-            // The OS back button then threw a null-check error instead of
-            // going back — on a tablet sitting at the overview, which is where
-            // it starts. What the root shows is the ROUTE's business, and
-            // [AppRoutes.home] answers it (see `app_router.dart`).
-            detail: child,
+        return TwoPaneScaffold(
+          pane: NavDrawer(
+            deviceId: ref.watch(shellDeviceProvider(threadIdOf(location))),
           ),
+          // ALWAYS `child`, on every route and every width.
+          //
+          // `child` is not just the screen — it is the router's own
+          // `Navigator`, the one carrying [shellNavigatorKey]. Swapping it
+          // for another widget (the root used to get [ShellWelcome] here)
+          // unmounts that navigator, and `GoRouterDelegate.popRoute` walks
+          // every shell match dereferencing `navigatorKey.currentState!`.
+          // The OS back button then threw a null-check error instead of
+          // going back — on a tablet sitting at the overview, which is where
+          // it starts. What the root shows is the ROUTE's business, and
+          // [AppRoutes.home] answers it (see `app_router.dart`).
+          detail: child,
         );
       },
+    );
+  }
+}
+
+/// The app's single answer to the OS back button and the back gesture.
+///
+/// It has to be a single one, and it has to be here, because of where the
+/// router's own `Navigator` sits: [AppShell] wraps it, so this widget's
+/// [PopScope] registers on the route **above** that navigator — the shell's
+/// page in the root navigator. Two consequences drove every line below, and
+/// both of them shipped as bugs.
+///
+/// **Android decides before it ever asks.** Predictive back reads
+/// `SystemNavigator.setFrameworkHandlesBack`, which Flutter derives from the
+/// last [NavigationNotification] to reach `WidgetsApp`. A route only emits one
+/// when its pop entries change — and removing this [PopScope] (what the
+/// full-screen routes did by returning `child` bare) emits `false`. From then
+/// on the OS took back for itself: opening Settings from the overview and
+/// pressing back CLOSED THE APP, while the app bar's own arrow — which pops
+/// the navigator directly, never consulting the OS — kept working. Reaching
+/// Settings from anywhere deeper hid it, because pushing onto an already-deep
+/// stack changes nothing here and leaves the last notification saying `true`.
+/// So the scope is now mounted on every route, at one fixed spot in the tree.
+///
+/// **The navigator underneath can contradict it.** It emits its own
+/// notification on every history change, from below this widget, so it is
+/// dispatched past the [PopScope] rather than through it — an ordinary
+/// `Navigator` upgrades a `false` from its subtree to `true` when it can pop,
+/// but nothing upgrades one that comes from a navigator *below* the route
+/// answering for it. A pane opened with `go` leaves exactly one page, that one
+/// page says "nothing to pop", and the tablet's own back handling was
+/// overruled the same way. The listener here does what `Navigator` does with
+/// its subtree: while back is ours to answer, a `false` from below is replaced
+/// with the truth on its way up.
+class _SystemBack extends StatelessWidget {
+  const _SystemBack({required this.location, required this.child});
+
+  /// The active route.
+  final String location;
+
+  final Widget child;
+
+  /// Whether back is this app's to answer rather than the OS's.
+  ///
+  /// Everywhere except the overview: either there is a screen to pop, or
+  /// there is a pane to empty / a parent to walk up to. At the overview there
+  /// is genuinely nothing left, and back must leave the app like it does in
+  /// every other Android app.
+  bool get _ours => location != AppRoutes.home;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: !_ours,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop || !_ours) return;
+        // Reached only when the router chose the ROOT navigator, i.e. the
+        // shell's stack had nothing to pop. Guarded anyway: a pop that IS
+        // available is always the right answer, and never this fallback.
+        final nested = shellNavigatorKey.currentState;
+        if (nested != null && nested.canPop()) {
+          nested.pop();
+          return;
+        }
+        // Nothing was left behind. With a permanent drawer back CLOSES what is
+        // open (the drawer, which never moved, is what remains); on a phone —
+        // rotate a tablet with a conversation open and this is exactly where
+        // you land — it walks the hierarchy the phone would have built.
+        context.go(
+          context.hasPermanentPane
+              ? AppRoutes.home
+              : parentOf(location, context),
+        );
+      },
+      child: NotificationListener<NavigationNotification>(
+        onNotification: (notification) {
+          // Same rule `Navigator` applies to its own subtree: a subtree that
+          // can handle a pop, or a state we are not answering for, passes
+          // through untouched.
+          if (notification.canHandlePop || !_ours) return false;
+          // Dispatched from THIS context — above the listener, so it does not
+          // come back around — exactly as `Navigator` re-dispatches.
+          const NavigationNotification(canHandlePop: true).dispatch(context);
+          return true;
+        },
+        child: child,
+      ),
     );
   }
 }

--- a/uxnanmobile/test/widget/presentation/system_back_test.dart
+++ b/uxnanmobile/test/widget/presentation/system_back_test.dart
@@ -1,0 +1,248 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:uxnan/domain/entities/agent_descriptor.dart';
+import 'package:uxnan/domain/enums/connection_transport.dart';
+import 'package:uxnan/domain/value_objects/metrics_snapshot.dart';
+import 'package:uxnan/domain/value_objects/profile_metrics.dart';
+import 'package:uxnan/l10n/app_localizations.dart';
+import 'package:uxnan/presentation/providers/application_providers.dart';
+import 'package:uxnan/presentation/router/app_router.dart';
+import 'package:uxnan/presentation/screens/devices/my_devices_screen.dart';
+import 'package:uxnan/presentation/screens/settings/settings_screen.dart';
+import 'package:uxnan/presentation/screens/shell/nav_drawer.dart';
+import 'package:uxnan/presentation/screens/shell/shell_welcome.dart';
+
+/// The OS back button, end to end — and the claim the app makes about it
+/// BEFORE it is ever pressed.
+///
+/// On Android the press is not the decision. Predictive back reads
+/// `SystemNavigator.setFrameworkHandlesBack`, which Flutter derives from the
+/// last `NavigationNotification` to reach `WidgetsApp`; when that says `false`
+/// the OS keeps the gesture and closes the app without asking Flutter at all.
+/// That is why this went unnoticed for so long: `handlePopRoute` — and the app
+/// bar's own arrow, which pops the navigator directly — kept working on the
+/// exact screens where a real phone was leaving the app.
+///
+/// So every test here checks BOTH halves: what the app told the OS, and what
+/// the press actually did. Reported from a phone: opening Settings from the
+/// overview and pressing back closed the app.
+Future<void> main() async {
+  /// Every `setFrameworkHandlesBack` claim, in order. The LAST one is what the
+  /// OS is acting on.
+  late List<bool> claims;
+
+  /// Set when the app asked the OS to close it.
+  late List<String> exits;
+
+  setUp(() {
+    claims = <bool>[];
+    exits = <String>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      switch (call.method) {
+        case 'SystemNavigator.setFrameworkHandlesBack':
+          claims.add(call.arguments as bool);
+        case 'SystemNavigator.pop':
+          exits.add(call.method);
+      }
+      return null;
+    });
+  });
+
+  /// Pumps the REAL router: the shell navigator, and therefore the whole
+  /// question of which navigator answers back, exists only there.
+  Future<GoRouter> pump(WidgetTester tester, {required double width}) async {
+    tester.view.physicalSize = Size(width, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    final container = ProviderContainer(
+      overrides: [
+        // Keeps the overview's and the drawer's own data out of a test about
+        // navigation — otherwise the real database opens and the test ends
+        // with pending timers.
+        metricsSnapshotsProvider.overrideWith(_EmptyMetrics.new),
+        // An EMPTY snapshot cache falls back to aggregating the whole local
+        // database, which opens drift for real; the profile route is one of
+        // the four this test walks.
+        profileMetricsProvider.overrideWith((ref) async => _noMetrics),
+        activityHeatmapProvider.overrideWith((ref, arg) async => const {}),
+        // Its agent breakdown asks the bridge, and an unanswered RPC leaves a
+        // 30 s timeout behind — on the tablet too, where Settings opens the
+        // profile into its own pane.
+        agentsProvider.overrideWith((ref) async => const <AgentDescriptor>[]),
+        profileNameProvider.overrideWith(_FixedName.new),
+        trustedDevicesProvider.overrideWith((ref) => Stream.value(const [])),
+        connectedDeviceProvider.overrideWith((ref) => Stream.value(null)),
+        connectingDeviceProvider.overrideWith((ref) => Stream.value(null)),
+        connectedEndpointProvider.overrideWith((ref) => Stream.value(null)),
+        threadsProvider.overrideWith((ref) => Stream.value(const [])),
+        threadActivityProvider.overrideWith((ref) => Stream.value(const {})),
+      ],
+    );
+    addTearDown(container.dispose);
+    final router = container.read(appRouterProvider);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    // `WidgetsApp` stays silent until the app is alive, so nothing reaches the
+    // engine — and nothing reaches this test — without it.
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+    return router;
+  }
+
+  /// Settles the notification, which is always dispatched post-frame.
+  Future<void> settle(WidgetTester tester) async {
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+  }
+
+  testWidgets('back from Settings returns to the overview, not to the launcher',
+      (tester) async {
+    // The reported bug, exactly as reported: overview → Settings → back.
+    final router = await pump(tester, width: 390);
+    unawaited(router.push(AppRoutes.settings));
+    await settle(tester);
+
+    expect(find.byType(SettingsScreen), findsOneWidget);
+    expect(
+      claims.last,
+      isTrue,
+      reason: 'the app told Android it does not handle back, so Android '
+          'closed it instead of popping Settings',
+    );
+
+    await tester.binding.handlePopRoute();
+    await settle(tester);
+
+    expect(find.byType(MyDevicesScreen), findsOneWidget);
+    expect(find.byType(SettingsScreen), findsNothing);
+    expect(exits, isEmpty, reason: 'the app left instead of going back');
+    // And once home, back belongs to the OS again — otherwise visiting
+    // Settings once would leave an app that can never be closed with back.
+    expect(claims.last, isFalse);
+  });
+
+  testWidgets('back at the overview leaves the app', (tester) async {
+    await pump(tester, width: 390);
+
+    expect(claims, isNot(contains(true)));
+    await tester.binding.handlePopRoute();
+    await settle(tester);
+
+    expect(exits, isNotEmpty, reason: 'the overview trapped the back button');
+  });
+
+  for (final route in [
+    AppRoutes.settings,
+    AppRoutes.profile,
+    AppRoutes.pairing,
+    AppRoutes.onboarding,
+  ]) {
+    testWidgets('a phone claims back on $route', (tester) async {
+      // These four are the app's full-screen routes, and the shell used to
+      // return the router's navigator BARE for them — which unregistered the
+      // scope answering for back and published "this app does not handle
+      // back". Every one of them closed the app; reaching one from a deeper
+      // screen hid it, because pushing onto an already-deep stack changes
+      // nothing in the shell and leaves the previous claim standing.
+      final router = await pump(tester, width: 390);
+      unawaited(router.push(route));
+      await settle(tester);
+
+      expect(claims.last, isTrue, reason: '$route handed back to the OS');
+
+      await tester.binding.handlePopRoute();
+      await settle(tester);
+
+      expect(find.byType(MyDevicesScreen), findsOneWidget);
+      expect(exits, isEmpty);
+    });
+  }
+
+  testWidgets('a destination opened over the drawer pops back to it',
+      (tester) async {
+    // Same bug on a tablet — Settings is full screen at every width, so it
+    // published the same claim there.
+    final router = await pump(tester, width: 1280);
+    unawaited(router.push(AppRoutes.settings));
+    await settle(tester);
+
+    expect(find.byType(NavDrawer), findsNothing);
+    expect(claims.last, isTrue);
+
+    await tester.binding.handlePopRoute();
+    await settle(tester);
+
+    expect(find.byType(NavDrawer), findsOneWidget);
+    expect(exits, isEmpty);
+  });
+
+  testWidgets('back empties a pane that was opened, not stacked',
+      (tester) async {
+    // Beside a permanent drawer, opening REPLACES the pane's route instead of
+    // stacking on it, so the navigator holds exactly one page and says it has
+    // nothing to pop. It says so from BELOW the scope that handles back here,
+    // which is late enough to overrule it: the tablet's "back empties the
+    // pane" was published to Android as "this app does not handle back", and
+    // the first press closed an app visibly full of your work.
+    final router = await pump(tester, width: 1280);
+    router.go(AppRoutes.deviceArchived('x'));
+    await settle(tester);
+
+    expect(find.byType(NavDrawer), findsOneWidget);
+    expect(claims.last, isTrue);
+
+    await tester.binding.handlePopRoute();
+    await settle(tester);
+
+    expect(find.byType(ShellWelcome), findsOneWidget);
+    expect(exits, isEmpty);
+  });
+}
+
+/// A profile with nothing in it: this test walks THROUGH the profile route,
+/// it never reads what the screen says.
+final _noMetrics = ProfileMetrics(
+  conversations: 0,
+  agentsUsed: 0,
+  modelsUsed: 0,
+  messages: 0,
+  gitActions: 0,
+  sessions: 0,
+  totalConnected: Duration.zero,
+  longestSession: Duration.zero,
+  relaySessions: 0,
+  directSessions: 0,
+  byAgent: const [],
+  memberSince: DateTime.utc(2026),
+  mostUsedTransport: ConnectionTransport.direct,
+);
+
+/// Metrics that resolve instantly with nothing, so the overview's header does
+/// not reach the cache store or schedule its refresh poll.
+class _EmptyMetrics extends MetricsController {
+  @override
+  Future<Map<String, MetricsSnapshot>> build() async => const {};
+}
+
+/// A profile name that needs no store behind it.
+class _FixedName extends ProfileName {
+  @override
+  String? build() => 'Tester';
+}


### PR DESCRIPTION
## The report

> "Estoy en un teléfono, si entro a configuraciones y uso el botón atrás de Android la app se cierra. Para regresar debo usar solo el botón atrás del appbar. Pasa lo mismo con perfiles — pero si entro a perfiles **desde** configuraciones, atrás sí funciona. ¿Acaso son dos pantallas?"

One screen, one route (`/profile`). What differed was the **depth**.

## Root cause

Android does not ask the app when back is pressed. Through the predictive-back dispatcher — which this app is on, targeting SDK 36 — the platform acts on a claim published *ahead* of the press: `SystemNavigator.setFrameworkHandlesBack`, which Flutter derives from the last `NavigationNotification` to reach `WidgetsApp`. When that claim says the framework does not handle back, the platform closes the activity **without ever calling into Flutter**.

That is why the app bar's arrow — a direct pop, never routed through the OS — kept working on the very screens that were leaving the app, and why `handlePopRoute()` in a test passed while a real phone closed.

`AppShell` returned the router's navigator **bare** on its four full-screen routes (onboarding, pairing, settings, profile). That unregistered the scope answering for back and published exactly that claim. Reaching one of those routes from a deeper screen changed nothing in the shell, so the earlier claim stood and back behaved — hence the "two Profile screens" impression.

**The same false claim reached tablets from the other direction.** A pane opened with `go` *replaces* the route rather than stacking on it, so the shell's navigator holds a single page and publishes its own "nothing to pop" — from below the scope answering for back, and late enough to overrule it. So back on a conversation open in the pane closed the app, despite the handler written to empty the pane instead.

## Measured, not theorised

Last value sent to the OS (`setFrameworkHandlesBack`) before and after:

| | before | after |
|---|---|---|
| phone `/settings` `/profile` `/pairing` `/onboarding` | **false** → app closes | true |
| phone `/device/x/threads` | true | true |
| phone `/settings` → `/profile` | true | true |
| tablet `/settings` pushed | **false** → app closes | true |
| tablet pane opened with `go` | **false** → app closes | true |

## The fix

One `_SystemBack` mounted on **every** route, at one fixed place in the tree, with `canPop: location == home` (the rule that was already there). It adds a `NotificationListener<NavigationNotification>` that upgrades a "cannot pop" coming from below — the same correction an ordinary `Navigator` performs for its own subtree.

Back still means what it meant: pop the screen you opened; with a permanent drawer, empty the pane; on a phone with nothing to pop, walk up the hierarchy; and at the overview, leave the app.

## Nothing about the layouts changed

`TwoPaneScaffold(pane: NavDrawer(...), detail: child)` is unchanged line for line — only the `PopScope` that wrapped it moved up. `isFullScreen` is untouched, so destinations still own the window and the drawer still steps aside. `PopScope` and `NotificationListener` are proxy widgets: the `LayoutBuilder` measures the same constraints, so the pane breakpoint is unaffected.

## Verification

- **`test/widget/presentation/system_back_test.dart`** — 8 new tests, phone and tablet, each checking **both halves**: the claim the app publishes before the press, and what the press then does. They pump the real router, mock `SystemChannels.platform`, and assert on `SystemNavigator.pop` (the app leaving) as well as on what is on screen.
- Full suite **1029 passing** (1021 + 8), `dart analyze` clean, `dart format` clean.
- The existing layout tests (`app_shell_test.dart`, `settings_two_pane_test.dart`, `shell_back_button_test.dart`) pass untouched — they are what pins the tablet behaviour.

## Docs synced in the same commit

- `uxnanmobile/CHANGELOG.md` → `[Unreleased]`
- `architecture/02a-system-architecture.md` — shell block: one scope answers for back on every route, and the two ways it broke
- `architecture/02c-implementation-guide.md` §3.3 — the pattern, with the code
- `uxnanmobile/docs/architecture.md` — corrected "back behaviour untouched", which was no longer true
- `uxnanmobile/docs/conventions.md` — which navigation API each kind of screen uses (go_router route / `openInPane` / raw `Navigator.push`), and why `context.pop` is never one of them

## Still to validate on device

Phone: back from Settings and from Profile. Tablet: open a conversation in the pane → back → the pane empties and the drawer stays. No tablet hardware here; that path is covered by tests only.
