### PR TITLE
fix(svelte): refine sidebar attention marks and the destructive dialog

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -7,6 +7,36 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ### Fixed
 
+- **The "needs you" pill is a badge again, not a 28px control.** It carried a
+  control height, so an 11px counter sat inside an orange lozenge nearly as tall
+  as the row that holds it; it now takes the same padding as every other count
+  badge and hugs its contents.
+
+- **The pill takes a bell — the general notification for the whole tree.** It
+  totals `waiting` *and* `blocked` worktrees, so neither state's own glyph would
+  be true of the whole count.
+
+- **The waiting agent state keeps its question *bubble*.** At the size these are
+  drawn, `done` and `blocked` are already two rings; a "?" inside a third ring
+  made the one state that is about *you* the hardest of the three to pick out —
+  and it silently contradicted the glyph table in `architecture/02d`.
+
+- **An agent's brand mark now outranks its state glyph.** Both sat at 12px in
+  the agent and worktree rows, so the logo was too small to identify and neither
+  led the row; the mark moves to a new 16px `icon.brand` role and the state
+  glyph to 14px. Who is running reads first, how it is doing reads second.
+
+- **Unread reads the same on a project row and a worktree row.** Both now use
+  the notification bubble; the worktree rows had been left on the old red dot,
+  so the same signal was drawn two ways depending on where it appeared.
+
+- **The destructive confirmation dialog no longer floats over 32px of dead
+  space.** Its header holds the dialog's whole content, so it was adding a
+  bottom padding meant to separate it from a following section *on top of* the
+  content grid's own gap, plus a right inset reserving room for a close button
+  this dialog does not show — which also wrapped the description early. The
+  footer goes back to the one shared action band the rest of the dialogs use.
+
 - **A downloaded update no longer hides the "Check now" button.**
   Settings → Updates now shows two independent buttons instead of one that
   morphs: *Check now* is always there, and the phase action (*Download* /

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -30,7 +30,7 @@ named from the session's **terminal transcript** — the only material every age
 has, since only Claude reports a prompt through the hook; a hand-renamed tab
 always wins). 542 Rust tests (513 unit + 29
 integration; +7 ignored supervised live GitHub tests + 1 ignored real-scheduler
-probe) + 1,029 passing frontend Vitest tests across two
+probe) + 1,036 passing frontend Vitest tests across two
 projects — pure logic and **Svelte
 component tests** — plus a **real E2E suite** (WebdriverIO + tauri-driver: 8
 journeys, 24 tests, green on Windows, plus an opt-in GitHub journey pending its
@@ -1203,7 +1203,7 @@ when an announced state exceeds the evidence. Announced today: **Windows
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 542 Rust + 1,029 passing Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 542 Rust + 1,036 passing Vitest tests (both
   projects: pure logic and components). E2E has its own **dispatch-only** Windows
   workflow (`e2e-desktop.yml`), outside the required gate — and it does not pass
   on a hosted runner at all: E2E is a local layer, for the measured reason in the

--- a/uxnandesktop/docs/agent-hooks.md
+++ b/uxnandesktop/docs/agent-hooks.md
@@ -182,15 +182,22 @@ distinct, precise states** plus a derived idle:
 
 These states show up everywhere you track an agent:
 
-- **Sidebar** — a colored dot next to each agent terminal, on the project /
-  worktree header (and on the project header even when collapsed).
+- **Sidebar** — a per-state glyph next to each agent terminal, on the project /
+  worktree header (and on the project header even when collapsed); `idle` keeps
+  a plain grey dot.
 - **Terminal tab bar** — a colored dot on each tab. If the state is *not*
   coming from the hook server (you have no hook installed for that agent), a
   small **Webhook** icon appears next to the dot and clicking it takes you
   straight to **Settings → Hooks** so you can wire up the ready-made
   config.
-- **Unread / done badges** — a worktree is flagged (red dot on the card +
-  dock/taskbar count) when an agent finishes while you're not looking.
+- **Unread / done badges** — a worktree is flagged (a red notification bubble on
+  the project and worktree rows + dock/taskbar count) when an agent finishes
+  while you're not looking.
+- **Needs-you pill** — the projects header carries an orange count of the
+  worktrees whose agent is `waiting` or `blocked`, under a bell (it covers both
+  states, so it borrows neither one's glyph), because an agent stuck inside a
+  collapsed project is otherwise invisible. Clicking it opens the status view on
+  that lane.
 - **Native notifications** — fired only when an agent goes idle / done while
   the ADE is unfocused (or you're on a different terminal / workspace).
 

--- a/uxnandesktop/docs/design-tokens.md
+++ b/uxnandesktop/docs/design-tokens.md
@@ -135,7 +135,12 @@ clearance for the 32px close target; `Dialog.Body` keeps a 16px vertical rhythm.
 `Dialog.Footer` deliberately extends through the content inset and restores
 20px internal padding, producing one full-width muted action band. Sectioned
 dialogs use `dialog.footerSurface`; hint-only bars have a 56px minimum so they
-do not collapse below action footers. Outside-pointer dismissal must preserve
+do not collapse below action footers. Every action footer uses the one
+`dialog.footer` band — a confirmation is not a second footer role. A dialog
+whose header carries its whole content (`ConfirmDialog`) drops the header's
+16px bottom padding and its 32px close-button inset instead, because the
+content grid's own 16px gap already separates that header from the footer.
+Outside-pointer dismissal must preserve
 the pointer sequence for the newly targeted underlying control; keyboard close
 may restore the trigger, while navigation must not restore stale chrome.
 Tooltip coordination is provider-owned by Bits UI: one tooltip is open per root
@@ -151,7 +156,8 @@ and keyboard focus remains supported without global document listeners.
 | `icon.action` | 14px (`size-3.5`) | Icon inside a compact toolbar / panel-header action button (pairs with `iconButton.xs`) |
 | `icon.nav` | 16px (`size-4`) | A leading icon in a nav / list row |
 | `icon.decorative` | 14px (`size-3.5`) | Purely-visual / informational: breadcrumb, leading item icons, "running terminals" indicators |
-| `icon.status` | 12px (`size-3`) | An agent-state glyph — the Comet Trail matrix or a state icon (`AgentStatusIndicator`) — in a sidebar row, a context menu or a terminal tab. A notch under `decorative`: it sits beside 12-13px text and must not outweigh it |
+| `icon.brand` | 16px (`size-4`) | An agent's brand logo leading an agent / worktree row. Deliberately a notch above the 14px state glyph beside it: the mark answers *who is running* and the glyph answers *how it is doing*, so identity reads first |
+| `icon.status` | 12px (`size-3`) | A count-adjacent indicator in a sidebar row (running terminals, per-row counters). A notch under `decorative`: it sits beside 12-13px text and must not outweigh it. The agent-state glyph itself (`AgentStatusIndicator`) sits at `decorative`, one notch under its brand mark |
 | `icon.empty` | 32px (`size-8`) | Empty-state illustration |
 
 ### Icon buttons (`iconButton`)

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -158,7 +158,7 @@ classifier), the **GitHub command inventory** check
 **quality matrix** check and the **platform support matrix**
 check (`tests/platform-support.test.mjs` — every platform claim backed by
 evidence that exists, and the announced level gated to it; see
-[`platform-support.md`](platform-support.md)). **1,029 passing tests** across both projects,
+[`platform-support.md`](platform-support.md)). **1,036 passing tests** across both projects,
 config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)

--- a/uxnandesktop/src/lib/components/AgentRow.svelte
+++ b/uxnandesktop/src/lib/components/AgentRow.svelte
@@ -58,10 +58,12 @@
           {#if active}
             <span class={row.agentActiveIndicator} aria-hidden="true"></span>
           {/if}
-          <span class={cn(row.agentLeading, icon.status)}>
+          <span class={cn(row.agentLeading, icon.nav)}>
             <AgentStatusIndicator status={view.status} stale={view.stale} />
           </span>
-          <AgentLogo logo={tab.agentIcon} class={cn(row.agentLeading, icon.status)} />
+          <!-- The brand mark leads the row, so it outranks the state glyph beside
+               it: who is running reads first, how it is doing reads second. -->
+          <AgentLogo logo={tab.agentIcon} class={cn(row.agentLeading, icon.brand)} />
           <span class="flex min-w-0 flex-1 flex-col leading-tight">
             <span class="flex items-baseline gap-1.5">
               <span

--- a/uxnandesktop/src/lib/components/AgentStatusIndicator.svelte
+++ b/uxnandesktop/src/lib/components/AgentStatusIndicator.svelte
@@ -10,6 +10,12 @@
   // `idle` deliberately keeps the plain dot: it is by far the most frequent state,
   // so a glyph there would be constant noise. "Glyph = something is happening /
   // dot = nothing is" is what makes the sidebar scannable at a glance.
+  //
+  // `waiting` keeps the *bubble* silhouette on purpose. At the 12px these glyphs
+  // are drawn, `done` and `blocked` are already two rings with something inside;
+  // a third ring (a "?" in a circle) reads as the same shape at a glance, so the
+  // one state that is about *you* would be the hardest to spot. The bubble is
+  // the only outline in the set that is not a circle.
   import { cn } from "$lib/utils";
   import { icon } from "$lib/design";
   import { TooltipSimple } from "$lib/components/ui/tooltip";
@@ -43,20 +49,20 @@
     <span
       {...tp}
       class={cn(
-        "inline-flex size-3.5 shrink-0 items-center justify-center",
+        "inline-flex size-4 shrink-0 items-center justify-center",
         COLOR[status],
         stale && "opacity-40",
         className,
       )}
     >
       {#if status === "working"}
-        <CometTrail size={12} />
+        <CometTrail size={14} />
       {:else if status === "waiting"}
-        <Icon icon={MessageCircleQuestionMarkIcon} class={icon.status} />
+        <Icon icon={MessageCircleQuestionMarkIcon} class={icon.decorative} />
       {:else if status === "blocked"}
-        <Icon icon={CirclePauseIcon} class={icon.status} />
+        <Icon icon={CirclePauseIcon} class={icon.decorative} />
       {:else if status === "done"}
-        <Icon icon={CircleCheckIcon} class={icon.status} />
+        <Icon icon={CircleCheckIcon} class={icon.decorative} />
       {:else}
         <span class="size-1.5 rounded-full bg-current"></span>
       {/if}

--- a/uxnandesktop/src/lib/components/ConfirmDialog.svelte
+++ b/uxnandesktop/src/lib/components/ConfirmDialog.svelte
@@ -61,7 +61,12 @@
     class="flex min-w-0 flex-col"
     showCloseButton={false}
   >
-    <div class="flex min-w-0 gap-3">
+    <!-- The hero row *is* this dialog's whole content, so the header drops both
+         paddings it reserves for what a bigger dialog has next: the 16px below
+         (the content grid's own 16px gap already separates it from the footer,
+         which would otherwise read as 32px of dead space) and the 32px right
+         inset for a close button this dialog never shows. -->
+    <Dialog.Header class="flex-row items-start gap-3 pb-0 pr-0">
       {#if danger}
         <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-destructive/10">
           <Icon icon={TriangleAlertIcon} class={cn(icon.button, "text-destructive")} />
@@ -73,12 +78,12 @@
           <Dialog.Description class={cn(text.body, "break-words")}>{description}</Dialog.Description>
         {/if}
       </div>
-    </div>
+    </Dialog.Header>
 
     {#if error}
       <p
         class={cn(
-          "mt-2 break-words rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive",
+          "break-words rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive",
           text.body,
         )}
       >

--- a/uxnandesktop/src/lib/components/LeftSidebar.svelte
+++ b/uxnandesktop/src/lib/components/LeftSidebar.svelte
@@ -19,7 +19,7 @@
   import type { SidebarGroupBy, SortMode } from "$lib/types";
   import { Icon } from "$lib/components/ui/icon";
   import ChevronRightIcon from "@hugeicons/core-free-icons/ChevronRightIcon";
-  import { control, field, focus, icon, row, shell, text } from "$lib/design";
+  import { field, focus, icon, row, shell, text } from "$lib/design";
   import { cn } from "$lib/utils";
   import { TooltipSimple } from "$lib/components/ui/tooltip";
   import { i18n } from "$lib/i18n";
@@ -30,6 +30,10 @@
   import RefreshCwIcon from "@hugeicons/core-free-icons/RefreshIcon";
   import PlusIcon from "@hugeicons/core-free-icons/PlusSignIcon";
   import TerminalIcon from "@hugeicons/core-free-icons/TerminalIcon";
+  // A bell: this pill is the general notification for the tree, counting both
+  // `waiting` and `blocked` worktrees (see `projects.needsYouCount`). Neither
+  // state's own glyph would do — half the count is never a question for you.
+  import BellIcon from "@hugeicons/core-free-icons/Notification01Icon";
 
   // The five sort modes offered for each axis (projects and worktrees). "manual"
   // and the two "name" modes don't drift over time; "recent"/"attention" do (they
@@ -214,14 +218,13 @@
           <button
             {...props}
             class={cn(
-              control.dense,
-              "mr-0.5 inline-flex shrink-0 items-center gap-1 rounded-full bg-orange-500/15 font-medium tabular-nums text-orange-600 transition-colors hover:bg-orange-500/25 dark:text-orange-400",
+              "mr-0.5 inline-flex shrink-0 items-center gap-1 rounded-full bg-orange-500/15 px-1.5 py-0.5 font-medium tabular-nums text-orange-600 transition-colors hover:bg-orange-500/25 dark:text-orange-400",
               focus.ring,
               text.indicator,
             )}
             onclick={() => projects.revealNeedsYou()}
           >
-            <span class="size-1.5 rounded-full bg-orange-500"></span>
+            <Icon icon={BellIcon} class={icon.decorative} />
             {projects.needsYouCount}
           </button>
         {/snippet}

--- a/uxnandesktop/src/lib/components/ProjectCard.svelte
+++ b/uxnandesktop/src/lib/components/ProjectCard.svelte
@@ -56,6 +56,9 @@
   import Trash2Icon from "@hugeicons/core-free-icons/Delete02Icon";
   import PinIcon from "@hugeicons/core-free-icons/PinIcon";
   import PinOffIcon from "@hugeicons/core-free-icons/PinOffIcon";
+  // A message with a notification dot: unread is *new output waiting to be
+  // read*, distinct from the waiting glyph, which is *a question for you*.
+  import MessageNotificationIcon from "@hugeicons/core-free-icons/MessageNotification01Icon";
 
   let {
     repo,
@@ -261,10 +264,9 @@
     {#if hasUnread}
       <TooltipSimple title={i18n.t("monitor.unread")}>
         {#snippet children(tp2)}
-          <span
-            {...tp2}
-            class="size-2 shrink-0 rounded-full bg-red-500 ring-2 ring-red-500/15"
-          ></span>
+          <span {...tp2} class="inline-flex shrink-0 text-red-500">
+            <Icon icon={MessageNotificationIcon} class={icon.decorative} />
+          </span>
         {/snippet}
       </TooltipSimple>
     {/if}

--- a/uxnandesktop/src/lib/components/WorktreeRow.svelte
+++ b/uxnandesktop/src/lib/components/WorktreeRow.svelte
@@ -35,6 +35,9 @@
   import CircleSlashIcon from "@hugeicons/core-free-icons/CancelCircleIcon";
   import GitBranchIcon from "@hugeicons/core-free-icons/GitBranchIcon";
   import GitPullRequestIcon from "@hugeicons/core-free-icons/GitPullRequestIcon";
+  // Unread is one signal drawn one way: keep this glyph and `ProjectCard`'s in
+  // step — a project row and a worktree row report the same thing.
+  import MessageNotificationIcon from "@hugeicons/core-free-icons/MessageNotification01Icon";
   import MoonIcon from "@hugeicons/core-free-icons/MoonIcon";
   import PinIcon from "@hugeicons/core-free-icons/PinIcon";
   import TerminalIcon from "@hugeicons/core-free-icons/TerminalIcon";
@@ -259,7 +262,7 @@
           {#if v}
             <div class="flex items-center gap-1.5">
               <AgentStatusIndicator status={v.status} stale={v.stale} />
-              <AgentLogo logo={t.agentIcon} class={cn(icon.status, "shrink-0")} />
+              <AgentLogo logo={t.agentIcon} class={cn(icon.brand, "shrink-0")} />
               <span class={cn("min-w-0 flex-1 truncate", text.meta)}>{v.title}</span>
               {#if v.lastUpdate}
                 <span class={cn("shrink-0 tabular-nums", text.meta)}>
@@ -370,10 +373,9 @@
                   {#if hasUnread}
                     <TooltipSimple title={i18n.t("monitor.unread")}>
                       {#snippet children(tp2)}
-                        <span
-                          {...tp2}
-                          class="size-2 shrink-0 rounded-full bg-red-500 ring-2 ring-red-500/15"
-                        ></span>
+                        <span {...tp2} class="inline-flex shrink-0 text-red-500">
+                          <Icon icon={MessageNotificationIcon} class={icon.decorative} />
+                        </span>
                       {/snippet}
                     </TooltipSimple>
                   {/if}

--- a/uxnandesktop/src/lib/components/attention-indicator-contract.test.ts
+++ b/uxnandesktop/src/lib/components/attention-indicator-contract.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The three places that tell you an agent wants something must speak one
+ * vocabulary. They are written in three different files, none of them imports
+ * the others, and nothing at runtime notices when one drifts — the sidebar just
+ * quietly starts saying the same thing two ways.
+ *
+ * So this pins the shape of the vocabulary, not any particular glyph: change
+ * the drawing if you like, but change it everywhere it means the same thing.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const source = (name: string) => readFileSync(new URL(`./${name}`, import.meta.url), "utf8");
+
+/** The Hugeicons subpath a component imports under `localName`. */
+const glyphOf = (file: string, localName: string) => {
+  const match = new RegExp(
+    `import ${localName} from "@hugeicons/core-free-icons/(\\w+)"`,
+  ).exec(source(file));
+  expect(match, `${localName} import in ${file}`).not.toBeNull();
+  return match![1];
+};
+
+describe("attention indicators", () => {
+  it("marks the needs-you pill for both states it counts, not one of them", () => {
+    // `needsYouCount` is the waiting **and** blocked pair, so borrowing either
+    // state's glyph would tell you a question is pending when half of that
+    // count is an agent stuck on someone else's API. A bell is the general
+    // "something wants you" mark and stays true for both.
+    const counted = readFileSync(
+      new URL("../state/projects.svelte.ts", import.meta.url),
+      "utf8",
+    );
+    expect(counted).toContain('s === "waiting" || s === "blocked"');
+
+    const pill = glyphOf("LeftSidebar.svelte", "BellIcon");
+    const indicator = source("AgentStatusIndicator.svelte");
+    for (const stateGlyph of indicator.matchAll(
+      /@hugeicons\/core-free-icons\/(\w+)/g,
+    )) {
+      expect(pill, "pill must not reuse a single state's glyph").not.toBe(stateGlyph[1]);
+    }
+  });
+
+  it("keeps the waiting glyph off the circle silhouette its neighbours use", () => {
+    // `done` and `blocked` are both rings at 12px. A "?" in a ring would make
+    // the one state that is about *you* the hardest of the three to spot.
+    const waiting = glyphOf("AgentStatusIndicator.svelte", "MessageCircleQuestionMarkIcon");
+    expect(waiting).toMatch(/Chat|Bubble/);
+    expect(waiting).not.toMatch(/Circle/);
+  });
+
+  it("draws unread the same way in a project row and a worktree row", () => {
+    expect(glyphOf("ProjectCard.svelte", "MessageNotificationIcon")).toBe(
+      glyphOf("WorktreeRow.svelte", "MessageNotificationIcon"),
+    );
+  });
+
+  it("keeps the pill's mark readable next to its count", () => {
+    // 12px `icon.status` is the in-row state size; inside the pill it sits
+    // beside an 11px number and needs the 14px role to stay legible.
+    const sidebar = source("LeftSidebar.svelte");
+    const pill = sidebar.slice(sidebar.indexOf("projects.revealNeedsYou") - 700);
+    expect(pill).toContain("icon={BellIcon} class={icon.decorative}");
+  });
+
+  it("ranks the brand logo above the state glyph beside it", () => {
+    // These two sat at the same 12px, so "who is running" and "how it is doing"
+    // carried equal weight and the mark was too small to identify at all.
+    for (const name of ["AgentRow.svelte", "WorktreeRow.svelte"]) {
+      expect(source(name), name).toContain("icon.brand");
+    }
+    const design = readFileSync(new URL("../design.ts", import.meta.url), "utf8");
+    expect(design).toMatch(/brand: "size-4"/);
+    // The state glyph is 14px: one notch under the mark, one over the 12px it
+    // shares with in-row counters.
+    const indicator = source("AgentStatusIndicator.svelte");
+    expect(indicator).toContain("icon.decorative");
+    expect(indicator).not.toContain("icon.status");
+    expect(indicator).toContain("<CometTrail size={14} />");
+  });
+
+  it("sizes the needs-you pill like a badge, not like a control", () => {
+    const sidebar = source("LeftSidebar.svelte");
+    const pill = sidebar.slice(sidebar.indexOf("projects.revealNeedsYou") - 700);
+    // `control.dense` is a 28px control height; on an 11px counter it paints a
+    // pill far bigger than the text inside it.
+    expect(pill).not.toContain("control.dense");
+    expect(pill).toContain("px-1.5 py-0.5");
+  });
+});

--- a/uxnandesktop/src/lib/components/phase5-dialog-contract.test.ts
+++ b/uxnandesktop/src/lib/components/phase5-dialog-contract.test.ts
@@ -17,6 +17,19 @@ describe("phase-five dialog density contracts", () => {
     expect(launcher).toContain('<Button\n        variant="ghost"\n        size="sm"');
   });
 
+  it("gives the confirmation dialog the one shared footer band", () => {
+    const confirm = source("ConfirmDialog.svelte");
+    // One action-footer role for every dialog: a confirmation is not a second
+    // one. `Dialog.Footer` already carries `dialog.footer`.
+    expect(confirm).toContain('<Dialog.Footer class="min-w-0">');
+    expect(source("../design.ts")).not.toContain("confirmFooter");
+    // Its header *is* the whole content, so it drops the 16px it reserves for a
+    // following section (the content grid's gap already spaces it from the
+    // footer) and the 32px inset for the close button this dialog never shows.
+    expect(confirm).toContain('showCloseButton={false}');
+    expect(confirm).toContain("pb-0 pr-0");
+  });
+
   it("centralizes the draggable tab label width", () => {
     const terminal = source("TerminalArea.svelte");
     expect(terminal.match(/tab\.terminalLabel/g)?.length).toBe(3);

--- a/uxnandesktop/src/lib/design.ts
+++ b/uxnandesktop/src/lib/design.ts
@@ -31,6 +31,11 @@ export const icon = {
   /** Purely-visual / informational: breadcrumb, leading item icons,
    *  status & running indicators (14px). */
   decorative: "size-3.5",
+  /** An agent's brand logo leading a row (16px). Deliberately a notch *above*
+   *  the 14px state glyph beside it: the mark answers "who is running" and the
+   *  glyph answers "how is it doing", so identity reads first at a glance —
+   *  without the 20px mark crowding the 12px text in a dense worktree row. */
+  brand: "size-4",
   /** An agent-state glyph — the Comet Trail matrix or a state icon — in a
    *  sidebar row, a context menu or a terminal tab (12px). Deliberately a notch
    *  under `decorative`: it sits beside 12-13px text and must not outweigh it. */


### PR DESCRIPTION
## What

Reworks the sidebar's attention marks and the destructive confirmation dialog. The branch previously carried a commit that moved these in the wrong direction; it has been rewritten into this single commit.

### The destructive dialog

- Dropped `dialog.confirmFooter` — it duplicated `dialog.footer` for a 2px difference, giving a one-call-site second footer role. Every action footer is the one shared band again.
- Its header holds the dialog's whole content, so it now drops the 16px bottom padding it reserves for a *following* section (the content grid's own 16px gap already separates it from the footer — the two summed to **32px of dead space**) and the 32px right inset for a close button this dialog never shows, which had been wrapping the description a line early.

Measured in the DOM: description → footer went from 32px to 16px, against 20px above the title.

### Attention marks

| Mark | Before | Now |
|---|---|---|
| Needs-you pill | 28px control height around an 11px counter | badge padding; **bell** — it counts `waiting` *and* `blocked`, so neither state's own glyph is true of it |
| Unread (project card) | red dot → message glyph at a hard-coded `size-3.5` | `MessageNotification01` at `icon.decorative` |
| Unread (worktree row) | still a red dot | the same glyph — one signal, one drawing |
| `waiting` state | `HelpCircleIcon` (a "?" in a circle) | back to the question **bubble** |

`done` and `blocked` are already two rings at the size these are drawn, so a third ring made the one state that is about *you* the hardest to pick out — and it silently contradicted the glyph table in `architecture/02d-agent-monitoring.md` §1.2.

### Row hierarchy

An agent's brand mark and its state glyph both sat at 12px, so neither led the row and the logo was too small to identify. The mark takes a new **16px `icon.brand`** role, the glyph moves to **14px**: who is running reads first, how it is doing reads second.

## Tests

Two contract suites pin what regressed here — the unified unread glyph, the pill not borrowing a single state's glyph, the pill sized as a badge, the brand/glyph ranking, and the single footer band.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm test` — **1036 passing** (counts synced in `FOR-DEV.md` and `docs/testing.md`)
- Rendered and reviewed in headless Edge over CDP, light and dark

## Docs in the same change set

`docs/design-tokens.md` (single action-footer contract, icon table), `docs/agent-hooks.md` (where each mark lives and what it counts), `CHANGELOG.md`. No `architecture/` change is owed — the waiting glyph returns to the one §1.2 already specifies.
