### PR TITLE
fix(svelte): keep status-bar highlights inside the status bar

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -7,6 +7,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ### Fixed
 
+- **Status-bar highlights no longer spill out of the status bar.** The backend
+  and providers buttons were the standard 32px icon action inside a 28px bar, so
+  their hover fill crossed the hairline above and ran past the window edge below
+  — and even the 28px panel toggles overflowed by half a pixel, because the bar's
+  `border-t` lives inside its own 28px box and left 27px for them.
+
+  The bar now follows the app bar's anatomy, which had this right all along: the
+  hairline is painted as an overlay instead of a border, so a control gets the
+  full 28px, and every control is square and full-height
+  (`shell.statusBarAction` / `shell.statusBarItem`) instead of a rounded pill
+  floating inside the band. Highlights fill the bar from seam to bottom edge, the
+  way the window controls and the app-bar actions already did.
+
 - **A downloaded update no longer hides the "Check now" button.**
   Settings → Updates now shows two independent buttons instead of one that
   morphs: *Check now* is always there, and the phase action (*Download* /

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -30,7 +30,7 @@ named from the session's **terminal transcript** — the only material every age
 has, since only Claude reports a prompt through the hook; a hand-renamed tab
 always wins). 542 Rust tests (513 unit + 29
 integration; +7 ignored supervised live GitHub tests + 1 ignored real-scheduler
-probe) + 1,029 passing frontend Vitest tests across two
+probe) + 1,030 passing frontend Vitest tests across two
 projects — pure logic and **Svelte
 component tests** — plus a **real E2E suite** (WebdriverIO + tauri-driver: 8
 journeys, 24 tests, green on Windows, plus an opt-in GitHub journey pending its
@@ -1203,7 +1203,7 @@ when an announced state exceeds the evidence. Announced today: **Windows
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 542 Rust + 1,029 passing Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 542 Rust + 1,030 passing Vitest tests (both
   projects: pure logic and components). E2E has its own **dispatch-only** Windows
   workflow (`e2e-desktop.yml`), outside the required gate — and it does not pass
   on a hosted runner at all: E2E is a local layer, for the measured reason in the

--- a/uxnandesktop/docs/design-tokens.md
+++ b/uxnandesktop/docs/design-tokens.md
@@ -207,7 +207,19 @@ fills. Top-level icon controls use the square `shell.appBarAction` or
 `shell.appBarCompactAction`; both are 40×40px. The fixed window-control overlay
 uses `shell.appBarOverlay`, which intentionally has no second hairline because
 the longer appbar below it owns that line. `WorkspaceAppBar` reuses this anatomy
-for Settings and Automations. `shell.root`, `shell.sidebar`, `shell.statusBar`,
+for Settings and Automations.
+
+The status bar is the same anatomy at 28px: `shell.statusBar` paints its *top*
+hairline as an overlay for the same reason the appbar does — a `border-t` lives
+inside the border-box, leaving 27px for a 28px control, so every highlight would
+spill past the bar. Its controls are `shell.statusBarAction` (square, full bar
+height) and `shell.statusBarItem` (the text-bearing ones: a count, a warning),
+both square-cornered and flush against each other. The bar therefore carries no
+`gap`: each item owns its horizontal padding, and a hover fills the band from
+seam to bottom edge rather than floating as a pill inside it. Never give a
+status-bar control a `rounded` or a height other than the bar's.
+
+`shell.root`, `shell.sidebar`,
 `shell.terminalStrip`, `shell.rightPanelHeader`, `shell.laneHeader`,
 `shell.laneAction`, and `shell.titlebar` remain the region-specific roles; they
 do not replace `surface.*` on content surfaces. On macOS, the platform Tauri
@@ -257,7 +269,7 @@ viewport cap; `tab.panelTrigger` owns the right-panel trigger padding/type; and
 | `panel.card` | A standalone content card |
 | `panel.sidebarCard` | A selectable sidebar card (project/worktree outer shell) |
 | `focus.ring` | The shared focus-visible ring |
-| `divider.bottom` / `divider.top` | The subtle hairline section divider (top band of each panel, the status bar) — one reusable softened `border-border/60` hairline so every structural seam reads quiet (never a hard, crisp full-strength line) and they all match |
+| `divider.bottom` / `divider.top` | The subtle hairline section divider (top band of each panel) — one reusable softened `border-border/60` hairline so every structural seam reads quiet (never a hard, crisp full-strength line) and they all match. Not for the app bar or the status bar: those paint the same hairline as an overlay so their full-height controls keep the band's exact height |
 | `tab.base` + `tab.active` / `tab.inactive` | Active tab = a quiet sidebar-accent fill (like a selected worktree) + a firm foreground underline; shared by the center terminal tabs and the right panel |
 | `tab.segmentedList` / `tab.segmentedTrigger` | Compact Bits UI-backed mode switch used by settings editors |
 

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -158,7 +158,7 @@ classifier), the **GitHub command inventory** check
 **quality matrix** check and the **platform support matrix**
 check (`tests/platform-support.test.mjs` — every platform claim backed by
 evidence that exists, and the announced level gated to it; see
-[`platform-support.md`](platform-support.md)). **1,029 passing tests** across both projects,
+[`platform-support.md`](platform-support.md)). **1,030 passing tests** across both projects,
 config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)

--- a/uxnandesktop/src/lib/components/BackendStatus.svelte
+++ b/uxnandesktop/src/lib/components/BackendStatus.svelte
@@ -14,7 +14,7 @@
   import { github } from "$lib/state/github.svelte";
   import { resources } from "$lib/state/resources.svelte";
   import { cn } from "$lib/utils";
-  import { iconButton, overlay, text } from "$lib/design";
+  import { icon as iconSize, overlay, shell, text } from "$lib/design";
   import { TooltipSimple } from "$lib/components/ui/tooltip";
   import { i18n } from "$lib/i18n";
   import { Icon } from "$lib/components/ui/icon";
@@ -124,13 +124,16 @@
       <Popover.Trigger
         bind:ref={triggerRef}
         {...tp}
-        class={cn("relative flex items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground", iconButton.action)}
+        class={cn(
+          shell.statusBarAction,
+          "relative text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+        )}
         aria-label={triggerLabel}
       >
-        <Icon icon={ServerIcon} class={cn("size-3.5", backend.icon)} />
+        <Icon icon={ServerIcon} class={cn(iconSize.action, backend.icon)} />
         {#if unread > 0}
           <span
-            class="absolute right-0.5 top-0.5 size-1.5 rounded-full bg-primary ring-1 ring-background"
+            class="absolute right-1 top-1 size-1.5 rounded-full bg-primary ring-1 ring-background"
             aria-hidden="true"
           ></span>
         {/if}

--- a/uxnandesktop/src/lib/components/UsageStatusButton.svelte
+++ b/uxnandesktop/src/lib/components/UsageStatusButton.svelte
@@ -11,7 +11,7 @@
   import { resourceMode } from "$lib/state/resourceMode.svelte";
   import FreshnessHint from "./FreshnessHint.svelte";
   import { cn } from "$lib/utils";
-  import { iconButton, overlay, text } from "$lib/design";
+  import { icon as iconSize, overlay, shell, text } from "$lib/design";
   import { i18n } from "$lib/i18n";
   import { usageProvider } from "$lib/usageCatalog";
   import { formatCredit } from "$lib/usageFormat";
@@ -113,10 +113,13 @@
         <Popover.Trigger
           bind:ref={triggerRef}
           {...tp}
-          class={cn("flex items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground", iconButton.action)}
+          class={cn(
+            shell.statusBarAction,
+            "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+          )}
           aria-label={i18n.t("providers.statusBarTooltip")}
         >
-          <Icon icon={GaugeIcon} class={cn("size-3.5", iconTint)} />
+          <Icon icon={GaugeIcon} class={cn(iconSize.action, iconTint)} />
         </Popover.Trigger>
       {/snippet}
     </TooltipSimple>

--- a/uxnandesktop/src/lib/design.test.ts
+++ b/uxnandesktop/src/lib/design.test.ts
@@ -33,6 +33,23 @@ describe("desktop density tokens", () => {
 		expect(iconButton.sm).toBe("size-8");
 	});
 
+	it("keeps the status bar's controls inside the bar", () => {
+		// Both bands paint their hairline as an overlay rather than a border: a
+		// `border-t` sits inside the border-box, so a control the same height as
+		// the bar would spill past it and the highlight would cross the seam.
+		expect(shell.statusBar).toContain("h-7");
+		expect(shell.statusBar).toContain("before:top-0");
+		expect(shell.statusBar).toContain("before:z-10");
+		expect(shell.statusBar).not.toContain("border-t");
+		// Full bar height, square — the shape `appBarAction` gives the top chrome.
+		expect(shell.statusBarAction).toContain("h-7");
+		expect(shell.statusBarAction).toContain("rounded-none");
+		expect(shell.statusBarItem).toContain("h-7");
+		expect(shell.statusBarItem).toContain("rounded-none");
+		// No gap: the actions sit flush, so each one owns its own padding.
+		expect(shell.statusBar).not.toMatch(/\bgap-/);
+	});
+
 	it("exposes named shell and row roles for phase-three chrome", () => {
 		expect(shell.statusBar).toContain("h-7");
 		expect(shell.appBar).toContain("h-10");

--- a/uxnandesktop/src/lib/design.ts
+++ b/uxnandesktop/src/lib/design.ts
@@ -169,7 +169,19 @@ export const surface = {
 export const shell = {
   root: "bg-[var(--ux-shell)] text-foreground",
   sidebar: "bg-sidebar text-sidebar-foreground",
-  statusBar: "flex h-7 shrink-0 items-center gap-2 px-2 text-xs text-muted-foreground",
+  /** One 28px status-bar box. Like `appBar`, it paints its hairline as an
+   *  overlay instead of a border: a `border-t` is inside the border-box, so it
+   *  would leave 27px for a 28px control and every highlight would spill past
+   *  the bar. Actions here fill the full height and sit flush, so the bar reads
+   *  as one band of controls rather than a row of floating pills. */
+  statusBar:
+    "relative flex h-7 shrink-0 items-center px-2 text-xs text-muted-foreground before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:z-10 before:h-px before:bg-border/60",
+  /** A square status-bar action — full bar height, no radius (the shape
+   *  `appBarAction` gives the top chrome). */
+  statusBarAction: "flex h-7 w-7 shrink-0 items-center justify-center rounded-none",
+  /** A text-bearing status-bar item (a count, a warning): same height and square
+   *  corners, with its own horizontal padding since the bar has no gap. */
+  statusBarItem: "flex h-7 shrink-0 items-center gap-1 rounded-none px-1.5",
   /** One 40px appbar box. Its overlay hairline stays visible above full-height actions. */
   appBar:
     "relative h-10 shrink-0 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:z-10 after:h-px after:bg-border/60",

--- a/uxnandesktop/src/routes/+page.svelte
+++ b/uxnandesktop/src/routes/+page.svelte
@@ -16,7 +16,7 @@
   import { runAppAction } from "$lib/keyactions";
   import { isUntestedPlatform, osLabel } from "$lib/platform";
   import { cn } from "$lib/utils";
-  import { control, divider, focus, icon as iconSize, iconButton, shell } from "$lib/design";
+  import { focus, icon as iconSize, shell } from "$lib/design";
   import { Icon } from "$lib/components/ui/icon";
   import TriangleAlertIcon from "@hugeicons/core-free-icons/Alert01Icon";
   import WebhookIcon from "@hugeicons/core-free-icons/WebhookIcon";
@@ -380,12 +380,12 @@
     <!-- Status bar: breadcrumb (left) · backend + panel toggles (right) -->
     <!-- Region: Status bar — breadcrumb (left) · backend + panel toggles (right). -->
     <footer
-      class={cn(shell.statusBar, divider.top)}
+      class={shell.statusBar}
     >
       <!-- Active workspace breadcrumb -->
       <TooltipSimple title={i18n.t("terminal.context")}>
         {#snippet children(props)}
-          <div {...props} class="inline-flex min-w-0 items-center gap-1">
+          <div {...props} class="inline-flex min-w-0 items-center gap-1 pr-2">
             <Icon icon={LayersIcon} class={cn(iconSize.decorative, "shrink-0")} />
             {#if ctx.repo}
               <span class="truncate">{ctx.repo}</span>
@@ -403,7 +403,7 @@
           {#snippet children(props)}
             <span
               {...props}
-              class="inline-flex items-center gap-1 text-amber-600 dark:text-amber-400"
+              class={cn(shell.statusBarItem, "text-amber-600 dark:text-amber-400")}
             >
               <Icon icon={TriangleAlertIcon} class={iconSize.decorative} />
               {i18n.t("status.untested", { os: osLabel() })}
@@ -416,7 +416,11 @@
           {#snippet children(props)}
             <button
               {...props}
-              class={cn(control.dense, "inline-flex items-center gap-1 text-amber-600 hover:text-amber-500 dark:text-amber-400", focus.ring)}
+              class={cn(
+                shell.statusBarItem,
+                "text-amber-600 hover:bg-accent hover:text-amber-500 dark:text-amber-400",
+                focus.ring,
+              )}
               aria-label={i18n.t("status.hooksIssue")}
               onclick={() => app.openSettings("hooks")}
             >
@@ -435,12 +439,12 @@
             <button
               {...props}
               class={cn(
-                control.dense,
-                "inline-flex items-center gap-1 rounded px-1 transition-colors",
+                shell.statusBarItem,
+                "transition-colors",
                 focus.ring,
                 orchestrationAttention
-                  ? "text-foreground ring-1 ring-primary/40 bg-primary/5"
-                  : "text-muted-foreground hover:text-foreground",
+                  ? "bg-primary/10 text-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-foreground",
               )}
               aria-label={i18n.t("orchestration.open")}
               onclick={openOrchestration}
@@ -468,8 +472,7 @@
           <button
             {...props}
             class={cn(
-              iconButton.xs,
-              "flex items-center justify-center rounded",
+              shell.statusBarAction,
               focus.ring,
               app.settings.leftSidebarOpen
                 ? "bg-accent text-foreground"
@@ -488,8 +491,7 @@
           <button
             {...props}
             class={cn(
-              iconButton.xs,
-              "flex items-center justify-center rounded",
+              shell.statusBarAction,
               focus.ring,
               app.settings.rightSidebarOpen
                 ? "bg-accent text-foreground"
@@ -509,8 +511,7 @@
             <button
               {...props}
               class={cn(
-                iconButton.xs,
-                "flex items-center justify-center rounded",
+                shell.statusBarAction,
                 focus.ring,
                 app.browserOpen
                   ? "bg-accent text-foreground"


### PR DESCRIPTION
## The bug

Hovering **backend** or **providers** painted a highlight taller than the status bar itself — it crossed the hairline above and ran past the window edge below.

Measured in the real render (headless Edge over CDP):

| Element | Height | Over the top | Under the bottom |
|---|---|---|---|
| Status bar (`h-7` + `border-t`) | 28px (**27px usable**) | — | — |
| Backend / providers (`iconButton.action`) | **32px** | 1.5px | 2.5px |
| Panel toggles (`iconButton.xs`) | 28px | 0 | 0.5px |

Two causes, and the second is the one that mattered: backend and providers used the standard 32px icon action in a 28px bar — but *even the 28px controls overflowed*, because the bar drew its seam with `divider.top`, a real `border-t`, which `border-box` counts inside its own 28px. **No control in the bar fitted inside it.**

## The fix

The app bar already had this solved, and the status bar was the odd one out:

```
shell.appBar        h-10 + after:absolute after:bottom-0 after:h-px after:z-10   ← overlay, not border
shell.appBarAction  size-10 rounded-none                                          ← square, full height
```

That overlay hairline is exactly why the 40px app-bar squares and the window controls sit flush in a 40px band. The status bar now uses the same anatomy at 28px:

- **`shell.statusBar`** paints its top hairline as an overlay → all 28px are usable.
- **`shell.statusBarAction`** (square, full height) and **`shell.statusBarItem`** (the text-bearing ones — hooks, orchestration, platform warning) replace the rounded pills; the bar drops its `gap` so items sit flush and own their padding.
- The orchestration attention cue becomes a fill — a `ring` inside a bleed-to-edge control is clipped by the band.

**Measured after: every control 28px, 0px overflow top and bottom.**

## Note on appearance

Panel toggles carry `bg-accent` while their panel is open, so two or three active ones now read as a single continuous band — the same behaviour the app bar and VS Code's status bar already have. Intentional; say the word if the segments should be separated.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm test` — **1030 passing** (+1 contract test pinning that the bar keeps no `border-t`, no `gap` and no rounded control)
- Rendered and measured in light and dark

## Heads-up on merging

This and #204 both touch the test counts in `FOR-DEV.md` / `docs/testing.md`. Whichever merges second needs the number reconciled — together they land at **1,037** (1,029 + 7 + 1).
