### PR TITLE
docs(mobile): Play release notes for the next mobile version

### DIFF
--- a/.github/whatsnew/whatsnew-en-US
+++ b/.github/whatsnew/whatsnew-en-US
@@ -1,3 +1,3 @@
-Settings and Profile now answer Android's back button: it takes you back to the screen you came from instead of closing the app.
+The model you are talking to now reads by name — "Gemini 3.7 Flash (High)" instead of a technical id — both in a conversation's top bar and when you start a new one. The exact id is still one tap away: press and hold the model name, or read it under the name in the model list.
 
-A conversation that gets its own copy of your project now lands wherever your PC puts it, in the folder the desktop app already uses — so the two apps stop making separate folders for the same branch.
+Session info also makes clear that a conversation's ids open it in the agent's desktop app, not only in its command line.

--- a/.github/whatsnew/whatsnew-es-ES
+++ b/.github/whatsnew/whatsnew-es-ES
@@ -1,3 +1,3 @@
-Ajustes y Perfil ya responden al botón atrás de Android: vuelves a la pantalla anterior en vez de salir de la app.
+El modelo con el que hablas ahora se lee por su nombre —«Gemini 3.7 Flash (High)» en vez de un id técnico— tanto en la barra superior de una conversación como al crear una nueva. El id exacto sigue a un toque: mantén pulsado el nombre del modelo o léelo bajo el nombre en la lista de modelos.
 
-Una conversación con su propia copia del proyecto ahora se crea donde la coloca tu PC, en la misma carpeta que ya usa la app de escritorio, así las dos apps dejan de crear carpetas distintas para la misma rama.
+Info de sesión también deja claro que los ids de una conversación la abren en la app de escritorio del agente, no solo en su línea de comandos.


### PR DESCRIPTION
`.github/whatsnew/*` still described **0.0.21** — the Android back button and
worktree placement. `release-mobile.yml` fails a release whose notes have not
changed since the previous `mobile-v*` tag, for exactly this reason: valid prose
about the *last* version would otherwise ship as this one's.

Rewritten for what this version changes for someone using the app:

- the model reads by **name** ("Gemini 3.7 Flash (High)") instead of a routing
  id, in a conversation's top bar and when starting a new one — with the id
  still one tap away;
- **Session info** now says a conversation's ids open it in the agent's desktop
  app, not only its command line.

Non-technical, and **401 / 438** characters against Play's 500 limit.

Needed on `main` before the mobile cut, which is next.