### PR TITLE
fix(desktop): agent launch race, agent shell label, macOS shortcut rendering

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -30,6 +30,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   *Smart default — zsh (login shell)* — and the description covers both cases
   instead of only Windows. The behaviour was already correct and is unchanged.
 
+- **macOS keyboard shortcuts read as shortcuts.** They rendered as `⌘`, `Shift`,
+  `ArrowRight` — one symbol and two English words in separate boxes, next to
+  Windows' tidy `Ctrl` + `Shift` + `ArrowRight`. Mac shortcuts now use Apple's
+  symbols (⌘ ⇧ ⌥ ⌃, and glyphs for Tab and the arrows) in Apple's canonical
+  modifier order, while keeping the shape every platform shares: one keycap per
+  key, joined by a `+`. The menu bar's run-together `⇧⌘→` is right for a menu and
+  unreadable in a settings list, so it is deliberately not copied.
+
 ## [0.0.46] - 20260903
 ### Added
 

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the Uxnan Desktop ADE are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- **An agent no longer gets its own launch command typed into it.** Sometimes a
+  freshly launched agent found the whole line — command, session id, MCP flags —
+  sitting in its prompt box, as if someone had pasted it there. Someone had: us.
+  The one-shot that types the launch line is re-armed by **every** chunk of PTY
+  output, and the flag it guards on was set only after two awaits (resolving the
+  MCP catalog, then the write). The launch's own output lands inside exactly that
+  window — the shell echoing the command, then the agent painting its TUI — so it
+  armed a second timer, which fired a quiet window later and typed the line again,
+  this time into the running agent. That is also why it favoured the long lines:
+  a pinned session id and MCP flags are what make the echo big enough to matter.
+
+  The sequence now lives in `$lib/terminal/agentLaunch`, which claims the
+  one-shot *before* it awaits anything and hands the claim back only when the
+  write genuinely failed (a PTY that is not ready must stay retryable). Making it
+  a function with a contract is the point: as a comment above a `try` it was one
+  stray `await` away from coming back.
 
 ## [0.0.46] - 20260903
 ### Added

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -23,6 +23,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   a function with a contract is the point: as a comment above a `try` it was one
   stray `await` away from coming back.
 
+- **The agent launch shell names the shell it will actually use.** The picker
+  read *Smart default (Command Prompt)* on every platform, so on a Mac the one
+  row whose job is to tell you which shell agents start in announced a Windows
+  shell the app would never launch. It now names what it resolves to here —
+  *Smart default — zsh (login shell)* — and the description covers both cases
+  instead of only Windows. The behaviour was already correct and is unchanged.
+
 ## [0.0.46] - 20260903
 ### Added
 

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -32,7 +32,7 @@ always wins). 811 Rust tests (774 unit + 37
 integration), of which 50 are ignored probes that need something real to talk to
 (41 live SSH probes — 29 against a real `sshd` and 12 against a **Linux host in a
 container**, `npm run test:ssh:linux` — one pwsh preflight, 7 supervised live
-GitHub tests, 1 real-scheduler probe) + 1,234 passing frontend Vitest tests across two
+GitHub tests, 1 real-scheduler probe) + 1,238 passing frontend Vitest tests across two
 projects — pure logic and **Svelte
 component tests** — plus a **real E2E suite** (WebdriverIO + tauri-driver: 8
 journeys, 24 tests, green on Windows, plus an opt-in GitHub journey pending its
@@ -1459,7 +1459,7 @@ when an announced state exceeds the evidence. Announced today: **Windows
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 811 Rust + 1,234 passing Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 811 Rust + 1,238 passing Vitest tests (both
   projects: pure logic and components). E2E has its own **dispatch-only** Windows
   workflow (`e2e-desktop.yml`), outside the required gate — and it does not pass
   on a hosted runner at all: E2E is a local layer, for the measured reason in the

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -32,7 +32,7 @@ always wins). 811 Rust tests (774 unit + 37
 integration), of which 50 are ignored probes that need something real to talk to
 (41 live SSH probes — 29 against a real `sshd` and 12 against a **Linux host in a
 container**, `npm run test:ssh:linux` — one pwsh preflight, 7 supervised live
-GitHub tests, 1 real-scheduler probe) + 1,238 passing frontend Vitest tests across two
+GitHub tests, 1 real-scheduler probe) + 1,244 passing frontend Vitest tests across two
 projects — pure logic and **Svelte
 component tests** — plus a **real E2E suite** (WebdriverIO + tauri-driver: 8
 journeys, 24 tests, green on Windows, plus an opt-in GitHub journey pending its
@@ -1459,7 +1459,7 @@ when an announced state exceeds the evidence. Announced today: **Windows
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 811 Rust + 1,238 passing Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 811 Rust + 1,244 passing Vitest tests (both
   projects: pure logic and components). E2E has its own **dispatch-only** Windows
   workflow (`e2e-desktop.yml`), outside the required gate — and it does not pass
   on a hosted runner at all: E2E is a local layer, for the measured reason in the

--- a/uxnandesktop/docs/agent-launch.md
+++ b/uxnandesktop/docs/agent-launch.md
@@ -115,6 +115,10 @@ The global default is **Smart default**, which means:
   default.
 - **macOS / Linux → your default terminal profile** (your login shell).
 
+The picker names whichever of those it resolves to on *this* machine —
+*Smart default — zsh (login shell)* on a Mac, *Smart default — Command Prompt*
+on Windows — rather than stating one platform's answer everywhere.
+
 Prefer PowerShell, Git Bash, WSL, or a specific profile? Pick it in **Agent launch
 shell** — or pin it on individual agents via **Launch in**. (Manage the available
 shells in **Settings → Terminal → Profiles**.)

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -249,7 +249,7 @@ evidence that exists, and the announced level gated to it; see
 (`tests/bundled-pets.test.mjs` — `BUILTIN_PET_IDS` and the packs in
 `static/pets/` are the same set, each manifest's id matches its folder, and
 each sheet divides exactly into the format's 192 × 208 cell; art nobody listed
-ships in every build and is never shown). **1,234 passing tests** across both
+ships in every build and is never shown). **1,238 passing tests** across both
 projects, config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -249,7 +249,7 @@ evidence that exists, and the announced level gated to it; see
 (`tests/bundled-pets.test.mjs` — `BUILTIN_PET_IDS` and the packs in
 `static/pets/` are the same set, each manifest's id matches its folder, and
 each sheet divides exactly into the format's 192 × 208 cell; art nobody listed
-ships in every build and is never shown). **1,238 passing tests** across both
+ships in every build and is never shown). **1,244 passing tests** across both
 projects, config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)

--- a/uxnandesktop/src/lib/chordFormat.svelte.test.ts
+++ b/uxnandesktop/src/lib/chordFormat.svelte.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { formatChordParts } from "./keybindings";
+
+// A chord is drawn as one keycap per key, joined by a `+`, on every platform —
+// that separation is what keeps a combo readable in a settings list. What macOS
+// changes is the tokens, not the shape: it used to leave "Shift" and
+// "ArrowRight" spelled out in English next to a ⌘ symbol.
+
+describe("formatChordParts — Windows / Linux", () => {
+  it("spells the keys out, one token each", () => {
+    expect(formatChordParts("Mod+Shift+N", false)).toEqual(["Ctrl", "Shift", "N"]);
+    expect(formatChordParts("Mod+,", false)).toEqual(["Ctrl", ","]);
+    expect(formatChordParts("Mod+Alt+ArrowRight", false)).toEqual([
+      "Ctrl",
+      "Alt",
+      "ArrowRight",
+    ]);
+  });
+});
+
+describe("formatChordParts — macOS", () => {
+  it("keeps one token per key, so the UI still joins them with +", () => {
+    expect(formatChordParts("Mod+S", true)).toEqual(["⌘", "S"]);
+    expect(formatChordParts("Mod+,", true)).toEqual(["⌘", ","]);
+  });
+
+  it("uses Apple's modifier symbols and their canonical order", () => {
+    // Apple orders ⌃ ⌥ ⇧ ⌘ regardless of how the binding was written.
+    expect(formatChordParts("Mod+Shift+N", true)).toEqual(["⇧", "⌘", "N"]);
+    expect(formatChordParts("Shift+Mod+N", true)).toEqual(["⇧", "⌘", "N"]);
+    expect(formatChordParts("Mod+Alt+ArrowLeft", true)).toEqual(["⌥", "⌘", "←"]);
+    expect(formatChordParts("Ctrl+Alt+Shift+Mod+K", true)).toEqual(["⌃", "⌥", "⇧", "⌘", "K"]);
+  });
+
+  it("draws named keys as glyphs instead of spelling them", () => {
+    expect(formatChordParts("Mod+Tab", true)).toEqual(["⌘", "⇥"]);
+    expect(formatChordParts("Mod+Shift+ArrowDown", true)).toEqual(["⇧", "⌘", "↓"]);
+    expect(formatChordParts("Mod+Shift+Tab", true)).toEqual(["⇧", "⌘", "⇥"]);
+  });
+
+  it("upper-cases a letter but leaves an unmapped key name alone", () => {
+    expect(formatChordParts("Mod+s", true)).toEqual(["⌘", "S"]);
+    expect(formatChordParts("Mod+PageDown", true)).toEqual(["⌘", "PageDown"]);
+  });
+});
+
+describe("formatChordParts — either platform", () => {
+  it("has nothing to draw for an unbound action", () => {
+    expect(formatChordParts("", true)).toEqual([]);
+    expect(formatChordParts("", false)).toEqual([]);
+  });
+});

--- a/uxnandesktop/src/lib/components/KeyChord.svelte
+++ b/uxnandesktop/src/lib/components/KeyChord.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  // Renders a keyboard chord as individual keycaps — each key its own <Kbd>, with
-  // a faint "+" between them (non-mac) — so a combo like "Ctrl+," stays legible
-  // instead of being crammed into a single cap. Pass the raw binding string
-  // (e.g. "Mod+,"); `formatChordParts` maps Mod → Ctrl/⌘ per platform.
+  // Renders a keyboard chord as individual keycaps — each key its own <Kbd> with
+  // a faint "+" between them — so a combo like "Ctrl+," stays legible instead of
+  // being crammed into a single cap. Pass the raw binding string (e.g. "Mod+,");
+  // `formatChordParts` picks the tokens per platform (Mod → Ctrl, or ⌘ with the
+  // rest of the Mac symbols). The separator is deliberately the same everywhere:
+  // the menu bar's run-together ⇧⌘N is unreadable in a settings list.
   import Kbd from "./Kbd.svelte";
-  import { formatChordParts, isMac } from "$lib/keybindings";
+  import { formatChordParts } from "$lib/keybindings";
   import { cn } from "$lib/utils";
 
   let {
@@ -19,7 +21,7 @@
 {#if parts.length}
   <span class={cn("inline-flex items-center gap-1", className)}>
     {#each parts as part, i (i)}
-      {#if i > 0 && !isMac}
+      {#if i > 0}
         <span class="text-[10px] font-medium text-muted-foreground/45" aria-hidden="true">+</span>
       {/if}
       <Kbd class={kbdClass}>{part}</Kbd>

--- a/uxnandesktop/src/lib/components/Settings.svelte
+++ b/uxnandesktop/src/lib/components/Settings.svelte
@@ -654,7 +654,19 @@
   const agentShellGroups = $derived<ComboGroup[]>([
     {
       items: [
-        { value: AGENT_SHELL_DEFAULT, label: i18n.t("settings.agentShellSmart") },
+        {
+          value: AGENT_SHELL_DEFAULT,
+          // Name the shell the smart default actually resolves to on THIS
+          // machine. The label used to read "Smart default (Command Prompt)"
+          // everywhere, which on a Mac announced a Windows shell the app would
+          // never launch — the one thing this row exists to tell you.
+          label: i18n.t("settings.agentShellSmart", {
+            shell:
+              app.agentShellProfile()?.name?.trim() ||
+              app.agentShellProfile()?.command?.trim() ||
+              i18n.t("settings.agentShellSmartUnknown"),
+          }),
+        },
         ...app.terminalProfiles.map((p) => ({
           value: p.id,
           label: p.name.trim() || i18n.t("terminal.unnamedProfile"),

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -1395,9 +1395,10 @@ export const en = {
   "settings.defaultAgentDesc":
     "Auto-launched in a worktree right after you create it. Leave on “None” to never start an agent automatically.",
   "settings.agentShell": "Agent launch shell",
-  "settings.agentShellSmart": "Smart default (Command Prompt)",
+  "settings.agentShellSmart": "Smart default — {shell}",
+  "settings.agentShellSmartUnknown": "your default terminal profile",
   "settings.agentShellDesc":
-    "The shell agents launch in when they don’t pin their own. Command Prompt starts agent CLIs faster and quotes more predictably than PowerShell on Windows; pick another shell if you prefer.",
+    "The shell agents launch in when they don’t pin their own. On Windows that is Command Prompt, which starts agent CLIs faster and quotes more predictably than PowerShell; everywhere else it is your default terminal profile. Pick another shell if you prefer.",
 
   // Settings → Agents → Hooks (ready-made hook configs)
   "hooks.title": "Hooks",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -1400,9 +1400,10 @@ export const es: Record<MessageKey, string> = {
   "settings.defaultAgentDesc":
     "Se lanza automáticamente en un worktree justo después de crearlo. Déjalo en “Ninguno” para no iniciar ningún agente automáticamente.",
   "settings.agentShell": "Shell de lanzamiento de agentes",
-  "settings.agentShellSmart": "Predeterminado (Símbolo del sistema)",
+  "settings.agentShellSmart": "Predeterminado — {shell}",
+  "settings.agentShellSmartUnknown": "tu perfil de terminal predeterminado",
   "settings.agentShellDesc":
-    "El shell en el que se lanzan los agentes cuando no fijan el suyo. En Windows, el Símbolo del sistema inicia los CLI de agente más rápido y entrecomilla de forma más predecible que PowerShell; elige otro shell si lo prefieres.",
+    "El shell en el que se lanzan los agentes cuando no fijan el suyo. En Windows es el Símbolo del sistema, que inicia los CLI de agente más rápido y entrecomilla de forma más predecible que PowerShell; en el resto es tu perfil de terminal predeterminado. Elige otro shell si lo prefieres.",
 
   // Settings → Agents → Hooks (configs listas para usar)
   "hooks.title": "Hooks",

--- a/uxnandesktop/src/lib/keybindings.ts
+++ b/uxnandesktop/src/lib/keybindings.ts
@@ -251,15 +251,64 @@ export function matchAction(e: KeyboardEvent): string | null {
  *  to the caller). */
 export function formatChord(chord: string): string {
   if (!chord) return "";
-  return formatChordParts(chord).join(isMac ? "" : "+");
+  return formatChordParts(chord).join("+");
 }
 
-/** The display tokens of a chord, one per key (Mod → Ctrl or ⌘). Lets the UI
- *  render each key as its own keycap (e.g. `Ctrl` `+` `,`) instead of cramming
- *  a whole combo into one — far more legible. `[]` for an empty/disabled chord. */
-export function formatChordParts(chord: string): string[] {
+/** Apple's symbols for the keys a chord can name, and the order it writes the
+ *  modifiers in: ⌃ ⌥ ⇧ ⌘, then the key. The symbols are what a Mac user reads;
+ *  the order is Apple's. What we do *not* copy is the menu bar's run-together
+ *  `⇧⌘→`: every chord here is drawn as one keycap per key, joined by a `+`, and
+ *  that separation is what makes a combo legible in a settings list rather than
+ *  a glyph soup. Same shape on every platform — only the tokens change. */
+const MAC_SYMBOLS: Record<string, string> = {
+  Mod: "⌘",
+  Ctrl: "⌃",
+  Control: "⌃",
+  Alt: "⌥",
+  Option: "⌥",
+  Shift: "⇧",
+  Tab: "⇥",
+  Enter: "↩",
+  Escape: "⎋",
+  Esc: "⎋",
+  Backspace: "⌫",
+  Delete: "⌦",
+  Space: "␣",
+  ArrowUp: "↑",
+  ArrowDown: "↓",
+  ArrowLeft: "←",
+  ArrowRight: "→",
+};
+
+/** Modifier order Apple prints them in; anything else is the key and goes last. */
+const MAC_MODIFIER_ORDER = ["Ctrl", "Control", "Alt", "Option", "Shift", "Mod"];
+
+/** The display tokens of a chord.
+ *
+ *  One token per key, on every platform, so the UI can render each as its own
+ *  keycap joined by a faint `+` — `Ctrl` `+` `Shift` `+` `N`. A combo crammed
+ *  into a single box is far harder to read in a settings list.
+ *
+ *  What changes on macOS is the *tokens*, not the shape: `Mod` becomes ⌘, the
+ *  other modifiers take their Mac symbols, named keys become glyphs (⇥, →), and
+ *  the modifiers are reordered into Apple's ⌃ ⌥ ⇧ ⌘. It used to leave "Shift"
+ *  and "ArrowRight" spelled out in English beside a ⌘ symbol.
+ *
+ *  `[]` for an empty/disabled chord. */
+export function formatChordParts(chord: string, mac: boolean = isMac): string[] {
   if (!chord) return [];
-  return chord.split("+").map((p) => (p === "Mod" ? (isMac ? "⌘" : "Ctrl") : p));
+  const parts = chord.split("+");
+  if (!mac) return parts.map((p) => (p === "Mod" ? "Ctrl" : p));
+  const modifiers = MAC_MODIFIER_ORDER.filter((m) => parts.includes(m)).map(
+    (m) => MAC_SYMBOLS[m],
+  );
+  const keys = parts
+    .filter((p) => !MAC_MODIFIER_ORDER.includes(p))
+    // A single character is a letter or punctuation and goes up (⌘S, not ⌘s);
+    // anything longer is a key name we have no symbol for, and mangling its case
+    // would only turn "PageDown" into "PAGEDOWN".
+    .map((p) => MAC_SYMBOLS[p] ?? (p.length === 1 ? p.toUpperCase() : p));
+  return [...modifiers, ...keys];
 }
 
 /** Convert a chord to a CodeMirror key name (`Mod+Shift+S` → `Mod-Shift-s`), or

--- a/uxnandesktop/src/lib/terminal/agentLaunch.test.ts
+++ b/uxnandesktop/src/lib/terminal/agentLaunch.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { runAgentLaunch } from "./agentLaunch";
+
+describe("runAgentLaunch", () => {
+  it("writes once", async () => {
+    const inst = { launched: false };
+    let writes = 0;
+    await runAgentLaunch(inst, async () => {
+      writes += 1;
+    });
+
+    expect(writes).toBe(1);
+    expect(inst.launched).toBe(true);
+  });
+
+  it("ignores a second call once the launch is claimed", async () => {
+    const inst = { launched: false };
+    let writes = 0;
+    const write = async () => {
+      writes += 1;
+    };
+
+    await runAgentLaunch(inst, write);
+    await runAgentLaunch(inst, write);
+
+    expect(writes).toBe(1);
+  });
+
+  it("claims before awaiting, so output arriving mid-write cannot start a second", async () => {
+    // The regression this exists for. A launch is not one statement — it
+    // resolves the MCP catalog and then writes, both backend round-trips — and
+    // every PTY output chunk re-arms the timer that calls this. The shell's echo
+    // of the command line lands inside exactly this window. If the claim came
+    // after the write, that second call would run and type the whole launch line
+    // into the agent that the first one just started.
+    const inst = { launched: false };
+    let writes = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    const first = runAgentLaunch(inst, async () => {
+      await gate;
+      writes += 1;
+    });
+
+    // Mid-write: the flag must already read claimed.
+    expect(inst.launched).toBe(true);
+    await runAgentLaunch(inst, async () => {
+      writes += 1;
+    });
+
+    release();
+    await first;
+    expect(writes).toBe(1);
+  });
+
+  it("hands the claim back when the write fails, so it stays retryable", async () => {
+    // A PTY the backend is not ready to write to must not burn the one-shot:
+    // the next output chunk (or the fallback timer) reschedules.
+    const inst = { launched: false };
+    let attempts = 0;
+
+    await runAgentLaunch(inst, async () => {
+      attempts += 1;
+      throw new Error("pty not ready");
+    });
+    expect(inst.launched).toBe(false);
+
+    await runAgentLaunch(inst, async () => {
+      attempts += 1;
+    });
+
+    expect(attempts).toBe(2);
+    expect(inst.launched).toBe(true);
+  });
+});

--- a/uxnandesktop/src/lib/terminal/agentLaunch.ts
+++ b/uxnandesktop/src/lib/terminal/agentLaunch.ts
@@ -1,0 +1,44 @@
+// The one-shot that types an agent's launch command into its shell.
+//
+// It lives here, apart from the terminal instance, because *when the one-shot is
+// claimed* is the whole correctness argument and it is far too easy to get wrong
+// in place. `scheduleAgentLaunch` is re-armed by **every** PTY output chunk and
+// guards on the instance's `launched` flag. The write itself is not one
+// statement: it resolves the MCP catalog (a backend round-trip on a cold start)
+// and then writes (another). While those awaits were in flight the flag still
+// read false — so the launch's own output, the shell echoing the command line
+// and then the agent painting its TUI, armed a second timer. One quiet window
+// after the agent settled, that timer typed the whole launch line *into the
+// running agent*: session id, MCP flags and all, straight into its prompt box.
+//
+// So the claim has to happen before the first await, and be given back only when
+// the write genuinely failed. Expressing that as a function makes it a contract
+// with a test, instead of a comment above a `try` that the next edit can slide
+// an `await` past.
+
+/** The slice of a terminal instance this owns: its one-shot launch flag. */
+export interface AgentLaunchTarget {
+  /** The agent `runCommand` was already typed (never re-type into a live agent). */
+  launched: boolean;
+}
+
+/**
+ * Run `write` at most once for `inst`, claiming the one-shot **before** awaiting
+ * anything.
+ *
+ * A write that throws hands the claim back, because the backend refusing this
+ * write (a PTY that is not ready yet) must stay retryable — the next output
+ * chunk, or the fallback timer, reschedules.
+ */
+export async function runAgentLaunch(
+  inst: AgentLaunchTarget,
+  write: () => Promise<void>,
+): Promise<void> {
+  if (inst.launched) return;
+  inst.launched = true;
+  try {
+    await write();
+  } catch {
+    inst.launched = false;
+  }
+}

--- a/uxnandesktop/src/lib/terminal/instances.ts
+++ b/uxnandesktop/src/lib/terminal/instances.ts
@@ -34,6 +34,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import type { WebglAddon } from '@xterm/addon-webgl';
 import { openUrl } from '$lib/api';
 import { ensureMcpLaunch, withMcpLaunch } from '$lib/mcpLaunch';
+import { runAgentLaunch } from '$lib/terminal/agentLaunch';
 import { agentMonitor } from '$lib/state/agentMonitor.svelte';
 import { KeyboardProtocol } from '$lib/terminal/keyboardProtocol';
 import { DEFAULT_TERMINAL_SCROLLBACK, SNAPSHOT_SCROLLBACK } from '$lib/terminal/scrollback';
@@ -460,9 +461,12 @@ export function scheduleAgentLaunch(inst: TerminalInstance, delay = RUN_COMMAND_
     sawOutput: inst.sawOutput,
     requested: delay,
   });
-  inst.launchTimer = setTimeout(async () => {
+  inst.launchTimer = setTimeout(() => {
     inst.launchTimer = undefined;
-    try {
+    // `runAgentLaunch` claims the one-shot before awaiting anything — see it for
+    // why that ordering is the whole correctness argument, and what typed the
+    // launch line into the running agent when it was not.
+    void runAgentLaunch(inst, async () => {
       await ensureMcpLaunch();
       const command = withMcpLaunch(runCommand, inst.spec.shell);
       // Auto-run appends Enter; "type only" leaves the line for the user to run.
@@ -470,11 +474,7 @@ export function scheduleAgentLaunch(inst: TerminalInstance, delay = RUN_COMMAND_
         id: inst.id,
         data: runCommandExecute ? `${command}\r` : command,
       });
-      inst.launched = true;
-    } catch {
-      // Backend not ready for this write — stay retryable (next output chunk
-      // or fallback reschedules).
-    }
+    });
   }, wait);
 }
 


### PR DESCRIPTION
Second round of macOS work on the desktop ADE. Three fixes; a fourth reported item turned out not to be ours.

## An agent got its own launch command typed into it

A freshly launched agent sometimes found the whole line — command, session id, MCP flags — sitting in its prompt box. We put it there.

The one-shot that types the launch line is re-armed by **every** chunk of PTY output, and the flag it guards on was set only *after* two awaits (resolving the MCP catalog, then the write). The launch's own output lands inside exactly that window — the shell echoing the command, then the agent painting its TUI — so it armed a second timer, which fired a quiet window later and typed the line again, into the running agent. That is also why it favoured long lines: a pinned session id and MCP flags are what make the echo big enough to span the awaits.

The sequence now lives in `$lib/terminal/agentLaunch`, claiming the one-shot *before* awaiting anything and handing it back only when the write genuinely failed (a not-ready PTY must stay retryable). A function with a contract rather than a comment above a `try`, because one stray `await` past that comment brings the bug straight back — the tests have teeth: moving the claim back to its old position fails the mid-write case.

**The first diagnosis was wrong and measurement killed it.** The obvious story was a slow macOS login shell outrunning the 160 ms quiet window, so I ran `zsh -l` in a real PTY here and timed it: all output inside 55 ms, no gaps. Not the shell.

## The agent launch shell announced a Windows shell on a Mac

The picker read *Smart default (Command Prompt)* on every platform — the one row whose job is to say which shell agents start in, naming one the app would never launch here. Behaviour was already correct (`agentShellProfile()` picks cmd.exe on Windows and the default terminal profile elsewhere, and `docs/agent-launch.md` said so); only the label stated one platform's answer as universal. It now names what it resolves to on this machine.

## macOS shortcuts read as shortcuts

They rendered as `⌘`, `Shift`, `ArrowRight` — one symbol and two English words in separate boxes — beside Windows' tidy `Ctrl` + `Shift` + `ArrowRight`. Only `Mod` was ever mapped, and the `+` was suppressed on macOS alone.

Now: Apple's symbols (⌘ ⇧ ⌥ ⌃, glyphs for Tab and the arrows) in Apple's canonical ⌃ ⌥ ⇧ ⌘ order — but keeping the shape every platform shares, one keycap per key joined by a `+`. A first pass copied the menu bar's run-together `⇧⌘→`; it is right for a menu and unreadable in a settings list of forty rows, and the missing separators were spotted immediately.

## Not changed: the agent trust prompt

Reported as "macOS asks permission every time I launch an agent". It is not macOS and not our code: it is each agent CLI asking to trust the folder. Verified on the machine — Claude Code keeps it in `~/.claude.json`, where the main repo reads `hasTrustDialogAccepted: true` and **no worktree appears at all**. uxnan manufactures new folders by design, so each one is unknown to the CLI. The same would happen on Windows with a new worktree.

Pre-seeding that trust is a security decision, not an ergonomic one, and `agentcli.rs:385` already records the deliberate stance ("Folder trust is a separate decision and is left untouched"). Left alone by the maintainer's call.

## Verification

`svelte-check` 1631 files / 0 errors · 1244 Vitest (10 new).

**Known flake, pre-existing:** `LauncherDialog.svelte.test.ts` is order-dependent on macOS — run alone it failed 1, 2, 1 times across three consecutive runs, while the new tests passed 3/3. It reproduces on clean `main`, so CI may need one re-run.

https://claude.ai/code/session_01TTJsPXrZ6k6UUH1Bp7kQ9k