### PR TITLE
fix(terminal): declare TERM on local PTYs, and record the renderer

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -6,6 +6,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 ## [Unreleased]
 ### Fixed
 
+- **Terminals have colour again.** Every CLI in every terminal rendered
+  monochrome — an agent's own branding included — because the shell was started
+  with **no `TERM` at all**. That variable is set by terminal emulators, and
+  nothing on the path from the Dock, Finder or a desktop launcher is one, so a
+  GUI launch inherits an empty environment and the child shell inherits that
+  emptiness. Anything that asks "can this terminal do colour?" got no for an
+  answer. Running the app *from* a terminal hides it completely, since it then
+  inherits that terminal's `TERM` — which is why it survived development.
+
+  A terminal now says what it is: `TERM=xterm-256color` and
+  `COLORTERM=truecolor`, exactly as the SSH path already declared for a remote
+  shell, and for the same stated reason — that is what the frontend's xterm
+  actually is, and claiming otherwise makes a TUI draw for a terminal that is not
+  there. Both are defaults rather than overrides: they are set before the
+  caller's own variables, so a profile or an agent that pins either keeps it.
+
+
 - **An agent no longer gets its own launch command typed into it.** Sometimes a
   freshly launched agent found the whole line — command, session id, MCP flags —
   sitting in its prompt box, as if someone had pasted it there. Someone had: us.

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the Uxnan Desktop ADE are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
+### Added
+
+- **The diagnostics log records which renderer the terminals got.** xterm draws
+  on WebGL when it can and silently falls back to a DOM renderer when it cannot
+  — a bare `catch` with a comment. That fallback is not cosmetic: it repaints
+  markedly slower under heavy output, so it surfaces as "the terminal feels
+  laggy", with nothing anywhere to explain it and no way to tell it apart from a
+  slow *program*. It now writes one line per outcome per session — `renderer:
+  WebGL (accelerated)`, or the DOM fallback with its reason — including the
+  second path into the fallback, a repeated WebGL context loss, which used to
+  leave a pane on the slow renderer just as quietly. A performance trade the app
+  makes on your behalf belongs in the record it already keeps.
+
 ### Fixed
 
 - **Terminals have colour again.** Every CLI in every terminal rendered

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -28,7 +28,7 @@ background consumers**, `docs/resource-mode.md`), **post-mortem diagnostics**
 the tab strip** (`convtitle.rs`, the agent's own CLI on its cheapest model,
 named from the session's **terminal transcript** — the only material every agent
 has, since only Claude reports a prompt through the hook; a hand-renamed tab
-always wins). 811 Rust tests (774 unit + 37
+always wins). 813 Rust tests (776 unit + 37
 integration), of which 50 are ignored probes that need something real to talk to
 (41 live SSH probes — 29 against a real `sshd` and 12 against a **Linux host in a
 container**, `npm run test:ssh:linux` — one pwsh preflight, 7 supervised live
@@ -1459,7 +1459,7 @@ when an announced state exceeds the evidence. Announced today: **Windows
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 811 Rust + 1,244 passing Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 813 Rust + 1,244 passing Vitest tests (both
   projects: pure logic and components). E2E has its own **dispatch-only** Windows
   workflow (`e2e-desktop.yml`), outside the required gate — and it does not pass
   on a hosted runner at all: E2E is a local layer, for the measured reason in the

--- a/uxnandesktop/docs/agent-hooks.md
+++ b/uxnandesktop/docs/agent-hooks.md
@@ -241,6 +241,15 @@ spawns (inherited by any agent run inside that terminal):
 | `UXNAN_AGENT_ID` | This terminal's id — echo it back as `agentId` |
 | `UXNAN_ENDPOINT_FILE` | Path to `endpoint.env` / `endpoint.cmd` — a file the ADE rewrites every launch with the live url + token. It is the **rescue**, not the first choice: a reporter uses the terminal's own environment and falls back to this file only when that fails, which is what a terminal that outlived an app restart needs. |
 
+Every terminal also starts with `TERM=xterm-256color` and `COLORTERM=truecolor`,
+because that is what the frontend's xterm actually is. They are defaults, not
+overrides — a terminal profile or an agent that sets either one keeps its value.
+The ADE has to state them: launched from the Dock, Finder or a desktop launcher
+there is no `TERM` to inherit (that variable comes from terminal emulators, and
+none of those is one), so without this every CLI in every terminal concluded the
+session had no colour. Running the app *from* a terminal hides the problem, which
+is why it never appears in development.
+
 You never need to set these by hand — the reporters pick them up from the
 environment, and so does anything else you write against the contract.
 

--- a/uxnandesktop/docs/diagnostics.md
+++ b/uxnandesktop/docs/diagnostics.md
@@ -54,6 +54,7 @@ message.
 | `webview.rejection` | An unhandled promise rejection in the frontend |
 | `persistence` | Failing to load the persisted state (the app then starts fresh) |
 | `hooks` | The agent hook server failing to start, or hook scripts failing to install |
+| `terminal` | Which renderer xterm actually got — `WebGL (accelerated)`, or the **DOM fallback** with the reason. Once per outcome per session. The fallback is not cosmetic: it repaints markedly slower under heavy output, which reads as "the terminal feels laggy" and is otherwise indistinguishable from a slow *program*, so the app records the trade it made on your behalf |
 
 ### What is never recorded
 

--- a/uxnandesktop/src-tauri/src/pty.rs
+++ b/uxnandesktop/src-tauri/src/pty.rs
@@ -46,6 +46,33 @@ pub struct PtySpec {
     pub rows: u16,
 }
 
+/// What the terminal declares itself to be, before the caller's own variables.
+///
+/// `TERM` is not inherited from anywhere useful. A GUI app launched from the
+/// Dock, Finder or a desktop launcher starts with **no** `TERM` at all — the
+/// variable is set by terminal emulators, and nothing on that path is one. The
+/// child shell then inherits that emptiness, every CLI inside it concludes the
+/// terminal cannot do colour, and the whole session renders monochrome. (Run the
+/// app from a terminal instead and it inherits that terminal's `TERM`, which is
+/// why this never shows up in development.)
+///
+/// So the terminal says what it is, exactly as the SSH path already does for a
+/// remote shell: `xterm-256color`, because that is what the frontend's xterm
+/// actually is — claiming anything else makes a TUI draw for a terminal that is
+/// not there. `COLORTERM` goes with it because xterm.js renders 24-bit colour,
+/// and a CLI that checks only `TERM` will otherwise quantise to 256.
+///
+/// Both are defaults, not overrides: they are emitted first, so a caller that
+/// sets either in `spec.env` still wins.
+fn terminal_env(caller: &[(String, String)]) -> Vec<(String, String)> {
+    let mut env: Vec<(String, String)> = vec![
+        ("TERM".to_string(), "xterm-256color".to_string()),
+        ("COLORTERM".to_string(), "truecolor".to_string()),
+    ];
+    env.extend(caller.iter().cloned());
+    env
+}
+
 /// One live pseudoterminal: the master handle (for resize), its writer (stdin)
 /// and the child process (for kill).
 struct PtySession {
@@ -105,7 +132,7 @@ impl PtyManager {
         for arg in &spec.args {
             cmd.arg(arg);
         }
-        for (key, value) in &spec.env {
+        for (key, value) in terminal_env(&spec.env) {
             cmd.env(key, value);
         }
         let cwd = spec.cwd.unwrap_or_else(default_cwd);
@@ -430,5 +457,36 @@ mod tests {
     fn close_unknown_pty_is_noop() {
         let mgr = PtyManager::default();
         assert!(mgr.close("missing").is_ok());
+    }
+
+    /// The bug this guards: launched from the Dock there is no `TERM` to
+    /// inherit, so every CLI in every terminal decided the session had no
+    /// colour. The terminal has to say what it is.
+    #[test]
+    fn a_terminal_declares_what_it_is() {
+        let env = terminal_env(&[]);
+        assert!(env.contains(&("TERM".to_string(), "xterm-256color".to_string())));
+        assert!(env.contains(&("COLORTERM".to_string(), "truecolor".to_string())));
+    }
+
+    #[test]
+    fn the_callers_own_variables_come_after_and_win() {
+        let env = terminal_env(&[
+            ("UXNAN_AGENT_ID".to_string(), "a1".to_string()),
+            ("TERM".to_string(), "dumb".to_string()),
+        ]);
+        // `CommandBuilder::env` is last-write-wins, so ours being first is what
+        // makes them defaults rather than overrides — a profile or an agent that
+        // deliberately sets TERM keeps its value.
+        let term_positions: Vec<usize> = env
+            .iter()
+            .enumerate()
+            .filter(|(_, (k, _))| k == "TERM")
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(term_positions.len(), 2);
+        assert!(term_positions[0] < term_positions[1]);
+        assert_eq!(env[term_positions[1]].1, "dumb");
+        assert!(env.contains(&("UXNAN_AGENT_ID".to_string(), "a1".to_string())));
     }
 }

--- a/uxnandesktop/src/lib/components/Terminal.svelte
+++ b/uxnandesktop/src/lib/components/Terminal.svelte
@@ -1,3 +1,12 @@
+<script module lang="ts">
+  // One-shot guards for `recordRenderer` (see it, below, for why the renderer is
+  // logged once per outcome rather than per attach). Module-level on purpose:
+  // which renderer xterm can get is a property of the webview, so the first
+  // terminal to find out has answered it for the whole app.
+  let loggedAccelerated = false;
+  let loggedFallback = false;
+</script>
+
 <script lang="ts">
   import { onDestroy, onMount, tick } from "svelte";
   import { invoke } from "@tauri-apps/api/core";
@@ -20,6 +29,8 @@
     type TerminalInstance,
   } from "$lib/terminal/instances";
   import { arbitrateTerminalKey, isMac, type ArbiterContext } from "$lib/keybindings";
+  import { diagnosticsLog } from "$lib/api";
+
   import { runAppAction } from "$lib/keyactions";
   import { terminalKeyboard } from "$lib/state/terminalKeyboard.svelte";
   import { agentStatus } from "$lib/state/agentStatus.svelte";
@@ -261,19 +272,52 @@
         const rapid = now - owner.webglLossAt < 2000;
         owner.webglLossAt = now;
         disposeRenderer(webgl);
-        if (!rapid) {
-          requestAnimationFrame(() => {
-            if (term && inst && !inst.renderer) attachRenderer();
-            forceRepaint();
-          });
+        if (rapid) {
+          // Over the context budget: we stay on the DOM fallback until the next
+          // reveal. That is a real drop in paint throughput, so say so.
+          recordRenderer(false, "repeated WebGL context loss");
+          return;
         }
+        requestAnimationFrame(() => {
+          if (term && inst && !inst.renderer) attachRenderer();
+          forceRepaint();
+        });
       });
       term.loadAddon(webgl);
       owner.renderer = webgl;
-    } catch {
+      recordRenderer(true);
+    } catch (err) {
       // WebGL unavailable — xterm falls back to the DOM renderer.
       owner.renderer = undefined;
+      recordRenderer(false, err instanceof Error ? err.message : String(err));
     }
+  }
+
+  // Which renderer the terminals actually got, recorded once per session per
+  // outcome.
+  //
+  // The fallback to xterm's DOM renderer used to be a bare `catch` with a
+  // comment: correct, and completely silent. But it is not a cosmetic
+  // difference — the DOM renderer repaints markedly slower under heavy output,
+  // which surfaces as "the terminal feels laggy" with nothing anywhere to
+  // explain it, and no way to tell it apart from a slow *program*. A perf cliff
+  // the app takes on your behalf belongs in the log it already keeps.
+  //
+  // Once per outcome, not per call: `attachRenderer` runs on every reveal, and
+  // the answer is a property of the webview, not of one pane.
+  function recordRenderer(accelerated: boolean, reason?: string): void {
+    if (accelerated ? loggedAccelerated : loggedFallback) return;
+    if (accelerated) loggedAccelerated = true;
+    else loggedFallback = true;
+    void diagnosticsLog(
+      accelerated ? "info" : "warn",
+      "terminal",
+      accelerated
+        ? "renderer: WebGL (accelerated)"
+        : `renderer: DOM fallback, output paints slower — ${reason ?? "WebGL unavailable"}`,
+    ).catch(() => {
+      // Diagnostics is best-effort; never let logging break a terminal.
+    });
   }
 
   // Dispose the accelerated addon defensively. xterm's WebGL disposer reaches into


### PR DESCRIPTION
Two terminal fixes found while running an agent inside a Dock-launched build.

## Terminals had no colour

Every CLI in every terminal rendered monochrome — an agent's own branding included — because the shell started with **no `TERM` at all**.

`TERM` is set by terminal emulators, and nothing on the path from the Dock, Finder or a desktop launcher is one: a GUI launch inherits an empty environment and the child shell inherits that emptiness, so anything asking "can this terminal do colour?" gets no for an answer. Verified from inside such a terminal: `TERM=`, `COLORTERM=`, `tput colors` silent.

Launching the app *from* a terminal hides it completely — it then inherits that terminal's own `TERM` — which is why it survived development and why it took an agent session inside an installed build to see.

The SSH path had already worked this out and says so in a comment: `xterm-256color`, *"because that is what the frontend's xterm actually is; claiming anything else makes a remote TUI draw for a terminal that is not there."* The local path never got the same treatment. It does now, with `COLORTERM=truecolor` alongside, since xterm.js renders 24-bit colour. Both are defaults, not overrides: emitted before the caller's own variables, so `CommandBuilder`'s last-write-wins leaves a profile or an agent that pins either one in charge.

## The renderer is no longer a silent choice

xterm falls back from WebGL to a DOM renderer through a bare `catch`. That fallback repaints markedly slower under heavy output, so it reads as "the terminal feels laggy" with nothing to explain it and no way to distinguish it from a slow *program*.

Diagnosing exactly that report meant measuring the PTY by hand (473 KB through `/dev/ttys000` at 45 MB/s — backend innocent) and then still being blind to the frontend half. The log now answers it in one line: `renderer: WebGL (accelerated)`, or the DOM fallback with its reason, once per outcome per session. The second path into the fallback — repeated WebGL context loss, which parks a pane on the slow renderer until the next reveal — was equally quiet and now says so too.

**The report that prompted this was not the renderer.** The verdict on the reporting machine was `WebGL (accelerated)`, so the sluggishness is not uxnan's terminal at all. The instrumentation stays because the fallback does, and because this is what the diagnostics log exists for — it was built after a black screen left nothing to investigate with.

## Verification

Rust suite green: 729 unit + 30 integration, 0 failures. `svelte-check` 1631 files / 0 errors, 1244 Vitest.

> Note for anyone running the Rust suite from inside an agent session: `git::tests::commit_sign_off_appends_trailer` fails there, because `GIT_AUTHOR_*` / `GIT_COMMITTER_*` in that environment override the test repo's local identity. `env -u GIT_AUTHOR_NAME -u GIT_COMMITTER_NAME …` makes it pass. Not an app bug — the app just runs `git commit -s`.

https://claude.ai/code/session_016RLmrYWJjtQy9xJGeQqp7Q