### PR TITLE
fix(desktop): dialogs that reset themselves, a flush footer, and provider panels that blamed your login

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -22,6 +22,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   since each tab owns its own actions. So the title had its full inset while the
   composer's Send sat on the border. It now carries a matching bottom inset.
 
+- **Claude Code's provider panel stops claiming you are signed out on macOS.**
+  There it writes no `~/.claude/.credentials.json` at all — the token lives in
+  the login Keychain — so the reader reported "not signed in" to people who were
+  signed in, and sent them off to re-run `claude login` for a problem that is
+  ours. It now says what is actually true: the token is somewhere Uxnan does not
+  read. The data stays unavailable, blocked on the same OS-keyring decision that
+  keeps Antigravity out (`docs/providers.md`, and the FOR-DEV item).
+
+
 ## [0.0.47] - 20260903
 ### Added
 

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -16,6 +16,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   the only visible symptom was the boxes emptying. The reset now depends on the
   dialog opening and nothing else.
 
+- **The orchestration console's buttons are no longer flat against its edge.**
+  Its content shell is `py-0` by design — the top inset comes from the header and
+  the bottom one from a footer's action band — and this console has no footer,
+  since each tab owns its own actions. So the title had its full inset while the
+  composer's Send sat on the border. It now carries a matching bottom inset.
+
 ## [0.0.47] - 20260903
 ### Added
 

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -22,6 +22,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   since each tab owns its own actions. So the title had its full inset while the
   composer's Send sat on the border. It now carries a matching bottom inset.
 
+- **A provider with no quota window stops being told to sign in again.** One
+  sentence covered two different situations and named the wrong one: a read that
+  came back live, with no windows, said *"No quota windows yet — refresh once
+  signed in."* Quota windows are percentages of an allowance, so an account
+  billed by spend has none to report — verified against the real API for a
+  pay-as-you-go Grok account, which returns no `creditUsagePercent` at all, and
+  with no on-demand cap and nothing spent has no balance worth drawing either.
+  Nothing was broken; the panel just blamed a login that was fine. It now says
+  the account reports no window when the read succeeded, and keeps the
+  sign-in wording for the case that really is one.
+
 - **Claude Code's provider panel stops claiming you are signed out on macOS.**
   There it writes no `~/.claude/.credentials.json` at all — the token lives in
   the login Keychain — so the reader reported "not signed in" to people who were

--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to the Uxnan Desktop ADE are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- **The remove-worktree dialog stops clearing your choices while you fill it in.**
+  Tick "delete remote branch", let an agent print a line, and the box silently
+  cleared itself; pressing the button did it too. The effect that resets the form
+  on open also *tracked* the worktree's git status and its live agent tabs — both
+  of which move on their own, the status poll every few seconds and an agent tab
+  on every burst of terminal output — so it was a reset-on-anything effect. The
+  removal still ran with the values the click had already captured, which is why
+  the only visible symptom was the boxes emptying. The reset now depends on the
+  dialog opening and nothing else.
 
 ## [0.0.47] - 20260903
 ### Added

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -1262,6 +1262,15 @@ durable persistence, orchestration MCP tools) — are **done** (see `CHANGELOG.m
       in the `serverUrl`.
 
 **Providers (usage statistics)**
+- [ ] **Claude Code usage on macOS — blocked on the same keyring decision.**
+      macOS Claude Code writes no `~/.claude/.credentials.json`; the token is in
+      the login Keychain as `Claude Code-credentials` (verified on a real
+      install: the file is absent while the keychain item is present, and
+      `~/.claude.json` exists, so the provider is still *detected*). The reader
+      now reports that honestly instead of "not signed in", but the data stays
+      unavailable. Unblocking it is the identical decision as the Antigravity
+      item below — read the OS keyring — and would cover both providers at once.
+      Site: `src-tauri/src/usage.rs` (`read_claude`).
 - [ ] **Antigravity (`agy`) as a usage provider — deferred on the token, not on the
       data.** Researched against a real install; nothing implemented. The data and
       the API are within reach: `agy` talks to Google's Code Assist backend (its own

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -32,7 +32,7 @@ always wins). 813 Rust tests (776 unit + 37
 integration), of which 50 are ignored probes that need something real to talk to
 (41 live SSH probes — 29 against a real `sshd` and 12 against a **Linux host in a
 container**, `npm run test:ssh:linux` — one pwsh preflight, 7 supervised live
-GitHub tests, 1 real-scheduler probe) + 1,244 passing frontend Vitest tests across two
+GitHub tests, 1 real-scheduler probe) + 1,245 passing frontend Vitest tests across two
 projects — pure logic and **Svelte
 component tests** — plus a **real E2E suite** (WebdriverIO + tauri-driver: 8
 journeys, 24 tests, green on Windows, plus an opt-in GitHub journey pending its
@@ -1459,7 +1459,7 @@ when an announced state exceeds the evidence. Announced today: **Windows
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 813 Rust + 1,244 passing Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 813 Rust + 1,245 passing Vitest tests (both
   projects: pure logic and components). E2E has its own **dispatch-only** Windows
   workflow (`e2e-desktop.yml`), outside the required gate — and it does not pass
   on a hosted runner at all: E2E is a local layer, for the measured reason in the

--- a/uxnandesktop/docs/providers.md
+++ b/uxnandesktop/docs/providers.md
@@ -15,7 +15,7 @@ into Uxnan — only the token the CLI already stored on disk.
 | Provider | Source file | Reads |
 |---|---|---|
 | **Codex** | `~/.codex/auth.json` | monthly/weekly windows, plan, credit, **rate-limit resets**, account type, email |
-| **Claude Code** | `~/.claude/.credentials.json` | session (5h) / weekly / model-scoped windows, plan, account type |
+| **Claude Code** | `~/.claude/.credentials.json` (**not on macOS** — see below) | session (5h) / weekly / model-scoped windows, plan, account type |
 | **GitHub Copilot** | `gh auth token` | premium/chat/completions quotas, plan, account type, GitHub login |
 | **Grok** | `~/.grok/auth.json` | credit-usage window, reset, **on-demand / prepaid $**, plan, account type, email |
 
@@ -24,6 +24,12 @@ A provider that isn't set up, isn't signed in, or errors shows a clear status
 each provider is read independently.
 
 ### What's missing
+
+**Claude Code has no usage on macOS.** There it does not write
+`~/.claude/.credentials.json` at all — the token lives in the login Keychain
+(`Claude Code-credentials`), so there is nothing to read under the posture above
+and the panel says so plainly rather than claiming you are signed out. This is
+the *same* blocker as Antigravity's below, and the same decision unblocks both.
 
 **Antigravity is not a provider yet.** Its quota sits behind the same Google Code
 Assist API this reader already speaks, but `agy` keeps its OAuth token in the OS

--- a/uxnandesktop/docs/providers.md
+++ b/uxnandesktop/docs/providers.md
@@ -23,6 +23,14 @@ A provider that isn't set up, isn't signed in, or errors shows a clear status
 (`Not set up` / `Sign in required` / `Unavailable`) instead of failing the rest —
 each provider is read independently.
 
+**A live provider can still have no meter.** Quota windows are percentages of an
+allowance, so an account billed by spend has none to report — a pay-as-you-go
+Grok account returns no `creditUsagePercent`, and with no on-demand cap and
+nothing spent there is no balance worth drawing either. That is not a failure
+and not a sign-in problem: the provider reads `Live`, and the status-bar
+section says the account reports no window rather than telling you to sign in
+again.
+
 ### What's missing
 
 **Claude Code has no usage on macOS.** There it does not write

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -249,7 +249,7 @@ evidence that exists, and the announced level gated to it; see
 (`tests/bundled-pets.test.mjs` — `BUILTIN_PET_IDS` and the packs in
 `static/pets/` are the same set, each manifest's id matches its folder, and
 each sheet divides exactly into the format's 192 × 208 cell; art nobody listed
-ships in every build and is never shown). **1,244 passing tests** across both
+ships in every build and is never shown). **1,245 passing tests** across both
 projects, config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)

--- a/uxnandesktop/src-tauri/src/usage.rs
+++ b/uxnandesktop/src-tauri/src/usage.rs
@@ -707,6 +707,21 @@ fn codex_base_url(home: &Path) -> String {
 async fn read_claude(home: &Path) -> ProviderUsage {
     let creds_path = home.join(".claude").join(".credentials.json");
     let Some(creds) = read_json(&creds_path) else {
+        // On macOS the file is absent even for a signed-in install: Claude Code
+        // keeps its token in the login Keychain (`Claude Code-credentials`)
+        // instead of on disk. Saying "not signed in" there is simply false — the
+        // user is signed in, we just do not read the OS keyring, which is the
+        // same documented posture that keeps Antigravity out (see
+        // `docs/providers.md` and the FOR-DEV item). Report what is actually
+        // true, so the panel does not send someone off to re-run `claude login`
+        // for a problem that is ours.
+        if cfg!(target_os = "macos") && home.join(".claude.json").exists() {
+            return ProviderUsage::base(UsageProvider::Claude, UsageStatus::AuthRequired)
+                .with_message(
+                    "Claude Code stores its token in the macOS Keychain, which Uxnan does not \
+                     read — usage is unavailable here even while you are signed in",
+                );
+        }
         return ProviderUsage::base(UsageProvider::Claude, UsageStatus::NotInstalled)
             .with_message("Claude Code is not signed in (~/.claude/.credentials.json missing)");
     };

--- a/uxnandesktop/src/lib/components/OrchestrationConsole.svelte
+++ b/uxnandesktop/src/lib/components/OrchestrationConsole.svelte
@@ -22,8 +22,14 @@
 
 <Dialog.Root bind:open={app.orchestrationOpen}>
   <!-- Workspace content needs a viewport-relative canvas for its split run and
-       log panes; the named workspace role supplies the desktop clamp. -->
-  <Dialog.Content size="workspace" class="flex max-h-[88vh] flex-col overflow-hidden">
+       log panes; the named workspace role supplies the desktop clamp.
+       `pb-5` because the content shell is `py-0` by design: the top inset comes
+       from `Dialog.Header`'s `pt-5` and the bottom one normally from
+       `Dialog.Footer`'s action band. This console has no footer — each tab owns
+       its own actions, the composer's Send among them — so without a bottom
+       inset those buttons sat flat against the dialog's edge while the title
+       above them had its full 20px. Matching `pt-5` restores the symmetry. -->
+  <Dialog.Content size="workspace" class="flex max-h-[88vh] flex-col overflow-hidden pb-5">
     <Dialog.Header>
       <Dialog.Title class="flex items-center gap-2">
         {i18n.t("orchestration.title")}

--- a/uxnandesktop/src/lib/components/ProviderUsageEditor.svelte
+++ b/uxnandesktop/src/lib/components/ProviderUsageEditor.svelte
@@ -373,7 +373,20 @@
             </label>
           {/each}
         {:else}
-          <span class={text.meta}>{i18n.t("providers.noWindowsToPick")}</span>
+          <!-- Two different situations used to share one sentence, and it named
+               the wrong one. A provider read that came back `ok` and has no
+               windows is not waiting on a sign-in — the account simply has no
+               quota window to meter, which is what a pay-as-you-go Grok account
+               looks like: live, authenticated, billed by spend rather than by a
+               percentage. Telling that user to "refresh once signed in" sends
+               them to fix a login that is already fine. -->
+          <span class={text.meta}>
+            {i18n.t(
+              snapshot?.status === "ok"
+                ? "providers.noWindowsForAccount"
+                : "providers.noWindowsToPick",
+            )}
+          </span>
         {/if}
         <label class="flex min-h-8 cursor-pointer items-center gap-2 py-1">
           <Checkbox

--- a/uxnandesktop/src/lib/components/RemoveWorktreeDialog.svelte
+++ b/uxnandesktop/src/lib/components/RemoveWorktreeDialog.svelte
@@ -14,6 +14,7 @@
   // Everything that destroys MORE than the default lives under "Advanced",
   // collapsed: forcing an unmerged branch delete, and forcing removal over
   // uncommitted work. They stay one click away — never a default, never hidden.
+  import { untrack } from "svelte";
   import * as Dialog from "$lib/components/ui/dialog";
   import * as Collapsible from "$lib/components/ui/collapsible";
   import { Button } from "$lib/components/ui/button";
@@ -63,29 +64,41 @@
     }),
   );
 
-  // Reset each time the dialog opens; look up whether the branch exists on origin
-  // so the remote option is only offered when it can do something.
+  // Reset when the dialog OPENS — and only then.
+  //
+  // `open` is the sole dependency on purpose, so the body runs `untrack`ed. It
+  // reads `defaults`, which derives from the worktree's git status and its live
+  // agent tabs; both move on their own while the dialog sits there (the status
+  // poll every few seconds, an agent tab's state on every burst of terminal
+  // output). Tracking those made this a *reset-on-anything* effect: tick "delete
+  // remote branch", let an agent print a line, and the box silently cleared
+  // itself. Pressing the button did it too — the removal it kicks off changes
+  // exactly that state, so the form wiped mid-flight. The actions still ran with
+  // the values `confirm()` had already captured, which is why the damage was
+  // invisible until you looked back at the boxes.
   $effect(() => {
     if (!open) return;
-    // Seeded from the verdict rather than always-false: a landed branch arrives
-    // ticked, so the common finished case is one button.
-    deleteLocal = defaults.deleteLocal;
-    forceLocal = false;
-    deleteRemote = false;
-    forceRemove = false;
-    advancedOpen = false;
-    remoteExists = false;
-    forceNeeded = false;
-    error = null;
-    if (!row.branch) return;
-    projects
-      .branchInfo(row.repoId)
-      .then((info) => {
-        remoteExists = info.remoteBranches.includes(row.branch as string);
-      })
-      .catch(() => {
-        // A missing remote just means no remote option — never block the removal.
-      });
+    untrack(() => {
+      // Seeded from the verdict rather than always-false: a landed branch
+      // arrives ticked, so the common finished case is one button.
+      deleteLocal = defaults.deleteLocal;
+      forceLocal = false;
+      deleteRemote = false;
+      forceRemove = false;
+      advancedOpen = false;
+      remoteExists = false;
+      forceNeeded = false;
+      error = null;
+      if (!row.branch) return;
+      projects
+        .branchInfo(row.repoId)
+        .then((info) => {
+          remoteExists = info.remoteBranches.includes(row.branch as string);
+        })
+        .catch(() => {
+          // A missing remote just means no remote option — never block removal.
+        });
+    });
   });
 
   function toggleLocal() {

--- a/uxnandesktop/src/lib/components/RemoveWorktreeDialog.svelte.test.ts
+++ b/uxnandesktop/src/lib/components/RemoveWorktreeDialog.svelte.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { mountWithProviders } from "../../test/render";
+import { app } from "$lib/state/app.svelte";
+import { projects, type WorktreeRow } from "$lib/state/projects.svelte";
+import type { RepoData } from "$lib/types";
+import RemoveWorktreeDialog from "./RemoveWorktreeDialog.svelte";
+
+const repo: RepoData = {
+  id: "repo-1",
+  name: "sample",
+  path: "C:/projects/sample",
+  worktrees: [],
+  isGit: true,
+};
+
+const row: WorktreeRow = {
+  path: "C:/projects/sample--feature",
+  branch: "feature",
+  head: "abc123",
+  isMain: false,
+  repoId: repo.id,
+  repoName: repo.name,
+};
+
+beforeEach(() => {
+  app.repos = [repo];
+  projects.statusByPath = {};
+  projects.error = null;
+});
+
+describe("RemoveWorktreeDialog", () => {
+  // The bug: the effect that resets the form on open also *tracked* the
+  // worktree's git status and its live agent tabs. Both move on their own while
+  // the dialog sits there — the status poll every few seconds, an agent tab on
+  // every burst of terminal output — so ticking a box and then letting an agent
+  // print a line silently cleared it. Pressing the button did it too: the
+  // removal changes exactly that state.
+  it("keeps the user's choices when the worktree status changes underneath", async () => {
+    const { screen, user } = mountWithProviders(RemoveWorktreeDialog, {
+      props: { open: true, row },
+      commands: {
+        branch_list: () => ({ branches: ["main"], remoteBranches: [], defaultBase: "main" }),
+      },
+    });
+
+    const boxes = await screen.findAllByRole("checkbox");
+    const local = boxes[0];
+    // Unchecked to begin with: this worktree has not landed, so the reset ran on
+    // open and seeded from `defaults`. That is the half of the effect worth
+    // keeping — the assertions below are about it not running a second time.
+    expect(local).not.toBeChecked();
+
+    await user.click(local);
+    expect(local).toBeChecked();
+
+    // What the status poll does on its next pass.
+    projects.statusByPath = {
+      ...projects.statusByPath,
+      [row.path]: { dirty: 2, ahead: 1, behind: 0 },
+    };
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(local, "a background status refresh cleared the form").toBeChecked();
+  });
+
+});

--- a/uxnandesktop/src/lib/i18n/locales/en.ts
+++ b/uxnandesktop/src/lib/i18n/locales/en.ts
@@ -857,6 +857,8 @@ export const en = {
   "providers.empty": "No providers yet. Add one above to track its usage.",
   "providers.showInStatusBar": "Show in status bar",
   "providers.noWindowsToPick": "No quota windows yet — refresh once signed in.",
+  "providers.noWindowsForAccount":
+    "This account reports no quota window, so there is nothing to meter in the status bar.",
   "providers.showPlan": "Plan",
   "providers.showCredit": "Credit balance",
   "providers.refreshGlobal": "Global default",

--- a/uxnandesktop/src/lib/i18n/locales/es.ts
+++ b/uxnandesktop/src/lib/i18n/locales/es.ts
@@ -861,6 +861,8 @@ export const es: Record<MessageKey, string> = {
   "providers.empty": "Aún no hay proveedores. Agrega uno arriba para ver su uso.",
   "providers.showInStatusBar": "Mostrar en la barra de estado",
   "providers.noWindowsToPick": "Aún no hay ventanas de cuota — actualiza tras iniciar sesión.",
+  "providers.noWindowsForAccount":
+    "Esta cuenta no reporta ninguna ventana de cuota, así que no hay nada que medir en la barra de estado.",
   "providers.showPlan": "Plan",
   "providers.showCredit": "Saldo de crédito",
   "providers.refreshGlobal": "Predeterminado global",


### PR DESCRIPTION
Four fixes. Two were real defects, two were the app saying something untrue about a system that was working.

## The remove-worktree dialog cleared your choices as you made them

Tick "delete remote branch", let an agent print a line, and the box emptied itself. Pressing the button did it too.

The effect that resets the form reads `open` — and also `defaults`, which derives from the worktree's git status and its live agent tabs. Both move on their own: the status poll every few seconds, an agent tab on every burst of terminal output. It was a reset-on-anything effect wearing a reset-on-open comment. The removal still ran correctly, because `confirm()` had already captured the values, which is exactly why the only visible symptom was the boxes emptying under you.

The body now runs `untrack`ed, leaving `open` as the sole dependency. The regression test has teeth: reverting the `untrack` fails it.

The other six dialogs with the same `if (!open) return` shape were **checked rather than assumed** — they read settings, or props that only change on an explicit user action, none of which can move while the dialog is modal. This was the only live one, and the only dialog that reads git status and agent tabs.

## The orchestration console's buttons sat on its bottom edge

`dialog.content` is `py-0` by design: the top inset comes from `Dialog.Header`'s `pt-5`, the bottom from `Dialog.Footer`'s action band. This console has a header and no footer — each tab owns its own actions — so nothing supplied the bottom half. `pb-5`, matching the header, rather than wrapping the tabs in a footer that would claim the actions belong to the dialog.

## Claude Code said you were signed out on macOS

macOS Claude Code writes no `~/.claude/.credentials.json` at all; the token is in the login Keychain. Verified on a real install: file absent, keychain item present, `~/.claude.json` present so the provider is still *detected*. The reader took the missing file as proof of a missing login and sent people to re-run `claude login` for a problem that is ours.

It now reports what is true. **The data stays unavailable, deliberately** — reading the OS keyring is the documented posture boundary this project has not crossed, and the FOR-DEV item for Antigravity already frames it as a decision rather than an oversight. Claude Code on macOS is the same blocker, recorded alongside it; one decision unblocks both. The maintainer was asked and chose to leave it.

## A live provider was told to sign in again

"No quota windows yet — refresh once signed in" covered two situations and named the wrong one.

Quota windows are percentages of an allowance, so an account billed by spend has none. Verified against the real billing API with the maintainer's consent: a pay-as-you-go Grok account returns no `subscriptionTier` and no `creditUsagePercent`, and `onDemandUsed` / `onDemandCap` / `prepaidBalance` all come back `{val: 0}`. Nothing to meter, no balance worth drawing.

**Nothing was broken.** `grok_credit` declining a zeroed on-demand block is right and the test pinning it is right — "$0.00 of $0.00" is noise. The panel was just blaming a login that was fine, the one thing that row must never do. The hint now branches on the read's own status.

## Verification

`svelte-check` 1632 files / 0 errors · 1245 Vitest (1 new) · Rust suite green.

https://claude.ai/code/session_016RLmrYWJjtQy9xJGeQqp7Q