### PR TITLE
fix(svelte): restore review panel after closing browser

### DIFF
--- a/uxnandesktop/CHANGELOG.md
+++ b/uxnandesktop/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
 
 ## [Unreleased]
 
+### Changed
+
+- Opening the integrated browser temporarily hides the review panel. Closing it
+  restores the panel only if it was previously open. The review-panel button and
+  shortcut switch back from the browser without losing the saved layout preference.
+
 ## [0.0.48] - 20260904
 ### Fixed
 

--- a/uxnandesktop/FOR-DEV.md
+++ b/uxnandesktop/FOR-DEV.md
@@ -32,7 +32,7 @@ always wins). 813 Rust tests (776 unit + 37
 integration), of which 50 are ignored probes that need something real to talk to
 (41 live SSH probes — 29 against a real `sshd` and 12 against a **Linux host in a
 container**, `npm run test:ssh:linux` — one pwsh preflight, 7 supervised live
-GitHub tests, 1 real-scheduler probe) + 1,245 passing frontend Vitest tests across two
+GitHub tests, 1 real-scheduler probe) + 1,249 passing frontend Vitest tests across two
 projects — pure logic and **Svelte
 component tests** — plus a **real E2E suite** (WebdriverIO + tauri-driver: 8
 journeys, 24 tests, green on Windows, plus an opt-in GitHub journey pending its
@@ -1468,7 +1468,7 @@ when an announced state exceeds the evidence. Announced today: **Windows
   (Vitest) + vite build + cargo fmt/clippy/test. CI covers `{ubuntu, windows,
   macos-14}` (via `verify-desktop.yml`'s `os-list` input; one Apple Silicon leg —
   Intel runners are being retired and the code is arch-identical); the release gate
-  keeps the default `{ubuntu, windows}`. 813 Rust + 1,245 passing Vitest tests (both
+  keeps the default `{ubuntu, windows}`. 813 Rust + 1,249 passing Vitest tests (both
   projects: pure logic and components). E2E has its own **dispatch-only** Windows
   workflow (`e2e-desktop.yml`), outside the required gate — and it does not pass
   on a hosted runner at all: E2E is a local layer, for the measured reason in the

--- a/uxnandesktop/README.md
+++ b/uxnandesktop/README.md
@@ -178,6 +178,8 @@ available today are:
   gauge surfaces the meters you pick; startup/focus catch-up and per-provider
   intervals keep reset windows current. See [provider usage](./docs/providers.md).
 - **Integrated developer browser.** A complete in-app browser in a right-side panel
+  that temporarily hides the review panel and restores it on close only if it was
+  previously open
   (a real system webview docked to the app, so it loads any site and has real
   DevTools) to preview and debug what your agents build — `localhost` dev servers
   and any site — and to open the links they create. Links route by a policy you

--- a/uxnandesktop/architecture/02a-system-architecture.md
+++ b/uxnandesktop/architecture/02a-system-architecture.md
@@ -3,6 +3,7 @@
 > Documento de arquitectura del sistema para el Uxnan Desktop ADE.
 > Cubre el modelo de tres actores, modelo de datos, navegacion, layout, review, conexiones, persistencia y diagnostico post-mortem (§7.3.1).
 > Derivado de las secciones 2, 3, 4, 6.3 y 7 del documento de arquitectura original.
+> Browser layout (§4.2b) temporarily hides the review panel while preserving its saved visibility.
 
 ---
 
@@ -361,6 +362,12 @@ Esto es una distincion importante que diferencia al ADE de un terminal convencio
 - Similar a como funcionan los splits en Vim o tmux.
 
 ### 4.2b Navegador integrado (tab `browser`) — implementado
+
+The browser temporarily hides the Files / Changes / History / GitHub panel.
+Its saved `rightSidebarOpen` preference remains unchanged, so closing the browser
+restores only a previously open panel, including after repeated URL navigation.
+The review-panel button and keyboard shortcut explicitly switch back to review,
+closing the browser and saving the review panel as open.
 
 El tipo de contenido `browser` (webview embebido) **está implementado** como un
 navegador *de desarrollo* ligero: para previsualizar/depurar lo que construyen los

--- a/uxnandesktop/docs/browser.md
+++ b/uxnandesktop/docs/browser.md
@@ -20,6 +20,11 @@ panel and destroyed when you close it.
 
 ## Opening the browser
 
+Opening the browser temporarily hides the Files / Changes / History / GitHub
+panel. Closing the browser restores that panel only if it was open beforehand;
+navigating to another URL does not change the saved preference. The review-panel
+button or keyboard shortcut switches back to that panel and closes the browser.
+
 - **Toggle it** from the status-bar **globe** button (bottom-right). It opens at
   your configured *home page*, or a blank page.
 - **From a link:** anything the ADE opens as a URL (a **Ctrl/Cmd-clicked** terminal

--- a/uxnandesktop/docs/testing.md
+++ b/uxnandesktop/docs/testing.md
@@ -249,7 +249,7 @@ evidence that exists, and the announced level gated to it; see
 (`tests/bundled-pets.test.mjs` — `BUILTIN_PET_IDS` and the packs in
 `static/pets/` are the same set, each manifest's id matches its folder, and
 each sheet divides exactly into the format's 192 × 208 cell; art nobody listed
-ships in every build and is never shown). **1,245 passing tests** across both
+ships in every build and is never shown). **1,249 passing tests** across both
 projects, config in `vitest.config.ts` / `vitest.dom.config.ts`.
 
 ### L2 — components (`dom`)

--- a/uxnandesktop/src/lib/keyactions.ts
+++ b/uxnandesktop/src/lib/keyactions.ts
@@ -97,8 +97,7 @@ export function runAppAction(id: string, opts: RunActionOpts = {}): boolean {
       void app.persistSettings();
       return true;
     case "toggleRightSidebar":
-      app.settings.rightSidebarOpen = !app.settings.rightSidebarOpen;
-      void app.persistSettings();
+      app.toggleRightSidebar();
       return true;
     case "saveFile":
       return false; // handled by the editor's own CodeMirror keymap when focused

--- a/uxnandesktop/src/lib/state/app.svelte.ts
+++ b/uxnandesktop/src/lib/state/app.svelte.ts
@@ -124,6 +124,8 @@ class AppStore {
   orchestrationOpen = $state(false);
   /** Whether the integrated browser panel (the right-side "4th panel") is open. */
   browserOpen = $state(false);
+  /** Browser visibility temporarily overrides the saved review-panel preference. */
+  rightSidebarVisible = $derived(this.settings.rightSidebarOpen && !this.browserOpen);
   /** Target URL shown in the integrated browser panel. */
   browserUrl = $state("");
   /** Which Settings pane is shown (deep-linked via `openSettings`). */
@@ -242,6 +244,17 @@ class AppStore {
   /** Close the integrated browser panel (its `WebviewWindow` is destroyed). */
   closeBrowser(): void {
     this.browserOpen = false;
+  }
+
+  /** Toggle the review panel, keeping browser-only changes out of saved layout. */
+  toggleRightSidebar(): void {
+    if (this.browserOpen) {
+      this.closeBrowser();
+      this.settings.rightSidebarOpen = true;
+    } else {
+      this.settings.rightSidebarOpen = !this.settings.rightSidebarOpen;
+    }
+    void this.persistSettings();
   }
 
   /** Toggle the integrated browser panel (opens at the homepage/blank). */

--- a/uxnandesktop/src/lib/state/browser-layout.svelte.test.ts
+++ b/uxnandesktop/src/lib/state/browser-layout.svelte.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { app } from "./app.svelte";
+
+beforeEach(() => {
+  app.closeBrowser();
+  app.settings.rightSidebarOpen = true;
+  vi.spyOn(app, "persistSettings").mockResolvedValue();
+});
+
+afterEach(() => {
+  app.closeBrowser();
+  vi.restoreAllMocks();
+});
+
+describe("browser and review panel layout", () => {
+  it("temporarily hides an open review panel and restores it after repeated navigation", () => {
+    app.openBrowser("http://localhost:3000");
+    expect(app.rightSidebarVisible).toBe(false);
+    expect(app.settings.rightSidebarOpen).toBe(true);
+    app.openBrowser("http://localhost:4000");
+    app.closeBrowser();
+    expect(app.rightSidebarVisible).toBe(true);
+    expect(app.persistSettings).not.toHaveBeenCalled();
+  });
+
+  it("keeps a previously closed review panel closed across browser toggle cycles", () => {
+    app.settings.rightSidebarOpen = false;
+    for (let cycle = 0; cycle < 2; cycle++) {
+      app.toggleBrowser();
+      expect(app.browserOpen).toBe(true);
+      expect(app.rightSidebarVisible).toBe(false);
+      app.toggleBrowser();
+      expect(app.rightSidebarVisible).toBe(false);
+    }
+    expect(app.persistSettings).not.toHaveBeenCalled();
+  });
+
+  it("switches from the browser to the review panel on an explicit review toggle", () => {
+    app.settings.rightSidebarOpen = false;
+    app.openBrowser();
+    app.toggleRightSidebar();
+    expect(app.browserOpen).toBe(false);
+    expect(app.rightSidebarVisible).toBe(true);
+    expect(app.persistSettings).toHaveBeenCalledOnce();
+  });
+
+  it("still saves ordinary review-panel toggles and ignores repeated browser closes", () => {
+    app.toggleRightSidebar();
+    expect(app.rightSidebarVisible).toBe(false);
+    app.closeBrowser();
+    app.closeBrowser();
+    expect(app.rightSidebarVisible).toBe(false);
+    app.toggleRightSidebar();
+    expect(app.rightSidebarVisible).toBe(true);
+    expect(app.persistSettings).toHaveBeenCalledTimes(2);
+  });
+});

--- a/uxnandesktop/src/routes/+page.svelte
+++ b/uxnandesktop/src/routes/+page.svelte
@@ -143,8 +143,7 @@
     void app.persistSettings();
   }
   function toggleRightSidebar() {
-    app.settings.rightSidebarOpen = !app.settings.rightSidebarOpen;
-    void app.persistSettings();
+    app.toggleRightSidebar();
   }
 
   // Aim the backend filesystem watcher at the active worktree (here, not in the
@@ -372,7 +371,7 @@
           <TerminalArea />
         </main>
 
-        {#if app.settings.rightSidebarOpen}
+        {#if app.rightSidebarVisible}
           <!-- Region: Right panel — window-controls header · Files/Changes/History. -->
           {@render resizeHandle("right")}
 
@@ -525,12 +524,12 @@
             class={cn(
               shell.statusBarAction,
               focus.ring,
-              app.settings.rightSidebarOpen
+              app.rightSidebarVisible
                 ? "bg-accent text-foreground"
                 : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
             )}
             aria-label={i18n.t("terminal.toggleRight")}
-            aria-pressed={app.settings.rightSidebarOpen}
+            aria-pressed={app.rightSidebarVisible}
             onclick={toggleRightSidebar}
           >
             <Icon icon={PanelRightIcon} class={iconSize.action} />


### PR DESCRIPTION
## Summary

Opening the integrated browser now temporarily hides the Files / Changes / History / GitHub panel. Closing the browser restores that panel only if it was previously open, including after repeated URL navigation. The review-panel button and keyboard shortcut switch back to review and close the browser.

The saved review-panel preference is preserved while browsing. This PR changes only panel behavior; the orchestration dialog already has its bottom-padding fix.

## Affected component(s)

- [x] `uxnandesktop` — Tauri desktop app

## Type of change

- [x] `fix` — bug fix

## How was it tested?

- macOS: `npm run check` — zero errors and warnings.
- `npm test -- --reporter=dot` — 1,249 tests passed across 132 files, including four new browser/review layout tests.
- `npm run build` — passed with existing warnings about an unused import, mixed static/dynamic imports, and bundle size.
- Chromium against the frontend dev server: confirmed restoration for previously open and closed review panels, repeated URL navigation, and actual status-bar button transitions. Native Tauri behavior was not exercised in this validation.
- Verified the existing orchestration padding at 20 px in Broadcast and Runs, light/dark modes, and 1440×900 / 1000×650 viewports. No dialog changes were needed.

## Resource impact (`uxnandesktop` only)

Adds one derived visibility value and reuses the existing browser open/close lifecycle. Adds no processes, webviews, watchers, polling, sockets, or caches. The review panel is unmounted while the browser is open.

## Documentation and spec sync

Updated the desktop changelog, browser guide, README, and test counts. `uxnandesktop/architecture/02a-system-architecture.md` executive summary and §4.2b describe the visibility override and explicit switch back to review.

## Checklist

- [x] Svelte checks and `git diff --check` pass.
- [x] Tests added and the suite passes.
- [x] Component changelog updated.
- [x] Documentation and architecture updated.
- [x] Conventional Commit used.
- Shared contracts and mobile releases: not applicable.
- New desktop background resources: not applicable.
