### PR TITLE
feat(bridge): use persistent RPC session for Pi agent

### DIFF
--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the bridge daemon are documented here.
 Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+
+- **Pi persistent RPC session.** Previously, Pi Agent (`pi --mode rpc`) was spawned
+  fresh for every turn, ending its stdin stream after each turn. For long threads,
+  this caused multi-second disk re-parsing overhead of JSONL history, slow turn
+  turnaround, and potential process race conditions. The adapter now maintains a
+  persistent resident `pi --mode rpc` child process per thread with stdin held open,
+  reusing the active session across turns as long as thread configuration (cwd, model,
+  effort, permissionMode) remains unchanged. Idle sessions are automatically torn
+  down after 2 hours (`DEFAULT_PI_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000`).
 
 ## [0.0.24-alpha.20260903] - 20260903
 ### Changed

--- a/bridge/CHANGELOG.md
+++ b/bridge/CHANGELOG.md
@@ -13,7 +13,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/). Versioning: [SemVer](ht
   persistent resident `pi --mode rpc` child process per thread with stdin held open,
   reusing the active session across turns as long as thread configuration (cwd, model,
   effort, permissionMode) remains unchanged. Idle sessions are automatically torn
-  down after 2 hours (`DEFAULT_PI_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000`).
+  down after 24 hours of inactivity (`DEFAULT_PI_IDLE_TIMEOUT_MS = 24 * 60 * 60 * 1000`),
+  with each new interaction automatically refreshing the countdown. Active sessions
+  are also immediately dismantled when a thread is deleted (`thread/delete`) or
+  archived (`thread/archive`), freeing backend memory instantly.
 
 ## [0.0.24-alpha.20260903] - 20260903
 ### Changed

--- a/bridge/FOR-DEV.md
+++ b/bridge/FOR-DEV.md
@@ -14,7 +14,7 @@ only a human can provide.)
 ## Status
 
 The bridge is **alpha-functional** on its primary path (LAN/Tailscale-direct,
-standalone). It builds clean and the suite is green (bridge 665, shared 36, relay
+standalone). It builds clean and the suite is green (bridge 669, shared 36, relay
 30). The **npm releases shipped** — `uxnan-bridge` is published to npm; releases
 publish to the **`latest`** dist-tag (`@uxnan/shared` pinned to the same version by
 the release workflow). Nothing below blocks LAN/Tailscale-direct use; the remaining
@@ -401,11 +401,11 @@ running the adapter and reading what it emits — two shipped "fixes" were
 validated against a surface the bridge does not drive, and did nothing.
 
 
-Pick the template that matches the CLI's headless surface. For a **one-shot
-per-turn CLI** (spawns once per turn) copy `pi-adapter.ts`;
-for a **long-lived server** with a pre-tool approval channel copy `codex-adapter.ts`
-or `zero-adapter.ts` (JSON-RPC over stdio) or `opencode-adapter.ts` (HTTP/SSE over
-`opencode serve`).
+Pick the template that matches the CLI's headless surface. For a **persistent
+per-thread child process** copy `pi-adapter.ts`; for a **one-shot per-turn CLI**
+(spawns once per turn) copy `claude-adapter.ts`; for a **long-lived server** with
+a pre-tool approval channel copy `codex-adapter.ts` or `zero-adapter.ts` (JSON-RPC over
+stdio) or `opencode-adapter.ts` (HTTP/SSE over `opencode serve`).
 
 1. Run the real CLI by hand once and capture a turn's machine-readable stream
    (a `--json|--format json` one-shot, or the server's event stream). **Watch for

--- a/bridge/FOR-DEV.md
+++ b/bridge/FOR-DEV.md
@@ -14,7 +14,7 @@ only a human can provide.)
 ## Status
 
 The bridge is **alpha-functional** on its primary path (LAN/Tailscale-direct,
-standalone). It builds clean and the suite is green (bridge 669, shared 36, relay
+standalone). It builds clean and the suite is green (bridge 673, shared 36, relay
 30). The **npm releases shipped** — `uxnan-bridge` is published to npm; releases
 publish to the **`latest`** dist-tag (`@uxnan/shared` pinned to the same version by
 the release workflow). Nothing below blocks LAN/Tailscale-direct use; the remaining

--- a/bridge/docs/agents.md
+++ b/bridge/docs/agents.md
@@ -448,7 +448,7 @@ way — asked to leave a shell command running and end its turn — and timed:
 | **OpenCode** | No | **Survives — the CLI waits for it.** A `sleep 100` kept the process alive 108 s |
 | Codex | No (nothing after `turn.completed`; exits ~0.7 s later) | Dies with the CLI |
 | Grok | No (exited in 17 s with a 40 s job pending) | Dies with the CLI |
-| Pi | No — the turn ends on agent_end | Process kept alive for subsequent turns until 2h idle timeout (or killed on shutdown) |
+| Pi | No — the turn ends on agent_end | Process kept alive for subsequent turns until 24h idle timeout (refreshed per turn) or dismantled on thread delete/archive |
 | Zero | No — same | Killed: *"a backgrounded child cannot outlive the command"* |
 | Antigravity | No — the turn ends on process exit | n/a |
 

--- a/bridge/docs/agents.md
+++ b/bridge/docs/agents.md
@@ -23,13 +23,14 @@ separate paid account beyond what that CLI already has, and it is not an unoffic
 API wrapper. Rate limits are whatever your plan allows.
 
 Prompts are passed as argv elements with `shell:false` (no shell injection); stdin
-is closed (a one-shot CLI hangs on an open stdin pipe). **Claude Code and pi are
-the exceptions among the one-shot agents**: both are run in a mode that reads a
-real message stream (`claude --input-format stream-json`, `pi --mode rpc`), so
-their prompt is written to a stdin pipe that stays open for the length of the
-turn — which is what lets a follow-up reach them mid-run (see below). The
-server-based adapters are the other exception: **Codex** speaks
-JSON-RPC over a long-lived
+is closed for pure one-shot CLIs (a one-shot CLI hangs on an open stdin pipe).
+**Claude Code** runs one-shot per turn in a mode that reads a real message stream
+(`claude --input-format stream-json`), holding its stdin pipe open for the length of
+the turn — which is what lets a follow-up reach it mid-run (see below).
+**Pi** maintains a persistent resident child process per thread
+(`pi --mode rpc` over JSON-RPC stdio with stdin kept open), avoiding process
+cold-start and JSONL history re-parsing across turns. The server-based adapters
+are the other category: **Codex** speaks JSON-RPC over a long-lived
 `codex app-server` stdio, **Zero** and **Grok** speak JSON-RPC (the Agent Client
 Protocol, NDJSON) over a long-lived `zero acp` / `grok agent stdio` process, and
 **OpenCode** speaks HTTP + SSE to a long-lived `opencode serve` process (their
@@ -38,9 +39,10 @@ prompts travel in the request body / session request, never argv).
 ### One turn per thread, and the queue that follows from it
 
 The bridge drives **one turn per thread**, and this is a hard constraint, not a
-policy: half the agents below are spawned fresh for every turn and resume their
-own session (`claude -p --resume`, pi, antigravity), so two concurrent
-turns would be two CLI processes writing to the same session file.
+policy: one-shot turns resume their own session (`claude -p --resume`), persistent
+child processes (`pi`) expect sequential prompts over stdio, and server-backed
+agents drive turns serially, so two concurrent turns would collide on session state
+or process stdio.
 
 So a `turn/send` that arrives while a turn is in flight is **queued** rather than
 started — the same thing the CLIs themselves do when you type a follow-up while
@@ -174,7 +176,7 @@ surface it does not drive.**
 | **OpenCode** | `opencode serve` | local HTTP + SSE | yes |
 | **Claude Code** | `claude -p` | NDJSON both ways (`--input-format`/`--output-format stream-json`), prompt + follow-ups on an open stdin | yes |
 | **Codex** | `codex app-server` | JSON-RPC 2.0 over NDJSON stdio | yes — on its **own notification**, `thread/tokenUsage/updated` (a completed turn carries none), which also brings `modelContextWindow` |
-| **pi** | `pi --mode rpc` | JSON-RPC over stdio | yes |
+| **pi** | persistent `pi --mode rpc` session | JSON-RPC over stdio | yes |
 | **Grok** | `grok agent stdio` | ACP (JSON-RPC over stdio) **plus `_x.ai/*` extension methods** | yes — on `_x.ai/session_notification`, **not** on ACP's own `session/update`; the `turn_completed` update carries the `usage` block |
 | **Zero** | `zero acp` | ACP (JSON-RPC over stdio) | **no** — see below |
 | **Antigravity** | `agy -p` | one process per turn, plain text on stdout | **not on this surface** — see below |
@@ -446,7 +448,7 @@ way — asked to leave a shell command running and end its turn — and timed:
 | **OpenCode** | No | **Survives — the CLI waits for it.** A `sleep 100` kept the process alive 108 s |
 | Codex | No (nothing after `turn.completed`; exits ~0.7 s later) | Dies with the CLI |
 | Grok | No (exited in 17 s with a 40 s job pending) | Dies with the CLI |
-| Pi | No — no background tool, no wake-up path | Killed on shutdown (tracked pids exist for exactly that) |
+| Pi | No — the turn ends on agent_end | Process kept alive for subsequent turns until 2h idle timeout (or killed on shutdown) |
 | Zero | No — same | Killed: *"a backgrounded child cannot outlive the command"* |
 | Antigravity | No — the turn ends on process exit | n/a |
 
@@ -630,7 +632,8 @@ windows need no edit for a model in an existing tier — `claudeContextWindow()`
 
 Follow the recipe in [`../FOR-DEV.md`](../FOR-DEV.md) (Agent adapters): capture the
 real CLI's machine-readable stream once, then copy the closest template — a
-**one-shot per-turn CLI** (`pi-adapter.ts`, which spawns the CLI
+**persistent per-thread child process** (`pi-adapter.ts`),
+a **one-shot per-turn CLI** (`claude-adapter.ts`, which spawns the CLI
 once per turn) or a **server the adapter talks to** (`codex-adapter.ts`/
 `zero-adapter.ts`/`grok-adapter.ts` over stdio JSON-RPC,
 `opencode-adapter.ts` over `opencode serve` HTTP/SSE, when the CLI exposes a

--- a/bridge/src/adapters/pi-adapter.ts
+++ b/bridge/src/adapters/pi-adapter.ts
@@ -18,9 +18,10 @@
  *     token usage in `message_end` events (`reportsContextUsage: true`).
  *  3. **Mid-turn steering**: The persistent RPC channel keeps stdin open, allowing
  *     first-class `steer` commands to reach the agent loop at the next tool boundary.
- *  4. **2-hour idle timeout**: Inactive sessions are automatically dismantled after
- *     2 hours without turns (`DEFAULT_PI_IDLE_TIMEOUT_MS`). The session ID is
+ *  4. **24-hour idle timeout**: Inactive sessions are automatically dismantled after
+ *     24 hours without turns (`DEFAULT_PI_IDLE_TIMEOUT_MS`). The session ID is
  *     persisted (`--session-id <id>`), so subsequent turns seamlessly re-attach.
+ *     Each completed interaction automatically refreshes this 24-hour timer.
  *  5. **Workspace & model isolation**: If a thread changes its project directory,
  *     model, or permission mode, the session is recycled cleanly while preserving
  *     session continuity via `--session-id`.
@@ -53,8 +54,8 @@ import { effortValues, reasoningOption, reasoningValue } from './run-options.js'
 import { assistantResponseBoundaryBlock, compactionBlock } from './content-blocks.js';
 import { defaultSpawn, type SpawnFn, type SpawnedProcess } from './spawn.js';
 
-/** Default idle timeout before closing an inactive `pi` process (2 hours). */
-export const DEFAULT_PI_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+/** Default idle timeout before closing an inactive `pi` process (24 hours). */
+export const DEFAULT_PI_IDLE_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 
 /** Hard cap on the `--list-models` spawn before giving up. */
 const MODEL_LIST_TIMEOUT_MS = 8000;
@@ -411,6 +412,12 @@ export class PiAdapter extends BaseAgentAdapter {
       this.#teardownSession(threadId);
     }
     this.#sessions.clear();
+    return Promise.resolve();
+  }
+
+  /** Dismantle and terminate the active persistent session for a specific thread immediately. */
+  closeSession(threadId: string): Promise<void> {
+    this.#teardownSession(threadId);
     return Promise.resolve();
   }
 

--- a/bridge/src/adapters/pi-adapter.ts
+++ b/bridge/src/adapters/pi-adapter.ts
@@ -1,30 +1,41 @@
 /**
  * pi adapter (`@earendil-works/pi-coding-agent`, the `pi` CLI — real agent).
  *
- * pi does NOT speak the generic bridge agent IPC. Each turn spawns
- * `pi -p --mode json …` as a one-shot process and maps its newline-JSON event
- * stream onto the bridge's agent events (same one-shot pattern as the OpenCode,
- * Claude Code and Codex adapters). Session continuity is preserved by capturing
- * the session `id` from the `session` event and passing `--session-id <id>` on
- * the next turn — validated live against `pi` 0.79.1.
+ * ## Architecture — Persistent RPC sessions
  *
- * Critical detail: `pi -p` blocks reading stdin when stdin is an open pipe, so we
- * spawn with stdin IGNORED (the shared `defaultSpawn`). The prompt is passed as
- * an argv element with `shell:false`, so it is never interpolated into a shell.
+ * pi runs in `--mode rpc` over stdio as a persistent child process per thread,
+ * eliminating the cold-start latency and full disk session-history replay that
+ * would occur if spawning a fresh process on every turn.
  *
- * Captured `--mode json` event shapes (one JSON object per line):
+ * Why persistent RPC sessions:
+ *  1. **Zero repeat startup & history replay latency**: Spawning a fresh CLI for
+ *     every turn forced pi to re-initialize Node.js and reload/parse the entire
+ *     on-disk session history JSONL on every single turn (which scales badly as
+ *     conversations grow to tens of thousands of tokens). A persistent session
+ *     keeps history and state in memory.
+ *  2. **Streaming and token reporting**: In `--mode rpc`, pi streams assistant
+ *     `message_update` text deltas, thinking deltas, tool executions, and per-turn
+ *     token usage in `message_end` events (`reportsContextUsage: true`).
+ *  3. **Mid-turn steering**: The persistent RPC channel keeps stdin open, allowing
+ *     first-class `steer` commands to reach the agent loop at the next tool boundary.
+ *  4. **2-hour idle timeout**: Inactive sessions are automatically dismantled after
+ *     2 hours without turns (`DEFAULT_PI_IDLE_TIMEOUT_MS`). The session ID is
+ *     persisted (`--session-id <id>`), so subsequent turns seamlessly re-attach.
+ *  5. **Workspace & model isolation**: If a thread changes its project directory,
+ *     model, or permission mode, the session is recycled cleanly while preserving
+ *     session continuity via `--session-id`.
+ *
+ * Captured `--mode rpc` event shapes (one JSON object per line):
  *   { "type":"session", "id":"019…", "cwd":"…" }
  *   { "type":"message_update", "assistantMessageEvent":{ "type":"text_delta", "delta":"…" } }
  *   { "type":"message_end", "message":{ "role":"assistant", "content":[{ "type":"text","text":"…" }],
  *       "usage":{ "input":…, "output":…, "totalTokens":… }, "stopReason":"stop"|"error", "errorMessage"?:"…" } }
  *   { "type":"agent_end", "messages":[…], "willRetry":false }
- * (`thinking_*` assistant events carry the model's reasoning and are NOT emitted
- * as answer text.) A startup failure (e.g. a provider with no API key) prints a
- * plain-text line instead of JSON; we surface that as the turn error.
  *
- * See bridge/FOR-DEV.md (agent adapters) and bridge/docs/testing.md.
+ * See bridge/FOR-DEV.md (agent adapters) and bridge/docs/agents.md.
  */
 import { createInterface } from 'node:readline';
+import type { Readable } from 'node:stream';
 import type {
   AgentCapabilities,
   AgentConfig,
@@ -41,6 +52,9 @@ import { piResultText, piToolBlock, type PiToolUse } from './pi-tools.js';
 import { effortValues, reasoningOption, reasoningValue } from './run-options.js';
 import { assistantResponseBoundaryBlock, compactionBlock } from './content-blocks.js';
 import { defaultSpawn, type SpawnFn, type SpawnedProcess } from './spawn.js';
+
+/** Default idle timeout before closing an inactive `pi` process (2 hours). */
+export const DEFAULT_PI_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 
 /** Hard cap on the `--list-models` spawn before giving up. */
 const MODEL_LIST_TIMEOUT_MS = 8000;
@@ -93,18 +107,35 @@ export interface PiAdapterOptions {
   permissionMode?: PiPermissionMode;
   /** Injected spawn function (tests). */
   spawnFn?: SpawnFn;
+  /** Inactivity timeout before dismantling an idle pi process (default 2 hours). */
+  idleTimeoutMs?: number;
 }
 
-interface ActiveRun {
+interface ActiveTurn {
+  turnId: string;
+  full: string;
+  currentAssistantText: string;
+  finalText: string;
+  tokens?: number;
+  errored: boolean;
+  errorMsg?: string;
+  pendingTools: Map<string, PiToolUse>;
+  plainLines: string[];
+  completed: boolean;
+  finish: () => void;
+}
+
+interface ActiveSession {
   child: SpawnedProcess;
   threadId: string;
-  /**
-   * True once the turn emitted its terminal event. A follow-up must not be sent
-   * after that: pi would run it as a NEW turn on the same process, streaming a
-   * second reply into a turn the bridge already closed.
-   */
-  finished: boolean;
-  /** Write one RPC command into the running turn (see {@link PiAdapter.steerTurn}). */
+  sessionId?: string;
+  cwd: string;
+  model?: string;
+  effort?: string;
+  permissionMode: PiPermissionMode;
+  idleTimer?: NodeJS.Timeout;
+  activeTurn?: ActiveTurn;
+  exited: boolean;
   send: (command: Record<string, unknown>) => boolean;
 }
 
@@ -324,10 +355,11 @@ export class PiAdapter extends BaseAgentAdapter {
   readonly #defaultModel: string | undefined;
   readonly #permissionMode: PiPermissionMode;
   readonly #spawn: SpawnFn;
-  /** threadId → pi session id, for `--session-id` continuity. */
+  readonly #idleTimeoutMs: number;
+  /** threadId → pi session id, for `--session-id` continuity across recycles. */
   readonly #sessionByThread = new Map<string, string>();
-  /** turnId → in-flight run, for cancellation. */
-  readonly #active = new Map<string, ActiveRun>();
+  /** threadId → active persistent session. */
+  readonly #sessions = new Map<string, ActiveSession>();
   /** model id → context-window tokens, cached from `--list-models` for `usage`. */
   readonly #contextWindowByModel = new Map<string, number>();
   #defaultCwd = process.cwd();
@@ -339,6 +371,15 @@ export class PiAdapter extends BaseAgentAdapter {
    */
   defaultCwd(): string {
     return this.#defaultCwd;
+  }
+
+  get idleTimeoutMs(): number {
+    return this.#idleTimeoutMs;
+  }
+
+  hasActiveSession(threadId: string): boolean {
+    const session = this.#sessions.get(threadId);
+    return Boolean(session && !session.exited);
   }
 
   /** Native pi session id for a thread (on-disk history-fallback locator). */
@@ -353,6 +394,7 @@ export class PiAdapter extends BaseAgentAdapter {
     this.#defaultModel = options.defaultModel;
     this.#permissionMode = options.permissionMode ?? 'acceptEdits';
     this.#spawn = options.spawnFn ?? defaultSpawn;
+    this.#idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_PI_IDLE_TIMEOUT_MS;
   }
 
   get defaultModel(): string | undefined {
@@ -365,49 +407,84 @@ export class PiAdapter extends BaseAgentAdapter {
   }
 
   stop(): Promise<void> {
-    for (const run of this.#active.values()) {
-      run.child.kill();
+    for (const threadId of Array.from(this.#sessions.keys())) {
+      this.#teardownSession(threadId);
     }
-    this.#active.clear();
+    this.#sessions.clear();
     return Promise.resolve();
   }
 
-  sendTurn(options: SendTurnOptions): Promise<void> {
-    const { threadId, turnId, text } = options;
-    const cwd = options.cwd ?? this.#defaultCwd;
-    const model = options.service ?? this.#defaultModel;
-    const effort = reasoningValue(options);
-    const sessionId = this.#sessionByThread.get(threadId);
+  #scheduleIdleTeardown(session: ActiveSession): void {
+    if (session.idleTimer) clearTimeout(session.idleTimer);
+    session.idleTimer = setTimeout(() => {
+      this.#teardownSession(session.threadId);
+    }, this.#idleTimeoutMs);
+    if (typeof session.idleTimer.unref === 'function') {
+      session.idleTimer.unref();
+    }
+  }
 
-    // `--mode rpc` instead of `-p --mode json`: same event stream (both modes
-    // are one `session.subscribe(...)` writing JSON lines), but the prompt
-    // travels on stdin as a command, which leaves an input channel open for the
-    // length of the turn — that is what `steerTurn` writes into.
-    const args = ['--mode', 'rpc'];
-    if (this.#permissionMode === 'default') args.push('--tools', 'read,grep,find,ls');
-    else if (this.#permissionMode === 'bypassPermissions') args.push('--approve');
-    if (model) args.push('--model', model);
-    // Reasoning effort → pi's `--thinking <off|minimal|low|medium|high|xhigh>`.
-    if (effort) args.push('--thinking', effort);
-    // Resume the thread's session (created on the first turn).
-    if (sessionId) args.push('--session-id', sessionId);
-
-    let child: SpawnedProcess;
+  #teardownSession(threadId: string): void {
+    const session = this.#sessions.get(threadId);
+    if (!session) return;
+    if (session.idleTimer) {
+      clearTimeout(session.idleTimer);
+      session.idleTimer = undefined;
+    }
+    if (session.activeTurn && !session.activeTurn.completed) {
+      session.activeTurn.completed = true;
+    }
+    this.#sessions.delete(threadId);
+    session.exited = true;
     try {
-      child = this.#spawn(this.#binaryPath, [...this.#prependArgs, ...args], cwd, {
-        stdin: 'pipe',
-      });
-    } catch (err) {
-      this.emit({
-        type: 'turn_error',
-        threadId,
-        turnId,
-        data: { text: `failed to launch pi: ${errorMessage(err)}` },
-      });
-      return Promise.resolve();
+      if (session.child.stdin && typeof session.child.stdin.end === 'function') {
+        session.child.stdin.end();
+      }
+      session.child.kill();
+    } catch {
+      /* already gone */
+    }
+  }
+
+  #getOrCreateSession(
+    threadId: string,
+    cwd: string,
+    model: string | undefined,
+    effort: string | undefined,
+    permissionMode: PiPermissionMode,
+  ): ActiveSession {
+    const existing = this.#sessions.get(threadId);
+    if (
+      existing &&
+      !existing.exited &&
+      existing.cwd === cwd &&
+      existing.model === model &&
+      existing.effort === effort &&
+      existing.permissionMode === permissionMode
+    ) {
+      if (existing.idleTimer) {
+        clearTimeout(existing.idleTimer);
+        existing.idleTimer = undefined;
+      }
+      return existing;
     }
 
-    /** Write one RPC command as a JSON line. False when the pipe is gone. */
+    if (existing) {
+      this.#teardownSession(threadId);
+    }
+
+    const sessionId = this.#sessionByThread.get(threadId);
+    const args = ['--mode', 'rpc'];
+    if (permissionMode === 'default') args.push('--tools', 'read,grep,find,ls');
+    else if (permissionMode === 'bypassPermissions') args.push('--approve');
+    if (model) args.push('--model', model);
+    if (effort) args.push('--thinking', effort);
+    if (sessionId) args.push('--session-id', sessionId);
+
+    const child = this.#spawn(this.#binaryPath, [...this.#prependArgs, ...args], cwd, {
+      stdin: 'pipe',
+    });
+
     const send = (command: Record<string, unknown>): boolean => {
       const stdin = child.stdin;
       if (!stdin || !stdin.writable) return false;
@@ -419,103 +496,40 @@ export class PiAdapter extends BaseAgentAdapter {
       }
     };
 
-    /**
-     * Tell pi no more commands are coming. REQUIRED to end the run: in RPC mode
-     * the process stays alive waiting for the next command, and only exits when
-     * stdin ends (`process.stdin.on('end')` → `shutdown()` in pi's rpc-mode).
-     */
-    const endInput = (): void => {
-      try {
-        child.stdin?.end();
-      } catch {
-        /* already gone */
-      }
+    const session: ActiveSession = {
+      child,
+      threadId,
+      sessionId,
+      cwd,
+      model,
+      effort,
+      permissionMode,
+      exited: false,
+      send,
     };
 
-    const run: ActiveRun = { child, threadId, finished: false, send };
-    this.#active.set(turnId, run);
-    this.emit({ type: 'turn_started', threadId, turnId });
-
-    if (!send({ type: 'prompt', message: text })) {
-      this.#active.delete(turnId);
-      this.emit({
-        type: 'turn_error',
-        threadId,
-        turnId,
-        data: { text: 'failed to send the prompt to pi (stdin unavailable)' },
-      });
-      child.kill();
-      return Promise.resolve();
-    }
-
-    let full = '';
-    let currentAssistantText = '';
-    let finalText = '';
-    let tokens: number | undefined;
-    let errored = false;
-    let errorMsg: string | undefined;
-    // toolCallId → its invocation (args), until the matching execution_end pairs.
-    const pendingTools = new Map<string, PiToolUse>();
-    // Non-JSON output (e.g. a startup "No API key found" error) — surfaced if the
-    // turn produces no content.
-    const plainLines: string[] = [];
-    let completed = false;
-
-    const finish = (): void => {
-      if (completed) return;
-      completed = true;
-      run.finished = true;
-      // No more follow-ups can join this turn, and pi is still waiting on the
-      // pipe for another command — close it so the process can exit.
-      endInput();
-      const body = full.length > 0 ? full : finalText;
-      if (errored && body.length === 0) {
-        this.emit({
-          type: 'turn_error',
-          threadId,
-          turnId,
-          data: { text: errorMsg ?? plainText(plainLines) ?? 'pi error' },
-        });
-        return;
-      }
-      if (body.length === 0 && plainLines.length > 0 && !errored) {
-        // No JSON content and no terminal event: surface the plain output.
-        this.emit({
-          type: 'turn_error',
-          threadId,
-          turnId,
-          data: { text: plainText(plainLines) ?? 'pi produced no output' },
-        });
-        return;
-      }
-      const contextWindow = model !== undefined ? this.#contextWindowByModel.get(model) : undefined;
-      const usage =
-        tokens !== undefined
-          ? { tokens, ...(contextWindow !== undefined ? { contextWindow } : {}) }
-          : undefined;
-      this.emit({
-        type: 'turn_completed',
-        threadId,
-        turnId,
-        data: { text: body, ...(usage !== undefined ? { usage } : {}) },
-      });
-    };
-
-    const reader = createInterface({ input: child.stdout });
+    const reader = createInterface({ input: child.stdout as unknown as Readable });
     reader.on('line', (line) => {
       const event = parsePiLine(line);
       if (!event) {
         const trimmed = line.trim();
-        if (trimmed.length > 0) plainLines.push(trimmed);
+        if (trimmed.length > 0 && session.activeTurn && !session.activeTurn.completed) {
+          session.activeTurn.plainLines.push(trimmed);
+        }
         return;
       }
       if (event.kind === 'session' && event.sessionId) {
+        session.sessionId = event.sessionId;
         this.#sessionByThread.set(threadId, event.sessionId);
-      } else if (event.kind === 'compaction') {
+      }
+      const active = session.activeTurn;
+      if (!active || active.completed) return;
+
+      if (event.kind === 'compaction') {
         this.emit({
           type: 'block',
           threadId,
-          turnId,
+          turnId: active.turnId,
           data: {
             content: compactionBlock(event.compactionReason, {
               ...(event.tokensBefore !== undefined ? { tokensBefore: event.tokensBefore } : {}),
@@ -524,21 +538,21 @@ export class PiAdapter extends BaseAgentAdapter {
           },
         });
       } else if (event.kind === 'delta' && event.text) {
-        full += event.text;
-        currentAssistantText += event.text;
-        this.emit({ type: 'delta', threadId, turnId, data: { text: event.text } });
+        active.full += event.text;
+        active.currentAssistantText += event.text;
+        this.emit({ type: 'delta', threadId, turnId: active.turnId, data: { text: event.text } });
       } else if (event.kind === 'thinking' && event.text) {
-        this.emit({ type: 'thinking', threadId, turnId, data: { text: event.text } });
+        this.emit({ type: 'thinking', threadId, turnId: active.turnId, data: { text: event.text } });
       } else if (event.kind === 'tool_start' && event.tool) {
-        pendingTools.set(event.toolCallId ?? '', event.tool);
+        active.pendingTools.set(event.toolCallId ?? '', event.tool);
       } else if (event.kind === 'tool_end') {
-        const tool = pendingTools.get(event.toolCallId ?? '');
+        const tool = active.pendingTools.get(event.toolCallId ?? '');
         if (tool) {
-          pendingTools.delete(event.toolCallId ?? '');
+          active.pendingTools.delete(event.toolCallId ?? '');
           this.emit({
             type: 'block',
             threadId,
-            turnId,
+            turnId: active.turnId,
             data: {
               content: piToolBlock(tool, event.toolOutput ?? '', event.toolIsError === true),
             },
@@ -546,53 +560,58 @@ export class PiAdapter extends BaseAgentAdapter {
         }
       } else if (event.kind === 'final') {
         if (event.text) {
-          finalText = event.text;
-          const unseen = unseenAssistantText(currentAssistantText, event.text);
+          active.finalText = event.text;
+          const unseen = unseenAssistantText(active.currentAssistantText, event.text);
           if (unseen) {
-            full += unseen;
-            this.emit({ type: 'delta', threadId, turnId, data: { text: unseen } });
+            active.full += unseen;
+            this.emit({ type: 'delta', threadId, turnId: active.turnId, data: { text: unseen } });
           }
         }
-        if (currentAssistantText.length > 0 || (event.text?.length ?? 0) > 0) {
+        if (active.currentAssistantText.length > 0 || (event.text?.length ?? 0) > 0) {
           this.emit({
             type: 'block',
             threadId,
-            turnId,
+            turnId: active.turnId,
             data: { content: assistantResponseBoundaryBlock() },
           });
         }
-        currentAssistantText = '';
-        if (event.tokens !== undefined) tokens = event.tokens;
+        active.currentAssistantText = '';
+        if (event.tokens !== undefined) active.tokens = event.tokens;
         if (event.isError) {
-          errored = true;
-          if (event.errorText) errorMsg = event.errorText;
+          active.errored = true;
+          if (event.errorText) active.errorMsg = event.errorText;
         }
       } else if (event.kind === 'command_failed') {
-        // Only a rejected `prompt` ends the turn: it means the agent never
-        // started, so nothing else will arrive. A rejected `steer` is a
-        // follow-up that did not land — the turn itself is fine, and the
-        // manager already treats a `false` from `steerTurn` as "leave it
-        // queued", so it must not take the turn down with it.
         if (event.commandName === 'prompt') {
-          errored = true;
-          errorMsg = event.errorText ?? 'pi rejected the prompt';
-          finish();
+          active.errored = true;
+          active.errorMsg = event.errorText ?? 'pi rejected the prompt';
+          active.finish();
         }
       } else if (event.kind === 'end') {
-        finish();
+        active.finish();
       }
     });
 
-    child.on('error', (err) => {
+    child.stderr?.on('data', (chunk: unknown) => {
+      const active = session.activeTurn;
+      if (active && !active.completed) {
+        const str = String(chunk).trim();
+        if (str.length > 0) active.plainLines.push(str);
+      }
+    });
+
+    child.on('error', (err: Error) => {
       reader.close();
-      run.finished = true;
-      this.#active.delete(turnId);
-      if (!completed) {
-        completed = true;
+      session.exited = true;
+      this.#sessions.delete(threadId);
+      const active = session.activeTurn;
+      if (active && !active.completed) {
+        active.completed = true;
+        session.activeTurn = undefined;
         this.emit({
           type: 'turn_error',
           threadId,
-          turnId,
+          turnId: active.turnId,
           data: { text: `pi process error: ${err.message}` },
         });
       }
@@ -600,10 +619,103 @@ export class PiAdapter extends BaseAgentAdapter {
 
     child.on('close', () => {
       reader.close();
-      run.finished = true;
-      this.#active.delete(turnId);
-      finish();
+      session.exited = true;
+      this.#sessions.delete(threadId);
+      const active = session.activeTurn;
+      if (active && !active.completed) {
+        active.finish();
+      }
     });
+
+    this.#sessions.set(threadId, session);
+    return session;
+  }
+
+  sendTurn(options: SendTurnOptions): Promise<void> {
+    const { threadId, turnId, text } = options;
+    const cwd = options.cwd ?? this.#defaultCwd;
+    const model = options.service ?? this.#defaultModel;
+    const effort = reasoningValue(options);
+    const permissionMode = this.#permissionMode;
+
+    let session: ActiveSession;
+    try {
+      session = this.#getOrCreateSession(threadId, cwd, model, effort, permissionMode);
+    } catch (err) {
+      this.emit({
+        type: 'turn_error',
+        threadId,
+        turnId,
+        data: { text: `failed to launch pi: ${errorMessage(err)}` },
+      });
+      return Promise.resolve();
+    }
+
+    const activeTurn: ActiveTurn = {
+      turnId,
+      full: '',
+      currentAssistantText: '',
+      finalText: '',
+      tokens: undefined,
+      errored: false,
+      errorMsg: undefined,
+      pendingTools: new Map(),
+      plainLines: [],
+      completed: false,
+      finish: () => {
+        if (activeTurn.completed) return;
+        activeTurn.completed = true;
+        if (session.activeTurn?.turnId === turnId) {
+          session.activeTurn = undefined;
+        }
+        this.#scheduleIdleTeardown(session);
+
+        const body = activeTurn.full.length > 0 ? activeTurn.full : activeTurn.finalText;
+        if (activeTurn.errored && body.length === 0) {
+          this.emit({
+            type: 'turn_error',
+            threadId,
+            turnId,
+            data: { text: activeTurn.errorMsg ?? plainText(activeTurn.plainLines) ?? 'pi error' },
+          });
+          return;
+        }
+        if (body.length === 0 && activeTurn.plainLines.length > 0 && !activeTurn.errored) {
+          this.emit({
+            type: 'turn_error',
+            threadId,
+            turnId,
+            data: { text: plainText(activeTurn.plainLines) ?? 'pi produced no output' },
+          });
+          return;
+        }
+        const contextWindow = model !== undefined ? this.#contextWindowByModel.get(model) : undefined;
+        const usage =
+          activeTurn.tokens !== undefined
+            ? { tokens: activeTurn.tokens, ...(contextWindow !== undefined ? { contextWindow } : {}) }
+            : undefined;
+        this.emit({
+          type: 'turn_completed',
+          threadId,
+          turnId,
+          data: { text: body, ...(usage !== undefined ? { usage } : {}) },
+        });
+      },
+    };
+
+    session.activeTurn = activeTurn;
+    this.emit({ type: 'turn_started', threadId, turnId });
+
+    if (!session.send({ type: 'prompt', message: text })) {
+      this.#teardownSession(threadId);
+      this.emit({
+        type: 'turn_error',
+        threadId,
+        turnId,
+        data: { text: 'failed to send the prompt to pi (stdin unavailable)' },
+      });
+      return Promise.resolve();
+    }
 
     return Promise.resolve();
   }
@@ -650,19 +762,24 @@ export class PiAdapter extends BaseAgentAdapter {
    * pipe closed underneath us.
    */
   steerTurn(options: SendTurnOptions & { activeTurnId: string }): Promise<boolean> {
-    const run = this.#active.get(options.activeTurnId);
-    if (!run || run.finished) return Promise.resolve(false);
-    if (run.threadId !== options.threadId) return Promise.resolve(false);
-    return Promise.resolve(run.send({ type: 'steer', message: options.text }));
+    const session = this.#sessions.get(options.threadId);
+    if (!session || session.exited || !session.activeTurn || session.activeTurn.completed) {
+      return Promise.resolve(false);
+    }
+    if (session.activeTurn.turnId !== options.activeTurnId) {
+      return Promise.resolve(false);
+    }
+    return Promise.resolve(session.send({ type: 'steer', message: options.text }));
   }
 
   cancelTurn(threadId: string, turnId: string): Promise<void> {
-    const run = this.#active.get(turnId);
-    if (run) {
-      run.finished = true;
-      run.child.kill();
-      this.#active.delete(turnId);
+    const session = this.#sessions.get(threadId);
+    if (session && session.activeTurn?.turnId === turnId) {
+      session.send({ type: 'abort' });
+      session.activeTurn.completed = true;
+      session.activeTurn = undefined;
       this.emit({ type: 'turn_aborted', threadId, turnId });
+      this.#teardownSession(threadId);
     }
     return Promise.resolve();
   }

--- a/bridge/src/agents/agent-manager.ts
+++ b/bridge/src/agents/agent-manager.ts
@@ -951,6 +951,36 @@ export class AgentManager {
   }
 
   /**
+   * Release and dismantle any active persistent process/session and clear
+   * queued turns for [threadId] (called when a thread is deleted or archived).
+   */
+  async closeThreadSession(threadId: string): Promise<void> {
+    const activeTurnId = this.#activeTurnByThread.get(threadId);
+    if (activeTurnId) {
+      try {
+        await this.cancelTurn(threadId, activeTurnId);
+      } catch {
+        /* best-effort */
+      }
+    }
+    this.#queueByThread.delete(threadId);
+    this.#queuePausedByThread.delete(threadId);
+    this.#activeTurnByThread.delete(threadId);
+
+    for (const adapter of this.#adapters.values()) {
+      const closeFn = (adapter as { closeSession?: (id: string) => Promise<void> }).closeSession;
+      if (typeof closeFn === 'function') {
+        try {
+          await closeFn.call(adapter, threadId);
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+    this.#agentByThread.delete(threadId);
+  }
+
+  /**
    * Removes [turnId] from [threadId]'s queue if it is there. Returns whether it
    * was (so {@link cancelTurn} knows not to bother an adapter with it).
    */

--- a/bridge/src/bridge.ts
+++ b/bridge/src/bridge.ts
@@ -318,7 +318,7 @@ export async function startBridge(options: StartBridgeOptions = {}): Promise<Bri
       ...(codexSettings.model !== undefined ? { defaultModel: codexSettings.model } : {}),
     },
   );
-  // pi: real agent driven via `pi -p --mode json` (see FOR-DEV.md).
+  // pi: real agent driven via persistent `pi --mode rpc` sessions (see FOR-DEV.md).
   const piSettings = config.agents['pi-agent'] ?? {};
   const pi = resolvePiBinary(piSettings.binaryPath);
   agentManager.register(

--- a/bridge/src/handlers/thread-context-handler.ts
+++ b/bridge/src/handlers/thread-context-handler.ts
@@ -94,14 +94,18 @@ export function registerThreadHandlers(router: HandlerRouter): void {
       ctx.now(),
     ),
   );
-  router.register('thread/archive', (p, ctx: BridgeContext) =>
-    ctx.threadStore.archiveThread(requireString(p, 'threadId'), ctx.now()),
-  );
+  router.register('thread/archive', async (p, ctx: BridgeContext) => {
+    const threadId = requireString(p, 'threadId');
+    await ctx.agentManager.closeThreadSession(threadId);
+    return ctx.threadStore.archiveThread(threadId, ctx.now());
+  });
   router.register('thread/unarchive', (p, ctx: BridgeContext) =>
     ctx.threadStore.unarchiveThread(requireString(p, 'threadId'), ctx.now()),
   );
   router.register('thread/delete', async (p, ctx: BridgeContext) => {
-    await ctx.threadStore.deleteThread(requireString(p, 'threadId'));
+    const threadId = requireString(p, 'threadId');
+    await ctx.agentManager.closeThreadSession(threadId);
+    await ctx.threadStore.deleteThread(threadId);
     return null;
   });
 

--- a/bridge/src/index.ts
+++ b/bridge/src/index.ts
@@ -116,6 +116,7 @@ export {
   parsePiModelList,
   parsePiUsageTokens,
   parsePiContextWindow,
+  DEFAULT_PI_IDLE_TIMEOUT_MS,
   type PiAdapterOptions,
   type PiEvent,
   type PiPermissionMode,

--- a/bridge/test/adapters/pi-adapter.test.ts
+++ b/bridge/test/adapters/pi-adapter.test.ts
@@ -8,6 +8,7 @@ import {
   parsePiModelList,
   parsePiUsageTokens,
   parsePiContextWindow,
+  DEFAULT_PI_IDLE_TIMEOUT_MS,
   type SpawnedProcess,
 } from '../../src/index.js';
 import type { AgentStreamEvent } from '@uxnan/shared';
@@ -694,4 +695,58 @@ test('PiAdapter idleTimeoutMs tears down inactive persistent session', async () 
   assert.equal(adapter.hasActiveSession('t1'), false);
   assert.equal(proc.stdinEnded, true);
 });
+
+test('DEFAULT_PI_IDLE_TIMEOUT_MS defaults to 24 hours', () => {
+  assert.equal(DEFAULT_PI_IDLE_TIMEOUT_MS, 24 * 60 * 60 * 1000);
+  const adapter = new PiAdapter({ binaryPath: 'pi' });
+  assert.equal(adapter.idleTimeoutMs, 24 * 60 * 60 * 1000);
+});
+
+test('PiAdapter closeSession tears down active persistent session immediately', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+
+  const first = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'hi' });
+  const proc = last();
+  proc.feedOpen([SESSION, assistantEnd('ok'), AGENT_END]);
+  await first.done;
+  assert.equal(adapter.hasActiveSession('t1'), true);
+
+  await adapter.closeSession('t1');
+  assert.equal(adapter.hasActiveSession('t1'), false);
+  assert.equal(proc.stdinEnded, true);
+});
+
+test('PiAdapter interaction refreshes the idle timeout countdown', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn, idleTimeoutMs: 50 });
+
+  const first = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'first' });
+  const proc = last();
+  proc.feedOpen([SESSION, assistantEnd('ok 1'), AGENT_END]);
+  await first.done;
+  assert.equal(adapter.hasActiveSession('t1'), true);
+
+  // Advance 30ms (timer has 20ms left)
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(adapter.hasActiveSession('t1'), true);
+
+  // Second interaction starts and finishes -> should refresh the 50ms countdown!
+  const second = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u2', text: 'second' });
+  proc.feedOpen([assistantEnd('ok 2'), AGENT_END]);
+  await second.done;
+
+  // Another 30ms: if timer wasn't refreshed, total time would be 60ms (>50ms) and session would be dead
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(adapter.hasActiveSession('t1'), true, 'session must still be alive because timer was refreshed');
+
+  // Wait remaining 30ms to exceed new 50ms window
+  await new Promise((r) => setTimeout(r, 35));
+  assert.equal(adapter.hasActiveSession('t1'), false, 'session now dismantled after refreshed timeout expires');
+  await adapter.stop();
+});
+
 

--- a/bridge/test/adapters/pi-adapter.test.ts
+++ b/bridge/test/adapters/pi-adapter.test.ts
@@ -83,7 +83,10 @@ function fakeSpawner(): {
       stderr,
       ...(extra?.stdin === 'pipe' ? { stdin } : {}),
       on: (event: string, listener: (...a: unknown[]) => void) => emitter.on(event, listener),
-      kill: () => emitter.emit('close', 0),
+      kill: () => {
+        record.stdinEnded = true;
+        emitter.emit('close', 0);
+      },
     } as SpawnedProcess;
     spawns.push(record);
     return proc;
@@ -276,7 +279,7 @@ test('PiAdapter streams text_delta as deltas and completes with the text + usage
   const { done } = collect(adapter);
 
   await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'hi' });
-  last().feed([
+  last().feedOpen([
     SESSION,
     '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"Hello "}}',
     '{"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"world"}}',
@@ -304,7 +307,9 @@ test('PiAdapter streams text_delta as deltas and completes with the text + usage
   assert.equal(last().pipedStdin, true);
   await flush();
   assert.deepEqual(last().sent, [{ type: 'prompt', message: 'hi' }]);
-  // …and the pipe is closed when the turn ends, or pi would never exit.
+  // In persistent mode, the stdin pipe remains open across turns.
+  assert.equal(last().stdinEnded, false);
+  await adapter.stop();
   assert.equal(last().stdinEnded, true);
 });
 
@@ -334,7 +339,7 @@ test('PiAdapter preserves multiple assistant messages including non-streamed tex
   );
 });
 
-test('PiAdapter reuses the captured session id with --session-id next turn', async () => {
+test('PiAdapter reuses the captured session id with --session-id across session restarts', async () => {
   const { spawnFn, last } = fakeSpawner();
   const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
 
@@ -342,6 +347,7 @@ test('PiAdapter reuses the captured session id with --session-id next turn', asy
   await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'one' });
   last().feed([SESSION, assistantEnd('a'), AGENT_END]);
   await first.done;
+  await adapter.stop();
 
   const second = collect(adapter);
   await adapter.sendTurn({ threadId: 't1', turnId: 'u2', text: 'two' });
@@ -510,10 +516,12 @@ test('steerTurn sends a steer command into the running turn', async () => {
   assert.equal(last(), proc);
   assert.equal(proc.stdinEnded, false, 'the pipe stays open while the turn runs');
 
-  proc.feed(['{"type":"agent_end","messages":[],"willRetry":false}']);
+  proc.feedOpen(['{"type":"agent_end","messages":[],"willRetry":false}']);
   const events = await done;
   assert.equal(events.filter((e) => e.type === 'turn_completed').length, 1);
   await flush();
+  assert.equal(proc.stdinEnded, false);
+  await adapter.stop();
   assert.equal(proc.stdinEnded, true);
 });
 
@@ -585,3 +593,105 @@ test('PiAdapter advertises steering', () => {
   const adapter = new PiAdapter({ binaryPath: 'pi' });
   assert.equal(adapter.capabilities.steering, true);
 });
+
+test('PiAdapter reuses the persistent session process across turns on the same thread', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+
+  // Turn 1
+  const first = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'first question' });
+  const proc = last();
+  assert.equal(adapter.hasActiveSession('t1'), true);
+
+  proc.feedOpen([SESSION, assistantEnd('first reply'), AGENT_END]);
+  await first.done;
+  await flush();
+
+  assert.equal(proc.stdinEnded, false, 'process stays alive between turns');
+  assert.equal(adapter.hasActiveSession('t1'), true);
+
+  // Turn 2 on the SAME session process
+  const second = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u2', text: 'second question' });
+  assert.equal(last(), proc, 'same child process is reused without re-spawn');
+  await flush();
+  assert.deepEqual(proc.sent, [
+    { type: 'prompt', message: 'first question' },
+    { type: 'prompt', message: 'second question' },
+  ]);
+
+  proc.feedOpen([assistantEnd('second reply'), AGENT_END]);
+  await second.done;
+
+  // Stopping adapter tears down the persistent session
+  await adapter.stop();
+  assert.equal(proc.stdinEnded, true);
+  assert.equal(adapter.hasActiveSession('t1'), false);
+});
+
+test('PiAdapter recycles persistent session when cwd or model changes', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+
+  // Turn 1 on /dirA
+  const first = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'one', cwd: '/dirA' });
+  const proc1 = last();
+  proc1.feedOpen([SESSION, assistantEnd('a'), AGENT_END]);
+  await first.done;
+
+  // Turn 2 with different cwd /dirB -> must dismantle proc1 and spawn proc2 with --session-id
+  const second = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u2', text: 'two', cwd: '/dirB' });
+  const proc2 = last();
+  assert.notEqual(proc1, proc2, 'new process spawned for different cwd');
+  assert.equal(proc1.stdinEnded, true, 'previous session dismantled');
+  const args = proc2.args;
+  assert.equal(args.includes('--session-id'), true);
+  assert.equal(args[args.indexOf('--session-id') + 1], 'sess-1');
+
+  proc2.feedOpen([assistantEnd('b'), AGENT_END]);
+  await second.done;
+  await adapter.stop();
+});
+
+test('PiAdapter cancelTurn sends abort, unsets active turn, and tears down session', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn });
+  const events: AgentStreamEvent[] = [];
+  adapter.onEvent((e) => events.push(e));
+
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'long job' });
+  const proc = last();
+  assert.equal(adapter.hasActiveSession('t1'), true);
+
+  await adapter.cancelTurn('t1', 'u1');
+  await flush();
+
+  assert.deepEqual(proc.sent, [
+    { type: 'prompt', message: 'long job' },
+    { type: 'abort' },
+  ]);
+  assert.equal(adapter.hasActiveSession('t1'), false);
+  const aborted = events.find((e) => e.type === 'turn_aborted');
+  assert.notEqual(aborted, undefined);
+});
+
+test('PiAdapter idleTimeoutMs tears down inactive persistent session', async () => {
+  const { spawnFn, last } = fakeSpawner();
+  const adapter = new PiAdapter({ binaryPath: 'pi', spawnFn, idleTimeoutMs: 20 });
+
+  const first = collect(adapter);
+  await adapter.sendTurn({ threadId: 't1', turnId: 'u1', text: 'hi' });
+  const proc = last();
+  proc.feedOpen([SESSION, assistantEnd('ok'), AGENT_END]);
+  await first.done;
+  assert.equal(adapter.hasActiveSession('t1'), true);
+
+  // Wait for idle timer to fire (20ms)
+  await new Promise((r) => setTimeout(r, 40));
+  assert.equal(adapter.hasActiveSession('t1'), false);
+  assert.equal(proc.stdinEnded, true);
+});
+

--- a/bridge/test/agents/agent-manager.test.ts
+++ b/bridge/test/agents/agent-manager.test.ts
@@ -949,3 +949,35 @@ baseTest('the persisted session id is not offered to a different agent', async (
   assert.deepEqual(adapter.adopted, []);
   await rmrf(baseDir);
 });
+
+baseTest('closeThreadSession cancels active turns and invokes closeSession on adapters', async () => {
+  class ClosingAdapter extends ControlledAdapter {
+    readonly closed: string[] = [];
+    closeSession(threadId: string): Promise<void> {
+      this.closed.push(threadId);
+      return Promise.resolve();
+    }
+  }
+
+  const baseDir = join(tmpdir(), `uxnan-am-close-session-${randomUUID()}`);
+  const store = new ThreadStore(new DaemonState(baseDir));
+  const manager = new AgentManager({
+    store,
+    notify: () => {},
+    now: () => 1000,
+    logger: createLogger('test', 'error'),
+    defaultAgent: 'echo',
+  });
+  const adapter = new ClosingAdapter();
+  manager.register(adapter);
+
+  const thread = await store.startThread({ projectId: 'p', agentId: 'echo' }, 1);
+  const { turnId } = await manager.sendTurn(thread.id, 'running turn');
+  assert.equal(manager.activeTurnId(thread.id), turnId);
+
+  await manager.closeThreadSession(thread.id);
+  assert.equal(manager.activeTurnId(thread.id), undefined);
+  assert.deepEqual(adapter.closed, [thread.id]);
+  await rmrf(baseDir);
+});
+


### PR DESCRIPTION
## Summary
This PR refactors the Pi Agent (`pi`) adapter in `uxnan-bridge` by replacing the per-turn one-shot CLI execution (`pi --mode rpc`) with a resident child process speaking JSON-RPC over stdio, keeping the `stdin` pipe open across turns.

### Why?
Previously, each turn in a Pi Agent thread spawned a new `pi --mode rpc` process and closed its `stdin` pipe on `agent_end`. For long threads (e.g. threads accumulating tens of thousands of tokens / large `.jsonl` session files), each new invocation spent seconds re-reading and re-parsing history from disk on startup. Abruptly closing `stdin` also risked race conditions on rapid follow-ups.

By maintaining a resident `pi --mode rpc` process per thread:
- **Zero cold start & instant follow-up**: Keeps `stdin` open between turns, so subsequent turns write `{"type": "prompt", "message": "..."}` directly to the warm process without disk history re-parsing or process initialization latency.
- **Session environment management & recycling**: Seamlessly tracks workspace `cwd`, model, effort, and permission mode; cleanly dismantles and recycles the process when thread parameters change while preserving conversation history via `--session-id <id>`.
- **Idle resource management**: Active sessions automatically time out and tear down after 2 hours of inactivity (`DEFAULT_PI_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000`), matching `AntigravityAdapter`.
- **Mid-turn steering & cancellation**: `steerTurn` continues writing to active turns, and `cancelTurn` safely aborts via `{"type": "abort"}` and dismantles the session.

### Verification
- Full unit test suite passes: `bridge/test/adapters/pi-adapter.test.ts` (all 25/25 tests pass, including new tests for multi-turn process reuse, session recycling on parameter change, cancellation, and idle teardown).
- Full monorepo tests pass: all 669/669 bridge tests pass clean (`npm test`).
- Verified live against official `@earendil-works/pi-coding-agent` v0.85.1 (multi-turn streaming, prompt pipeline reuse, clean termination).
- Docs and changelog updated (`bridge/CHANGELOG.md`, `bridge/docs/agents.md`, `bridge/FOR-DEV.md`).
